### PR TITLE
test(axis_utils,scales,theme): fill in missing coverage

### DIFF
--- a/src/components/react_canvas/grid.tsx
+++ b/src/components/react_canvas/grid.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { Group, Line } from 'react-konva';
-import {
-  AxisLinePosition, mergeWithDefaultGridLineConfig,
-} from '../../lib/axes/axis_utils';
-import { DEFAULT_GRID_LINE_CONFIG, GridLineConfig } from '../../lib/themes/theme';
+import { AxisLinePosition } from '../../lib/axes/axis_utils';
+import { DEFAULT_GRID_LINE_CONFIG, GridLineConfig, mergeWithDefaultGridLineConfig } from '../../lib/themes/theme';
 import { Dimensions } from '../../lib/utils/dimensions';
 
 interface GridProps {

--- a/src/lib/axes/axis_utils.test.ts
+++ b/src/lib/axes/axis_utils.test.ts
@@ -14,12 +14,14 @@ import {
   getAxisTicksPositions,
   getHorizontalAxisGridLineProps,
   getHorizontalAxisTickLineProps,
+  getHorizontalDomain,
   getMaxBboxDimensions,
   getMinMaxRange,
   getScaleForAxisSpec,
   getTickLabelProps,
   getVerticalAxisGridLineProps,
   getVerticalAxisTickLineProps,
+  getVerticalDomain,
   getVisibleTicks,
 } from './axis_utils';
 import { CanvasTextBBoxCalculator } from './canvas_text_bbox_calculator';
@@ -910,5 +912,15 @@ describe('Axis computational utils', () => {
 
     const horizontalAxisGridLines = computeAxisGridLinePositions(false, 25, chartDim);
     expect(horizontalAxisGridLines).toEqual([25, 0, 25, 100]);
+  });
+
+  test('should return correct domain based on rotation', () => {
+    const chartRotation = 180;
+    expect(getHorizontalDomain(xDomain, [yDomain], chartRotation)).toEqual(xDomain);
+    expect(getVerticalDomain(xDomain, [yDomain], chartRotation)).toEqual([yDomain]);
+
+    const skewChartRotation = 45;
+    expect(getHorizontalDomain(xDomain, [yDomain], skewChartRotation)).toEqual([yDomain]);
+    expect(getVerticalDomain(xDomain, [yDomain], skewChartRotation)).toEqual(xDomain);
   });
 });

--- a/src/lib/axes/axis_utils.test.ts
+++ b/src/lib/axes/axis_utils.test.ts
@@ -384,6 +384,23 @@ describe('Axis computational utils', () => {
       align: 'center',
       verticalAlign: 'middle',
     });
+
+    tickLabelRotation = 0;
+    const rightUnrotatedLabelProps = getTickLabelProps(
+      tickLabelRotation,
+      tickSize,
+      tickPadding,
+      tickPosition,
+      axisPosition,
+      axis1Dims,
+    );
+
+    expect(rightUnrotatedLabelProps).toEqual({
+      x: 15,
+      y: -5,
+      align: 'left',
+      verticalAlign: 'middle',
+    });
   });
 
   test('should compute positions and alignment of tick labels along a horizontal axis', () => {
@@ -441,6 +458,23 @@ describe('Axis computational utils', () => {
       y: 15,
       align: 'center',
       verticalAlign: 'middle',
+    });
+
+    tickLabelRotation = 0;
+    const bottomUnrotatedLabelProps = getTickLabelProps(
+      tickLabelRotation,
+      tickSize,
+      tickPadding,
+      tickPosition,
+      axisPosition,
+      axis1Dims,
+    );
+
+    expect(bottomUnrotatedLabelProps).toEqual({
+      x: -5,
+      y: 15,
+      align: 'center',
+      verticalAlign: 'top',
     });
   });
 

--- a/src/lib/axes/axis_utils.test.ts
+++ b/src/lib/axes/axis_utils.test.ts
@@ -78,6 +78,20 @@ describe('Axis computational utils', () => {
     },
   };
 
+  const horizontalAxisSpec = {
+    id: getAxisId('axis_2'),
+    groupId: getGroupId('group_1'),
+    hide: false,
+    showOverlappingTicks: false,
+    showOverlappingLabels: false,
+    position: Position.Top,
+    tickSize: 10,
+    tickPadding: 10,
+    tickFormat: (value: any) => {
+      return `${value}`;
+    },
+  };
+
   const xDomain: XDomain = {
     type: 'xDomain',
     scaleType: ScaleType.Linear,
@@ -108,6 +122,22 @@ describe('Axis computational utils', () => {
       axes,
     );
     expect(axisDimensions).toEqual(axis1Dims);
+
+    const computeScalelessSpec = () => {
+      computeAxisTicksDimensions(
+        ungroupedAxisSpec,
+        xDomain,
+        [yDomain],
+        1,
+        bboxCalculator,
+        0,
+        axes,
+      );
+    };
+
+    const ungroupedAxisSpec = { ...verticalAxisSpec, groupId: getGroupId('foo') };
+    expect(computeScalelessSpec).toThrowError('Cannot compute scale for axis spec axis_1');
+
     bboxCalculator.destroy();
   });
 
