### PR TITLE
fix(axis): use titleFontSize for debug rect for horizontal axis title

### DIFF
--- a/src/components/react_canvas/axis.tsx
+++ b/src/components/react_canvas/axis.tsx
@@ -256,7 +256,7 @@ export class Axis extends React.PureComponent<AxisProps> {
             x={left}
             y={top}
             width={width}
-            height={maxLabelBboxHeight}
+            height={titleFontSize}
             stroke="black"
             strokeWidth={1}
             fill="violet"


### PR DESCRIPTION
fixes #11 

PR #14 actually mostly addressed the original spacing gap, but there were still a couple of pixels of space between the edge of the title and the edge of the parent, but it turns out the issue wasn't the spacing computations, just that the debug rect was drawn for the wrong height :) 

This was the spacing gap before:

<img width="520" alt="image" src="https://user-images.githubusercontent.com/452850/52084153-41a10e80-2556-11e9-876f-52020f4b9259.png">

And now, using the right value for the debug rect:

<img width="524" alt="image" src="https://user-images.githubusercontent.com/452850/52084046-fa1a8280-2555-11e9-9796-5880c02bce2d.png">
