### PR TITLE
refactor(axis/grid): render grid lines in separate layer from axis

### DIFF
--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -30,6 +30,7 @@ function loadStories() {
   require('../src/stories/interactions.tsx');
   require('../src/stories/rotations.tsx');
   require('../src/stories/styling.tsx');
+  require('../src/stories/grid.tsx');
 }
 
 configure(loadStories, module);

--- a/src/components/react_canvas/axis.tsx
+++ b/src/components/react_canvas/axis.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Group, Line, Rect, Text } from 'react-konva';
 import {
-  AxisTick, AxisTicksDimensions, centerRotationOrigin, getHorizontalAxisGridLineProps,
-  getHorizontalAxisTickLineProps, getTickLabelProps, getVerticalAxisGridLineProps,
-  getVerticalAxisTickLineProps, isHorizontal, isVertical, mergeWithDefaultGridLineConfig,
+  AxisTick, AxisTicksDimensions, centerRotationOrigin,
+  getHorizontalAxisTickLineProps, getTickLabelProps,
+  getVerticalAxisTickLineProps, isHorizontal, isVertical,
 } from '../../lib/axes/axis_utils';
 import { AxisSpec, Position } from '../../lib/series/specs';
-import { DEFAULT_GRID_LINE_CONFIG, Theme } from '../../lib/themes/theme';
+import { Theme } from '../../lib/themes/theme';
 import { Dimensions } from '../../lib/utils/dimensions';
 
 interface AxisProps {
@@ -74,43 +74,6 @@ export class Axis extends React.PureComponent<AxisProps> {
     );
   }
 
