### PR TITLE
build(storybook): fix missing story source view

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = (baseConfig, env, config) => {
   });
   config.module.rules.push({
     test: /\.tsx?$/,
-    include: [path.resolve(__dirname, '../src/stories')],
+    include: [path.resolve(__dirname, '../stories')],
     loaders: [
       {
         loader: require.resolve('@storybook/addon-storysource/loader'),


### PR DESCRIPTION

## Summary

The story source was missing because of the folder change introduced in e1b3ddf

fix #71


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- ~[ ] Unit tests were updated or added to match the most common scenarios~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
