### PR TITLE
fix(chart): fix duplicated keys for chart elements

### DIFF
--- a/src/components/react_canvas/area_geometries.tsx
+++ b/src/components/react_canvas/area_geometries.tsx
@@ -5,6 +5,7 @@ import { animated, Spring } from 'react-spring/renderprops-konva';
 import { LegendItem } from '../../lib/series/legend';
 import { AreaGeometry, getGeometryStyle, PointGeometry } from '../../lib/series/rendering';
 import { AreaSeriesStyle, SharedGeometryStyle } from '../../lib/themes/theme';
+import { GlobalKonvaElementProps } from './globals';
 
 interface AreaGeometriesDataProps {
   animated?: boolean;
@@ -52,18 +53,18 @@ export class AreaGeometries extends React.PureComponent<
       [] as JSX.Element[],
     );
   }
-  private renderPoints = (areaPoints: PointGeometry[], i: number): JSX.Element[] => {
+  private renderPoints = (areaPoints: PointGeometry[], areaIndex: number): JSX.Element[] => {
     const { radius, stroke, strokeWidth, opacity } = this.props.style.point;
 
     return areaPoints.map((areaPoint, index) => {
       const { x, y, color, transform } = areaPoint;
       if (this.props.animated) {
         return (
-          <Group key={`area-point-group-${i}-${index}`} x={transform.x}>
+          <Group key={`area-point-group-${areaIndex}-${index}`} x={transform.x}>
             <Spring native from={{ y }} to={{ y }}>
               {(props: { y: number }) => (
                 <animated.Circle
-                  key={`area-point-${index}`}
+                  key={`area-point-${areaIndex}-${index}`}
                   x={x}
                   y={y}
                   radius={radius}
@@ -72,9 +73,7 @@ export class AreaGeometries extends React.PureComponent<
                   stroke={color}
                   fill={'white'}
                   opacity={opacity}
-                  strokeHitEnabled={false}
-                  listening={false}
-                  perfectDrawEnabled={false}
+                  {...GlobalKonvaElementProps}
                 />
               )}
             </Spring>
@@ -83,7 +82,7 @@ export class AreaGeometries extends React.PureComponent<
       } else {
         return (
           <Circle
-            key={`area-point-${index}`}
+            key={`area-point-${areaIndex}-${index}`}
             x={transform.x + x}
             y={y}
             radius={radius}
@@ -91,9 +90,7 @@ export class AreaGeometries extends React.PureComponent<
             stroke={stroke}
             fill={color}
             opacity={opacity}
-            strokeHitEnabled={false}
-            listening={false}
-            perfectDrawEnabled={false}
+            {...GlobalKonvaElementProps}
           />
         );
       }
@@ -119,6 +116,7 @@ export class AreaGeometries extends React.PureComponent<
                   lineCap="round"
                   lineJoin="round"
                   opacity={opacity}
+                  {...GlobalKonvaElementProps}
                 />
               )}
             </Spring>
@@ -133,6 +131,7 @@ export class AreaGeometries extends React.PureComponent<
             opacity={opacity}
             lineCap="round"
             lineJoin="round"
+            {...GlobalKonvaElementProps}
           />
         );
       }
@@ -157,14 +156,14 @@ export class AreaGeometries extends React.PureComponent<
             <Spring native from={{ line }} to={{ line }}>
               {(props: { line: string }) => (
                 <animated.Path
-                  key={`line-${i}`}
+                  key={`area-line-${i}`}
                   data={props.line}
                   stroke={color}
                   strokeWidth={strokeWidth}
-                  listening={false}
                   lineCap="round"
                   lineJoin="round"
                   {...geometryStyle}
+                  {...GlobalKonvaElementProps}
                 />
               )}
             </Spring>
@@ -172,7 +171,13 @@ export class AreaGeometries extends React.PureComponent<
         );
       } else {
         return (
-          <Path key={`line-${i}`} data={line} fill={color} listening={false} {...geometryStyle} />
+          <Path
+            key={`area-line-${i}`}
+            data={line}
+            fill={color}
+            {...geometryStyle}
+            {...GlobalKonvaElementProps}
+          />
         );
       }
     });

--- a/src/components/react_canvas/bar_geometries.tsx
+++ b/src/components/react_canvas/bar_geometries.tsx
@@ -5,6 +5,7 @@ import { animated, Spring } from 'react-spring/renderprops-konva';
 import { LegendItem } from '../../lib/series/legend';
 import { BarGeometry, getGeometryStyle } from '../../lib/series/rendering';
 import { BarSeriesStyle, SharedGeometryStyle } from '../../lib/themes/theme';
+import { GlobalKonvaElementProps } from './globals';
 
 interface BarGeometriesDataProps {
   animated?: boolean;
@@ -81,7 +82,7 @@ export class BarGeometries extends React.PureComponent<
                   strokeWidth={border.strokeWidth}
                   stroke={border.stroke}
                   strokeEnabled={borderEnabled}
-                  perfectDrawEnabled={true}
+                  {...GlobalKonvaElementProps}
                   {...geometryStyle}
                 />
               )}
