### PR TITLE
chore(csp): add CSP meta tag and nonce for styles

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,4 @@
+<meta
+  http-equiv="Content-Security-Policy"
+  content="default-src 'self'; style-src 'nonce-Pk1rZ1XDlMuYe8ubWV3Lh0BzwrTigJQ='"
+/>

--- a/.storybook/theme_service.ts
+++ b/.storybook/theme_service.ts
@@ -1,7 +1,8 @@
+/* tslint:disable */
 // @ts-ignore
-import themeDark from '!!style-loader/useable!css-loader!@elastic/eui/dist/eui_theme_dark.css';
+import themeDark from '!!style-loader/useable?{attrs:{"nonce":"Pk1rZ1XDlMuYe8ubWV3Lh0BzwrTigJQ="}}!css-loader!@elastic/eui/dist/eui_theme_dark.css';
 // @ts-ignore
-import themeLight from '!!style-loader/useable!css-loader!@elastic/eui/dist/eui_theme_light.css';
+import themeLight from '!!style-loader/useable?{attrs:{"nonce":"Pk1rZ1XDlMuYe8ubWV3Lh0BzwrTigJQ="}}!css-loader!@elastic/eui/dist/eui_theme_light.css';
 
 export function switchTheme(theme: string) {
   switch (theme) {

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -35,6 +35,11 @@ module.exports = (baseConfig, env, config) => {
     use: [
       {
         loader: 'style-loader',
+        options: {
+          attrs: {
+            nonce: 'Pk1rZ1XDlMuYe8ubWV3Lh0BzwrTigJQ=',
+          },
+        },
       },
       {
         loader: 'css-loader',


### PR DESCRIPTION
## Summary
close #97

This adds a Content Security Policy to the Elastic Charts docs for testing our compatibility against a strict setup.

We are currently using the following rules:
`default-src 'self' style-src 'nonce-Pk1rZ1XDlMuYe8ubWV3Lh0BzwrTigJQ='`

The nonce is for the dynamic loading of our chart style and the EUI CSS styls - this is otherwise handled by a consuming application (Cloud, Kibana).

We currently have two main CSP broken rules that are here bacause we depends on EUI https://github.com/elastic/eui/pull/1472 :
- react-ace (inline styles)
- color picker (Refused to load the image `'<URL>'`)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- ~[ ] Unit tests were updated or added to match the most common scenarios~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
