### PR TITLE
fix: add missing min interval compare function

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint-fix": "tslint -c ./tslint.yaml -p ./tsconfig.json --fix",
     "prettier": "prettier -l \"{,!(node_modules)/}**/*.{ts,tsx}\"",
     "prettier-fix": "prettier --write \"{,!(node_modules)/}**/*.{ts,tsx}\"",
-    "test": "jest --config jest.config.json --coverage",
+    "test": "jest --config jest.config.json",
     "watch": "yarn test --watch",
     "format-fix": "yarn prettier-fix && yarn lint-fix",
     "format-check": "yarn prettier && yarn lint",

--- a/src/lib/series/domains/x_domain.test.ts
+++ b/src/lib/series/domains/x_domain.test.ts
@@ -2,13 +2,19 @@ import { getGroupId, getSpecId, SpecId } from '../../utils/ids';
 import { ScaleType } from '../../utils/scales/scales';
 import { getSplittedSeries } from '../series';
 import { BasicSeriesSpec } from '../specs';
-import { convertXScaleTypes, mergeXDomain } from './x_domain';
+import { convertXScaleTypes, findMinInterval, mergeXDomain } from './x_domain';
 
 describe('X Domain', () => {
   test('Should return null when missing specs or specs types', () => {
     const seriesSpecs: BasicSeriesSpec[] = [];
     const mainXScale = convertXScaleTypes(seriesSpecs);
     expect(mainXScale).toBe(null);
+  });
+
+  test('should throw if we miss calling merge X domain without specs configured', () => {
+    expect(() => {
+      mergeXDomain([], new Set());
+    }).toThrow();
   });
 
   test('Should return correct scale type with single bar', () => {
@@ -599,5 +605,29 @@ describe('X Domain', () => {
       xValues,
     );
     expect(mergedDomain.domain.length).toEqual(maxValues);
+  });
+  test('should compute minInterval an ordered list of numbers', () => {
+    const minInterval = findMinInterval([0, 1, 2, 3, 4, 5]);
+    expect(minInterval).toBe(1);
+  });
+  test('should compute minInterval an unordered list of numbers', () => {
+    const minInterval = findMinInterval([2, 10, 3, 1, 5]);
+    expect(minInterval).toBe(1);
+  });
+  test('should compute minInterval an list grether than 9', () => {
+    const minInterval = findMinInterval([0, 2, 4, 6, 8, 10, 20, 30, 40, 50, 80]);
+    expect(minInterval).toBe(2);
+  });
+  test('should compute minInterval an list with negative numbers', () => {
+    const minInterval = findMinInterval([-1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12]);
+    expect(minInterval).toBe(1);
+  });
+  test('should compute minInterval an list with negative and positive numbers', () => {
+    const minInterval = findMinInterval([-2, -4, -6, -8, -10, -12, 0, 2, 4, 6, 8, 10, 12]);
+    expect(minInterval).toBe(2);
+  });
+  test('should compute minInterval a single element array', () => {
+    const minInterval = findMinInterval([100]);
+    expect(minInterval).toBe(1);
   });
 });

--- a/src/lib/series/domains/x_domain.ts
+++ b/src/lib/series/domains/x_domain.ts
@@ -1,4 +1,4 @@
-import { identity } from '../../utils/commons';
+import { compareByValueAsc, identity } from '../../utils/commons';
 import { computeContinuousDataDomain, computeOrdinalDataDomain } from '../../utils/domain';
 import { ScaleType } from '../../utils/scales/scales';
 import { BasicSeriesSpec } from '../specs';
@@ -49,14 +49,17 @@ export function mergeXDomain(
  * to display a bar chart in a linear scale.
  */
 export function findMinInterval(xValues: number[]): number | null {
-  const sortedValues = xValues.slice().sort();
+  if (xValues.length === 1) {
+    return 1;
+  }
+  const sortedValues = xValues.slice().sort(compareByValueAsc);
   const sortedValuesLength = sortedValues.length - 1;
   let i;
   let minInterval = null;
   for (i = 0; i < sortedValuesLength; i++) {
     const current = sortedValues[i];
     const next = sortedValues[i + 1];
-    const interval = next - current;
+    const interval = Math.abs(next - current);
     if (minInterval === null) {
       minInterval = interval;
     } else {

--- a/src/lib/utils/commons.ts
+++ b/src/lib/utils/commons.ts
@@ -1,3 +1,7 @@
 export function identity<T>(value: T): T {
   return value;
 }
+
+export function compareByValueAsc(firstEl: number, secondEl: number): number {
+  return firstEl - secondEl;
+}

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -283,7 +283,7 @@ export class ChartStore {
     // console.log({colors: seriesDomains.seriesColors});
 
     // tslint:disable-next-line:no-console
-    // console.log({seriesDomains});
+    // console.log({ seriesDomains });
     const seriesColorMap = getSeriesColorMap(seriesDomains.seriesColors, this.chartTheme.colors);
     this.legendItems = computeLegend(
       seriesDomains.seriesColors,
@@ -292,7 +292,7 @@ export class ChartStore {
       this.chartTheme.colors.defaultVizColor,
     );
     // tslint:disable-next-line:no-console
-    // console.log({legendItems: this.legendItems});
+    // console.log({ legendItems: this.legendItems });
 
     const {
       xDomain,
@@ -351,7 +351,7 @@ export class ChartStore {
     );
 
     // tslint:disable-next-line:no-console
-    // console.log({geometries});
+    // console.log({ seriesGeometries });
     this.geometries = seriesGeometries.geometries;
     this.xScale = seriesGeometries.scales.xScale;
     this.yScales = seriesGeometries.scales.yScales;

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -65,7 +65,7 @@ export function computeSeriesDomains(
   const xDomain = mergeXDomain(specsArray, xValues);
   const yDomain = mergeYDomain(splittedSeries, specsArray);
   const formattedDataSeries = getFormattedDataseries(specsArray, splittedSeries);
-
+  // tslint:disable-next-line:no-console
   // console.log({ formattedDataSeries, xDomain, yDomain });
 
   return {

--- a/src/stories/bar_chart.tsx
+++ b/src/stories/bar_chart.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Axis, BarSeries, Chart, getAxisId, getSpecId, Position, ScaleType, Settings } from '..';
 import * as TestDatasets from '../lib/series/utils/test_dataset';
 import { niceTimeFormatter } from '../utils/data/formatters';
+import { DataGenerator } from '../utils/data_generators/data_generator';
 
 storiesOf('Bar Chart', module)
   .add('basic', () => {
@@ -506,6 +507,146 @@ storiesOf('Bar Chart', module)
           yAccessors={['y1', 'y2']}
           splitSeriesAccessors={['g1', 'g2']}
           data={TestDatasets.BARCHART_2Y2G}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('with high data volume', () => {
+    const dg = new DataGenerator();
+    const data = dg.generateSimpleSeries(200);
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Axis id={getAxisId('bottom')} position={Position.Bottom} title={'Bottom axis'} />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={data}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('single data chart', () => {
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Axis id={getAxisId('bottom')} position={Position.Bottom} title={'Bottom axis'} />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={[{ x: 1, y: 10 }]}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('single data clusterd chart', () => {
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Axis id={getAxisId('bottom')} position={Position.Bottom} title={'Bottom axis'} />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          splitSeriesAccessors={['g']}
+          data={[
+            { x: 1, y: 10, g: 'a' },
+            { x: 1, y: 5, g: 'b' },
+            { x: 1, y: 3, g: 'c' },
+            { x: 1, y: 10, g: 'd' },
+          ]}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('single data stacked chart', () => {
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Axis id={getAxisId('bottom')} position={Position.Bottom} title={'Bottom axis'} />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          splitSeriesAccessors={['g']}
+          stackAccessors={['x']}
+          data={[
+            { x: 1, y: 10, g: 'a' },
+            { x: 1, y: 5, g: 'b' },
+            { x: 1, y: 3, g: 'c' },
+            { x: 1, y: 10, g: 'd' },
+          ]}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('negative and positive x values', () => {
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Axis id={getAxisId('bottom')} position={Position.Bottom} title={'Bottom axis'} />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          splitSeriesAccessors={['g']}
+          stackAccessors={['x']}
+          data={[
+            { x: -3, y: 1 },
+            { x: 0, y: 4 },
+            { x: -2, y: 2 },
+            { x: 1, y: 3 },
+            { x: 2, y: 2 },
+            { x: -1, y: 3 },
+            { x: 3, y: 1 },
+          ]}
           yScaleToDataExtent={false}
         />
       </Chart>


### PR DESCRIPTION
Min interval is used on linear scales to compute the minimum interval between two adjacent values on X axis.
It currently works using sorting the unique list of x values.
The sort function was not implemented and the x rendering was based on string comparison of numbers: `0, 1, 10, 11, 2, 3, 4, 5, 6, 7, 8, 9`
I've added a numeric ascending compare function with tests.
I've also fixed the case when we have a single x value on a barchart with linear axis
 