### PR TITLE
fix(axis): scale tick labels to fix text truncation on chrome

### DIFF
--- a/src/lib/axes/canvas_text_bbox_calculator.ts
+++ b/src/lib/axes/canvas_text_bbox_calculator.ts
@@ -6,9 +6,7 @@ export class CanvasTextBBoxCalculator implements BBoxCalculator {
   private offscreenCanvas: HTMLCanvasElement;
   private context: CanvasRenderingContext2D | null;
   private fontScale: number;
-  // TODO specify styles for text
-  // TODO specify how to hide the svg from the current dom view
-  // like moving it a -9999999px
+
   constructor(rootElement?: HTMLElement) {
     this.offscreenCanvas = document.createElement('canvas');
     this.context = this.offscreenCanvas.getContext('2d');

--- a/src/lib/axes/canvas_text_bbox_calculator.ts
+++ b/src/lib/axes/canvas_text_bbox_calculator.ts
@@ -5,6 +5,7 @@ export class CanvasTextBBoxCalculator implements BBoxCalculator {
   private attachedRoot: HTMLElement;
   private offscreenCanvas: HTMLCanvasElement;
   private context: CanvasRenderingContext2D | null;
+  private fontScale: number;
   // TODO specify styles for text
   // TODO specify how to hide the svg from the current dom view
   // like moving it a -9999999px
@@ -13,15 +14,21 @@ export class CanvasTextBBoxCalculator implements BBoxCalculator {
     this.context = this.offscreenCanvas.getContext('2d');
     this.attachedRoot = rootElement || document.documentElement;
     this.attachedRoot.appendChild(this.offscreenCanvas);
+    this.fontScale = 100;
   }
   compute(text: string, fontSize = 16, fontFamily = 'Arial'): Option<BBox> {
     if (!this.context) {
       return none;
     }
-    this.context.font = `${fontSize}px ${fontFamily}`;
+
+    // We scale the text up to get a more accurate computation of the width of the text
+    // because `measureText` can vary a lot between browsers.
+    const scaledFontSize = fontSize * this.fontScale;
+    this.context.font = `${scaledFontSize}px ${fontFamily}`;
     const measure = this.context.measureText(text);
+
     return some({
-      width: measure.width,
+      width: measure.width / this.fontScale,
       height: fontSize,
     });
   }

--- a/src/lib/axes/canvas_text_bbox_calculator.ts
+++ b/src/lib/axes/canvas_text_bbox_calculator.ts
@@ -5,14 +5,14 @@ export class CanvasTextBBoxCalculator implements BBoxCalculator {
   private attachedRoot: HTMLElement;
   private offscreenCanvas: HTMLCanvasElement;
   private context: CanvasRenderingContext2D | null;
-  private fontScale: number;
+  private scaledFontSize: number;
 
   constructor(rootElement?: HTMLElement) {
     this.offscreenCanvas = document.createElement('canvas');
     this.context = this.offscreenCanvas.getContext('2d');
     this.attachedRoot = rootElement || document.documentElement;
     this.attachedRoot.appendChild(this.offscreenCanvas);
-    this.fontScale = 100;
+    this.scaledFontSize = 100;
   }
   compute(text: string, fontSize = 16, fontFamily = 'Arial'): Option<BBox> {
     if (!this.context) {
@@ -21,12 +21,12 @@ export class CanvasTextBBoxCalculator implements BBoxCalculator {
 
     // We scale the text up to get a more accurate computation of the width of the text
     // because `measureText` can vary a lot between browsers.
-    const scaledFontSize = fontSize * this.fontScale;
-    this.context.font = `${scaledFontSize}px ${fontFamily}`;
+    const scalingFactor = this.scaledFontSize / fontSize;
+    this.context.font = `${this.scaledFontSize}px ${fontFamily}`;
     const measure = this.context.measureText(text);
 
     return some({
-      width: measure.width / this.fontScale,
+      width: measure.width / scalingFactor,
       height: fontSize,
     });
   }

--- a/src/stories/axis.tsx
+++ b/src/stories/axis.tsx
@@ -15,6 +15,7 @@ import {
 } from '..';
 import { PartialTheme } from '../lib/themes/theme';
 import { LineSeries } from '../specs';
+import { DataGenerator } from '../utils/data_generators/data_generator';
 
 function createThemeAction(title: string, min: number, max: number, value: number) {
   return number(title, value, {
@@ -262,6 +263,30 @@ storiesOf('Axis', module)
           stackAccessors={['x']}
           splitSeriesAccessors={['g']}
           data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('w many tick labels', () => {
+    const dg = new DataGenerator();
+    const data = dg.generateSimpleSeries(31);
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Settings debug={true} />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <AreaSeries
+          id={getSpecId('lines')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={data}
           yScaleToDataExtent={false}
         />
       </Chart>


### PR DESCRIPTION
fixes #18 

tl;dr the `measureText` function returns very different results from browser to browser and also possibly within the same browser as well, especially with very small font sizes.  We employ a strategy that scales up the font, measures the text size, then divides the result with the scaling factor to get a more accurate measurement of the text width.  Labels should now render fully in Chrome (the labels remain the same in Firefox):

<img width="913" alt="image" src="https://user-images.githubusercontent.com/452850/52306291-5f9eb280-294c-11e9-9ee5-8af4e5ae41b9.png">