@@ -100,7 +101,7 @@ export class BarGeometries extends React.PureComponent<
             strokeWidth={border.strokeWidth}
             stroke={border.stroke}
             strokeEnabled={borderEnabled}
-            perfectDrawEnabled={false}
+            {...GlobalKonvaElementProps}
             {...geometryStyle}
           />
         );

--- a/src/components/react_canvas/globals.ts
+++ b/src/components/react_canvas/globals.ts
@@ -1,0 +1,7 @@
+import { ShapeConfig } from 'konva';
+
+export const GlobalKonvaElementProps: ShapeConfig = {
+  strokeHitEnabled: false,
+  perfectDrawEnabled: false,
+  listening: false,
+};

--- a/src/components/react_canvas/line_geometries.tsx
+++ b/src/components/react_canvas/line_geometries.tsx
@@ -5,6 +5,7 @@ import { animated, Spring } from 'react-spring/renderprops-konva';
 import { LegendItem } from '../../lib/series/legend';
 import { getGeometryStyle, LineGeometry, PointGeometry } from '../../lib/series/rendering';
 import { LineSeriesStyle, SharedGeometryStyle } from '../../lib/themes/theme';
+import { GlobalKonvaElementProps } from './globals';
 
 interface LineGeometriesDataProps {
   animated?: boolean;
@@ -55,7 +56,7 @@ export class LineGeometries extends React.PureComponent<
   }
 
   private renderPoints = (linePoints: PointGeometry[], i: number): JSX.Element[] => {
-    const { radius, stroke, strokeWidth, opacity } = this.props.style.point;
+    const { radius, strokeWidth, opacity } = this.props.style.point;
 
     return linePoints.map((areaPoint, index) => {
       const { x, y, color, transform } = areaPoint;
@@ -69,14 +70,12 @@ export class LineGeometries extends React.PureComponent<
                   x={x}
                   y={y}
                   radius={radius}
+                  stroke={color}
                   strokeWidth={strokeWidth}
                   strokeEnabled={strokeWidth !== 0}
-                  stroke={color}
                   fill={'white'}
                   opacity={opacity}
-                  strokeHitEnabled={false}
-                  listening={false}
-                  perfectDrawEnabled={false}
+                  {...GlobalKonvaElementProps}
                 />
               )}
             </Spring>
@@ -89,13 +88,12 @@ export class LineGeometries extends React.PureComponent<
             x={transform.x + x}
             y={y}
             radius={radius}
+            stroke={color}
             strokeWidth={strokeWidth}
-            stroke={stroke}
-            fill={color}
+            strokeEnabled={strokeWidth !== 0}
+            fill={'white'}
             opacity={opacity}
-            strokeHitEnabled={false}
-            listening={false}
-            perfectDrawEnabled={false}
+            {...GlobalKonvaElementProps}
           />
         );
       }
@@ -120,15 +118,15 @@ export class LineGeometries extends React.PureComponent<
             <Spring native reset from={{ opacity: 0 }} to={{ opacity: 1 }}>
               {(props: { opacity: number }) => (
                 <animated.Path
-                  opacity={props.opacity}
-                  key="line"
+                  key={`line-${i}`}
                   data={line}
-                  strokeWidth={strokeWidth}
                   stroke={color}
-                  listening={false}
+                  strokeWidth={strokeWidth}
+                  opacity={props.opacity}
                   lineCap="round"
                   lineJoin="round"
                   {...geometryStyle}
+                  {...GlobalKonvaElementProps}
                 />
               )}
             </Spring>
@@ -137,14 +135,14 @@ export class LineGeometries extends React.PureComponent<
       } else {
         return (
           <Path
-            key={i}
+            key={`line-${i}`}
             data={line}
-            strokeWidth={strokeWidth}
             stroke={color}
-            listening={false}
+            strokeWidth={strokeWidth}
             lineCap="round"
             lineJoin="round"
             {...geometryStyle}
+            {...GlobalKonvaElementProps}
           />
         );
       }

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -299,7 +299,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
           }}
           {...brushProps}
         >
-          <Layer hitGraphEnabled={false} {...gridClippings}>
+          <Layer hitGraphEnabled={false} listening={false} {...gridClippings}>
             {this.renderGrids()}
           </Layer>
 
@@ -315,14 +315,18 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
             {this.renderAreaSeries()}
             {this.renderLineSeries()}
           </Layer>
-          <Layer hitGraphEnabled={false}>{debug && this.renderDebugChartBorders()}</Layer>
+          <Layer hitGraphEnabled={false} listening={false}>
+            {debug && this.renderDebugChartBorders()}
+          </Layer>
           {isBrushEnabled && (
             <Layer hitGraphEnabled={false} listening={false}>
               {this.renderBrushTool()}
             </Layer>
           )}
 
-          <Layer hitGraphEnabled={false}>{this.renderAxes()}</Layer>
+          <Layer hitGraphEnabled={false} listening={false}>
+            {this.renderAxes()}
+          </Layer>
         </Stage>
       </div>
     );


### PR DESCRIPTION
## Summary

This PR will fix errors caused by duplicated react element keys in line and area chart.
It also move 3 global properties used on Konva elements to a global object.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