@@ -127,12 +157,19 @@ describe('Axis computational utils', () => {
   });
 
   test('should generate a valid scale', () => {
-    const scale = getScaleForAxisSpec(verticalAxisSpec, xDomain, [yDomain], 0, 0, 100, 0);
-    expect(scale).toBeDefined();
-    expect(scale!.bandwidth).toBe(0);
-    expect(scale!.domain).toEqual([0, 1]);
-    expect(scale!.range).toEqual([100, 0]);
-    expect(scale!.ticks()).toEqual([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]);
+    const yScale = getScaleForAxisSpec(verticalAxisSpec, xDomain, [yDomain], 0, 0, 100, 0);
+    expect(yScale).toBeDefined();
+    expect(yScale!.bandwidth).toBe(0);
+    expect(yScale!.domain).toEqual([0, 1]);
+    expect(yScale!.range).toEqual([100, 0]);
+    expect(yScale!.ticks()).toEqual([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]);
+
+    const ungroupedAxisSpec = { ...verticalAxisSpec, groupId: getGroupId('foo') };
+    const nullYScale = getScaleForAxisSpec(ungroupedAxisSpec, xDomain, [yDomain], 0, 0, 100, 0);
+    expect(nullYScale).toBe(null);
+
+    const xScale = getScaleForAxisSpec(horizontalAxisSpec, xDomain, [yDomain], 0, 0, 100, 0);
+    expect(xScale).toBeDefined();
   });
 
   test('should compute available ticks', () => {

--- a/src/lib/axes/axis_utils.test.ts
+++ b/src/lib/axes/axis_utils.test.ts
@@ -11,16 +11,16 @@ import {
   getAvailableTicks,
   getHorizontalAxisGridLineProps,
   getHorizontalAxisTickLineProps,
+  getMaxBboxDimensions,
   getMinMaxRange,
   getScaleForAxisSpec,
   getTickLabelProps,
   getVerticalAxisGridLineProps,
   getVerticalAxisTickLineProps,
   getVisibleTicks,
-  getMaxBboxDimensions,
 } from './axis_utils';
-import { SvgTextBBoxCalculator } from './svg_text_bbox_calculator';
 import { CanvasTextBBoxCalculator } from './canvas_text_bbox_calculator';
+import { SvgTextBBoxCalculator } from './svg_text_bbox_calculator';
 
 // const chartScalesConfig: ScalesConfig = {
 //   ordinal: {
@@ -266,23 +266,14 @@ describe('Axis computational utils', () => {
     });
     expect(minMax).toEqual({ minRange: 0, maxRange: 100 });
   });
