### PR TITLE
feat(legend/series): add hover interaction on legend items

### DIFF
--- a/src/components/_legend.scss
+++ b/src/components/_legend.scss
@@ -48,7 +48,7 @@ $euiChartLegendMaxHeight: $euiSize * 4 + $euiSize;
   top: 0;
   bottom: 0;
   left: 0;
-  width: $euiChartLegendMaxWidth;  
+  width: $euiChartLegendMaxWidth;
   order: 1;
   .euiChartLegend__listItem {
     min-width: 100%;
@@ -58,7 +58,7 @@ $euiChartLegendMaxHeight: $euiSize * 4 + $euiSize;
   top: 0;
   bottom: 0;
   right: 0;
-  width: $euiChartLegendMaxWidth;  
+  width: $euiChartLegendMaxWidth;
   .euiChartLegend__listItem {
     min-width: 100%;
   }
@@ -93,4 +93,8 @@ $euiChartLegendMaxHeight: $euiSize * 4 + $euiSize;
 .euiChartLegendListItem__title {
   width: $euiChartLegendMaxWidth - 4 * $euiSize;
   max-width: $euiChartLegendMaxWidth - 4 * $euiSize;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }

--- a/src/components/_legend.scss
+++ b/src/components/_legend.scss
@@ -93,7 +93,8 @@ $euiChartLegendMaxHeight: $euiSize * 4 + $euiSize;
 .euiChartLegendListItem__title {
   width: $euiChartLegendMaxWidth - 4 * $euiSize;
   max-width: $euiChartLegendMaxWidth - 4 * $euiSize;
-
+}
+.euiChartLegendList__item {
   &:hover {
     text-decoration: underline;
   }

--- a/src/components/legend.tsx
+++ b/src/components/legend.tsx
@@ -89,8 +89,8 @@ class LegendComponent extends React.Component<ReactiveChartProps> {
               const legendItemProps = {
                 key: index,
                 className: 'euiChartLegendList__item',
-                onMouseOver: this.onLegendItemMouseover(index),
-                onMouseOut: this.onLegendItemMouseout,
+                onMouseEnter: this.onLegendItemMouseover(index),
+                onMouseLeave: this.onLegendItemMouseout,
               };
 
               return (

--- a/src/components/legend.tsx
+++ b/src/components/legend.tsx
@@ -86,8 +86,14 @@ class LegendComponent extends React.Component<ReactiveChartProps> {
             responsive={false}
           >
             {legendItems.map((item, index) => {
+              const legendItemProps = {
+                key: index,
+                className: 'euiChartLegendList__item',
+                onMouseOver: this.onLegendItemMouseover(index),
+              };
+
               return (
-                <EuiFlexItem key={index} className="euiChartLegendList__item">
+                <EuiFlexItem {...legendItemProps}>
                   <LegendElement color={item.color} label={item.label} />
                 </EuiFlexItem>
               );
@@ -96,6 +102,10 @@ class LegendComponent extends React.Component<ReactiveChartProps> {
         </div>
       </div>
     );
+  }
+
+  private onLegendItemMouseover = (legendItemIndex: number) => () => {
+    this.props.chartStore!.updateHighlightedLegendItem(legendItemIndex);
   }
 }
 function LegendElement({ color, label }: Partial<LegendItem>) {

--- a/src/components/legend.tsx
+++ b/src/components/legend.tsx
@@ -4,7 +4,6 @@ import {
   EuiFlexItem,
   EuiIcon,
   EuiText,
-  EuiToolTip,
 } from '@elastic/eui';
 import classNames from 'classnames';
 import { inject, observer } from 'mobx-react';
@@ -120,13 +119,11 @@ function LegendElement({ color, label }: Partial<LegendItem>) {
         <EuiIcon type="dot" color={color} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiToolTip position="right" content={<EuiText size="xs">{label}</EuiText>}>
-          <EuiFlexItem grow={true} className="euiChartLegendListItem__title">
-            <EuiText size="xs" className="eui-textTruncate">
-              {label}
-            </EuiText>
-          </EuiFlexItem>
-        </EuiToolTip>
+        <EuiFlexItem grow={true} className="euiChartLegendListItem__title" title={label}>
+          <EuiText size="xs" className="eui-textTruncate">
+            {label}
+          </EuiText>
+        </EuiFlexItem>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/src/components/legend.tsx
+++ b/src/components/legend.tsx
@@ -90,6 +90,7 @@ class LegendComponent extends React.Component<ReactiveChartProps> {
                 key: index,
                 className: 'euiChartLegendList__item',
                 onMouseOver: this.onLegendItemMouseover(index),
+                onMouseOut: this.onLegendItemMouseout,
               };
 
               return (
@@ -106,6 +107,10 @@ class LegendComponent extends React.Component<ReactiveChartProps> {
 
   private onLegendItemMouseover = (legendItemIndex: number) => () => {
     this.props.chartStore!.updateHighlightedLegendItem(legendItemIndex);
+  }
+
+  private onLegendItemMouseout = () => {
+    this.props.chartStore!.updateHighlightedLegendItem(null);
   }
 }
 function LegendElement({ color, label }: Partial<LegendItem>) {

--- a/src/components/legend.tsx
+++ b/src/components/legend.tsx
@@ -106,6 +106,7 @@ class LegendComponent extends React.Component<ReactiveChartProps> {
   }
 
   private onLegendItemMouseover = (legendItemIndex: number) => () => {
+    this.props.chartStore!.onLegendItemOver();
     this.props.chartStore!.updateHighlightedLegendItem(legendItemIndex);
   }
 

--- a/src/components/legend.tsx
+++ b/src/components/legend.tsx
@@ -106,12 +106,11 @@ class LegendComponent extends React.Component<ReactiveChartProps> {
   }
 
   private onLegendItemMouseover = (legendItemIndex: number) => () => {
-    this.props.chartStore!.onLegendItemOver();
-    this.props.chartStore!.updateHighlightedLegendItem(legendItemIndex);
+    this.props.chartStore!.onLegendItemOver(legendItemIndex);
   }
 
   private onLegendItemMouseout = () => {
-    this.props.chartStore!.updateHighlightedLegendItem(null);
+    this.props.chartStore!.onLegendItemOut();
   }
 }
 function LegendElement({ color, label }: Partial<LegendItem>) {

--- a/src/components/react_canvas/area_geometries.tsx
+++ b/src/components/react_canvas/area_geometries.tsx
@@ -4,8 +4,7 @@ import React from 'react';
 import { Circle, Group, Path } from 'react-konva';
 import { animated, Spring } from 'react-spring/konva';
 import { LegendItem } from '../../lib/series/legend';
-import { AreaGeometry, GeometryId, GeometryValue, PointGeometry } from '../../lib/series/rendering';
-import { belongsToDataSeries } from '../../lib/series/series_utils';
+import { AreaGeometry, GeometryValue, getGeometryStyle, PointGeometry } from '../../lib/series/rendering';
 import { AreaSeriesStyle } from '../../lib/themes/theme';
 import { ElementClickListener, TooltipData } from '../../state/chart_state';
 
@@ -135,27 +134,12 @@ export class AreaGeometries extends React.PureComponent<
     });
   }
 
-  private computeAreaOpacity = (geometryId: GeometryId): number => {
-    const { highlightedLegendItem } = this.props;
-
-    if (highlightedLegendItem != null) {
-      const isPartOfHighlightedSeries = belongsToDataSeries(geometryId, highlightedLegendItem.value);
-
-      if (isPartOfHighlightedSeries) {
-        return 1;
-      }
-
-      return 0.25;
-    }
-    return 1;
-  }
-
   private renderAreaGeoms = (): JSX.Element[] => {
     const { areas } = this.props;
     return areas.map((glyph, i) => {
       const { area, color, transform, geometryId } = glyph;
 
-      const opacity = this.computeAreaOpacity(geometryId);
+      const geometryStyle = getGeometryStyle(geometryId, this.props.highlightedLegendItem);
 
       if (this.props.animated) {
         return (
@@ -167,7 +151,7 @@ export class AreaGeometries extends React.PureComponent<
                   data={props.area}
                   fill={color}
                   listening={false}
-                  opacity={opacity}
+                  {...geometryStyle}
                 // areaCap="round"
                 // areaJoin="round"
                 />
@@ -182,7 +166,7 @@ export class AreaGeometries extends React.PureComponent<
             data={area}
             fill={color}
             listening={false}
-            opacity={opacity}
+            {...geometryStyle}
           // areaCap="round"
           // areaJoin="round"
           />

--- a/src/components/react_canvas/area_geometries.tsx
+++ b/src/components/react_canvas/area_geometries.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Circle, Group, Path } from 'react-konva';
 import { animated, Spring } from 'react-spring/konva';
 import { LegendItem } from '../../lib/series/legend';
-import { AreaGeometry, GeometryValue, PointGeometry } from '../../lib/series/rendering';
+import { AreaGeometry, GeometryId, GeometryValue, PointGeometry } from '../../lib/series/rendering';
 import { belongsToDataSeries } from '../../lib/series/series_utils';
 import { AreaSeriesStyle } from '../../lib/themes/theme';
 import { ElementClickListener, TooltipData } from '../../state/chart_state';
@@ -135,11 +135,11 @@ export class AreaGeometries extends React.PureComponent<
     });
   }
 
-  private computeAreaOpacity = (point: PointGeometry): number => {
+  private computeAreaOpacity = (geometryId: GeometryId): number => {
     const { highlightedLegendItem } = this.props;
 
     if (highlightedLegendItem != null) {
-      const isPartOfHighlightedSeries = belongsToDataSeries(point.value, highlightedLegendItem.value);
+      const isPartOfHighlightedSeries = belongsToDataSeries(geometryId, highlightedLegendItem.value);
 
       if (isPartOfHighlightedSeries) {
         return 1;
@@ -153,11 +153,9 @@ export class AreaGeometries extends React.PureComponent<
   private renderAreaGeoms = (): JSX.Element[] => {
     const { areas } = this.props;
     return areas.map((glyph, i) => {
-      const { area, color, transform, points } = glyph;
+      const { area, color, transform, geometryId } = glyph;
 
-      // TODO: May want to consider a way to get GeometryValue from LineGeometry instead of
-      // PointGeometry (which is why we currently use the first point)
-      const opacity = this.computeAreaOpacity(points[0]);
+      const opacity = this.computeAreaOpacity(geometryId);
 
       if (this.props.animated) {
         return (

--- a/src/components/react_canvas/bar_geometries.tsx
+++ b/src/components/react_canvas/bar_geometries.tsx
@@ -91,7 +91,7 @@ export class BarGeometries extends React.PureComponent<
         return 1;
       }
 
-      return 0.6;
+      return 0.25;
     }
     return 1;
   }

--- a/src/components/react_canvas/bar_geometries.tsx
+++ b/src/components/react_canvas/bar_geometries.tsx
@@ -73,22 +73,20 @@ export class BarGeometries extends React.PureComponent<
     onElementOut();
   }
 
-  private computeBarOpacity = (bar: BarGeometry, overBar: BarGeometry | undefined): number => {
-    if (overBar && overBar !== bar) {
-      return 0.6;
-    }
-    return 1;
-  }
-
   private renderBarGeoms = (bars: BarGeometry[]): JSX.Element[] => {
     const { overBar } = this.state;
     return bars.map((bar, i) => {
       const { x, y, width, height, color, value } = bar;
 
-      // This sets the opacity if any bars within the chart are hovered over
-      const opacity = this.computeBarOpacity(bar, overBar);
+      // Properties to determine if we need to highlight individual bars depending on hover state
+      const hasGeometryHover = overBar != null;
+      const hasHighlight = overBar === bar;
+      const individualHighlight = {
+        hasGeometryHover,
+        hasHighlight,
+      };
 
-      const geometryStyle = getGeometryStyle(bar.geometryId, this.props.highlightedLegendItem);
+      const geometryStyle = getGeometryStyle(bar.geometryId, this.props.highlightedLegendItem, individualHighlight);
 
       if (this.props.animated) {
         return (
@@ -103,7 +101,6 @@ export class BarGeometries extends React.PureComponent<
                   height={props.height}
                   fill={color}
                   strokeWidth={0}
-                  opacity={opacity}
                   perfectDrawEnabled={true}
                   onMouseOver={this.onOverBar(bar)}
                   onMouseLeave={this.onOutBar}
@@ -124,7 +121,6 @@ export class BarGeometries extends React.PureComponent<
             height={height}
             fill={color}
             strokeWidth={0}
-            opacity={opacity}
             perfectDrawEnabled={false}
             onMouseOver={this.onOverBar(bar)}
             onMouseLeave={this.onOutBar}

--- a/src/components/react_canvas/bar_geometries.tsx
+++ b/src/components/react_canvas/bar_geometries.tsx
@@ -85,7 +85,7 @@ export class BarGeometries extends React.PureComponent<
       }
       return 1;
     } else if (highlightedLegendItem != null) {
-      const isPartOfHighlightedSeries = belongsToDataSeries(bar.value, highlightedLegendItem.value);
+      const isPartOfHighlightedSeries = belongsToDataSeries(bar.geometryId, highlightedLegendItem.value);
 
       if (isPartOfHighlightedSeries) {
         return 1;

--- a/src/components/react_canvas/line_geometries.tsx
+++ b/src/components/react_canvas/line_geometries.tsx
@@ -186,6 +186,7 @@ export class LineGeometries extends React.PureComponent<
             listening={false}
             lineCap="round"
             lineJoin="round"
+            opacity={opacity}
           />
         );
       }

--- a/src/components/react_canvas/line_geometries.tsx
+++ b/src/components/react_canvas/line_geometries.tsx
@@ -4,8 +4,7 @@ import React from 'react';
 import { Circle, Group, Path } from 'react-konva';
 import { animated, Spring } from 'react-spring/konva';
 import { LegendItem } from '../../lib/series/legend';
-import { GeometryId, GeometryValue, LineGeometry, PointGeometry } from '../../lib/series/rendering';
-import { belongsToDataSeries } from '../../lib/series/series_utils';
+import { GeometryValue, getGeometryStyle, LineGeometry, PointGeometry } from '../../lib/series/rendering';
 import { LineSeriesStyle } from '../../lib/themes/theme';
 import { ElementClickListener, TooltipData } from '../../state/chart_state';
 
@@ -133,27 +132,12 @@ export class LineGeometries extends React.PureComponent<
     });
   }
 
-  private computeLineOpacity = (geometryId: GeometryId): number => {
-    const { highlightedLegendItem } = this.props;
-
-    if (highlightedLegendItem != null) {
-      const isPartOfHighlightedSeries = belongsToDataSeries(geometryId, highlightedLegendItem.value);
-
-      if (isPartOfHighlightedSeries) {
-        return 1;
-      }
-
-      return 0.25;
-    }
-    return 1;
-  }
-
   private renderLineGeoms = (): JSX.Element[] => {
     const { style, lines } = this.props;
     return lines.map((glyph, i) => {
       const { line, color, transform, geometryId } = glyph;
 
-      const opacity = this.computeLineOpacity(geometryId);
+      const geometryStyle = getGeometryStyle(geometryId, this.props.highlightedLegendItem);
 
       if (this.props.animated) {
         return (
@@ -168,7 +152,7 @@ export class LineGeometries extends React.PureComponent<
                   listening={false}
                   lineCap="round"
                   lineJoin="round"
-                  opacity={opacity}
+                  {...geometryStyle}
                 />
               )}
             </Spring>
@@ -184,7 +168,7 @@ export class LineGeometries extends React.PureComponent<
             listening={false}
             lineCap="round"
             lineJoin="round"
-            opacity={opacity}
+            {...geometryStyle}
           />
         );
       }

--- a/src/components/react_canvas/line_geometries.tsx
+++ b/src/components/react_canvas/line_geometries.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Circle, Group, Path } from 'react-konva';
 import { animated, Spring } from 'react-spring/konva';
 import { LegendItem } from '../../lib/series/legend';
-import { GeometryValue, LineGeometry, PointGeometry } from '../../lib/series/rendering';
+import { GeometryId, GeometryValue, LineGeometry, PointGeometry } from '../../lib/series/rendering';
 import { belongsToDataSeries } from '../../lib/series/series_utils';
 import { LineSeriesStyle } from '../../lib/themes/theme';
 import { ElementClickListener, TooltipData } from '../../state/chart_state';
@@ -133,11 +133,11 @@ export class LineGeometries extends React.PureComponent<
     });
   }
 
-  private computeLineOpacity = (point: PointGeometry): number => {
+  private computeLineOpacity = (geometryId: GeometryId): number => {
     const { highlightedLegendItem } = this.props;
 
     if (highlightedLegendItem != null) {
-      const isPartOfHighlightedSeries = belongsToDataSeries(point.value, highlightedLegendItem.value);
+      const isPartOfHighlightedSeries = belongsToDataSeries(geometryId, highlightedLegendItem.value);
 
       if (isPartOfHighlightedSeries) {
         return 1;
@@ -151,11 +151,9 @@ export class LineGeometries extends React.PureComponent<
   private renderLineGeoms = (): JSX.Element[] => {
     const { style, lines } = this.props;
     return lines.map((glyph, i) => {
-      const { line, color, transform, points } = glyph;
+      const { line, color, transform, geometryId } = glyph;
 
-      // TODO: May want to consider a way to get GeometryValue from LineGeometry instead of
-      // PointGeometry (which is why we currently use the first point)
-      const opacity = this.computeLineOpacity(points[0]);
+      const opacity = this.computeLineOpacity(geometryId);
 
       if (this.props.animated) {
         return (

--- a/src/components/react_canvas/line_geometries.tsx
+++ b/src/components/react_canvas/line_geometries.tsx
@@ -3,7 +3,9 @@ import { IAction } from 'mobx';
 import React from 'react';
 import { Circle, Group, Path } from 'react-konva';
 import { animated, Spring } from 'react-spring/konva';
+import { LegendItem } from '../../lib/series/legend';
 import { GeometryValue, LineGeometry, PointGeometry } from '../../lib/series/rendering';
+import { belongsToDataSeries } from '../../lib/series/series_utils';
 import { LineSeriesStyle } from '../../lib/themes/theme';
 import { ElementClickListener, TooltipData } from '../../state/chart_state';
 
@@ -14,6 +16,7 @@ interface LineGeometriesDataProps {
   onElementClick?: ElementClickListener;
   onElementOver: ((tooltip: TooltipData) => void) & IAction;
   onElementOut: (() => void) & IAction;
+  highlightedLegendItem: LegendItem | null;
 }
 interface LineGeometriesDataState {
   overPoint?: PointGeometry;
@@ -21,7 +24,7 @@ interface LineGeometriesDataState {
 export class LineGeometries extends React.PureComponent<
   LineGeometriesDataProps,
   LineGeometriesDataState
-> {
+  > {
   static defaultProps: Partial<LineGeometriesDataProps> = {
     animated: false,
   };
@@ -129,10 +132,31 @@ export class LineGeometries extends React.PureComponent<
       );
     });
   }
+
+  private computeLineOpacity = (point: PointGeometry): number => {
+    const { highlightedLegendItem } = this.props;
+
+    if (highlightedLegendItem != null) {
+      const isPartOfHighlightedSeries = belongsToDataSeries(point.value, highlightedLegendItem.value);
+
+      if (isPartOfHighlightedSeries) {
+        return 1;
+      }
+
+      return 0.25;
+    }
+    return 1;
+  }
+
   private renderLineGeoms = (): JSX.Element[] => {
     const { style, lines } = this.props;
     return lines.map((glyph, i) => {
-      const { line, color, transform } = glyph;
+      const { line, color, transform, points } = glyph;
+
+      // TODO: May want to consider a way to get GeometryValue from LineGeometry instead of
+      // PointGeometry (which is why we currently use the first point)
+      const opacity = this.computeLineOpacity(points[0]);
+
       if (this.props.animated) {
         return (
           <Group key={i} x={transform.x}>
@@ -146,6 +170,7 @@ export class LineGeometries extends React.PureComponent<
                   listening={false}
                   lineCap="round"
                   lineJoin="round"
+                  opacity={opacity}
                 />
               )}
             </Spring>

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -67,13 +67,11 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
       onOverElement,
       onOutElement,
       onElementClickListener,
-      highlightedLegendItemIndex,
-      legendItems,
     } = this.props.chartStore!;
     if (!geometries) {
       return;
     }
-    const highlightedLegendItem = highlightedLegendItemIndex != null ? legendItems[highlightedLegendItemIndex] : null;
+    const highlightedLegendItem = this.getHighlightedLegendItem();
 
     return (
       <BarGeometries
@@ -98,6 +96,9 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     if (!geometries) {
       return;
     }
+
+    const highlightedLegendItem = this.getHighlightedLegendItem();
+
     return (
       <LineGeometries
         animated={canDataBeAnimated}
@@ -106,6 +107,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         onElementOver={onOverElement}
         onElementOut={onOutElement}
         onElementClick={onElementClickListener}
+        highlightedLegendItem={highlightedLegendItem}
       />
     );
   }
@@ -357,6 +359,16 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         dash={[2, 2]}
       />
     );
+  }
+
+  private getHighlightedLegendItem = () => {
+    const {
+      highlightedLegendItemIndex,
+      legendItems,
+    } = this.props.chartStore!;
+    const highlightedLegendItem = highlightedLegendItemIndex != null ? legendItems[highlightedLegendItemIndex] : null;
+
+    return highlightedLegendItem;
   }
 }
 

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -366,7 +366,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
   }
 
   private getHighlightedLegendItem = () => {
-    return this.props.chartStore!.getHighlightedLegendItem();
+    return this.props.chartStore!.highlightedLegendItem.get();
   }
 }
 

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -67,10 +67,14 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
       onOverElement,
       onOutElement,
       onElementClickListener,
+      highlightedLegendItemIndex,
+      legendItems,
     } = this.props.chartStore!;
     if (!geometries) {
       return;
     }
+    const highlightedLegendItem = highlightedLegendItemIndex ? legendItems[highlightedLegendItemIndex] : null;
+
     return (
       <BarGeometries
         animated={canDataBeAnimated}
@@ -78,6 +82,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         onElementOver={onOverElement}
         onElementOut={onOutElement}
         onElementClick={onElementClickListener}
+        highlightedLegendItem={highlightedLegendItem}
       />
     );
   }

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -73,7 +73,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     if (!geometries) {
       return;
     }
-    const highlightedLegendItem = highlightedLegendItemIndex ? legendItems[highlightedLegendItemIndex] : null;
+    const highlightedLegendItem = highlightedLegendItemIndex != null ? legendItems[highlightedLegendItemIndex] : null;
 
     return (
       <BarGeometries

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -123,6 +123,9 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     if (!geometries) {
       return;
     }
+
+    const highlightedLegendItem = this.getHighlightedLegendItem();
+
     return (
       <AreaGeometries
         animated={canDataBeAnimated}
@@ -131,6 +134,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         onElementOver={onOverElement}
         onElementOut={onOutElement}
         onElementClick={onElementClickListener}
+        highlightedLegendItem={highlightedLegendItem}
       />
     );
   }

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -366,13 +366,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
   }
 
   private getHighlightedLegendItem = () => {
-    const {
-      highlightedLegendItemIndex,
-      legendItems,
-    } = this.props.chartStore!;
-    const highlightedLegendItem = highlightedLegendItemIndex != null ? legendItems[highlightedLegendItemIndex] : null;
-
-    return highlightedLegendItem;
+    return this.props.chartStore!.getHighlightedLegendItem();
   }
 }
 

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -1,4 +1,5 @@
 import { area, line } from 'd3-shape';
+import { DEFAULT_THEME } from '../themes/theme';
 import { SpecId } from '../utils/ids';
 import { Scale } from '../utils/scales/scales';
 import { CurveType, getCurveFactory } from './curves';
@@ -181,23 +182,12 @@ export function getGeometryStyle(
   geometryId: GeometryId,
   highlightedLegendItem: LegendItem | null,
 ): GeometryStyle {
+  const { shared } = DEFAULT_THEME.chart.styles;
   if (highlightedLegendItem != null) {
     const isPartOfHighlightedSeries = belongsToDataSeries(geometryId, highlightedLegendItem.value);
 
-    return isPartOfHighlightedSeries ? GEOMETRY_STYLES.highlighted : GEOMETRY_STYLES.unhighlighted;
+    return isPartOfHighlightedSeries ? shared.highlighted : shared.unhighlighted;
   }
 
-  return GEOMETRY_STYLES.default;
+  return shared.default;
 }
-
-const GEOMETRY_STYLES: { [key: string]: GeometryStyle } = {
-  default: {
-    opacity: 1,
-  },
-  highlighted: {
-    opacity: 1,
-  },
-  unhighlighted: {
-    opacity: 0.25,
-  },
-};

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -181,14 +181,23 @@ export function getGeometryStyle(
   geometryId: GeometryId,
   highlightedLegendItem: LegendItem | null,
 ): GeometryStyle {
-  let opacity = 1;
   if (highlightedLegendItem != null) {
     const isPartOfHighlightedSeries = belongsToDataSeries(geometryId, highlightedLegendItem.value);
 
-    if (!isPartOfHighlightedSeries) {
-      opacity = 0.25;
-    }
+    return isPartOfHighlightedSeries ? GEOMETRY_STYLES.highlighted : GEOMETRY_STYLES.unhighlighted;
   }
 
-  return { opacity };
+  return GEOMETRY_STYLES.default;
 }
+
+const GEOMETRY_STYLES: { [key: string]: GeometryStyle } = {
+  default: {
+    opacity: 1,
+  },
+  highlighted: {
+    opacity: 1,
+  },
+  unhighlighted: {
+    opacity: 0.25,
+  },
+};

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -4,10 +4,13 @@ import { Scale } from '../utils/scales/scales';
 import { CurveType, getCurveFactory } from './curves';
 import { DataSeriesDatum } from './series';
 
-export interface GeometryValue {
+export interface GeometryId {
   specId: SpecId;
-  datum: any;
   seriesKey: any[];
+}
+
+export interface GeometryValue extends GeometryId {
+  datum: any;
 }
 export interface PointGeometry {
   x: number;
@@ -26,6 +29,7 @@ export interface BarGeometry {
   height: number;
   color: string;
   value: GeometryValue;
+  geometryId: GeometryId;
 }
 export interface LineGeometry {
   line: string;
@@ -35,6 +39,7 @@ export interface LineGeometry {
     x: number;
     y: number;
   };
+  geometryId: GeometryId;
 }
 export interface AreaGeometry {
   area: string;
@@ -45,6 +50,7 @@ export interface AreaGeometry {
     x: number;
     y: number;
   };
+  geometryId: GeometryId;
 }
 
 export function renderPoints(
@@ -95,6 +101,10 @@ export function renderBars(
         datum: datum.datum,
         seriesKey,
       },
+      geometryId: {
+        specId,
+        seriesKey,
+      },
     };
   });
 }
@@ -123,6 +133,10 @@ export function renderLine(
       x,
       y,
     },
+    geometryId: {
+      specId,
+      seriesKey,
+    },
   };
 }
 
@@ -148,5 +162,9 @@ export function renderArea(
     points: lineGeometry.points,
     color,
     transform: lineGeometry.transform,
+    geometryId: {
+      specId,
+      seriesKey,
+    },
   };
 }

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -2,7 +2,9 @@ import { area, line } from 'd3-shape';
 import { SpecId } from '../utils/ids';
 import { Scale } from '../utils/scales/scales';
 import { CurveType, getCurveFactory } from './curves';
+import { LegendItem } from './legend';
 import { DataSeriesDatum } from './series';
+import { belongsToDataSeries } from './series_utils';
 
 export interface GeometryId {
   specId: SpecId;
@@ -12,6 +14,12 @@ export interface GeometryId {
 export interface GeometryValue extends GeometryId {
   datum: any;
 }
+
+/** Shared style properties for varies geometries */
+export interface GeometryStyle {
+  opacity: number;
+}
+
 export interface PointGeometry {
   x: number;
   y: number;
@@ -167,4 +175,20 @@ export function renderArea(
       seriesKey,
     },
   };
+}
+
+export function getGeometryStyle(
+  geometryId: GeometryId,
+  highlightedLegendItem: LegendItem | null,
+): GeometryStyle {
+  let opacity = 1;
+  if (highlightedLegendItem != null) {
+    const isPartOfHighlightedSeries = belongsToDataSeries(geometryId, highlightedLegendItem.value);
+
+    if (!isPartOfHighlightedSeries) {
+      opacity = 0.25;
+    }
+  }
+
+  return { opacity };
 }

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -181,12 +181,22 @@ export function renderArea(
 export function getGeometryStyle(
   geometryId: GeometryId,
   highlightedLegendItem: LegendItem | null,
+  individualHighlight?: { [key: string]: boolean },
 ): GeometryStyle {
   const { shared } = DEFAULT_THEME.chart.styles;
+
   if (highlightedLegendItem != null) {
     const isPartOfHighlightedSeries = belongsToDataSeries(geometryId, highlightedLegendItem.value);
 
     return isPartOfHighlightedSeries ? shared.highlighted : shared.unhighlighted;
+  }
+
+  if (individualHighlight) {
+    const { hasHighlight, hasGeometryHover } = individualHighlight;
+    if (!hasGeometryHover) {
+      return shared.highlighted;
+    }
+    return hasHighlight ? shared.highlighted : shared.unhighlighted;
   }
 
   return shared.default;

--- a/src/lib/series/series_utils.test.ts
+++ b/src/lib/series/series_utils.test.ts
@@ -1,5 +1,5 @@
 import { getSpecId } from '../utils/ids';
-import { GeometryValue } from './rendering';
+import { GeometryId } from './rendering';
 import { DataSeriesColorsValues } from './series';
 import { belongsToDataSeries, isEqualSeriesKey } from './series_utils';
 
@@ -18,10 +18,9 @@ describe('Series utility functions', () => {
     expect(isEqualSeriesKey(seriesKeyA, [])).toBe(false);
   });
 
-  test('can determine if a geometry value belongs to a data series', () => {
-    const geometryValueA: GeometryValue = {
+  test('can determine if a geometry id belongs to a data series', () => {
+    const geometryIdA: GeometryId = {
       specId: getSpecId('a'),
-      datum: null,
       seriesKey: ['a', 'b', 'c'],
     };
 
@@ -40,8 +39,8 @@ describe('Series utility functions', () => {
       colorValues: ['a', 'b', 'd'],
     };
 
-    expect(belongsToDataSeries(geometryValueA, dataSeriesValuesA)).toBe(true);
-    expect(belongsToDataSeries(geometryValueA, dataSeriesValuesB)).toBe(false);
-    expect(belongsToDataSeries(geometryValueA, dataSeriesValuesC)).toBe(false);
+    expect(belongsToDataSeries(geometryIdA, dataSeriesValuesA)).toBe(true);
+    expect(belongsToDataSeries(geometryIdA, dataSeriesValuesB)).toBe(false);
+    expect(belongsToDataSeries(geometryIdA, dataSeriesValuesC)).toBe(false);
   });
 });

--- a/src/lib/series/series_utils.test.ts
+++ b/src/lib/series/series_utils.test.ts
@@ -1,0 +1,47 @@
+import { getSpecId } from '../utils/ids';
+import { GeometryValue } from './rendering';
+import { DataSeriesColorsValues } from './series';
+import { belongsToDataSeries, isEqualSeriesKey } from './series_utils';
+
+describe('Series utility functions', () => {
+  test('can compare series keys for identity', () => {
+    const seriesKeyA = ['a', 'b', 'c'];
+    const seriesKeyB = ['a', 'b', 'c'];
+    const seriesKeyC = ['a', 'b', 'd'];
+    const seriesKeyD = ['d'];
+    const seriesKeyE = ['b', 'a', 'c'];
+
+    expect(isEqualSeriesKey(seriesKeyA, seriesKeyB)).toBe(true);
+    expect(isEqualSeriesKey(seriesKeyB, seriesKeyC)).toBe(false);
+    expect(isEqualSeriesKey(seriesKeyA, seriesKeyD)).toBe(false);
+    expect(isEqualSeriesKey(seriesKeyA, seriesKeyE)).toBe(false);
+    expect(isEqualSeriesKey(seriesKeyA, [])).toBe(false);
+  });
+
+  test('can determine if a geometry value belongs to a data series', () => {
+    const geometryValueA: GeometryValue = {
+      specId: getSpecId('a'),
+      datum: null,
+      seriesKey: ['a', 'b', 'c'],
+    };
+
+    const dataSeriesValuesA: DataSeriesColorsValues = {
+      specId: getSpecId('a'),
+      colorValues: ['a', 'b', 'c'],
+    };
+
+    const dataSeriesValuesB: DataSeriesColorsValues = {
+      specId: getSpecId('b'),
+      colorValues: ['a', 'b', 'c'],
+    };
+
+    const dataSeriesValuesC: DataSeriesColorsValues = {
+      specId: getSpecId('a'),
+      colorValues: ['a', 'b', 'd'],
+    };
+
+    expect(belongsToDataSeries(geometryValueA, dataSeriesValuesA)).toBe(true);
+    expect(belongsToDataSeries(geometryValueA, dataSeriesValuesB)).toBe(false);
+    expect(belongsToDataSeries(geometryValueA, dataSeriesValuesC)).toBe(false);
+  });
+});

--- a/src/lib/series/series_utils.ts
+++ b/src/lib/series/series_utils.ts
@@ -6,15 +6,13 @@ export function isEqualSeriesKey(a: any[], b: any[]): boolean {
     return false;
   }
 
-  let ret = true;
-
-  a.forEach((aVal: any, idx: number) => {
-    if (aVal !== b[idx]) {
-      ret = false;
+  for (let i = 0, l = a.length; i < l; i++) {
+    if (a[i] !== b[i]) {
+      return false;
     }
-  });
+  }
 
-  return ret;
+  return true;
 }
 
 export function belongsToDataSeries(geometryValue: GeometryId, dataSeriesValues: DataSeriesColorsValues): boolean {

--- a/src/lib/series/series_utils.ts
+++ b/src/lib/series/series_utils.ts
@@ -1,0 +1,31 @@
+import { GeometryValue } from './rendering';
+import { DataSeriesColorsValues } from './series';
+
+export function isEqualSeriesKey(a: any[], b: any[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  let ret = true;
+
+  a.forEach((aVal: any, idx: number) => {
+    if (aVal !== b[idx]) {
+      ret = false;
+    }
+  });
+
+  return ret;
+}
+
+export function belongsToDataSeries(geometryValue: GeometryValue, dataSeriesValues: DataSeriesColorsValues): boolean {
+  const legendItemSeriesKey = dataSeriesValues.colorValues;
+  const legendItemSpecId = dataSeriesValues.specId;
+
+  const geometrySeriesKey = geometryValue.seriesKey;
+  const geometrySpecId = geometryValue.specId;
+
+  const hasSameSpecId = legendItemSpecId === geometrySpecId;
+  const hasSameSeriesKey = isEqualSeriesKey(legendItemSeriesKey, geometrySeriesKey);
+
+  return hasSameSpecId && hasSameSeriesKey;
+}

--- a/src/lib/series/series_utils.ts
+++ b/src/lib/series/series_utils.ts
@@ -1,4 +1,4 @@
-import { GeometryValue } from './rendering';
+import { GeometryId } from './rendering';
 import { DataSeriesColorsValues } from './series';
 
 export function isEqualSeriesKey(a: any[], b: any[]): boolean {
@@ -17,7 +17,7 @@ export function isEqualSeriesKey(a: any[], b: any[]): boolean {
   return ret;
 }
 
-export function belongsToDataSeries(geometryValue: GeometryValue, dataSeriesValues: DataSeriesColorsValues): boolean {
+export function belongsToDataSeries(geometryValue: GeometryId, dataSeriesValues: DataSeriesColorsValues): boolean {
   const legendItemSeriesKey = dataSeriesValues.colorValues;
   const legendItemSpecId = dataSeriesValues.specId;
 

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -1,3 +1,4 @@
+import { GeometryStyle } from '../series/rendering';
 import { Margins } from '../utils/dimensions';
 
 export interface ChartConfig {
@@ -11,6 +12,7 @@ export interface ChartConfig {
   styles: {
     lineSeries: LineSeriesStyle;
     areaSeries: AreaSeriesStyle;
+    shared: { [key: string]: GeometryStyle };
   };
 }
 export interface AxisConfig {
@@ -91,6 +93,18 @@ export const DEFAULT_GRID_LINE_CONFIG: GridLineConfig = {
   opacity: 1,
 };
 
+export const GEOMETRY_STYLES: { [key: string]: GeometryStyle } = {
+  default: {
+    opacity: 1,
+  },
+  highlighted: {
+    opacity: 1,
+  },
+  unhighlighted: {
+    opacity: 0.25,
+  },
+};
+
 export const DEFAULT_THEME: Theme = {
   chart: {
     paddings: {
@@ -130,6 +144,7 @@ export const DEFAULT_THEME: Theme = {
         dataPointsStroke: 'white',
         dataPointsStrokeWidth: 1,
       },
+      shared: GEOMETRY_STYLES,
     },
   },
   scales: {

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -7,6 +7,7 @@ import {
   ChartStore,
   ElementClickListener,
   ElementOverListener,
+  LegendItemListener,
 } from '../state/chart_state';
 
 interface SettingSpecProps {
@@ -22,6 +23,8 @@ interface SettingSpecProps {
   onElementOver?: ElementOverListener;
   onElementOut?: () => undefined;
   onBrushEnd?: BrushEndListener;
+  onLegendItemOver?: LegendItemListener;
+  onLegendItemOut?: LegendItemListener;
 }
 
 function updateChartStore(props: SettingSpecProps) {
@@ -37,6 +40,8 @@ function updateChartStore(props: SettingSpecProps) {
     onElementOver,
     onElementOut,
     onBrushEnd,
+    onLegendItemOver,
+    onLegendItemOut,
     debug,
   } = props;
   if (!chartStore) {
@@ -62,6 +67,12 @@ function updateChartStore(props: SettingSpecProps) {
   }
   if (onBrushEnd) {
     chartStore.setOnBrushEndListener(onBrushEnd);
+  }
+  if (onLegendItemOver) {
+    chartStore.setOnLegendItemOverListener(onLegendItemOver);
+  }
+  if (onLegendItemOut) {
+    chartStore.setOnLegendItemOutListener(onLegendItemOut);
   }
 }
 

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -24,7 +24,7 @@ interface SettingSpecProps {
   onElementOut?: () => undefined;
   onBrushEnd?: BrushEndListener;
   onLegendItemOver?: LegendItemListener;
-  onLegendItemOut?: LegendItemListener;
+  onLegendItemOut?: () => undefined;
 }
 
 function updateChartStore(props: SettingSpecProps) {

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -1,4 +1,4 @@
-import { action, observable } from 'mobx';
+import { action, IObservableValue, observable } from 'mobx';
 import {
   AxisLinePosition,
   AxisTick,
@@ -123,7 +123,7 @@ export class ChartStore {
   yScales?: Map<GroupId, Scale>;
 
   legendItems: LegendItem[] = [];
-  highlightedLegendItemIndex: number | null = null;
+  highlightedLegendItemIndex: IObservableValue<number | null> = observable.box(null);
 
   tooltipData = observable.box<Array<[any, any]> | null>(null);
   tooltipPosition = observable.box<{ x: number; y: number } | null>();
@@ -231,17 +231,12 @@ export class ChartStore {
   }
 
   updateHighlightedLegendItem(legendItemIndex: number | null) {
-    if (legendItemIndex !== this.highlightedLegendItemIndex) {
-      this.highlightedLegendItemIndex = legendItemIndex;
-      this.computeChart();
-    }
+    this.highlightedLegendItemIndex.set(legendItemIndex);
   }
 
   getHighlightedLegendItem(): LegendItem | null {
-    if (this.highlightedLegendItemIndex != null) {
-      return this.legendItems[this.highlightedLegendItemIndex];
-    }
-    return null;
+    const index = this.highlightedLegendItemIndex.get();
+    return index == null ? null : this.legendItems[index];
   }
 
   updateParentDimensions(width: number, height: number, top: number, left: number) {

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -123,6 +123,7 @@ export class ChartStore {
   yScales?: Map<GroupId, Scale>;
 
   legendItems: LegendItem[] = [];
+  highlightedLegendItemIndex: number | null = null;
 
   tooltipData = observable.box<Array<[any, any]> | null>(null);
   tooltipPosition = observable.box<{ x: number; y: number } | null>();
@@ -227,6 +228,13 @@ export class ChartStore {
       return false;
     }
     return this.xScale.type !== ScaleType.Ordinal && Boolean(this.onBrushEndListener);
+  }
+
+  updateHighlightedLegendItem(legendItemIndex: number) {
+    if (legendItemIndex !== this.highlightedLegendItemIndex) {
+      this.highlightedLegendItemIndex = legendItemIndex;
+      this.computeChart();
+    }
   }
 
   updateParentDimensions(width: number, height: number, top: number, left: number) {

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -1,4 +1,4 @@
-import { action, IObservableValue, observable } from 'mobx';
+import { action, computed, IObservableValue, observable } from 'mobx';
 import {
   AxisLinePosition,
   AxisTick,
@@ -187,6 +187,11 @@ export class ChartStore {
     this.showLegend.set(showLegend);
   });
 
+  highlightedLegendItem = computed(() => {
+    const index = this.highlightedLegendItemIndex.get();
+    return index == null ? null : this.legendItems[index];
+  });
+
   setOnElementClickListener(listener: ElementClickListener) {
     this.onElementClickListener = listener;
   }
@@ -232,11 +237,6 @@ export class ChartStore {
 
   updateHighlightedLegendItem(legendItemIndex: number | null) {
     this.highlightedLegendItemIndex.set(legendItemIndex);
-  }
-
-  getHighlightedLegendItem(): LegendItem | null {
-    const index = this.highlightedLegendItemIndex.get();
-    return index == null ? null : this.legendItems[index];
   }
 
   updateParentDimensions(width: number, height: number, top: number, left: number) {

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -237,6 +237,13 @@ export class ChartStore {
     }
   }
 
+  getHighlightedLegendItem(): LegendItem | null {
+    if (this.highlightedLegendItemIndex != null) {
+      return this.legendItems[this.highlightedLegendItemIndex];
+    }
+    return null;
+  }
+
   updateParentDimensions(width: number, height: number, top: number, left: number) {
     let isChanged = false;
     if (width !== this.parentDimensions.width) {

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -76,6 +76,7 @@ export interface SeriesDomainsAndData {
 export type ElementClickListener = (value: GeometryValue) => void;
 export type ElementOverListener = (value: GeometryValue) => void;
 export type BrushEndListener = (min: number, max: number) => void;
+export type LegendItemListener = () => void;
 // const MAX_ANIMATABLE_GLYPHS = 500;
 
 export class ChartStore {
@@ -133,6 +134,9 @@ export class ChartStore {
   onElementOverListener?: ElementOverListener;
   onElementOutListener?: () => undefined;
   onBrushEndListener?: BrushEndListener;
+
+  onLegendItemOverListener?: LegendItemListener;
+  onLegendItemOutListener?: LegendItemListener;
 
   geometries: {
     points: PointGeometry[];
@@ -192,6 +196,18 @@ export class ChartStore {
     return index == null ? null : this.legendItems[index];
   });
 
+  onLegendItemOver = action(() => {
+    if (this.onLegendItemOverListener) {
+      this.onLegendItemOverListener();
+    }
+  });
+
+  onLegendItemOut = action(() => {
+    if (this.onLegendItemOutListener) {
+      this.onLegendItemOutListener();
+    }
+  });
+
   setOnElementClickListener(listener: ElementClickListener) {
     this.onElementClickListener = listener;
   }
@@ -204,6 +220,12 @@ export class ChartStore {
   setOnBrushEndListener(listener: BrushEndListener) {
     this.onBrushEndListener = listener;
   }
+  setOnLegendItemOverListener(listener: LegendItemListener) {
+    this.onLegendItemOverListener = listener;
+  }
+  setOnLegendItemOutListener(listener: LegendItemListener) {
+    this.onLegendItemOutListener = listener;
+  }
   removeElementClickListener() {
     this.onElementClickListener = undefined;
   }
@@ -212,6 +234,12 @@ export class ChartStore {
   }
   removeElementOutListener() {
     this.onElementOutListener = undefined;
+  }
+  removeOnLegendItemOverListener() {
+    this.onLegendItemOverListener = undefined;
+  }
+  removeOnLegendItemOutListener() {
+    this.onLegendItemOutListener = undefined;
   }
   onBrushEnd(start: Point, end: Point) {
     if (!this.onBrushEndListener) {

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -230,7 +230,7 @@ export class ChartStore {
     return this.xScale.type !== ScaleType.Ordinal && Boolean(this.onBrushEndListener);
   }
 
-  updateHighlightedLegendItem(legendItemIndex: number) {
+  updateHighlightedLegendItem(legendItemIndex: number | null) {
     if (legendItemIndex !== this.highlightedLegendItemIndex) {
       this.highlightedLegendItemIndex = legendItemIndex;
       this.computeChart();

--- a/stories/interactions.tsx
+++ b/stories/interactions.tsx
@@ -14,6 +14,8 @@ import {
 
 import { boolean } from '@storybook/addon-knobs';
 import { DateTime } from 'luxon';
+import { CurveType } from '../src/lib/series/curves';
+import * as TestDatasets from '../src/lib/series/utils/test_dataset';
 import { AreaSeries, LineSeries } from '../src/specs';
 import { niceTimeFormatter } from '../src/utils/data/formatters';
 
@@ -111,7 +113,196 @@ storiesOf('Interactions', module)
       </Chart>
     );
   })
-  .add('click/hovers on legend items (TO DO)', () => <h1>TO DO</h1>)
+  .add('click/hovers on legend items [bar chart] (TO DO click)', () => {
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y1', 'y2']}
+          splitSeriesAccessors={['g1', 'g2']}
+          data={TestDatasets.BARCHART_2Y2G}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('click/hovers on legend items [area chart] (TO DO click)', () => {
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <AreaSeries
+          id={getSpecId('lines')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          stackAccessors={['x']}
+          splitSeriesAccessors={['g']}
+          data={[
+            { x: 0, y: 2, g: 'a' },
+            { x: 1, y: 7, g: 'a' },
+            { x: 2, y: 3, g: 'a' },
+            { x: 3, y: 6, g: 'a' },
+            { x: 0, y: 4, g: 'b' },
+            { x: 1, y: 5, g: 'b' },
+            { x: 2, y: 8, g: 'b' },
+            { x: 3, y: 2, g: 'b' },
+          ]}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('click/hovers on legend items [line chart] (TO DO click)', () => {
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <LineSeries
+          id={getSpecId('lines1')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          curve={CurveType.CURVE_MONOTONE_X}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+          yScaleToDataExtent={false}
+        />
+        <LineSeries
+          id={getSpecId('lines2')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          curve={CurveType.CURVE_BASIS}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+          yScaleToDataExtent={false}
+        />
+        <LineSeries
+          id={getSpecId('lines3')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          curve={CurveType.CURVE_CARDINAL}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+          yScaleToDataExtent={false}
+        />
+        <LineSeries
+          id={getSpecId('lines4')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          curve={CurveType.CURVE_CATMULL_ROM}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+          yScaleToDataExtent={false}
+        />
+        <LineSeries
+          id={getSpecId('lines5')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          curve={CurveType.CURVE_NATURAL}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+          yScaleToDataExtent={false}
+        />
+        <LineSeries
+          id={getSpecId('lines6')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          curve={CurveType.LINEAR}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('click/hovers on legend items [mixed chart] (TO DO click)', () => {
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+          yScaleToDataExtent={false}
+        />
+        <LineSeries
+          id={getSpecId('lines')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          stackAccessors={['x']}
+          splitSeriesAccessors={['g']}
+          data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
   .add('brush selection tool on linear', () => {
     return (
       <Chart renderer="canvas" className={'story-chart'}>

--- a/stories/interactions.tsx
+++ b/stories/interactions.tsx
@@ -25,6 +25,11 @@ const onElementListeners = {
   onElementOut: action('onElementOut'),
 };
 
+const onLegendItemListeners = {
+  onLegendItemOver: action('onLegendItemOver'),
+  onLegendItemOut: action('onLegendItemOut'),
+};
+
 storiesOf('Interactions', module)
   .add('bar clicks and hovers', () => {
     return (
@@ -116,7 +121,7 @@ storiesOf('Interactions', module)
   .add('click/hovers on legend items [bar chart] (TO DO click)', () => {
     return (
       <Chart renderer="canvas" className={'story-chart'}>
-        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Settings showLegend={true} legendPosition={Position.Right} {...onLegendItemListeners} />
         <Axis
           id={getAxisId('bottom')}
           position={Position.Bottom}


### PR DESCRIPTION
This PR implements the feature (see #24) to add a hover interaction with legend items that highlights the corresponding series in the chart.  Currently, this is implemented to set the opacity of the non-highlighted series to 0.25 and the highlighted series to 1.  This renders like below:

bar series:
![bar_legend](https://user-images.githubusercontent.com/452850/52435834-a238ca00-2ac7-11e9-9bfb-2fbbc79fa4e8.gif)

line series:
![line_legend](https://user-images.githubusercontent.com/452850/52435849-aa910500-2ac7-11e9-8690-fd7bdc778b4c.gif)

area series:
![area_legend](https://user-images.githubusercontent.com/452850/52435866-b41a6d00-2ac7-11e9-95e1-41a10034c9b6.gif)

mixed series:
![mixed_legend](https://user-images.githubusercontent.com/452850/52435874-ba104e00-2ac7-11e9-84c1-2e536a03e2c5.gif)

Per the discussion below, there is also a refactoring of how `specId` and `seriesKey` are associated with a Geometry.  All Geometries now have will have these properties as they are required to be able to identify a specific geometry belonging to a spec within a series.

Also, per the discussion below, as we will likely want to share some common styles across all the different geometries, while this PR only introduces the stylistic feature of changing the opacity based on a highlighted legend item, there is the ability to update these shared styles in a way that allows for re-use across geometries.