### PR TITLE
test(chart_state): fill in missing coverage

### DIFF
--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -146,4 +146,11 @@ describe('Chart Store', () => {
 
     expect(store.tooltipPosition.get()).toEqual(position);
   });
+
+  test('can set legend visibility', () => {
+    store.showLegend.set(false);
+    store.setShowLegend(true);
+
+    expect(store.showLegend.get()).toEqual(true);
+  });
 });

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -269,4 +269,34 @@ describe('Chart Store', () => {
     store.xScale = undefined;
     expect(store.isBrushEnabled()).toBe(false);
   });
+
+  test('can update parent dimensions', () => {
+    const computeChart = jest.fn((): void => { return; });
+    store.computeChart = computeChart;
+
+    store.parentDimensions = {
+      width: 10,
+      height: 20,
+      top: 5,
+      left: 15,
+    };
+
+    store.updateParentDimensions(10, 20, 5, 15);
+    expect(store.parentDimensions).toEqual({
+      width: 10,
+      height: 20,
+      top: 5,
+      left: 15,
+    });
+    expect(computeChart).not.toBeCalled();
+
+    store.updateParentDimensions(15, 25, 10, 20);
+    expect(store.parentDimensions).toEqual({
+      width: 15,
+      height: 25,
+      top: 10,
+      left: 20,
+    });
+    expect(computeChart).toBeCalled();
+  });
 });

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -139,4 +139,11 @@ describe('Chart Store', () => {
     store.onOutElement();
     expect(mockFn).toBeCalled();
   });
+
+  test('can set tooltip position', () => {
+    const position = { x: 10, y: 20 };
+    store.setTooltipPosition(position.x, position.y);
+
+    expect(store.tooltipPosition.get()).toEqual(position);
+  });
 });

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -209,4 +209,18 @@ describe('Chart Store', () => {
 
     expect(outListener.mock.calls.length).toBe(1);
   });
+
+  test('can set an element click listener', () => {
+    const clickListener = (value: GeometryValue): void => { return; };
+    store.setOnElementClickListener(clickListener);
+
+    expect(store.onElementClickListener).toEqual(clickListener);
+  });
+
+  test('can set a brush end listener', () => {
+    const brushEndListener = (min: number, max: number): void => { return; };
+    store.setOnBrushEndListener(brushEndListener);
+
+    expect(store.onBrushEndListener).toEqual(brushEndListener);
+  });
 });

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -125,4 +125,18 @@ describe('Chart Store', () => {
     expect(store.showTooltip.get()).toBe(true);
     expect(mockFn).toBeCalled();
   });
+
+  test('can respond to mouseout event', () => {
+    store.showTooltip.set(true);
+
+    store.onOutElement();
+    expect(store.showTooltip.get()).toBe(false);
+
+    const mockFn = jest.fn();
+    const onOutListener = (): undefined => { mockFn(); return undefined; };
+    store.setOnElementOutListener(onOutListener);
+
+    store.onOutElement();
+    expect(mockFn).toBeCalled();
+  });
 });

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -299,4 +299,28 @@ describe('Chart Store', () => {
     });
     expect(computeChart).toBeCalled();
   });
