### PR TITLE
docs(wiki): add wiki pages and updated README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+## Contributing to Elastic Charts
+
+🙌 Thanks for your interest in contributing to Elastic Charts! 🙌
+
+We are trying to enforce some good practices in this library:
+
+- All commits must follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
+- [semantic-release](https://semantic-release.gitbook.io) is used as an automated release manager suite.
+  This will automatically publish on NPM on every push on master, will automatically create the changelog and bump the correct semver depending on the commits. To avoid too many new releases, especially in this initial phase of the project, we are going to work against a `dev` branch and then merge on master periodically.
+- Every commit count in the version bump: this means that we can merge a PR with two methods:
+  - merge all the PR commit history (please follow the commit convention or squash partial commits)
+  - squash and merge all commits using a single commit that follows the conventions.
+
+The following tools are used to ensure this convention:
+
+- `commitlint` hook ensure that you are following correctly the convention,
+- `yarn cz` can be used to start `commitizen` as a cli tool that prompts you with selections and questions to help you in writing a conventional commit.

--- a/README.md
+++ b/README.md
@@ -3,120 +3,19 @@
 </h1>
 <p align="center">
   <a href="(https://travis-ci.org/elastic/elastic-charts"><img alt="Build Status" src="https://travis-ci.org/elastic/elastic-charts.svg?branch=master"></a>
+  <a href="https://www.npmjs.com/@elastic/charts"><img alt="NPM version" src="https://img.shields.io/npm/v/@elastic/charts.svg?style=flat"></a>
   <a href="http://commitizen.github.io/cz-cli/"><img alt="Commitizen friendly" src="https://img.shields.io/badge/commitizen-friendly-brightgreen.svg"></a>
+  <a href="https://elastic.github.io/elastic-charts"><img alt="Storybook" src="https://github.com/storybooks/press/raw/master/badges/storybook.svg?sanitize=true"></a>
+  
 </p>
 
 🚨 **WARNING** While open source, the intended consumers of this repository are Elastic products. Read the [FAQ][faq] for details.
 
 ---
 
-This library is a complete rewrite of the current vislib in Kibana and EUISeriesChart in EUI.
-The rationale behind this refactoring is the need for a testable and decoupled architecture for displaying data within charts. The current EUI implementation is based on ReactVis, which directly manipulates the data series inside components without a clear rendering pipeline and without a clean way to extend it. Some of the downsides of using ReactVis are:
-
-- the main chart component, before rendering children, looks at their props and recomputes them, injecting new props. Some configuration is accessed through references to children components.
-- the components are themselves SVG components that render bars, lines, and axes. The problem with this is that not all components can be rendered at the same time, but there is the need for a rendering pipeline to allow a correct placement for all the geometries, especially when we face the need for having auto-scaled axis dimensions.
-- the only way to test the chart is testing the resulting SVG component. If rendered through canvas the test can be only a visual regression test.
-- no possibility of manage x-indexing of elements
-
-This new implementation revisits the concept of a charting library and tries to apply a unidirectional rendering flow to the concept of charting. The rendering flow is the following:
-
-![rendering-pipeline](https://user-images.githubusercontent.com/1421091/49724064-bba8cb80-fc68-11e8-8378-9d59b941f15d.png)
-
-This controlled flow allows us to achieve the following points:
-
-- the computation of series dimensions (x and y domains of the datasets, for example) are required to precompute the space required for the axis labeling. Axis rendering is dependent on the axis displayed values, and thus on the data series provided. This is a required passage to accommodate automatically spaced axes . Other libraries just live the developer with the needs to specify static margin space to render the axis labels, and this can result in truncated labels.
-- put a testing probe just before rendering the chart, the computed geometries are the exact values that need to be used to render on SVG, canvas or WebGL on that exact portion of the screen. No further calculation is needed on the rendered component. x, y, width, height, color, and transforms are computed before the rendering phase.
-- reduce the rendering operation to the minimum required. Resizing, for example, will only require the last 3 phases to complete.
-- decouple the chart from its rendering medium: can be SVG, canvas or WebGL, using React or any other DOM library.
-- part of this computation can also be processed server side or on a WebWorker.
-
-The rendering pipeline is achieved by revisiting the way a chart library is built. Instead of creating a chart library around a set of rendering components: bar series, axis etc., this new implementation decouples the specification of the chart from the rendering components. The rendering components are part of the internals of the library. We are exposing `empty` react components to the developer, using the JSX format just as a declarative language to describe the specification of your chart and not as a set of real react components that will render something.
-That is achieved using the following render function on the main `Chart` component:
-
-```jsx
-<Provider chartStore={this.chartSpecStore}>
-  <Fragment>
-    <SpecsParser>{this.props.children}</SpecsParser>
-    <ChartResizer />
-    {renderer === 'svg' && <SVGChart />}
-    {renderer === 'canvas' && <CanvasChart />}
-    {renderer === 'canvas_native' && <NativeChart />}
-    <Tooltips />
-  </Fragment>
-</Provider>
-```
-
-Where all the children passed are rendered inside the `SpecsParser`, that signal a state manager that we are updating the specification of the chart, but doesn't render anything.
-The actual rendering is done by one of the rendered like the `ReactChart` that is rendered after the rendering pipeline produced and saved the geometries on the state manager.
-
-A spec can be something like the following:
-
-```js
-<Chart renderer={renderer}>
-  <Settings rotation={rotation} animateData={true} />
-  <Axis id={getAxisId('bottom')} position={AxisPosition.Bottom} title={`Rendering test`} />
-  <Axis id={getAxisId('left')} position={AxisPosition.Left} />
-  <LineSeries
-    id={getSpecId('1')}
-    yScaleType={ScaleType.Linear}
-    xScaleType={ScaleType.Linear}
-    xAccessor="x"
-    yAccessors={['y']}
-    data={BARCHART_1Y0G}
-  />
-  <BarSeries
-    id={getSpecId('2')}
-    yScaleType={ScaleType.Linear}
-    xScaleType={ScaleType.Linear}
-    xAccessor="x"
-    yAccessors={['y1', 'y2']}
-    splitSeriesAccessors={['g']}
-    stackAccessors={['x', 'g']}
-    data={BARCHART_2Y1G}
-  />
-</Chart>
-```
-
-## Setting Up Your Development Environment
-
-Fork, then clone the `elastic-chart` repo and change directory into it
-
-```bash
-git clone git@github.com:<YOUR_GITHUB_NAME>/elastic-charts.git elastic-charts
-cd kibana
-```
-
-Install the latest version of [yarn](https://yarnpkg.com)
-
-We depend upon the version of node defined in [.nvmrc](.nvmrc).
-
-You will probably want to install a node version manager. [nvm](https://github.com/creationix/nvm) is recommended.
-
-To install and use the correct node version with `nvm`:
-
-```bash
-nvm install
-```
-
-Install all the dependencies
-
-```bash
-yarn install
-```
-
-### Storybook
-
-We develop using [storybook](https://storybook.js.org) to document API, edge-cases, and usage of the library.
-A hosted version is available at [https://elastic.github.io/elastic-charts](https://elastic.github.io/elastic-charts).
-You can run locally at [http://localhost:9001/](http://localhost:9001/) by running:
-
-```
-yarn storybook
-```
+You should check out our [living style guide][docs], which contains many examples on how charts look and feel, and how to use them in your products.
 
 ## Installation
-
-**note:** there is no published package on NPM at the moment (30/01/2018). Will be part of the Roadmap #1.
 
 To install the Elastic Charts into an existing project, use the `yarn` CLI (`npm` is not supported).
 
@@ -124,157 +23,66 @@ To install the Elastic Charts into an existing project, use the `yarn` CLI (`npm
 yarn add @elastic/charts
 ```
 
+Note that Elastic Charts itself has some dependencies itself mostly around styles and management of dates and times. If you are installing it into a blank project you will need to install the following with it. You can read more about other ways to [consume Elastic Charts][consuming].
+
+```
+yarn add @elastic/eui @elastic/datemath moment
+```
+
+## Running Locally
+
+### Node
+
+We depend upon the version of node defined in [.nvmrc](.nvmrc).
+
+You will probably want to install a node version manager. [nvm](https://github.com/creationix/nvm) is recommended.
+
+To install and use the correct node version with `nvm`:
+
+```
+nvm install
+```
+
+### Development environment
+
+You can run the dev environment locally at [http://localhost:9001](http://localhost:9001/) by running:
+
+```
+yarn
+yarn start
+```
+
+We use [storybook](https://storybook.js.org) to document API, edge-cases, and the usage of the library.
+A hosted version is available at [https://elastic.github.io/elastic-charts][docs].
+
+## Goals
+
+The primary goal of this library is to provide reusable set of chart components that can be used throughout Elastic's web products.
+As a single source of truth, the framework allows our designers to make changes to our look-and-feel directly in the code. And unit test coverage for the charts components allows us to deliver a stable "API for charts".
+
 ## Contributing
 
-We are trying to enforce some good practices in this library:
+You can find documentation around creating and submitting new features in [CONTRIBUTING.md][contributing].
 
-- All commits must follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
-- [semantic-release](https://semantic-release.gitbook.io) is used as an automated release manager suite.
-  This will automatically publish on NPM on every push on master, will automatically create the changelog and bump the correct semver depending on the commits. To avoid too many new releases, especially in this initial phase of the project, we are going to work against a `dev` branch and then merge on master periodically.
-- Every commit count in the version bump: this means that we can merge a PR with two methods:
-  - merge all the PR commit history (please follow the commit convention or squash partial commits)
-  - squash and merge all commits using a single commit that follows the conventions.
+## Wiki
 
-The following tools are used to ensure this convention:
+### Consumption
 
-- `commitlint` hook ensure that you are following correctly the convention
-- `yarn cz` can be used to start `commitizen` as a cli tool that prompts you with selections and questions
-  to help you in writing a conventional commit
-- `commitlint-bot` is a github app that checks PR commits to help you on writing the correct commit message (not currently enabled on github)
+- [Consuming Elastic Charts][consuming]
 
-## Concepts
+### Documentation
 
-### Axes
-
-The concept of an axis in this library follow the following constraints:
-
-- there is no distinction between x-axis or y-axis.
-- the distinction is between the position of the axis on the chart (top, bottom, left, or right) in relation to the rotation of the chart: A standard horizontal bar chart with a Y axis (for a dependent variable whose values rise to the top) can be supported by left and right axis that will show the Y values, and the bottom and top axes will show the X axis for an independent variable. In contrast, a 90-degree (clockwise-rotated) bar chart, with Y values that spread from left to right, will have a horizontal (bottom/top) axis that shows the Y independent variable and the left/right vertical axis that shows the X variable.
-
-As a constraint, we allow only one X-axis, but we provide the ability to add multiple Y-axes (also if it's a discouraged practice (see https://blog.datawrapper.de/dualaxis/ or http://www.storytellingwithdata.com/blog/2016/2/1/be-gone-dual-y-axis)).
-
-### Dataset Domains:
-
-Related to a dataset is the extent of a variable. It usually used to draw the position of the specific value/datum along one axis (vertical or horizontal).
-On a series chart, we always need to have at least two domains, representing the 2 dimensions of the data we are drawing.
-
-### Data
-
-It's an array of values, that will be used to compute the chart. Usually, each element must have at least 2 values to be charted. Multiple values can be used to specify how we want to split the chart by series and by y values.
-
-Examples of datasets:
-
-```ts
-// 1 metric (y) and no groups/split series ===> 1 single series
-const BARCHART_1Y0G = [{ x: 0, y: 1 }, { x: 1, y: 2 }, { x: 2, y: 10 }, { x: 3, y: 6 }];
-
-// 2 metrics (2y) and 1 group/split series ===> 4 different data series
-const BARCHART_2Y1G = [
-  { x: 0, g: 'a', y1: 1, y2: 4 },
-  { x: 0, g: 'b', y1: 3, y2: 6 },
-  { x: 1, g: 'a', y1: 2, y2: 1 },
-  { x: 1, g: 'b', y1: 2, y2: 5 },
-  { x: 2, g: 'a', y1: 10, y2: 5 },
-  { x: 2, g: 'b', y1: 3, y2: 1 },
-  { x: 3, g: 'a', y1: 7, y2: 3 },
-  { x: 3, g: 'b', y1: 6, y2: 4 },
-];
-```
-
-These datasets can be used as input for any type of chart specification. These are the interfaces that make up a `BasicSpec` (some sort of abstract specification)
-
-```ts
-export interface SeriesSpec {
-  /* The ID of the spec, generated via getSpecId method */
-  id: SpecId;
-  /* The ID of the spec, generated via getGroupId method, default to __global__ */
-  groupId: GroupId;
-  /* An array of data */
-  data: Datum[];
-  /* If specified, it constrant the x domain to these values */
-  xDomain?: Domain;
-  /* If specified, it constrant the y Domain to these values */
-  yDomain?: Domain;
-  /* The type of series you are looking to render */
-  seriesType: 'bar' | 'line' | 'area' | 'basic';
-}
-
-export interface SeriesAccessors {
-  /* The field name of the x value on Datum object */
-  xAccessor: Accessor;
-  /* An array of field names one per y metric value */
-  yAccessors: Accessor[];
-  /* An array of fields thats indicates the datum series membership */
-  splitSeriesAccessors?: Accessor[];
-  /* An array of fields thats indicates the stack membership */
-  stackAccessors?: Accessor[];
-  /* An optional array of field name thats indicates the stack membership */
-  colorAccessors?: Accessor[];
-}
-
-export interface SeriesScales {
-  /* The x axis scale type */
-  xScaleType: ScaleType;
-  /* The y axis scale type */
-  yScaleType: ScaleContinuousType;
-  /** if true, the min y value is set to the minimum domain value, 0 otherwise */
-  yScaleToDataExtent: boolean;
-}
-```
-
-A `BarSeriesSpec` for example is the following union type:
-
-```ts
-export type BarSeriesSpec = SeriesSpec &
-  SeriesAccessors &
-  SeriesScales & {
-    seriesType: 'bar';
-  };
-```
-
-A chart can be feed with data in the following ways:
-
-- one series type specification with one `data` props configured.
-- a set of series types with `data` props configured. In these case the data arrays are merged together as the following rules:
-  - x values are merged together. If the chart has multiple different `xScaleType`s, the main x scale type is coerced to `ScaleType.Linear` if all the scales are continuous or to `ScaleType.Ordinal` if one scale type is ordinal. Also, a temporal scale is, in specific cases, coerced to linear, so be careful to configure correctly the scales.
-  - if there is a specified x domain on the spec, this is used as x domain for that series, and it's merged together with the existing x domains.
-  - specifications with `splitAccessors` are split into different series. Each specification is treated in a separated manner: if you have one chart with 3 series merged to one chart with 1 series, this results in a chart that has each x value split in two (the number of specification used, two charts) than on split is used to accommodate 3 series and the other to accommodate the remaining series. If you want to treat each series in the same way, split your chart before and create 4 different BarSeries specs, so that these are rendered evenly on the x-axis.
-  - bar, area, line series with a `stackAccessor` are stacked together each stacked above their respective group (areas with areas, bars with bars, lines with lines. You cannot mix stacking bars above lines above areas).
-  - bar series without `stackAccessors` are clustered together for the same x value
-  - area and line series, without `stackAccessors` are just drawn each one on their own layer (not stacked nor clustered).
-  - the y value is influenced by the following aspects:
-    - if there is a specified y domain on the spec, this is used as y domain for that series
-    - if no or only one y-axis is specified, each y value is treated as part of the same domain.
-    - if there is more than one y-axis (visible or not), the y domains are merged in respect of the same `groupId`. For e.g. two bar charts, and two y-axes, each for a spec, one per bar value. The rendered bar heights are independent of each other, because of the two axes.
-    - if the data are stacked or not. Stacked produce a rendering where the lower bottom of the chart is the previous series y value.
-
-On the current `Visualize Editor`, you can stack or cluster in the following cases:
-
-- when adding multiple Y values: each Y value can be stacked (every type) or clustered (only bars)
-- when splitting a series, each series can be stacked (every type) or clustered (only bars)
-
-### Multiple charts/Split charts/Small Multiples (phase 2)
-
-Small multiples are created using the `<SmallMultiples>` component, that takes multiple `<SplittedSeries>` component with the usual element inside. `<SplittedSeries>` can contain only `BarSeries` `AreaSeries` and `LineSeries` Axis and other configuration need to be configured outside the `SplittedSeries` element.
-
-In the case of small multiples, each `SplittedSeries` computes its own x and y domains. Then the x domains are merged and expanded. The same happens with the main Y domains; they are merged together.
-
-### Colors
-
-Each data series can have its own color.
-The color is assigned through the `colorAccessors` prop that specifies which data attributes are used to define the color,
-for example:
-
-- a dataset without any split accessor or fields that can be used to identify a color will have a single color.
-- a dataset that has 1 variable to split the dataset into 3 different series, will have 3 different colors if that variable is specified through the `colorAccessors`.
-- a dataset with 2 split variables, each with 3 different values (a dataset with 3 \* 2 series) will have 6 different colors if the two variables are defined in `colorAccessors`
-- a dataset with 2 split variables, each with 3 different values, but only one specified in the `colorAccessors` will have only 3 colors.
-- if no `colorAccessors` is specified, `splitAccessors` will be used to identify how to coloring the series
-
+- [Overview][overview]
+- [Theming][theming]
 
 ## License
 
-[Apache Licensed.][license] Read the [FAQ][faq] for details.
+[Apache Licensed][license]. Read the [FAQ][faq] for details.
 
 [license]: LICENSE.md
 [faq]: FAQ.md
+[docs]: https://elastic.github.io/elastic-charts/
+[consuming]: wiki/consuming.md
+[overview]: wiki/overview.md
+[theming]: wiki/theming.md
+[contributing]: CONTRIBUTING.md

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:ts": "tsc -p ./tsconfig.json",
     "build:sass": "node-sass src/index.scss dist/style.css  --output-style compressed",
     "build": "yarn build:clean && yarn build:ts && yarn build:sass",
-    "start": "webpack-dev-server --open --config webpack.dev.js",
+    "start": "yarn storybook",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "storybook:build": "rm -rf .out && build-storybook -c .storybook -o .out",
     "lint": "yarn build:ts --noEmit && tslint -c ./tslint.yaml -p ./tsconfig.json",
@@ -46,6 +46,8 @@
     "@babel/core": "^7.2.2",
     "@commitlint/cli": "^7.4.0",
     "@commitlint/config-conventional": "^7.3.1",
+    "@elastic/eui": "^6.10.0",
+    "@elastic/datemath": "^5.0.2",
     "@semantic-release/changelog": "^3.0.2",
     "@semantic-release/commit-analyzer": "^6.1.0",
     "@semantic-release/git": "^7.0.8",
@@ -89,6 +91,7 @@
     "html-webpack-template": "^6.2.0",
     "husky": "^1.3.1",
     "jest": "23",
+    "moment": "^2.23.0",
     "node-sass": "^4.11.0",
     "prettier": "1.15.3",
     "prettier-tslint": "^0.4.2",
@@ -106,8 +109,6 @@
     "webpack": "^4.29.2"
   },
   "dependencies": {
-    "@elastic/datemath": "^5.0.2",
-    "@elastic/eui": "^6.10.0",
     "classnames": "^2.2.6",
     "d3-array": "^2.0.3",
     "d3-collection": "^1.0.7",
@@ -119,7 +120,6 @@
     "luxon": "^1.10.0",
     "mobx": "^4.8.0",
     "mobx-react": "^5.4.3",
-    "moment": "^2.23.0",
     "newtype-ts": "^0.2.3",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
@@ -127,6 +127,11 @@
     "react-konva": "^16.7.1",
     "react-spring": "^7.2.8",
     "resize-observer-polyfill": "^1.5.1"
+  },
+  "peerDependencies": {
+    "@elastic/eui": "^6.10.0",
+    "@elastic/datemath": "^5.0.2",
+    "moment": "^2.23.0"
   },
   "config": {
     "commitizen": {

--- a/wiki/consuming.md
+++ b/wiki/consuming.md
@@ -10,11 +10,11 @@ import { Axis, BarSeries, Chart, getAxisId, getSpecId, Position, ScaleType } fro
 
 ## Requirements and dependencies
 
-Elastic Charts depends on EUI framework for styles and it's subsequent peer dependencies (`moment` and `@elastic/datemath`). These are already loaded in most Elastic repos, but make sure to install them if you are starting from scratch.
+Elastic Charts depends on EUI framework for styles and its subsequent peer dependencies (`moment` and `@elastic/datemath`). These are already loaded in most Elastic repos, but make sure to install them if you are starting from scratch.
 
 ## Using Elastic Charts in Kibana
 
-TTo use Elastic Charts code in Kibana, check if `@elastic/charts` packages is already configured as dependency in `package.json` and simply import the components you want.
+To use Elastic Charts code in Kibana, check if `@elastic/charts` packages is already configured as dependency in `package.json` and simply import the components you want.
 
 ## Using Elastic Charts in a standalone project
 

--- a/wiki/consuming.md
+++ b/wiki/consuming.md
@@ -1,0 +1,38 @@
+# Consuming Elastic Charts
+
+### Components
+
+You can import Chart components from the top-level Elastic Chart module.
+
+```js
+import { Axis, BarSeries, Chart, getAxisId, getSpecId, Position, ScaleType } from '@elastic/charts';
+```
+
+## Requirements and dependencies
+
+Elastic Charts depends on EUI framework for styles and it's subsequent peer dependencies (`moment` and `@elastic/datemath`). These are already loaded in most Elastic repos, but make sure to install them if you are starting from scratch.
+
+## Using Elastic Charts in Kibana
+
+TTo use Elastic Charts code in Kibana, check if `@elastic/charts` packages is already configured as dependency in `package.json` and simply import the components you want.
+
+## Using Elastic Charts in a standalone project
+
+You can consume Elastic Charts in standalone projects, such as plugins and prototypes.
+
+### Importing CSS
+
+You need to import the CSS to provide the correct theme styling for some of the EUI components we are using (legend and tooltips). In this case, you can use Webpack or another bundler to import the compiled EUI CSS and the Elastic Charts with the `style`,`css`, and `postcss` loaders.
+
+```js
+import '@elastic/eui/dist/eui_theme_dark.css';
+import '@elastic/charts/dist/style.css';
+```
+
+By default, EUI ships with a font stack that includes some outside, open source fonts. If your system is internet available you can include these by adding the following imports to your SCSS/CSS files, otherwise you'll need to bundle the physical fonts in your build. EUI will drop to System Fonts (which you may prefer) in their absence.
+
+```scss
+// index.scss
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:400,400i,700,700i');
+@import url('https://rsms.me/inter/inter-ui.css');
+```

--- a/wiki/overview.md
+++ b/wiki/overview.md
@@ -1,0 +1,201 @@
+# Elastic Charts overview
+
+## Rationale
+
+This library is a complete rewrite of the current vislib in Kibana and EUISeriesChart in EUI.
+The rationale behind this refactoring is the need for a testable and decoupled architecture for displaying data within charts. The current EUI implementation is based on ReactVis, which directly manipulates the data series inside components without a clear rendering pipeline and without a clean way to extend it. Some of the downsides of using ReactVis are:
+
+- the main chart component, before rendering children, looks at their props and recomputes them, injecting new props. Some configuration is accessed through references to children components.
+- the components are themselves SVG components that render bars, lines, and axes. The problem with this is that not all components can be rendered at the same time, but there is the need for a rendering pipeline to allow a correct placement for all the geometries, especially when we face the need for having auto-scaled axis dimensions.
+- the only way to test the chart is testing the resulting SVG component. If rendered through canvas the test can be only a visual regression test.
+- no possibility of manage x-indexing of elements
+
+## Rendering pipeline
+
+This new implementation revisits the concept of a charting library and tries to apply a unidirectional rendering flow to the concept of charting. The rendering flow is the following:
+
+![rendering-pipeline](https://user-images.githubusercontent.com/1421091/49724064-bba8cb80-fc68-11e8-8378-9d59b941f15d.png)
+
+This controlled flow allows us to achieve the following points:
+
+- the computation of series dimensions (x and y domains of the datasets, for example) are required to precompute the space required for the axis labeling. Axis rendering is dependent on the axis displayed values, and thus on the data series provided. This is a required passage to accommodate automatically spaced axes . Other libraries just live the developer with the needs to specify static margin space to render the axis labels, and this can result in truncated labels.
+- put a testing probe just before rendering the chart, the computed geometries are the exact values that need to be used to render on SVG, canvas or WebGL on that exact portion of the screen. No further calculation is needed on the rendered component. x, y, width, height, color, and transforms are computed before the rendering phase.
+- reduce the rendering operation to the minimum required. Resizing, for example, will only require the last 3 phases to complete.
+- decouple the chart from its rendering medium: can be SVG, canvas or WebGL, using React or any other DOM library.
+- part of this computation can also be processed server side or on a WebWorker.
+
+The rendering pipeline is achieved by revisiting the way a chart library is built. Instead of creating a chart library around a set of rendering components: bar series, axis etc., this new implementation decouples the specification of the chart from the rendering components. The rendering components are part of the internals of the library. We are exposing `empty` react components to the developer, using the JSX format just as a declarative language to describe the specification of your chart and not as a set of real react components that will render something.
+That is achieved using the following render function on the main `Chart` component:
+
+```jsx
+<Provider chartStore={this.chartSpecStore}>
+  <Fragment>
+    <SpecsParser>{this.props.children}</SpecsParser>
+    <ChartResizer />
+    {renderer === 'svg' && <SVGChart />}
+    {renderer === 'canvas' && <CanvasChart />}
+    {renderer === 'canvas_native' && <NativeChart />}
+    <Tooltips />
+  </Fragment>
+</Provider>
+```
+
+Where all the children passed are rendered inside the `SpecsParser`, that signal a state manager that we are updating the specification of the chart, but doesn't render anything.
+The actual rendering is done by one of the rendered like the `ReactChart` that is rendered after the rendering pipeline produced and saved the geometries on the state manager.
+
+A spec can be something like the following:
+
+```jsx
+<Chart renderer={renderer}>
+  <Settings rotation={rotation} animateData={true} />
+  <Axis id={getAxisId('bottom')} position={AxisPosition.Bottom} title={`Rendering test`} />
+  <Axis id={getAxisId('left')} position={AxisPosition.Left} />
+  <LineSeries
+    id={getSpecId('1')}
+    yScaleType={ScaleType.Linear}
+    xScaleType={ScaleType.Linear}
+    xAccessor="x"
+    yAccessors={['y']}
+    data={BARCHART_1Y0G}
+  />
+  <BarSeries
+    id={getSpecId('2')}
+    yScaleType={ScaleType.Linear}
+    xScaleType={ScaleType.Linear}
+    xAccessor="x"
+    yAccessors={['y1', 'y2']}
+    splitSeriesAccessors={['g']}
+    stackAccessors={['x', 'g']}
+    data={BARCHART_2Y1G}
+  />
+</Chart>
+```
+
+## General concepts
+
+### Axes
+
+The concept of an axis in this library follow the following constraints:
+
+- there is no distinction between x-axis or y-axis.
+- the distinction is between the position of the axis on the chart (top, bottom, left, or right) in relation to the rotation of the chart: A standard horizontal bar chart with a Y axis (for a dependent variable whose values rise to the top) can be supported by left and right axis that will show the Y values, and the bottom and top axes will show the X axis for an independent variable. In contrast, a 90-degree (clockwise-rotated) bar chart, with Y values that spread from left to right, will have a horizontal (bottom/top) axis that shows the Y independent variable and the left/right vertical axis that shows the X variable.
+
+As a constraint, we allow only one X-axis, but we provide the ability to add multiple Y-axes (also if it's a discouraged practice (see https://blog.datawrapper.de/dualaxis/ or http://www.storytellingwithdata.com/blog/2016/2/1/be-gone-dual-y-axis)).
+
+### Dataset Domains
+
+Related to a dataset is the extent of a variable. It usually used to draw the position of the specific value/datum along one axis (vertical or horizontal).
+On a series chart, we always need to have at least two domains, representing the 2 dimensions of the data we are drawing.
+
+### Data
+
+It's an array of values, that will be used to compute the chart. Usually, each element must have at least 2 values to be charted. Multiple values can be used to specify how we want to split the chart by series and by y values.
+
+Examples of datasets:
+
+```ts
+// 1 metric (y) and no groups/split series ===> 1 single series
+const BARCHART_1Y0G = [{ x: 0, y: 1 }, { x: 1, y: 2 }, { x: 2, y: 10 }, { x: 3, y: 6 }];
+
+// 2 metrics (2y) and 1 group/split series ===> 4 different data series
+const BARCHART_2Y1G = [
+  { x: 0, g: 'a', y1: 1, y2: 4 },
+  { x: 0, g: 'b', y1: 3, y2: 6 },
+  { x: 1, g: 'a', y1: 2, y2: 1 },
+  { x: 1, g: 'b', y1: 2, y2: 5 },
+  { x: 2, g: 'a', y1: 10, y2: 5 },
+  { x: 2, g: 'b', y1: 3, y2: 1 },
+  { x: 3, g: 'a', y1: 7, y2: 3 },
+  { x: 3, g: 'b', y1: 6, y2: 4 },
+];
+```
+
+These datasets can be used as input for any type of chart specification. These are the interfaces that make up a `BasicSpec` (some sort of abstract specification)
+
+```ts
+export interface SeriesSpec {
+  /* The ID of the spec, generated via getSpecId method */
+  id: SpecId;
+  /* The ID of the spec, generated via getGroupId method, default to __global__ */
+  groupId: GroupId;
+  /* An array of data */
+  data: Datum[];
+  /* If specified, it constrant the x domain to these values */
+  xDomain?: Domain;
+  /* If specified, it constrant the y Domain to these values */
+  yDomain?: Domain;
+  /* The type of series you are looking to render */
+  seriesType: 'bar' | 'line' | 'area' | 'basic';
+}
+
+export interface SeriesAccessors {
+  /* The field name of the x value on Datum object */
+  xAccessor: Accessor;
+  /* An array of field names one per y metric value */
+  yAccessors: Accessor[];
+  /* An array of fields thats indicates the datum series membership */
+  splitSeriesAccessors?: Accessor[];
+  /* An array of fields thats indicates the stack membership */
+  stackAccessors?: Accessor[];
+  /* An optional array of field name thats indicates the stack membership */
+  colorAccessors?: Accessor[];
+}
+
+export interface SeriesScales {
+  /* The x axis scale type */
+  xScaleType: ScaleType;
+  /* The y axis scale type */
+  yScaleType: ScaleContinuousType;
+  /** if true, the min y value is set to the minimum domain value, 0 otherwise */
+  yScaleToDataExtent: boolean;
+}
+```
+
+A `BarSeriesSpec` for example is the following union type:
+
+```ts
+export type BarSeriesSpec = SeriesSpec &
+  SeriesAccessors &
+  SeriesScales & {
+    seriesType: 'bar';
+  };
+```
+
+A chart can be feed with data in the following ways:
+
+- one series type specification with one `data` props configured.
+- a set of series types with `data` props configured. In these case the data arrays are merged together as the following rules:
+  - x values are merged together. If the chart has multiple different `xScaleType`s, the main x scale type is coerced to `ScaleType.Linear` if all the scales are continuous or to `ScaleType.Ordinal` if one scale type is ordinal. Also, a temporal scale is, in specific cases, coerced to linear, so be careful to configure correctly the scales.
+  - if there is a specified x domain on the spec, this is used as x domain for that series, and it's merged together with the existing x domains.
+  - specifications with `splitAccessors` are split into different series. Each specification is treated in a separated manner: if you have one chart with 3 series merged to one chart with 1 series, this results in a chart that has each x value split in two (the number of specification used, two charts) than on split is used to accommodate 3 series and the other to accommodate the remaining series. If you want to treat each series in the same way, split your chart before and create 4 different BarSeries specs, so that these are rendered evenly on the x-axis.
+  - bar, area, line series with a `stackAccessor` are stacked together each stacked above their respective group (areas with areas, bars with bars, lines with lines. You cannot mix stacking bars above lines above areas).
+  - bar series without `stackAccessors` are clustered together for the same x value
+  - area and line series, without `stackAccessors` are just drawn each one on their own layer (not stacked nor clustered).
+  - the y value is influenced by the following aspects:
+    - if there is a specified y domain on the spec, this is used as y domain for that series
+    - if no or only one y-axis is specified, each y value is treated as part of the same domain.
+    - if there is more than one y-axis (visible or not), the y domains are merged in respect of the same `groupId`. For e.g. two bar charts, and two y-axes, each for a spec, one per bar value. The rendered bar heights are independent of each other, because of the two axes.
+    - if the data are stacked or not. Stacked produce a rendering where the lower bottom of the chart is the previous series y value.
+
+On the current `Visualize Editor`, you can stack or cluster in the following cases:
+
+- when adding multiple Y values: each Y value can be stacked (every type) or clustered (only bars)
+- when splitting a series, each series can be stacked (every type) or clustered (only bars)
+
+### Multiple charts/Split charts/Small Multiples (phase 2)
+
+Small multiples are created using the `<SmallMultiples>` component, that takes multiple `<SplittedSeries>` component with the usual element inside. `<SplittedSeries>` can contain only `BarSeries` `AreaSeries` and `LineSeries` Axis and other configuration need to be configured outside the `SplittedSeries` element.
+
+In the case of small multiples, each `SplittedSeries` computes its own x and y domains. Then the x domains are merged and expanded. The same happens with the main Y domains; they are merged together.
+
+### Colors
+
+Each data series can have its own color.
+The color is assigned through the `colorAccessors` prop that specifies which data attributes are used to define the color,
+for example:
+
+- a dataset without any split accessor or fields that can be used to identify a color will have a single color.
+- a dataset that has 1 variable to split the dataset into 3 different series, will have 3 different colors if that variable is specified through the `colorAccessors`.
+- a dataset with 2 split variables, each with 3 different values (a dataset with 3 \* 2 series) will have 6 different colors if the two variables are defined in `colorAccessors`
+- a dataset with 2 split variables, each with 3 different values, but only one specified in the `colorAccessors` will have only 3 colors.
+- if no `colorAccessors` is specified, `splitAccessors` will be used to identify how to coloring the series

--- a/wiki/theming.md
+++ b/wiki/theming.md
@@ -1,0 +1,34 @@
+## How Elastic Charts theming works
+
+Elastic Charts can be easily themed by creating a JSON object with the same shape of the existing [Theme](https://github.com/elastic/elastic-charts/tree/master/src/lib/themes/theme.ts) interface. Currently we maintain the following themes:
+
+- LIGHT_THEME (the default Elastic Chart theme)
+- DARK_THEME (the same theme in dark)
+
+Each of these themes simply include a series of variables that adjust colors, sizing and styles to fit the needs of that theme.
+
+## How to create and test a theme
+
+### Create a new theme
+
+1. Copy one theme from `src/lib/themes/` directory and tweak it variables.
+2. Pass it to the `Setting` component:
+
+   ```
+   <Setting theme={customTheme} />
+   ```
+
+### Extend an existing one
+
+1. Create a JSON object that respect the `PartialTheme` interface.
+2. Merge your partial theme with one of the existing one to be sure to create a valid `Theme` object:
+
+   ```
+   const customTheme = mergeWithDefaultTheme(partialTheme, existingTheme);
+   ```
+
+3. Pass it to the `Setting` component:
+
+   ```
+   <Setting theme={customTheme} />
+   ```


### PR DESCRIPTION
With this PR I'm introducing a better `README` plus various markdown files that describes some how-tos on the charts.
I've added the following:
- `wiki/consuming.md` to describe how to use the chart library on your own project
- `wiki/overview.md` where I moved the overview from the `README`
- `wiki/theming.md` where I described briefly how to theme a chart
- `CONTRIBUTING.md` where I moved the contributing part from the `README`

I've updated the `README` with a better installation and run.

I've also updated the `package.json` moving external dependencies like EUI and it's peers as peers dependencies.