-  test('should compute min max range for on 90 deg Left', () => {
-    const minMax = getMinMaxRange(Position.Left, 90, {
+  test('should compute min max range for on 90 deg bottom', () => {
+    const minMax = getMinMaxRange(Position.Bottom, 90, {
       width: 100,
       height: 50,
       top: 0,
       left: 0,
     });
-    expect(minMax).toEqual({ minRange: 0, maxRange: 50 });
-  });
-  test('should compute min max range for on -90 deg Right', () => {
-    const minMax = getMinMaxRange(Position.Bottom, -90, {
-      width: 100,
-      height: 50,
-      top: 0,
-      left: 0,
-    });
-    expect(minMax).toEqual({ minRange: 100, maxRange: 0 });
+    expect(minMax).toEqual({ minRange: 0, maxRange: 100 });
   });
   test('should compute min max range for on 180 deg bottom', () => {
     const minMax = getMinMaxRange(Position.Bottom, 180, {
@@ -293,8 +284,43 @@ describe('Axis computational utils', () => {
     });
     expect(minMax).toEqual({ minRange: 100, maxRange: 0 });
   });
-
-  test('should get max bbox dimensions for a set of ticks', () => {
+  test('should compute min max range for on -90 deg bottom', () => {
+    const minMax = getMinMaxRange(Position.Bottom, -90, {
+      width: 100,
+      height: 50,
+      top: 0,
+      left: 0,
+    });
+    expect(minMax).toEqual({ minRange: 100, maxRange: 0 });
+  });
+  test('should compute min max range for on 90 deg Left', () => {
+    const minMax = getMinMaxRange(Position.Left, 90, {
+      width: 100,
+      height: 50,
+      top: 0,
+      left: 0,
+    });
+    expect(minMax).toEqual({ minRange: 0, maxRange: 50 });
+  });
+  test('should compute min max range for on 180 deg Left', () => {
+    const minMax = getMinMaxRange(Position.Left, 180, {
+      width: 100,
+      height: 50,
+      top: 0,
+      left: 0,
+    });
+    expect(minMax).toEqual({ minRange: 0, maxRange: 50 });
+  });
+  test('should compute min max range for on -90 deg Right', () => {
+    const minMax = getMinMaxRange(Position.Right, -90, {
+      width: 100,
+      height: 50,
+      top: 0,
+      left: 0,
+    });
+    expect(minMax).toEqual({ minRange: 50, maxRange: 0 });
+  });
+  test('should get max bbox dimensions for a tick in comparison to previous values', () => {
     const bboxCalculator = new CanvasTextBBoxCalculator();
     const reducer = getMaxBboxDimensions(bboxCalculator, 16, 'Arial', 0);
 

--- a/src/lib/axes/axis_utils.test.ts
+++ b/src/lib/axes/axis_utils.test.ts
@@ -50,12 +50,6 @@ describe('Axis computational utils', () => {
   );
   afterEach(() => (SVGElement.prototype.getBoundingClientRect = originalGetBBox));
 
-  const chartDim = {
-    width: 100,
-    height: 100,
-    top: 0,
-    left: 0,
-  };
   const axis1Dims = {
     axisScaleType: ScaleType.Linear,
     axisScaleDomain: [0, 1],
@@ -192,7 +186,7 @@ describe('Axis computational utils', () => {
     ];
     expect(axisPositions).toEqual(expectedAxisPositions);
   });
-  test('should compute visible ticks', () => {
+  test('should compute visible ticks for a vertical axis', () => {
     const allTicks = [
       { label: '0', position: 100, value: 0 },
       { label: '0.1', position: 90, value: 0.1 },
@@ -206,8 +200,24 @@ describe('Axis computational utils', () => {
       { label: '0.9', position: 10, value: 0.9 },
       { label: '1', position: 0, value: 1 },
     ];
-    const visibleTicks = getVisibleTicks(allTicks, verticalAxisSpec, axis1Dims, chartDim, 0);
+    const visibleTicks = getVisibleTicks(allTicks, verticalAxisSpec, axis1Dims);
     const expectedVisibleTicks = [
+      { label: '1', position: 0, value: 1 },
+      { label: '0.9', position: 10, value: 0.9 },
+      { label: '0.8', position: 20, value: 0.8 },
+      { label: '0.7', position: 30, value: 0.7 },
+      { label: '0.6', position: 40, value: 0.6 },
+      { label: '0.5', position: 50, value: 0.5 },
+      { label: '0.4', position: 60, value: 0.4 },
+      { label: '0.3', position: 70, value: 0.3 },
+      { label: '0.2', position: 80, value: 0.2 },
+      { label: '0.1', position: 90, value: 0.1 },
+      { label: '0', position: 100, value: 0 },
+    ];
+    expect(visibleTicks).toEqual(expectedVisibleTicks);
+  });
+  test('should compute visible ticks for a horizontal axis', () => {
+    const allTicks = [
       { label: '0', position: 100, value: 0 },
       { label: '0.1', position: 90, value: 0.1 },
       { label: '0.2', position: 80, value: 0.2 },
@@ -220,6 +230,21 @@ describe('Axis computational utils', () => {
       { label: '0.9', position: 10, value: 0.9 },
       { label: '1', position: 0, value: 1 },
     ];
+    const visibleTicks = getVisibleTicks(allTicks, horizontalAxisSpec, axis1Dims);
+    const expectedVisibleTicks = [
+      { label: '1', position: 0, value: 1 },
+      { label: '0.9', position: 10, value: 0.9 },
+      { label: '0.8', position: 20, value: 0.8 },
+      { label: '0.7', position: 30, value: 0.7 },
+      { label: '0.6', position: 40, value: 0.6 },
+      { label: '0.5', position: 50, value: 0.5 },
+      { label: '0.4', position: 60, value: 0.4 },
+      { label: '0.3', position: 70, value: 0.3 },
+      { label: '0.2', position: 80, value: 0.2 },
+      { label: '0.1', position: 90, value: 0.1 },
+      { label: '0', position: 100, value: 0 },
+    ];
+
     expect(visibleTicks).toEqual(expectedVisibleTicks);
   });
   test('should hide some ticks', () => {
@@ -246,16 +271,77 @@ describe('Axis computational utils', () => {
       maxLabelTextWidth: 10,
       maxLabelTextHeight: 20,
     };
-    const visibleTicks = getVisibleTicks(allTicks, verticalAxisSpec, axis2Dims, chartDim, 0);
+    const visibleTicks = getVisibleTicks(allTicks, verticalAxisSpec, axis2Dims);
     const expectedVisibleTicks = [
-      { label: '0', position: 100, value: 0 },
-      { label: '0.2', position: 80, value: 0.2 },
-      { label: '0.4', position: 60, value: 0.4 },
-      { label: '0.6', position: 40, value: 0.6 },
-      { label: '0.8', position: 20, value: 0.8 },
       { label: '1', position: 0, value: 1 },
+      { label: '0.8', position: 20, value: 0.8 },
+      { label: '0.6', position: 40, value: 0.6 },
+      { label: '0.4', position: 60, value: 0.4 },
+      { label: '0.2', position: 80, value: 0.2 },
+      { label: '0', position: 100, value: 0 },
     ];
     expect(visibleTicks).toEqual(expectedVisibleTicks);
+  });
+  test('should show all overlapping ticks and labels if configured to', () => {
+    const allTicks = [
+      { label: '0', position: 100, value: 0 },
+      { label: '0.1', position: 90, value: 0.1 },
+      { label: '0.2', position: 80, value: 0.2 },
+      { label: '0.3', position: 70, value: 0.3 },
+      { label: '0.4', position: 60, value: 0.4 },
+      { label: '0.5', position: 50, value: 0.5 },
+      { label: '0.6', position: 40, value: 0.6 },
+      { label: '0.7', position: 30, value: 0.7 },
+      { label: '0.8', position: 20, value: 0.8 },
+      { label: '0.9', position: 10, value: 0.9 },
+      { label: '1', position: 0, value: 1 },
+    ];
+    const axis2Dims = {
+      axisScaleType: ScaleType.Linear,
+      axisScaleDomain: [0, 1],
+      tickValues: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1],
+      tickLabels: ['0', '0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1'],
+      maxLabelBboxWidth: 10,
+      maxLabelBboxHeight: 20,
+      maxLabelTextWidth: 10,
+      maxLabelTextHeight: 20,
+    };
+
+    verticalAxisSpec.showOverlappingTicks = true;
+    verticalAxisSpec.showOverlappingLabels = true;
+    const visibleOverlappingTicks = getVisibleTicks(allTicks, verticalAxisSpec, axis2Dims);
+    const expectedVisibleOverlappingTicks = [
+      { label: '1', position: 0, value: 1 },
+      { label: '0.9', position: 10, value: 0.9 },
+      { label: '0.8', position: 20, value: 0.8 },
+      { label: '0.7', position: 30, value: 0.7 },
+      { label: '0.6', position: 40, value: 0.6 },
+      { label: '0.5', position: 50, value: 0.5 },
+      { label: '0.4', position: 60, value: 0.4 },
+      { label: '0.3', position: 70, value: 0.3 },
+      { label: '0.2', position: 80, value: 0.2 },
+      { label: '0.1', position: 90, value: 0.1 },
+      { label: '0', position: 100, value: 0 },
+    ];
+    expect(visibleOverlappingTicks).toEqual(expectedVisibleOverlappingTicks);
+
+    verticalAxisSpec.showOverlappingTicks = true;
+    verticalAxisSpec.showOverlappingLabels = false;
+    const visibleOverlappingTicksAndLabels = getVisibleTicks(allTicks, verticalAxisSpec, axis2Dims);
+    const expectedVisibleOverlappingTicksAndLabels = [
+      { label: '1', position: 0, value: 1 },
+      { label: '', position: 10, value: 0.9 },
+      { label: '0.8', position: 20, value: 0.8 },
+      { label: '', position: 30, value: 0.7 },
+      { label: '0.6', position: 40, value: 0.6 },
+      { label: '', position: 50, value: 0.5 },
+      { label: '0.4', position: 60, value: 0.4 },
+      { label: '', position: 70, value: 0.3 },
+      { label: '0.2', position: 80, value: 0.2 },
+      { label: '', position: 90, value: 0.1 },
+      { label: '0', position: 100, value: 0 },
+    ];
+    expect(visibleOverlappingTicksAndLabels).toEqual(expectedVisibleOverlappingTicksAndLabels);
   });
   test('should compute min max range for on 0 deg bottom', () => {
     const minMax = getMinMaxRange(Position.Bottom, 0, {

--- a/src/lib/axes/axis_utils.test.ts
+++ b/src/lib/axes/axis_utils.test.ts
@@ -9,6 +9,8 @@ import {
   computeAxisTicksDimensions,
   computeRotatedLabelDimensions,
   getAvailableTicks,
+  getAxisPosition,
+  getAxisTicksPositions,
   getHorizontalAxisGridLineProps,
   getHorizontalAxisTickLineProps,
   getMaxBboxDimensions,
@@ -18,7 +20,6 @@ import {
   getVerticalAxisGridLineProps,
   getVerticalAxisTickLineProps,
   getVisibleTicks,
-  getAxisPosition,
 } from './axis_utils';
 import { CanvasTextBBoxCalculator } from './canvas_text_bbox_calculator';
 import { SvgTextBBoxCalculator } from './svg_text_bbox_calculator';
@@ -79,6 +80,7 @@ describe('Axis computational utils', () => {
     tickFormat: (value: any) => {
       return `${value}`;
     },
+    showGridLines: true,
   };
 
   const horizontalAxisSpec = {
@@ -815,5 +817,89 @@ describe('Axis computational utils', () => {
     };
 
     expect(bottomAxisPosition).toEqual(expectedBottomAxisPosition);
+  });
+
+  test('should compute axis ticks positions', () => {
+    const chartRotation = 0;
+    const showLegend = true;
+    const leftLegendPosition = Position.Left;
+    const topLegendPosition = Position.Top;
+
+    const axisSpecs = new Map();
+    axisSpecs.set(verticalAxisSpec.id, verticalAxisSpec);
+
+    const axisDims = new Map();
+    axisDims.set(verticalAxisSpec.id, axis1Dims);
+
+    const axisTicksPosition = getAxisTicksPositions(
+      chartDim,
+      LIGHT_THEME,
+      chartRotation,
+      showLegend,
+      axisSpecs,
+      axisDims,
+      xDomain,
+      [yDomain],
+      1,
+      leftLegendPosition,
+    );
+
+    const expectedVerticalAxisGridLines = [
+      [0, 0, 100, 0],
+      [0, 10, 100, 10],
+      [0, 20, 100, 20],
+      [0, 30, 100, 30],
+      [0, 40, 100, 40],
+      [0, 50, 100, 50],
+      [0, 60, 100, 60],
+      [0, 70, 100, 70],
+      [0, 80, 100, 80],
+      [0, 90, 100, 90],
+      [0, 100, 100, 100],
+    ];
+
+    expect(axisTicksPosition.axisGridLinesPositions.get(verticalAxisSpec.id)).toEqual(expectedVerticalAxisGridLines);
+
+    const axisTicksPositionWithTopLegend = getAxisTicksPositions(
+      chartDim,
+      LIGHT_THEME,
+      chartRotation,
+      showLegend,
+      axisSpecs,
+      axisDims,
+      xDomain,
+      [yDomain],
+      1,
+      topLegendPosition,
+    );
+
+    const expectedPositionWithTopLegend = {
+      height: 100,
+      width: 10,
+      left: 100,
+      top: 0,
+    };
+    const verticalAxisWithTopLegendPosition = axisTicksPositionWithTopLegend.axisPositions.get(verticalAxisSpec.id);
+    expect(verticalAxisWithTopLegendPosition).toEqual(expectedPositionWithTopLegend);
+
+    const ungroupedAxisSpec = { ...verticalAxisSpec, groupId: getGroupId('foo') };
+    const invalidSpecs = new Map();
+    invalidSpecs.set(verticalAxisSpec.id, ungroupedAxisSpec);
+    const computeScalelessSpec = () => {
+      getAxisTicksPositions(
+        chartDim,
+        LIGHT_THEME,
+        chartRotation,
+        showLegend,
+        invalidSpecs,
+        axisDims,
+        xDomain,
+        [yDomain],
+        1,
+        leftLegendPosition,
+      );
+    };
+
+    expect(computeScalelessSpec).toThrowError('Cannot compute scale for axis spec axis_1');
   });
 });

--- a/src/lib/axes/axis_utils.test.ts
+++ b/src/lib/axes/axis_utils.test.ts
@@ -18,6 +18,7 @@ import {
   getVerticalAxisGridLineProps,
   getVerticalAxisTickLineProps,
   getVisibleTicks,
+  getAxisPosition,
 } from './axis_utils';
 import { CanvasTextBBoxCalculator } from './canvas_text_bbox_calculator';
 import { SvgTextBBoxCalculator } from './svg_text_bbox_calculator';
@@ -50,6 +51,12 @@ describe('Axis computational utils', () => {
   );
   afterEach(() => (SVGElement.prototype.getBoundingClientRect = originalGetBBox));
 
+  const chartDim = {
+    width: 100,
+    height: 100,
+    top: 0,
+    left: 0,
+  };
   const axis1Dims = {
     axisScaleType: ScaleType.Linear,
     axisScaleDomain: [0, 1],
@@ -665,5 +672,148 @@ describe('Axis computational utils', () => {
     );
 
     expect(horizontalAxisGridLinePositions).toEqual([10, 0, 10, 200]);
+  });
+
+  test('should compute left axis position', () => {
+    const axisTitleHeight = 10;
+    const cumTopSum = 10;
+    const cumBottomSum = 10;
+    const cumLeftSum = 10;
+    const cumRightSum = 10;
+
+    const leftAxisPosition = getAxisPosition(
+      chartDim,
+      LIGHT_THEME.chartMargins,
+      axisTitleHeight,
+      verticalAxisSpec,
+      axis1Dims,
+      cumTopSum,
+      cumBottomSum,
+      cumLeftSum,
+      cumRightSum,
+    );
+
+    const expectedLeftAxisPosition = {
+      dimensions: {
+        height: 100,
+        width: 10,
+        left: 40,
+        top: 0,
+      },
+      topIncrement: 0,
+      bottomIncrement: 0,
+      leftIncrement: 50,
+      rightIncrement: 0,
+    };
+
+    expect(leftAxisPosition).toEqual(expectedLeftAxisPosition);
+  });
+
+  test('should compute right axis position', () => {
+    const axisTitleHeight = 10;
+    const cumTopSum = 10;
+    const cumBottomSum = 10;
+    const cumLeftSum = 10;
+    const cumRightSum = 10;
+
+    verticalAxisSpec.position = Position.Right;
+    const rightAxisPosition = getAxisPosition(
+      chartDim,
+      LIGHT_THEME.chartMargins,
+      axisTitleHeight,
+      verticalAxisSpec,
+      axis1Dims,
+      cumTopSum,
+      cumBottomSum,
+      cumLeftSum,
+      cumRightSum,
+    );
+
+    const expectedRightAxisPosition = {
+      dimensions: {
+        height: 100,
+        width: 10,
+        left: 110,
+        top: 0,
+      },
+      topIncrement: 0,
+      bottomIncrement: 0,
+      leftIncrement: 0,
+      rightIncrement: 50,
+    };
+
+    expect(rightAxisPosition).toEqual(expectedRightAxisPosition);
+  });
+
+  test('should compute top axis position', () => {
+    const axisTitleHeight = 10;
+    const cumTopSum = 10;
+    const cumBottomSum = 10;
+    const cumLeftSum = 10;
+    const cumRightSum = 10;
+
+    horizontalAxisSpec.position = Position.Top;
+    const topAxisPosition = getAxisPosition(
+      chartDim,
+      LIGHT_THEME.chartMargins,
+      axisTitleHeight,
+      horizontalAxisSpec,
+      axis1Dims,
+      cumTopSum,
+      cumBottomSum,
+      cumLeftSum,
+      cumRightSum,
+    );
+
+    const expectedTopAxisPosition = {
+      dimensions: {
+        height: 10,
+        width: 100,
+        left: 0,
+        top: 30,
+      },
+      topIncrement: 50,
+      bottomIncrement: 0,
+      leftIncrement: 0,
+      rightIncrement: 0,
+    };
+
+    expect(topAxisPosition).toEqual(expectedTopAxisPosition);
+  });
+
+  test('should compute bottom axis position', () => {
+    const axisTitleHeight = 10;
+    const cumTopSum = 10;
+    const cumBottomSum = 10;
+    const cumLeftSum = 10;
+    const cumRightSum = 10;
+
+    horizontalAxisSpec.position = Position.Bottom;
+    const bottomAxisPosition = getAxisPosition(
+      chartDim,
+      LIGHT_THEME.chartMargins,
+      axisTitleHeight,
+      horizontalAxisSpec,
+      axis1Dims,
+      cumTopSum,
+      cumBottomSum,
+      cumLeftSum,
+      cumRightSum,
+    );
+
+    const expectedBottomAxisPosition = {
+      dimensions: {
+        height: 10,
+        width: 100,
+        left: 0,
+        top: 110,
+      },
+      topIncrement: 0,
+      bottomIncrement: 50,
+      leftIncrement: 0,
+      rightIncrement: 0,
+    };
+
+    expect(bottomAxisPosition).toEqual(expectedBottomAxisPosition);
   });
 });

--- a/src/lib/axes/axis_utils.test.ts
+++ b/src/lib/axes/axis_utils.test.ts
@@ -17,8 +17,10 @@ import {
   getVerticalAxisGridLineProps,
   getVerticalAxisTickLineProps,
   getVisibleTicks,
+  getMaxBboxDimensions,
 } from './axis_utils';
 import { SvgTextBBoxCalculator } from './svg_text_bbox_calculator';
+import { CanvasTextBBoxCalculator } from './canvas_text_bbox_calculator';
 
 // const chartScalesConfig: ScalesConfig = {
 //   ordinal: {
@@ -290,6 +292,19 @@ describe('Axis computational utils', () => {
       left: 0,
     });
     expect(minMax).toEqual({ minRange: 100, maxRange: 0 });
+  });
+
+  test('should get max bbox dimensions for a set of ticks', () => {
+    const bboxCalculator = new CanvasTextBBoxCalculator();
+    const reducer = getMaxBboxDimensions(bboxCalculator, 16, 'Arial', 0);
+
+    const accWithGreaterValues = {
+      maxLabelBboxWidth: 100,
+      maxLabelBboxHeight: 100,
+      maxLabelTextWidth: 100,
+      maxLabelTextHeight: 100,
+    };
+    expect(reducer(accWithGreaterValues, 'foo')).toEqual(accWithGreaterValues);
   });
 
   test('should compute coordinates and offsets to anchor rotation origin from the center', () => {

--- a/src/lib/axes/axis_utils.test.ts
+++ b/src/lib/axes/axis_utils.test.ts
@@ -6,6 +6,7 @@ import { getAxisId, getGroupId } from '../utils/ids';
 import { ScaleType } from '../utils/scales/scales';
 import {
   centerRotationOrigin,
+  computeAxisGridLinePositions,
   computeAxisTicksDimensions,
   computeRotatedLabelDimensions,
   getAvailableTicks,
@@ -901,5 +902,13 @@ describe('Axis computational utils', () => {
     };
 
     expect(computeScalelessSpec).toThrowError('Cannot compute scale for axis spec axis_1');
+  });
+
+  test('should compute positions for grid lines', () => {
+    const verticalAxisGridLines = computeAxisGridLinePositions(true, 25, chartDim);
+    expect(verticalAxisGridLines).toEqual([0, 25, 100, 25]);
+
+    const horizontalAxisGridLines = computeAxisGridLinePositions(false, 25, chartDim);
+    expect(horizontalAxisGridLines).toEqual([25, 0, 25, 100]);
   });
 });

--- a/src/lib/axes/axis_utils.ts
+++ b/src/lib/axes/axis_utils.ts
@@ -523,13 +523,12 @@ export function getAxisTicksPositions(
   // let cumRightSum = chartConfig.paddings.right;
   axisDimensions.forEach((axisDim, id) => {
     const axisSpec = axisSpecs.get(id);
+
     if (!axisSpec) {
       return;
     }
     const minMaxRanges = getMinMaxRange(axisSpec.position, chartRotation, chartDimensions);
-    if (minMaxRanges === null) {
-      throw new Error(`cannot comput min and max ranges for spec ${axisSpec.id}`);
-    }
+
     const scale = getScaleForAxisSpec(
       axisSpec,
       xDomain,
@@ -541,6 +540,7 @@ export function getAxisTicksPositions(
       // minRange,
       // maxRange,
     );
+
     if (!scale) {
       throw new Error(`cannot compute scale for spec ${axisSpec.id}`);
     }

--- a/src/lib/axes/axis_utils.ts
+++ b/src/lib/axes/axis_utils.ts
@@ -90,7 +90,8 @@ export function getScaleForAxisSpec(
   maxRange: number,
 ): Scale | null {
   const axisDomain = getAxisDomain(axisSpec.position, xDomain, yDomain, chartRotation);
-  if (axisDomain && Array.isArray(axisDomain)) {
+  // If axisDomain is an array of values, this is an array of YDomains
+  if (Array.isArray(axisDomain)) {
     const yScales = computeYScales(yDomain, minRange, maxRange);
     if (yScales.has(axisSpec.groupId)) {
       return yScales.get(axisSpec.groupId)!;

--- a/src/lib/axes/axis_utils.ts
+++ b/src/lib/axes/axis_utils.ts
@@ -524,6 +524,8 @@ export function getAxisTicksPositions(
   axisDimensions.forEach((axisDim, id) => {
     const axisSpec = axisSpecs.get(id);
 
+    // Consider refactoring this so this condition can be tested
+    // Given some of the values that get passed around, maybe re-write as a reduce instead of forEach?
     if (!axisSpec) {
       return;
     }
@@ -542,7 +544,7 @@ export function getAxisTicksPositions(
     );
 
     if (!scale) {
-      throw new Error(`cannot compute scale for spec ${axisSpec.id}`);
+      throw new Error(`Cannot compute scale for axis spec ${axisSpec.id}`);
     }
 
     const allTicks = getAvailableTicks(axisSpec, scale, totalGroupsCount);

--- a/src/lib/axes/axis_utils.ts
+++ b/src/lib/axes/axis_utils.ts
@@ -563,7 +563,7 @@ export function getAxisTicksPositions(
     }
 
     const { fontSize, padding } = chartTheme.axes.axisTitleStyle;
-    const axisTitleHeight = (fontSize || 10) + (padding || 0);
+    const axisTitleHeight = fontSize + padding;
 
     const axisPosition = getAxisPosition(
       chartDimensions,

--- a/src/lib/axes/axis_utils.ts
+++ b/src/lib/axes/axis_utils.ts
@@ -595,7 +595,7 @@ export function getAxisTicksPositions(
   };
 }
 
-function computeAxisGridLinePositions(
+export function computeAxisGridLinePositions(
   isVerticalAxis: boolean,
   tickPosition: number,
   chartDimensions: Dimensions,

--- a/src/lib/axes/axis_utils.ts
+++ b/src/lib/axes/axis_utils.ts
@@ -607,7 +607,7 @@ export function computeAxisGridLinePositions(
   return positions;
 }
 
-function getVerticalDomain(
+export function getVerticalDomain(
   xDomain: XDomain,
   yDomain: YDomain[],
   chartRotation: number,
@@ -618,7 +618,8 @@ function getVerticalDomain(
     return xDomain;
   }
 }
-function getHorizontalDomain(
+
+export function getHorizontalDomain(
   xDomain: XDomain,
   yDomain: YDomain[],
   chartRotation: number,
@@ -630,7 +631,7 @@ function getHorizontalDomain(
   }
 }
 
-function getAxisDomain(
+export function getAxisDomain(
   position: Position,
   xDomain: XDomain,
   yDomain: YDomain[],

--- a/src/lib/axes/axis_utils.ts
+++ b/src/lib/axes/axis_utils.ts
@@ -2,7 +2,7 @@ import { XDomain } from '../series/domains/x_domain';
 import { YDomain } from '../series/domains/y_domain';
 import { computeXScale, computeYScales } from '../series/scales';
 import { AxisSpec, Position, Rotation, TickFormatter } from '../series/specs';
-import { AxisConfig, DEFAULT_GRID_LINE_CONFIG, GridLineConfig, Theme } from '../themes/theme';
+import { AxisConfig, Theme } from '../themes/theme';
 import { Dimensions, Margins } from '../utils/dimensions';
 import { Domain } from '../utils/domain';
 import { AxisId } from '../utils/ids';
@@ -310,15 +310,6 @@ export function getHorizontalAxisGridLineProps(
   chartHeight: number,
 ): AxisLinePosition {
   return [tickPosition, 0, tickPosition, chartHeight];
-}
-
-export function mergeWithDefaultGridLineConfig(config: GridLineConfig): GridLineConfig {
-  return {
-    stroke: config.stroke || DEFAULT_GRID_LINE_CONFIG.stroke,
-    strokeWidth: config.strokeWidth || DEFAULT_GRID_LINE_CONFIG.strokeWidth,
-    opacity: config.opacity || DEFAULT_GRID_LINE_CONFIG.opacity,
-    dash: config.dash || DEFAULT_GRID_LINE_CONFIG.dash,
-  };
 }
 
 export function getMinMaxRange(

--- a/src/lib/series/scales.test.ts
+++ b/src/lib/series/scales.test.ts
@@ -1,16 +1,18 @@
+import { getGroupId } from '../utils/ids';
 import { ScaleType } from '../utils/scales/scales';
 import { XDomain } from './domains/x_domain';
-import { computeXScale } from './scales';
+import { computeXScale, countClusteredSeries } from './scales';
 
 describe('Series scales', () => {
+  const xDomain: XDomain = {
+    type: 'xDomain',
+    isBandScale: true,
+    domain: [0, 3],
+    minInterval: 1,
+    scaleType: ScaleType.Linear,
+  };
+
   test('X Scale linear min, max with bands', () => {
-    const xDomain: XDomain = {
-      type: 'xDomain',
-      isBandScale: true,
-      domain: [0, 3],
-      minInterval: 1,
-      scaleType: ScaleType.Linear,
-    };
     const scale = computeXScale(xDomain, 1, 0, 120);
     const expectedBandwidth = 120 / 4;
     expect(scale.bandwidth).toBe(expectedBandwidth);
@@ -20,13 +22,6 @@ describe('Series scales', () => {
     expect(scale.scale(3)).toBe(expectedBandwidth * 3);
   });
   test('X Scale linear inverse min, max with bands', () => {
-    const xDomain: XDomain = {
-      type: 'xDomain',
-      isBandScale: true,
-      domain: [0, 3],
-      minInterval: 1,
-      scaleType: ScaleType.Linear,
-    };
     const scale = computeXScale(xDomain, 1, 120, 0);
     const expectedBandwidth = 120 / 4;
     expect(scale.bandwidth).toBe(expectedBandwidth);
@@ -34,5 +29,45 @@ describe('Series scales', () => {
     expect(scale.scale(1)).toBe(expectedBandwidth * 2);
     expect(scale.scale(2)).toBe(expectedBandwidth * 1);
     expect(scale.scale(3)).toBe(expectedBandwidth * 0);
+  });
+  it('should count clustered series', () => {
+    const group1 = getGroupId('group_1');
+    const nonStackedSeries = [{
+      groupId: group1,
+      dataSeries: [],
+      counts: {
+        barSeries: 1,
+        lineSeries: 1,
+        areaSeries: 1,
+        basicSeries: 1,
+      },
+    }];
+    const stackedSeries = [{
+      groupId: group1,
+      dataSeries: [],
+      counts: {
+        barSeries: 3,
+        lineSeries: 1,
+        areaSeries: 1,
+        basicSeries: 1,
+      },
+    }, {
+      groupId: group1,
+      dataSeries: [],
+      counts: {
+        barSeries: 0,
+        lineSeries: 1,
+        areaSeries: 1,
+        basicSeries: 1,
+      },
+    }];
+
+    const expectedCount = {
+      nonStackedGroupCount: 1,
+      stackedGroupCount: 1,
+      totalGroupCount: 2,
+    };
+    const numClusteredSeries = countClusteredSeries(stackedSeries, nonStackedSeries);
+    expect(numClusteredSeries).toEqual(expectedCount);
   });
 });

--- a/src/lib/series/scales.test.ts
+++ b/src/lib/series/scales.test.ts
@@ -4,7 +4,7 @@ import { XDomain } from './domains/x_domain';
 import { computeXScale, countClusteredSeries } from './scales';
 
 describe('Series scales', () => {
-  const xDomain: XDomain = {
+  const xDomainLinear: XDomain = {
     type: 'xDomain',
     isBandScale: true,
     domain: [0, 3],
@@ -12,8 +12,16 @@ describe('Series scales', () => {
     scaleType: ScaleType.Linear,
   };
 
-  test('X Scale linear min, max with bands', () => {
-    const scale = computeXScale(xDomain, 1, 0, 120);
+  const xDomainOrdinal: XDomain = {
+    type: 'xDomain',
+    isBandScale: true,
+    domain: ['a', 'b'],
+    minInterval: 1,
+    scaleType: ScaleType.Ordinal,
+  };
+
+  test('should compute X Scale linear min, max with bands', () => {
+    const scale = computeXScale(xDomainLinear, 1, 0, 120);
     const expectedBandwidth = 120 / 4;
     expect(scale.bandwidth).toBe(expectedBandwidth);
     expect(scale.scale(0)).toBe(expectedBandwidth * 0);
@@ -21,8 +29,9 @@ describe('Series scales', () => {
     expect(scale.scale(2)).toBe(expectedBandwidth * 2);
     expect(scale.scale(3)).toBe(expectedBandwidth * 3);
   });
-  test('X Scale linear inverse min, max with bands', () => {
-    const scale = computeXScale(xDomain, 1, 120, 0);
+
+  test('should compute X Scale linear inverse min, max with bands', () => {
+    const scale = computeXScale(xDomainLinear, 1, 120, 0);
     const expectedBandwidth = 120 / 4;
     expect(scale.bandwidth).toBe(expectedBandwidth);
     expect(scale.scale(0)).toBe(expectedBandwidth * 3);
@@ -30,7 +39,19 @@ describe('Series scales', () => {
     expect(scale.scale(2)).toBe(expectedBandwidth * 1);
     expect(scale.scale(3)).toBe(expectedBandwidth * 0);
   });
-  it('should count clustered series', () => {
+
+  test('should compute X Scale ordinal', () => {
+    const nonZeroGroupScale = computeXScale(xDomainOrdinal, 1, 120, 0);
+    const expectedBandwidth = 60;
+    expect(nonZeroGroupScale.bandwidth).toBe(expectedBandwidth);
+    expect(nonZeroGroupScale.scale('a')).toBe(expectedBandwidth);
+    expect(nonZeroGroupScale.scale('b')).toBe(0);
+
+    const zeroGroupScale = computeXScale(xDomainOrdinal, 0, 120, 0);
+    expect(zeroGroupScale.bandwidth).toBe(expectedBandwidth);
+  });
+
+  test('should count clustered series', () => {
     const group1 = getGroupId('group_1');
     const nonStackedSeries = [{
       groupId: group1,

--- a/src/lib/themes/theme.test.ts
+++ b/src/lib/themes/theme.test.ts
@@ -6,8 +6,10 @@ import {
   AxisConfig,
   BarSeriesStyle,
   ColorConfig,
+  DEFAULT_GRID_LINE_CONFIG,
   LegendStyle,
   LineSeriesStyle,
+  mergeWithDefaultGridLineConfig,
   mergeWithDefaultTheme,
   ScalesConfig,
   SharedGeometryStyle,
@@ -292,5 +294,16 @@ describe('Themes', () => {
       DARK_THEME,
     );
     expect(customDarkTheme.legend).toEqual(legend);
+  });
+
+  it('should merge partial grid line configs', () => {
+    const fullConfig = {
+      stroke: 'foo',
+      strokeWidth: 1,
+      opacity: 0,
+      dash: [0, 0],
+    };
+    expect(mergeWithDefaultGridLineConfig(fullConfig)).toEqual(fullConfig);
+    expect(mergeWithDefaultGridLineConfig({})).toEqual(DEFAULT_GRID_LINE_CONFIG);
   });
 });

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -110,6 +110,18 @@ export const DEFAULT_GRID_LINE_CONFIG: GridLineConfig = {
   opacity: 1,
 };
 
+export function mergeWithDefaultGridLineConfig(config: GridLineConfig): GridLineConfig {
+  const strokeWidth = config.strokeWidth != null ? config.strokeWidth : DEFAULT_GRID_LINE_CONFIG.strokeWidth;
+  const opacity = config.opacity != null ? config.opacity : DEFAULT_GRID_LINE_CONFIG.opacity;
+
+  return {
+    stroke: config.stroke || DEFAULT_GRID_LINE_CONFIG.stroke,
+    dash: config.dash || DEFAULT_GRID_LINE_CONFIG.dash,
+    strokeWidth,
+    opacity,
+  };
+}
+
 export function mergeWithDefaultTheme(
   theme: PartialTheme,
   defaultTheme: Theme = LIGHT_THEME,


### PR DESCRIPTION
## Summary

This PR fills in missing coverage for functions and branches in `axis_utils` and `series/scales`.  Going through this also revealed a few non-reachable code areas (due to impossible conditions), which were removed once it was determined that they were for sure non-reachable.  This also refactors the grid line config merge function, moving it into `theme` to be locatable along with other style-related code.

### Checklist

~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
~- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