+
+  test('can remove a series spec', () => {
+    store.addSeriesSpec(spec);
+    store.removeSeriesSpec(SPEC_ID);
+    expect(store.seriesSpecs.get(SPEC_ID)).toBe(undefined);
+  });
+
+  test('can remove an axis spec', () => {
+    const axisSpec: AxisSpec = {
+      id: AXIS_ID,
+      groupId: GROUP_ID,
+      hide: false,
+      showOverlappingTicks: false,
+      showOverlappingLabels: false,
+      position: Position.Left,
+      tickSize: 30,
+      tickPadding: 10,
+      tickFormat: (value: any) => `value ${value}`,
+    };
+
+    store.addAxisSpec(axisSpec);
+    store.removeAxisSpec(AXIS_ID);
+    expect(store.axesSpecs.get(AXIS_ID)).toBe(undefined);
+  });
 });

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -191,6 +191,12 @@ describe('Chart Store', () => {
     store.setOnLegendItemOverListener(legendListener);
     store.onLegendItemOver(1);
     expect(legendListener).toBeCalledWith(secondLegendItem.value);
+
+    store.onLegendItemOver(-1);
+    expect(legendListener).toBeCalledWith(null);
+
+    store.onLegendItemOver(3);
+    expect(legendListener).toBeCalledWith(null);
   });
 
   test('can respond to legend item mouseout event', () => {

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -250,10 +250,11 @@ describe('Chart Store', () => {
     store.onBrushEnd(start, end1);
     expect(brushEndListener).not.toBeCalled();
 
+    store.setOnBrushEndListener(brushEndListener);
+
     store.onBrushEnd(start, start);
     expect(brushEndListener).not.toBeCalled();
 
-    store.setOnBrushEndListener(brushEndListener);
     store.onBrushEnd(start, end1);
     expect(brushEndListener.mock.calls[0][0]).toEqual(0.9426386233269598);
     expect(brushEndListener.mock.calls[0][1]).toEqual(1.5162523900573615);

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -1,8 +1,8 @@
+import { GeometryValue } from '../lib/series/rendering';
 import { AxisSpec, BarSeriesSpec, Position } from '../lib/series/specs';
 import { getAxisId, getGroupId, getSpecId } from '../lib/utils/ids';
 import { ScaleType } from '../lib/utils/scales/scales';
 import { ChartStore, TooltipData } from './chart_state';
-import { GeometryValue } from '../lib/series/rendering';
 
 describe('Chart Store', () => {
   const mockedRect = {
@@ -152,5 +152,29 @@ describe('Chart Store', () => {
     store.setShowLegend(true);
 
     expect(store.showLegend.get()).toEqual(true);
+  });
+
+  test('can get highlighted legend item', () => {
+    const firstLegendItem = {
+      color: 'foo', label: 'bar', value: {
+        specId: SPEC_ID,
+        colorValues: [],
+      },
+    };
+
+    const secondLegendItem = {
+      color: 'baz', label: 'qux', value: {
+        specId: SPEC_ID,
+        colorValues: [],
+      },
+    };
+
+    store.legendItems = [firstLegendItem, secondLegendItem];
+
+    store.highlightedLegendItemIndex.set(null);
+    expect(store.highlightedLegendItem.get()).toBe(null);
+
+    store.highlightedLegendItemIndex.set(1);
+    expect(store.highlightedLegendItem.get()).toEqual(secondLegendItem);
   });
 });

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -223,4 +223,18 @@ describe('Chart Store', () => {
 
     expect(store.onBrushEndListener).toEqual(brushEndListener);
   });
+
+  test('can remove listeners', () => {
+    store.removeElementClickListener();
+    expect(store.onElementClickListener).toEqual(undefined);
+
+    store.removeElementOverListener();
+    expect(store.onElementOverListener).toEqual(undefined);
+
+    store.removeElementOutListener();
+    expect(store.onElementOutListener).toEqual(undefined);
+
+    store.removeOnLegendItemOverListener();
+    expect(store.onLegendItemOverListener).toEqual(undefined);
+  });
 });

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -323,4 +323,18 @@ describe('Chart Store', () => {
     store.removeAxisSpec(AXIS_ID);
     expect(store.axesSpecs.get(AXIS_ID)).toBe(undefined);
   });
+
+  test('only computes chart if parent dimensions are computed', () => {
+    const localStore = new ChartStore();
+
+    localStore.parentDimensions = {
+      width: 0,
+      height: 0,
+      top: 0,
+      left: 0,
+    };
+
+    localStore.computeChart();
+    expect(localStore.initialized.get()).toBe(false);
+  });
 });

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -201,7 +201,7 @@ export class ChartStore {
     this.highlightedLegendItemIndex.set(legendItemIndex);
     if (this.onLegendItemOverListener) {
       const currentLegendItem = this.highlightedLegendItem.get();
-      const listenerData = currentLegendItem ? currentLegendItem.value : null;
+      const listenerData = currentLegendItem!.value;
       this.onLegendItemOverListener(listenerData);
     }
   });

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -198,10 +198,15 @@ export class ChartStore {
   });
 
   onLegendItemOver = action((legendItemIndex: number) => {
-    this.highlightedLegendItemIndex.set(legendItemIndex);
+    if (legendItemIndex >= this.legendItems.length || legendItemIndex < 0) {
+      this.highlightedLegendItemIndex.set(null);
+    } else {
+      this.highlightedLegendItemIndex.set(legendItemIndex);
+    }
+
     if (this.onLegendItemOverListener) {
       const currentLegendItem = this.highlightedLegendItem.get();
-      const listenerData = currentLegendItem!.value;
+      const listenerData = currentLegendItem ? currentLegendItem.value : null;
       this.onLegendItemOverListener(listenerData);
     }
   });


### PR DESCRIPTION
## Summary

This PR adds test coverage for the chart_state functions, bringing test coverage up to nearly 100% (there is 100% coverage of functions, but still a few branches and statements not covered).  The remaining missing coverage items reveal opportunities for refactoring the `computeChart` function to be a more pure function, so they are not addressed here but are left with the hope that our idea to refactor this will also lend itself to making these remaining states easier to test (see https://github.com/elastic/elastic-charts/issues/75).

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
~~- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials~~
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
