### PR TITLE
test: fix outdated snapshot and small tslint error

### DIFF
--- a/src/lib/axes/axis_utils.test.ts
+++ b/src/lib/axes/axis_utils.test.ts
@@ -36,7 +36,7 @@ describe('Axis computational utils', () => {
   const originalGetBBox = SVGElement.prototype.getBoundingClientRect;
   beforeEach(
     () =>
-      (SVGElement.prototype.getBoundingClientRect = function () {
+      (SVGElement.prototype.getBoundingClientRect = function() {
         const text = this.textContent || 0;
         return { ...mockedRect, width: Number(text) * 10, heigh: Number(text) * 10 };
       }),
@@ -107,7 +107,10 @@ describe('Axis computational utils', () => {
   });
 
   test('should compute dimensions for the bounding box containing a rotated label', () => {
-    expect(computeRotatedLabelDimensions({ width: 1, height: 2 }, 0)).toEqual({ width: 1, height: 2 });
+    expect(computeRotatedLabelDimensions({ width: 1, height: 2 }, 0)).toEqual({
+      width: 1,
+      height: 2,
+    });
 
     const dims90 = computeRotatedLabelDimensions({ width: 1, height: 2 }, 90);
     expect(dims90.width).toBeCloseTo(2);
@@ -250,12 +253,15 @@ describe('Axis computational utils', () => {
   });
 
   test('should compute coordinates and offsets to anchor rotation origin from the center', () => {
-    const simpleCenteredProps = centerRotationOrigin({
-      maxLabelBboxWidth: 10,
-      maxLabelBboxHeight: 20,
-      maxLabelTextWidth: 10,
-      maxLabelTextHeight: 20,
-    }, { x: 0, y: 0 });
+    const simpleCenteredProps = centerRotationOrigin(
+      {
+        maxLabelBboxWidth: 10,
+        maxLabelBboxHeight: 20,
+        maxLabelTextWidth: 10,
+        maxLabelTextHeight: 20,
+      },
+      { x: 0, y: 0 },
+    );
 
     expect(simpleCenteredProps).toEqual({
       offsetX: 5,
@@ -264,12 +270,15 @@ describe('Axis computational utils', () => {
       y: 10,
     });
 
-    const rotatedCenteredProps = centerRotationOrigin({
-      maxLabelBboxWidth: 10,
-      maxLabelBboxHeight: 20,
-      maxLabelTextWidth: 20,
-      maxLabelTextHeight: 10,
-    }, { x: 30, y: 40 });
+    const rotatedCenteredProps = centerRotationOrigin(
+      {
+        maxLabelBboxWidth: 10,
+        maxLabelBboxHeight: 20,
+        maxLabelTextWidth: 20,
+        maxLabelTextHeight: 10,
+      },
+      { x: 30, y: 40 },
+    );
 
     expect(rotatedCenteredProps).toEqual({
       offsetX: 10,

--- a/src/lib/utils/__snapshots__/dimensions.test.ts.snap
+++ b/src/lib/utils/__snapshots__/dimensions.test.ts.snap
@@ -11,7 +11,7 @@ Object {
 
 exports[`Computed chart dimensions should be padded by a bottom axis 1`] = `
 Object {
-  "height": 30,
+  "height": 10,
   "left": 20,
   "top": 20,
   "width": 60,
@@ -21,9 +21,9 @@ Object {
 exports[`Computed chart dimensions should be padded by a left axis 1`] = `
 Object {
   "height": 60,
-  "left": 50,
+  "left": 70,
   "top": 20,
-  "width": 30,
+  "width": 10,
 }
 `;
 
@@ -32,15 +32,15 @@ Object {
   "height": 60,
   "left": 20,
   "top": 20,
-  "width": 30,
+  "width": 10,
 }
 `;
 
 exports[`Computed chart dimensions should be padded by a top axis 1`] = `
 Object {
-  "height": 30,
+  "height": 10,
   "left": 20,
-  "top": 50,
+  "top": 70,
   "width": 60,
 }
 `;

--- a/src/lib/utils/dimensions.test.ts
+++ b/src/lib/utils/dimensions.test.ts
@@ -25,18 +25,17 @@ describe('Computed chart dimensions', () => {
     bottom: 10,
   };
 
-  const axis1Dims = {
+  const axis1Dims: AxisTicksDimensions = {
     axisScaleType: ScaleType.Linear,
     axisScaleDomain: [0, 1],
     tickValues: [0, 1],
-    ticksDimensions: [{ width: 10, height: 10 }, { width: 10, height: 10 }],
     tickLabels: ['first', 'second'],
     maxLabelBboxWidth: 10,
     maxLabelBboxHeight: 10,
     maxLabelTextWidth: 10,
     maxLabelTextHeight: 10,
   };
-  const axis1Spec = {
+  const axisLeftSpec: AxisSpec = {
     id: getAxisId('axis_1'),
     groupId: getGroupId('group_1'),
     hide: false,
@@ -50,8 +49,8 @@ describe('Computed chart dimensions', () => {
     },
   };
   const legend: LegendStyle = {
-    verticalWidth: 0,
-    horizontalHeight: 0,
+    verticalWidth: 10,
+    horizontalHeight: 10,
   };
   const showLegend = false;
 
@@ -61,6 +60,11 @@ describe('Computed chart dimensions', () => {
       ...DEFAULT_THEME.chart,
       margins: chartMargins,
       paddings: chartPaddings,
+    },
+    axes: {
+      ...DEFAULT_THEME.axes,
+      titleFontSize: 10,
+      titlePadding: 10,
     },
     ...legend,
   };
@@ -77,10 +81,12 @@ describe('Computed chart dimensions', () => {
     expect(chartDimensions).toMatchSnapshot();
   });
   test('should be padded by a left axis', () => {
+    // |margin|titleFontSize|titlePadding|maxLabelBboxWidth|tickPadding|tickSize|padding|
+    // \10|10|10|10|10|10|10| = 70px from left
     const axisDims = new Map<AxisId, AxisTicksDimensions>();
     const axisSpecs = new Map<AxisId, AxisSpec>();
     axisDims.set(getAxisId('axis_1'), axis1Dims);
-    axisSpecs.set(getAxisId('axis_1'), axis1Spec);
+    axisSpecs.set(getAxisId('axis_1'), axisLeftSpec);
     const chartDimensions = computeChartDimensions(
       parentDim,
       chartTheme,
@@ -91,10 +97,12 @@ describe('Computed chart dimensions', () => {
     expect(chartDimensions).toMatchSnapshot();
   });
   test('should be padded by a right axis', () => {
+    // |padding|tickSize|tickPadding|maxLabelBBoxWidth|titlePadding|titleFontSize\margin|
+    // \10|10|10|10|10|10|10| = 70px from right
     const axisDims = new Map<AxisId, AxisTicksDimensions>();
     const axisSpecs = new Map<AxisId, AxisSpec>();
     axisDims.set(getAxisId('axis_1'), axis1Dims);
-    axisSpecs.set(getAxisId('axis_1'), { ...axis1Spec, position: Position.Right });
+    axisSpecs.set(getAxisId('axis_1'), { ...axisLeftSpec, position: Position.Right });
     const chartDimensions = computeChartDimensions(
       parentDim,
       chartTheme,
@@ -105,11 +113,13 @@ describe('Computed chart dimensions', () => {
     expect(chartDimensions).toMatchSnapshot();
   });
   test('should be padded by a top axis', () => {
+    // |margin|titleFontSize|titlePadding|maxLabelBboxHeight|tickPadding|tickSize|padding|
+    // \10|10|10|10|10|10|10| = 70px from top
     const axisDims = new Map<AxisId, AxisTicksDimensions>();
     const axisSpecs = new Map<AxisId, AxisSpec>();
     axisDims.set(getAxisId('axis_1'), axis1Dims);
     axisSpecs.set(getAxisId('axis_1'), {
-      ...axis1Spec,
+      ...axisLeftSpec,
       position: Position.Top,
     });
     const chartDimensions = computeChartDimensions(
@@ -122,11 +132,13 @@ describe('Computed chart dimensions', () => {
     expect(chartDimensions).toMatchSnapshot();
   });
   test('should be padded by a bottom axis', () => {
+    // |margin|titleFontSize|titlePadding|maxLabelBboxHeight|tickPadding|tickSize|padding|
+    // \10|10|10|10|10|10|10| = 70px from bottom
     const axisDims = new Map<AxisId, AxisTicksDimensions>();
     const axisSpecs = new Map<AxisId, AxisSpec>();
     axisDims.set(getAxisId('axis_1'), axis1Dims);
     axisSpecs.set(getAxisId('axis_1'), {
-      ...axis1Spec,
+      ...axisLeftSpec,
       position: Position.Bottom,
     });
     const chartDimensions = computeChartDimensions(

--- a/src/lib/utils/dimensions.ts
+++ b/src/lib/utils/dimensions.ts
@@ -16,6 +16,7 @@ export interface Margins {
   left: number;
   right: number;
 }
+
 /**
  * Compute the chart dimension padding the parent dimension by the specified set of axis
  * @param parentDimensions the parent dimension
@@ -50,16 +51,20 @@ export function computeChartDimensions(
     const { position, tickSize, tickPadding } = axisSpec;
     switch (position) {
       case Position.Top:
-        hTopAxisSpecHeight += maxLabelBboxHeight + tickSize + tickPadding + chartMargins.top + axisTitleHeight;
+        hTopAxisSpecHeight +=
+          maxLabelBboxHeight + tickSize + tickPadding + chartMargins.top + axisTitleHeight;
         break;
       case Position.Bottom:
-        hBottomAxisSpecHeight += maxLabelBboxHeight + tickSize + tickPadding + chartMargins.bottom + axisTitleHeight;
+        hBottomAxisSpecHeight +=
+          maxLabelBboxHeight + tickSize + tickPadding + chartMargins.bottom + axisTitleHeight;
         break;
       case Position.Left:
-        vLeftAxisSpecWidth += maxLabelBboxWidth + tickSize + tickPadding + chartMargins.left + axisTitleHeight;
+        vLeftAxisSpecWidth +=
+          maxLabelBboxWidth + tickSize + tickPadding + chartMargins.left + axisTitleHeight;
         break;
       case Position.Right:
-        vRightAxisSpecWidth += maxLabelBboxWidth + tickSize + tickPadding + chartMargins.right + axisTitleHeight;
+        vRightAxisSpecWidth +=
+          maxLabelBboxWidth + tickSize + tickPadding + chartMargins.right + axisTitleHeight;
         break;
     }
   });
@@ -84,18 +89,18 @@ export function computeChartDimensions(
   let legendLeftMargin = 0;
   if (showLegend) {
     switch (legendPosition) {
-      case 'right':
+      case Position.Right:
         hMargin += legendStyle.verticalWidth;
         break;
-      case 'left':
+      case Position.Left:
         hMargin += legendStyle.verticalWidth;
         legendLeftMargin = legendStyle.verticalWidth;
         break;
-      case 'top':
+      case Position.Top:
         vMargin += legendStyle.horizontalHeight;
         legendTopMargin = legendStyle.horizontalHeight;
         break;
-      case 'bottom':
+      case Position.Bottom:
         vMargin += legendStyle.horizontalHeight;
         break;
     }


### PR DESCRIPTION
`computeChartDimensions` now takes in account also `titleFontSize` and the `titlePadding`. The
snapshot are updated in relation to this new behaviour. I've fixed also the tslint error on
axis_utils test.