-  private renderGridLine = (tick: AxisTick, i: number) => {
-    const showGridLines = this.props.axisSpec.showGridLines || false;
-
-    if (!showGridLines) {
-      return null;
-    }
-
-    const {
-      axisSpec: { tickSize, tickPadding, position, gridLineStyle },
-      axisTicksDimensions: { maxLabelBboxHeight },
-      chartDimensions,
-      chartTheme: { chart: { paddings } },
-    } = this.props;
-
-    const config = gridLineStyle ? mergeWithDefaultGridLineConfig(gridLineStyle) : DEFAULT_GRID_LINE_CONFIG;
-
-    const lineProps = isVertical(position) ?
-      getVerticalAxisGridLineProps(
-        position,
-        tickPadding,
-        tickSize,
-        tick.position,
-        chartDimensions.width,
-        paddings,
-      ) : getHorizontalAxisGridLineProps(
-        position,
-        tickPadding,
-        tickSize,
-        tick.position,
-        maxLabelBboxHeight,
-        chartDimensions.height,
-        paddings,
-      );
-
-    return <Line key={`tick-${i}`} points={lineProps} {...config} />;
-  }
-
   private renderTickLine = (tick: AxisTick, i: number) => {
     const {
       axisSpec: { tickSize, tickPadding, position },
@@ -139,7 +102,6 @@ export class Axis extends React.PureComponent<AxisProps> {
       <Group x={axisPosition.left} y={axisPosition.top}>
         <Group key="lines">{this.renderAxisLine()}</Group>
         <Group key="tick-lines">{ticks.map(this.renderTickLine)}</Group>
-        <Group key="grid-lines">{ticks.map(this.renderGridLine)}</Group>
         <Group key="ticks">
           {ticks.filter((tick) => tick.label !== null).map(this.renderTickLabel)}
         </Group>

--- a/src/components/react_canvas/grid.tsx
+++ b/src/components/react_canvas/grid.tsx
@@ -30,39 +30,29 @@ export class Grid extends React.PureComponent<GridProps> {
     }
 
     const {
-      axisSpec: { tickSize, tickPadding, position, gridLineStyle },
-      axisTicksDimensions: { maxLabelBboxHeight },
+      axisSpec: { position, gridLineStyle },
       chartDimensions,
-      chartTheme: { chart: { paddings } },
     } = this.props;
 
     const config = gridLineStyle ? mergeWithDefaultGridLineConfig(gridLineStyle) : DEFAULT_GRID_LINE_CONFIG;
 
     const lineProps = isVertical(position) ?
       getVerticalAxisGridLineProps(
-        position,
-        tickPadding,
-        tickSize,
         tick.position,
         chartDimensions.width,
-        paddings,
       ) : getHorizontalAxisGridLineProps(
-        position,
-        tickPadding,
-        tickSize,
         tick.position,
-        maxLabelBboxHeight,
         chartDimensions.height,
-        paddings,
       );
 
     return <Line key={`tick-${i}`} points={lineProps} {...config} />;
   }
 
   private renderGrid = () => {
-    const { ticks, axisPosition } = this.props;
+    const { ticks, chartDimensions } = this.props;
+
     return (
-      <Group x={axisPosition.left} y={axisPosition.top}>
+      <Group x={chartDimensions.left} y={chartDimensions.top}>
         <Group key="grid-lines">{ticks.map(this.renderGridLine)}</Group>
       </Group>
     );

--- a/src/components/react_canvas/grid.tsx
+++ b/src/components/react_canvas/grid.tsx
@@ -1,18 +1,15 @@
 import React from 'react';
 import { Group, Line } from 'react-konva';
 import {
-  AxisTick, AxisTicksDimensions, getHorizontalAxisGridLineProps, getVerticalAxisGridLineProps,
+  AxisTick, getHorizontalAxisGridLineProps, getVerticalAxisGridLineProps,
   isVertical, mergeWithDefaultGridLineConfig,
 } from '../../lib/axes/axis_utils';
 import { AxisSpec } from '../../lib/series/specs';
-import { DEFAULT_GRID_LINE_CONFIG, Theme } from '../../lib/themes/theme';
+import { DEFAULT_GRID_LINE_CONFIG } from '../../lib/themes/theme';
 import { Dimensions } from '../../lib/utils/dimensions';
 
 interface GridProps {
-  chartTheme: Theme;
   axisSpec: AxisSpec;
-  axisTicksDimensions: AxisTicksDimensions;
-  axisPosition: Dimensions;
   ticks: AxisTick[];
   debug: boolean;
   chartDimensions: Dimensions;

--- a/src/components/react_canvas/grid.tsx
+++ b/src/components/react_canvas/grid.tsx
@@ -1,56 +1,38 @@
 import React from 'react';
 import { Group, Line } from 'react-konva';
 import {
-  AxisTick, getHorizontalAxisGridLineProps, getVerticalAxisGridLineProps,
-  isVertical, mergeWithDefaultGridLineConfig,
+  AxisLinePosition, mergeWithDefaultGridLineConfig,
 } from '../../lib/axes/axis_utils';
-import { AxisSpec } from '../../lib/series/specs';
-import { DEFAULT_GRID_LINE_CONFIG } from '../../lib/themes/theme';
+import { DEFAULT_GRID_LINE_CONFIG, GridLineConfig } from '../../lib/themes/theme';
 import { Dimensions } from '../../lib/utils/dimensions';
 
 interface GridProps {
-  axisSpec: AxisSpec;
-  ticks: AxisTick[];
-  debug: boolean;
   chartDimensions: Dimensions;
+  debug: boolean;
+  gridLineStyle: GridLineConfig | undefined;
+  linesPositions: AxisLinePosition[];
 }
 
 export class Grid extends React.PureComponent<GridProps> {
   render() {
     return this.renderGrid();
   }
-  private renderGridLine = (tick: AxisTick, i: number) => {
-    const showGridLines = this.props.axisSpec.showGridLines || false;
-
-    if (!showGridLines) {
-      return null;
-    }
-
+  private renderGridLine = (linePosition: AxisLinePosition, i: number) => {
     const {
-      axisSpec: { position, gridLineStyle },
-      chartDimensions,
+      gridLineStyle,
     } = this.props;
 
     const config = gridLineStyle ? mergeWithDefaultGridLineConfig(gridLineStyle) : DEFAULT_GRID_LINE_CONFIG;
 
-    const lineProps = isVertical(position) ?
-      getVerticalAxisGridLineProps(
-        tick.position,
-        chartDimensions.width,
-      ) : getHorizontalAxisGridLineProps(
-        tick.position,
-        chartDimensions.height,
-      );
-
-    return <Line key={`tick-${i}`} points={lineProps} {...config} />;
+    return <Line key={`tick-${i}`} points={linePosition} {...config} />;
   }
 
   private renderGrid = () => {
-    const { ticks, chartDimensions } = this.props;
+    const { chartDimensions, linesPositions } = this.props;
 
     return (
       <Group x={chartDimensions.left} y={chartDimensions.top}>
-        <Group key="grid-lines">{ticks.map(this.renderGridLine)}</Group>
+        <Group key="grid-lines">{linesPositions.map(this.renderGridLine)}</Group>
       </Group>
     );
   }

--- a/src/components/react_canvas/grid.tsx
+++ b/src/components/react_canvas/grid.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Group, Line } from 'react-konva';
+import {
+  AxisTick, AxisTicksDimensions, getHorizontalAxisGridLineProps, getVerticalAxisGridLineProps,
+  isVertical, mergeWithDefaultGridLineConfig,
+} from '../../lib/axes/axis_utils';
+import { AxisSpec } from '../../lib/series/specs';
+import { DEFAULT_GRID_LINE_CONFIG, Theme } from '../../lib/themes/theme';
+import { Dimensions } from '../../lib/utils/dimensions';
+
+interface GridProps {
+  chartTheme: Theme;
+  axisSpec: AxisSpec;
+  axisTicksDimensions: AxisTicksDimensions;
+  axisPosition: Dimensions;
+  ticks: AxisTick[];
+  debug: boolean;
+  chartDimensions: Dimensions;
+}
+
+export class Grid extends React.PureComponent<GridProps> {
+  render() {
+    return this.renderGrid();
+  }
+  private renderGridLine = (tick: AxisTick, i: number) => {
+    const showGridLines = this.props.axisSpec.showGridLines || false;
+
+    if (!showGridLines) {
+      return null;
+    }
+
+    const {
+      axisSpec: { tickSize, tickPadding, position, gridLineStyle },
+      axisTicksDimensions: { maxLabelBboxHeight },
+      chartDimensions,
+      chartTheme: { chart: { paddings } },
+    } = this.props;
+
+    const config = gridLineStyle ? mergeWithDefaultGridLineConfig(gridLineStyle) : DEFAULT_GRID_LINE_CONFIG;
+
+    const lineProps = isVertical(position) ?
+      getVerticalAxisGridLineProps(
+        position,
+        tickPadding,
+        tickSize,
+        tick.position,
+        chartDimensions.width,
+        paddings,
+      ) : getHorizontalAxisGridLineProps(
+        position,
+        tickPadding,
+        tickSize,
+        tick.position,
+        maxLabelBboxHeight,
+        chartDimensions.height,
+        paddings,
+      );
+
+    return <Line key={`tick-${i}`} points={lineProps} {...config} />;
+  }
+
+  private renderGrid = () => {
+    const { ticks, axisPosition } = this.props;
+    return (
+      <Group x={axisPosition.left} y={axisPosition.top}>
+        <Group key="grid-lines">{ticks.map(this.renderGridLine)}</Group>
+      </Group>
+    );
+  }
+}

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -271,6 +271,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
           ? chartDimensions.width
           : chartDimensions.height,
       };
+
     let brushProps = {};
     const isBrushEnabled = this.props.chartStore!.isBrushEnabled();
     if (isBrushEnabled) {
@@ -280,6 +281,13 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         onMouseMove: this.onBrushing,
       };
     }
+
+    const gridClippings = {
+      clipX: chartDimensions.left,
+      clipY: chartDimensions.top,
+      clipWidth: chartDimensions.width,
+      clipHeight: chartDimensions.height,
+    };
 
     return (
       <div
@@ -301,7 +309,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
           }}
           {...brushProps}
         >
-          <Layer hitGraphEnabled={false}>{this.renderGrids()}</Layer>
+          <Layer hitGraphEnabled={false} {...gridClippings}>{this.renderGrids()}</Layer>
 
           <Layer
             ref={this.renderingLayerRef}

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -167,9 +167,6 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     const {
       axesVisibleTicks,
       axesSpecs,
-      axesTicksDimensions,
-      axesPositions,
-      chartTheme,
       debug,
       chartDimensions,
     } = this.props.chartStore!;
@@ -177,20 +174,15 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     const gridComponents: JSX.Element[] = [];
     axesVisibleTicks.forEach((axisTicks, axisId) => {
       const axisSpec = axesSpecs.get(axisId);
-      const axisTicksDimensions = axesTicksDimensions.get(axisId);
-      const axisPosition = axesPositions.get(axisId);
       const ticks = axesVisibleTicks.get(axisId);
-      if (!ticks || !axisSpec || !axisTicksDimensions || !axisPosition) {
+      if (!ticks || !axisSpec) {
         return;
       }
       gridComponents.push(
         <Grid
           key={`axis-grid-${axisId}`}
           axisSpec={axisSpec}
-          axisTicksDimensions={axisTicksDimensions}
-          axisPosition={axisPosition}
           ticks={ticks}
-          chartTheme={chartTheme}
           debug={debug}
           chartDimensions={chartDimensions}
         />,

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -165,28 +165,26 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
 
   renderGrids = () => {
     const {
-      axesVisibleTicks,
+      axesGridLinesPositions,
       axesSpecs,
-      debug,
       chartDimensions,
+      debug,
     } = this.props.chartStore!;
 
     const gridComponents: JSX.Element[] = [];
-    axesVisibleTicks.forEach((axisTicks, axisId) => {
+    axesGridLinesPositions.forEach((axisGridLinesPositions, axisId) => {
       const axisSpec = axesSpecs.get(axisId);
-      const ticks = axesVisibleTicks.get(axisId);
-      if (!ticks || !axisSpec) {
-        return;
+      if (axisSpec && axisGridLinesPositions.length > 0) {
+        gridComponents.push(
+          <Grid
+            key={`axis-grid-${axisId}`}
+            chartDimensions={chartDimensions}
+            debug={debug}
+            gridLineStyle={axisSpec.gridLineStyle}
+            linesPositions={axisGridLinesPositions}
+          />,
+        );
       }
-      gridComponents.push(
-        <Grid
-          key={`axis-grid-${axisId}`}
-          axisSpec={axisSpec}
-          ticks={ticks}
-          debug={debug}
-          chartDimensions={chartDimensions}
-        />,
-      );
     });
     return gridComponents;
   }

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -7,6 +7,7 @@ import { BrushExtent } from '../../state/utils';
 import { AreaGeometries } from './area_geometries';
 import { Axis } from './axis';
 import { BarGeometries } from './bar_geometries';
+import { Grid } from './grid';
 import { LineGeometries } from './line_geometries';
 
 interface ReactiveChartProps {
@@ -161,6 +162,43 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     });
     return axesComponents;
   }
+
+  renderGrids = () => {
+    const {
+      axesVisibleTicks,
+      axesSpecs,
+      axesTicksDimensions,
+      axesPositions,
+      chartTheme,
+      debug,
+      chartDimensions,
+    } = this.props.chartStore!;
+
+    const axesComponents: JSX.Element[] = [];
+    axesVisibleTicks.forEach((axisTicks, axisId) => {
+      const axisSpec = axesSpecs.get(axisId);
+      const axisTicksDimensions = axesTicksDimensions.get(axisId);
+      const axisPosition = axesPositions.get(axisId);
+      const ticks = axesVisibleTicks.get(axisId);
+      if (!ticks || !axisSpec || !axisTicksDimensions || !axisPosition) {
+        return;
+      }
+      axesComponents.push(
+        <Grid
+          key={`axis-${axisId}`}
+          axisSpec={axisSpec}
+          axisTicksDimensions={axisTicksDimensions}
+          axisPosition={axisPosition}
+          ticks={ticks}
+          chartTheme={chartTheme}
+          debug={debug}
+          chartDimensions={chartDimensions}
+        />,
+      );
+    });
+    return axesComponents;
+  }
+
   renderBrushTool = () => {
     const { brushing, brushStart, brushEnd } = this.state;
     const { chartDimensions, chartRotation, chartTransform } = this.props.chartStore!;
@@ -273,6 +311,8 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
           }}
           {...brushProps}
         >
+          <Layer hitGraphEnabled={false}>{this.renderGrids()}</Layer>
+
           <Layer
             ref={this.renderingLayerRef}
             x={chartDimensions.left + chartTransform.x}

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -174,7 +174,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
       chartDimensions,
     } = this.props.chartStore!;
 
-    const axesComponents: JSX.Element[] = [];
+    const gridComponents: JSX.Element[] = [];
     axesVisibleTicks.forEach((axisTicks, axisId) => {
       const axisSpec = axesSpecs.get(axisId);
       const axisTicksDimensions = axesTicksDimensions.get(axisId);
@@ -183,9 +183,9 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
       if (!ticks || !axisSpec || !axisTicksDimensions || !axisPosition) {
         return;
       }
-      axesComponents.push(
+      gridComponents.push(
         <Grid
-          key={`axis-${axisId}`}
+          key={`axis-grid-${axisId}`}
           axisSpec={axisSpec}
           axisTicksDimensions={axisTicksDimensions}
           axisPosition={axisPosition}
@@ -196,7 +196,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         />,
       );
     });
-    return axesComponents;
+    return gridComponents;
   }
 
   renderBrushTool = () => {

--- a/src/lib/axes/axis_utils.test.ts
+++ b/src/lib/axes/axis_utils.test.ts
@@ -2,7 +2,6 @@ import { XDomain } from '../series/domains/x_domain';
 import { YDomain } from '../series/domains/y_domain';
 import { Position } from '../series/specs';
 import { DEFAULT_THEME } from '../themes/theme';
-import { Margins } from '../utils/dimensions';
 import { getAxisId, getGroupId } from '../utils/ids';
 import { ScaleType } from '../utils/scales/scales';
 import {
@@ -454,63 +453,22 @@ describe('Axis computational utils', () => {
   });
 
   test('should compute axis grid line positions', () => {
-    const tickPadding = 5;
-    const tickSize = 10;
     const tickPosition = 10;
-    const maxLabelBboxHeight = 20;
     const chartWidth = 100;
     const chartHeight = 200;
-    const paddings: Margins = {
-      top: 3,
-      left: 6,
-      bottom: 9,
-      right: 12,
-    };
 
-    const leftAxisGridLinePositions = getVerticalAxisGridLineProps(
-      Position.Left,
-      tickPadding,
-      tickSize,
+    const verticalAxisGridLinePositions = getVerticalAxisGridLineProps(
       tickPosition,
       chartWidth,
-      paddings,
     );
 
-    expect(leftAxisGridLinePositions).toEqual([21, 10, 121, 10]);
+    expect(verticalAxisGridLinePositions).toEqual([0, 10, 100, 10]);
 
-    const rightAxisGridLinePositions = getVerticalAxisGridLineProps(
-      Position.Right,
-      tickPadding,
-      tickSize,
+    const horizontalAxisGridLinePositions = getHorizontalAxisGridLineProps(
       tickPosition,
-      chartWidth,
-      paddings,
-    );
-
-    expect(rightAxisGridLinePositions).toEqual([-112, 10, -12, 10]);
-
-    const topAxisGridLinePositions = getHorizontalAxisGridLineProps(
-      Position.Top,
-      tickPadding,
-      tickSize,
-      tickPosition,
-      maxLabelBboxHeight,
       chartHeight,
-      paddings,
     );
 
-    expect(topAxisGridLinePositions).toEqual([10, 38, 10, 238]);
-
-    const bottomAxisGridLinePositions = getHorizontalAxisGridLineProps(
-      Position.Bottom,
-      tickPadding,
-      tickSize,
-      tickPosition,
-      maxLabelBboxHeight,
-      chartHeight,
-      paddings,
-    );
-
-    expect(bottomAxisGridLinePositions).toEqual([10, -209, 10, -9]);
+    expect(horizontalAxisGridLinePositions).toEqual([10, 0, 10, 200]);
   });
 });

--- a/src/lib/axes/axis_utils.ts
+++ b/src/lib/axes/axis_utils.ts
@@ -271,42 +271,17 @@ export function getHorizontalAxisTickLineProps(
 }
 
 export function getVerticalAxisGridLineProps(
-  position: Position,
-  tickPadding: number,
-  tickSize: number,
   tickPosition: number,
   chartWidth: number,
-  paddings: Margins,
 ): number[] {
-  const isLeftAxis = position === Position.Left;
-  const y = tickPosition;
-
-  const leftX1 = tickSize + tickPadding + paddings.left;
-  const rightX1 = - chartWidth - paddings.right;
-
-  const x1 = isLeftAxis ? leftX1 : rightX1;
-
-  return [x1, y, x1 + chartWidth, y];
+  return [0, tickPosition, chartWidth, tickPosition];
 }
 
 export function getHorizontalAxisGridLineProps(
-  position: Position,
-  tickPadding: number,
-  tickSize: number,
   tickPosition: number,
-  labelHeight: number,
   chartHeight: number,
-  paddings: Margins,
 ): number[] {
-  const isTopAxis = position === Position.Top;
-  const x = tickPosition;
-
-  const topY1 = labelHeight + tickPadding + tickSize + paddings.top;
-  const bottomY1 = - chartHeight - paddings.bottom;
-
-  const y1 = isTopAxis ? topY1 : bottomY1;
-
-  return [x, y1, x, y1 + chartHeight];
+  return [tickPosition, 0, tickPosition, chartHeight];
 }
 
 export function mergeWithDefaultGridLineConfig(config: GridLineConfig): GridLineConfig {

--- a/src/lib/axes/axis_utils.ts
+++ b/src/lib/axes/axis_utils.ts
@@ -246,7 +246,7 @@ export function getVerticalAxisTickLineProps(
   tickPadding: number,
   tickSize: number,
   tickPosition: number,
-): number[] {
+): [number, number, number, number] {
   const isLeftAxis = position === Position.Left;
   const y = tickPosition;
   const x1 = isLeftAxis ? tickPadding : 0;
@@ -261,7 +261,7 @@ export function getHorizontalAxisTickLineProps(
   tickSize: number,
   tickPosition: number,
   labelHeight: number,
-): number[] {
+): [number, number, number, number] {
   const isTopAxis = position === Position.Top;
   const x = tickPosition;
   const y1 = isTopAxis ? labelHeight + tickPadding : 0;
@@ -273,14 +273,14 @@ export function getHorizontalAxisTickLineProps(
 export function getVerticalAxisGridLineProps(
   tickPosition: number,
   chartWidth: number,
-): number[] {
+): [number, number, number, number] {
   return [0, tickPosition, chartWidth, tickPosition];
 }
 
 export function getHorizontalAxisGridLineProps(
   tickPosition: number,
   chartHeight: number,
-): number[] {
+): [number, number, number, number] {
   return [tickPosition, 0, tickPosition, chartHeight];
 }
 

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -1,5 +1,6 @@
 import { action, observable } from 'mobx';
 import {
+  AxisLinePosition,
   AxisTick,
   AxisTicksDimensions,
   computeAxisTicksDimensions,
@@ -113,6 +114,7 @@ export class ChartStore {
   axesPositions: Map<AxisId, Dimensions> = new Map(); // computed
   axesVisibleTicks: Map<AxisId, AxisTick[]> = new Map(); // computed
   axesTicks: Map<AxisId, AxisTick[]> = new Map(); // computed
+  axesGridLinesPositions: Map<AxisId, AxisLinePosition[]> = new Map(); // computed
 
   seriesSpecs: Map<SpecId, BasicSeriesSpec> = new Map(); // readed from jsx
 
@@ -374,6 +376,7 @@ export class ChartStore {
     this.axesPositions = axisTicksPositions.axisPositions;
     this.axesTicks = axisTicksPositions.axisTicks;
     this.axesVisibleTicks = axisTicksPositions.axisVisibleTicks;
+    this.axesGridLinesPositions = axisTicksPositions.axisGridLinesPositions;
     // if (glyphsCount > MAX_ANIMATABLE_GLYPHS) {
     //   this.canDataBeAnimated = false;
     // } else {

--- a/src/stories/grid.tsx
+++ b/src/stories/grid.tsx
@@ -1,0 +1,118 @@
+import { boolean, color, number } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import { Axis, BarSeries, Chart, getAxisId, getSpecId, LineSeries, Position, ScaleType, Settings } from '..';
+import { GridLineConfig } from '../lib/themes/theme';
+import { getGroupId } from '../lib/utils/ids';
+import './stories.scss';
+
+function generateGridLineConfig(group: string): GridLineConfig {
+  const groupId = `${group} axis`;
+
+  return {
+    stroke: color(`${groupId} grid line stroke color`, 'purple', groupId),
+    strokeWidth: number(`${groupId} grid line stroke width`, 1, {
+      range: true,
+      min: 0,
+      max: 10,
+      step: 1,
+    }, groupId),
+    opacity: number(`${groupId} grid line stroke opacity`, 1, {
+      range: true,
+      min: 0,
+      max: 1,
+      step: 0.01,
+    }, groupId),
+    dash: [
+      number(`${groupId} grid line dash length`, 1, {
+        range: true,
+        min: 0,
+        max: 10,
+        step: 1,
+      }, groupId),
+      number(`${groupId} grid line dash spacing`, 1, {
+        range: true,
+        min: 0,
+        max: 10,
+        step: 1,
+      }, groupId),
+    ],
+  };
+}
+
+storiesOf('Grids', module)
+  .add('basic', () => {
+    const leftAxisGridLineConfig = generateGridLineConfig(Position.Left);
+    const leftAxisGridLineConfig2 = generateGridLineConfig(`${Position.Left}2`);
+    const rightAxisGridLineConfig = generateGridLineConfig(Position.Right);
+    const topAxisGridLineConfig = generateGridLineConfig(Position.Top);
+    const bottomAxisGridLineConfig = generateGridLineConfig(Position.Bottom);
+
+    return (
+      <Chart renderer="canvas" size={[500, 300]} className={'story-chart'}>
+        <Settings debug={boolean('debug', false)} />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          title={'Bottom axis'}
+          showOverlappingTicks={true}
+          showGridLines={boolean('show bottom axis grid lines', false, 'bottom axis')}
+          gridLineStyle={bottomAxisGridLineConfig}
+        />
+        <Axis
+          id={getAxisId('left1')}
+          title={'Left axis 1'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+          showGridLines={boolean('show left axis grid lines', false, 'left axis')}
+          gridLineStyle={leftAxisGridLineConfig}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis 2'}
+          groupId={getGroupId('group2')}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+          showGridLines={boolean('show left axis 2 grid lines', false, 'left2 axis')}
+          gridLineStyle={leftAxisGridLineConfig2}
+        />
+        <Axis
+          id={getAxisId('top')}
+          position={Position.Top}
+          title={'Top axis'}
+          showOverlappingTicks={true}
+          showGridLines={boolean('show top axis grid lines', false, 'top axis')}
+          gridLineStyle={topAxisGridLineConfig}
+        />
+        <Axis
+          id={getAxisId('right')}
+          title={'Right axis'}
+          position={Position.Right}
+          tickFormat={(d) => Number(d).toFixed(2)}
+          showGridLines={boolean('show right axis grid lines', false, 'right axis')}
+          gridLineStyle={rightAxisGridLineConfig}
+        />
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+          yScaleToDataExtent={false}
+        />
+        <LineSeries
+          id={getSpecId('lines')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          groupId={getGroupId('group2')}
+          xAccessor="x"
+          yAccessors={['y']}
+          stackAccessors={['x']}
+          splitSeriesAccessors={['g']}
+          data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  });

--- a/src/stories/grid.tsx
+++ b/src/stories/grid.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { Axis, BarSeries, Chart, getAxisId, getSpecId, LineSeries, Position, ScaleType, Settings } from '..';
 import { GridLineConfig } from '../lib/themes/theme';
 import { getGroupId } from '../lib/utils/ids';
-import './stories.scss';
 
 function generateGridLineConfig(group: string): GridLineConfig {
   const groupId = `${group} axis`;

--- a/src/stories/grid.tsx
+++ b/src/stories/grid.tsx
@@ -43,7 +43,6 @@ function generateGridLineConfig(group: string): GridLineConfig {
 storiesOf('Grids', module)
   .add('basic', () => {
     const leftAxisGridLineConfig = generateGridLineConfig(Position.Left);
-    const leftAxisGridLineConfig2 = generateGridLineConfig(`${Position.Left}2`);
     const rightAxisGridLineConfig = generateGridLineConfig(Position.Right);
     const topAxisGridLineConfig = generateGridLineConfig(Position.Top);
     const bottomAxisGridLineConfig = generateGridLineConfig(Position.Bottom);
@@ -68,15 +67,6 @@ storiesOf('Grids', module)
           gridLineStyle={leftAxisGridLineConfig}
         />
         <Axis
-          id={getAxisId('left2')}
-          title={'Left axis 2'}
-          groupId={getGroupId('group2')}
-          position={Position.Left}
-          tickFormat={(d) => Number(d).toFixed(2)}
-          showGridLines={boolean('show left axis 2 grid lines', false, 'left2 axis')}
-          gridLineStyle={leftAxisGridLineConfig2}
-        />
-        <Axis
           id={getAxisId('top')}
           position={Position.Top}
           title={'Top axis'}
@@ -91,6 +81,54 @@ storiesOf('Grids', module)
           tickFormat={(d) => Number(d).toFixed(2)}
           showGridLines={boolean('show right axis grid lines', false, 'right axis')}
           gridLineStyle={rightAxisGridLineConfig}
+        />
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+          yScaleToDataExtent={false}
+        />
+        <LineSeries
+          id={getSpecId('lines')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          groupId={getGroupId('group2')}
+          xAccessor="x"
+          yAccessors={['y']}
+          stackAccessors={['x']}
+          splitSeriesAccessors={['g']}
+          data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('multiple axes with the same position', () => {
+    const leftAxisGridLineConfig = generateGridLineConfig(Position.Left);
+    const leftAxisGridLineConfig2 = generateGridLineConfig(`${Position.Left}2`);
+
+    return (
+      <Chart renderer="canvas" size={[500, 300]} className={'story-chart'}>
+        <Settings debug={boolean('debug', false)} />
+        <Axis
+          id={getAxisId('left1')}
+          title={'Left axis 1'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+          showGridLines={boolean('show left axis grid lines', false, 'left axis')}
+          gridLineStyle={leftAxisGridLineConfig}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis 2'}
+          groupId={getGroupId('group2')}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+          showGridLines={boolean('show left axis 2 grid lines', false, 'left2 axis')}
+          gridLineStyle={leftAxisGridLineConfig2}
         />
         <BarSeries
           id={getSpecId('bars')}

--- a/src/stories/styling.tsx
+++ b/src/stories/styling.tsx
@@ -2,7 +2,7 @@ import { boolean, number, select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { Axis, BarSeries, Chart, getAxisId, getSpecId, Position, ScaleType, Settings } from '..';
-import { GridLineConfig, PartialTheme } from '../lib/themes/theme';
+import { PartialTheme } from '../lib/themes/theme';
 import './stories.scss';
 
 function createThemeAction(title: string, min: number, max: number, value: number) {

--- a/src/stories/styling.tsx
+++ b/src/stories/styling.tsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { Axis, BarSeries, Chart, getAxisId, getSpecId, Position, ScaleType, Settings } from '..';
 import { GridLineConfig, PartialTheme } from '../lib/themes/theme';
+import './stories.scss';
 
 function createThemeAction(title: string, min: number, max: number, value: number) {
   return number(title, value, {
@@ -32,36 +33,6 @@ storiesOf('Stylings', module)
       },
     };
 
-    const leftAxisGridLine: GridLineConfig = {
-      stroke: 'purple',
-      strokeWidth: number('left axis grid line stroke width', 1, {
-        range: true,
-        min: 0,
-        max: 10,
-        step: 1,
-      }),
-      opacity: number('left axis grid line stroke opacity', 1, {
-        range: true,
-        min: 0,
-        max: 1,
-        step: 0.01,
-      }),
-      dash: [
-        number('left axis grid line dash length', 1, {
-          range: true,
-          min: 0,
-          max: 10,
-          step: 1,
-        }),
-        number('left axis grid line dash spacing', 1, {
-          range: true,
-          min: 0,
-          max: 10,
-          step: 1,
-        }),
-      ],
-    };
-
     return (
       <Chart renderer="canvas" className={'story-chart'}>
         <Settings theme={theme} debug={boolean('debug', true)} />
@@ -78,7 +49,6 @@ storiesOf('Stylings', module)
           position={Position.Left}
           tickFormat={(d) => Number(d).toFixed(2)}
           showGridLines={boolean('show left axis grid lines', false)}
-          gridLineStyle={leftAxisGridLine}
         />
         <Axis
           id={getAxisId('top')}

--- a/src/stories/styling.tsx
+++ b/src/stories/styling.tsx
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { Axis, BarSeries, Chart, getAxisId, getSpecId, Position, ScaleType, Settings } from '..';
 import { PartialTheme } from '../lib/themes/theme';
-import './stories.scss';
 
 function createThemeAction(title: string, min: number, max: number, value: number) {
   return number(title, value, {


### PR DESCRIPTION
addresses #16 

Previously, we were rendering the grid lines relative to each axis in the same layer as the axis.  Now, each axis' grid lines are rendered in a separate layer just for grid lines and the coordinates for the lines are relative to the chart (instead of the axis).  This simplifies much of the positioning logic and also gives us the option to draw anything we might want onto the grid layer without affect the axes.

Also, in combination with PR #29, this fixes the issues with rendering grid lines for multiple axes with the same position (there was both overflow and spacing issues previously). 

Since we render the grid layer first, the lines render behind the chart elements:

<img width="513" alt="image" src="https://user-images.githubusercontent.com/452850/52144589-9bb3d980-2613-11e9-8cf9-f0b9da7bdd6b.png">
