### PR TITLE
fix(chart_state): maintain series visibility state on props update

### DIFF
--- a/src/lib/series/legend.test.ts
+++ b/src/lib/series/legend.test.ts
@@ -134,33 +134,33 @@ describe('Legends', () => {
     ];
     expect(Array.from(legend.values())).toEqual(expected);
   });
-  it('sets all series legend items to visible when selectedDataSeries is null', () => {
+  it('default all series legend items to visible when deselectedDataSeries is null', () => {
     seriesColor.set('colorSeries1a', colorValues1a);
     seriesColor.set('colorSeries1b', colorValues1b);
     seriesColor.set('colorSeries2a', colorValues2a);
     seriesColor.set('colorSeries2b', colorValues2b);
 
     const emptyColorMap = new Map<string, string>();
-    const selectedDataSeries = null;
+    const deselectedDataSeries = null;
 
-    const legend = computeLegend(seriesColor, emptyColorMap, specs, 'violet', selectedDataSeries);
+    const legend = computeLegend(seriesColor, emptyColorMap, specs, 'violet', deselectedDataSeries);
 
     const visibility = [...legend.values()].map((item) => item.isVisible);
 
     expect(visibility).toEqual([true, true, true, true]);
   });
-  it('selectively sets series to visible when there are selectedDataSeries items', () => {
+  it('selectively sets series to visible when there are deselectedDataSeries items', () => {
     seriesColor.set('colorSeries1a', colorValues1a);
     seriesColor.set('colorSeries1b', colorValues1b);
     seriesColor.set('colorSeries2a', colorValues2a);
     seriesColor.set('colorSeries2b', colorValues2b);
 
     const emptyColorMap = new Map<string, string>();
-    const selectedDataSeries = [colorValues1a, colorValues1b];
+    const deselectedDataSeries = [colorValues1a, colorValues1b];
 
-    const legend = computeLegend(seriesColor, emptyColorMap, specs, 'violet', selectedDataSeries);
+    const legend = computeLegend(seriesColor, emptyColorMap, specs, 'violet', deselectedDataSeries);
 
     const visibility = [...legend.values()].map((item) => item.isVisible);
-    expect(visibility).toEqual([true, true, false, false]);
+    expect(visibility).toEqual([false, false, true, true]);
   });
 });

--- a/src/lib/series/legend.ts
+++ b/src/lib/series/legend.ts
@@ -1,4 +1,4 @@
-import { findSelectedDataSeries } from '../../state/utils';
+import { findDataSeriesByColorValues } from '../../state/utils';
 import { SpecId } from '../utils/ids';
 import { DataSeriesColorsValues } from './series';
 import { BasicSeriesSpec } from './specs';
@@ -15,7 +15,7 @@ export function computeLegend(
   seriesColorMap: Map<string, string>,
   specs: Map<SpecId, BasicSeriesSpec>,
   defaultColor: string,
-  selectedDataSeries?: DataSeriesColorsValues[] | null,
+  deselectedDataSeries?: DataSeriesColorsValues[] | null,
 ): Map<string, LegendItem> {
   const legendItems: Map<string, LegendItem> = new Map();
   seriesColor.forEach((series, key) => {
@@ -24,8 +24,8 @@ export function computeLegend(
     const color = seriesColorMap.get(key) || defaultColor;
     const hasSingleSeries = seriesColor.size === 1;
     const label = getSeriesColorLabel(series, hasSingleSeries, spec);
-    const isVisible = selectedDataSeries
-      ? findSelectedDataSeries(selectedDataSeries, series) > -1
+    const isVisible = deselectedDataSeries
+      ? findDataSeriesByColorValues(deselectedDataSeries, series) < 0
       : true;
 
     if (!label) {

--- a/src/lib/series/series.test.ts
+++ b/src/lib/series/series.test.ts
@@ -278,7 +278,7 @@ describe('Series', () => {
     expectedCustomizedColorMap.set('spec1', 'custom_color');
     expect(customizedColorMap).toEqual(expectedCustomizedColorMap);
   });
-  test('should only include selectedDataSeries when splitting series if selectedDataSeries is defined', () => {
+  test('should only include deselectedDataSeries when splitting series if deselectedDataSeries is defined', () => {
     const seriesSpecs = new Map<SpecId, BasicSeriesSpec>();
     const specId = getSpecId('splitSpec');
 
@@ -300,14 +300,14 @@ describe('Series', () => {
     const allSeries = getSplittedSeries(seriesSpecs, null);
     expect(allSeries.splittedSeries.get(specId)!.length).toBe(2);
 
-    const emptySplit = getSplittedSeries(seriesSpecs, []);
-    expect(emptySplit.splittedSeries.get(specId)!.length).toBe(0);
+    const emptyDeselected = getSplittedSeries(seriesSpecs, []);
+    expect(emptyDeselected.splittedSeries.get(specId)!.length).toBe(2);
 
-    const selectedDataSeries: DataSeriesColorsValues[] = [{
+    const deselectedDataSeries: DataSeriesColorsValues[] = [{
       specId,
       colorValues: ['y1'],
     }];
-    const subsetSplit = getSplittedSeries(seriesSpecs, selectedDataSeries);
+    const subsetSplit = getSplittedSeries(seriesSpecs, deselectedDataSeries);
     expect(subsetSplit.splittedSeries.get(specId)!.length).toBe(1);
   });
 });

--- a/src/lib/series/series.ts
+++ b/src/lib/series/series.ts
@@ -1,4 +1,4 @@
-import { findSelectedDataSeries } from '../../state/utils';
+import { findDataSeriesByColorValues } from '../../state/utils';
 import { ColorConfig } from '../themes/theme';
 import { Accessor } from '../utils/accessor';
 import { GroupId, SpecId } from '../utils/ids';
@@ -342,7 +342,7 @@ export function formatStackedDataSeriesValues(
 
 export function getSplittedSeries(
   seriesSpecs: Map<SpecId, BasicSeriesSpec>,
-  selectedDataSeries?: DataSeriesColorsValues[] | null,
+  deselectedDataSeries?: DataSeriesColorsValues[] | null,
 ): {
   splittedSeries: Map<SpecId, RawDataSeries[]>;
   seriesColors: Map<string, DataSeriesColorsValues>;
@@ -354,7 +354,7 @@ export function getSplittedSeries(
   for (const [specId, spec] of seriesSpecs) {
     const dataSeries = splitSeries(spec.data, spec, specId);
     let currentRawDataSeries = dataSeries.rawDataSeries;
-    if (selectedDataSeries) {
+    if (deselectedDataSeries) {
       currentRawDataSeries = dataSeries.rawDataSeries.filter(
         (series): boolean => {
           const seriesValues = {
@@ -362,7 +362,7 @@ export function getSplittedSeries(
             colorValues: series.key,
           };
 
-          return findSelectedDataSeries(selectedDataSeries, seriesValues) > -1;
+          return findDataSeriesByColorValues(deselectedDataSeries, seriesValues) < 0;
         },
       );
     }

--- a/src/specs/specs_parser.test.tsx
+++ b/src/specs/specs_parser.test.tsx
@@ -11,16 +11,6 @@ describe('Specs parser', () => {
     mount(component);
     expect(chartStore.specsInitialized.get()).toBe(true);
   });
-  test('resets selectedDataSeries on component update', () => {
-    const chartStore = new ChartStore();
-    const reset = jest.fn((): void => { return; });
-    chartStore.resetSelectedDataSeries = reset;
-
-    const component = mount(<SpecsSpecRootComponent chartStore={chartStore} />);
-    component.update();
-    component.setState({ foo: 'bar' });
-    expect(reset).toBeCalled();
-  });
   test('updates initialization state on unmount', () => {
     const chartStore = new ChartStore();
     chartStore.initialized.set(true);

--- a/src/specs/specs_parser.test.tsx
+++ b/src/specs/specs_parser.test.tsx
@@ -11,6 +11,17 @@ describe('Specs parser', () => {
     mount(component);
     expect(chartStore.specsInitialized.get()).toBe(true);
   });
+  test('chart store initialized and computeChart on component update', () => {
+    const chartStore = new ChartStore();
+    const computeChart = jest.fn((): void => { return; });
+    chartStore.computeChart = computeChart;
+
+    const component = mount(<SpecsSpecRootComponent chartStore={chartStore} />);
+    component.update();
+    component.setState({ foo: 'bar' });
+    expect(chartStore.specsInitialized.get()).toBe(true);
+    expect(computeChart).toBeCalled();
+  });
   test('updates initialization state on unmount', () => {
     const chartStore = new ChartStore();
     chartStore.initialized.set(true);

--- a/src/specs/specs_parser.tsx
+++ b/src/specs/specs_parser.tsx
@@ -18,7 +18,6 @@ export class SpecsSpecRootComponent extends PureComponent<SpecProps> {
   }
   componentDidUpdate() {
     this.props.chartStore!.specsInitialized.set(true);
-    this.props.chartStore!.resetSelectedDataSeries();
     this.props.chartStore!.computeChart();
   }
   componentWillUnmount() {

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -53,29 +53,10 @@ describe('Chart Store', () => {
     expect(seriesDomainsAndData).not.toBeUndefined();
   });
 
-  test('resets selectedDataSeries in state if series colors change on addSeriesSpec', () => {
-    const localStore = new ChartStore();
-    localStore.seriesSpecs = new Map();
-    localStore.addSeriesSpec(spec);
-    localStore.updateParentDimensions(600, 600, 0, 0);
-    localStore.computeChart();
-
-    const updatedSpec = { ...spec, splitSeriesAccessors: ['g'] };
-    localStore.addSeriesSpec(updatedSpec);
-    expect(localStore.selectedDataSeries).toBe(null);
-  });
-
-  test('can initialize selectedDataSeries depending on previous state', () => {
-    const selectedDataSeries = [{ specId: SPEC_ID, colorValues: [] }];
-
-    store.selectedDataSeries = null;
+  test('can initialize deselectedDataSeries depending on previous state', () => {
+    store.specsInitialized.set(false);
     store.computeChart();
-    expect(store.selectedDataSeries).toEqual(selectedDataSeries);
-
-    store.selectedDataSeries = selectedDataSeries;
-    store.specsInitialized.set(true);
-    store.computeChart();
-    expect(store.selectedDataSeries).toEqual(selectedDataSeries);
+    expect(store.deselectedDataSeries).toEqual(null);
   });
 
   test('can add an axis', () => {
@@ -264,21 +245,21 @@ describe('Chart Store', () => {
       [firstLegendItem.key, firstLegendItem],
       [secondLegendItem.key, secondLegendItem],
     ]);
-    store.selectedDataSeries = null;
+    store.deselectedDataSeries = null;
     store.computeChart = computeChart;
 
     store.toggleSeriesVisibility('other');
-    expect(store.selectedDataSeries).toEqual(null);
+    expect(store.deselectedDataSeries).toEqual(null);
     expect(computeChart).not.toBeCalled();
 
-    store.selectedDataSeries = [firstLegendItem.value, secondLegendItem.value];
+    store.deselectedDataSeries = [firstLegendItem.value, secondLegendItem.value];
     store.toggleSeriesVisibility(firstLegendItem.key);
-    expect(store.selectedDataSeries).toEqual([secondLegendItem.value]);
+    expect(store.deselectedDataSeries).toEqual([secondLegendItem.value]);
     expect(computeChart).toBeCalled();
 
-    store.selectedDataSeries = [firstLegendItem.value];
+    store.deselectedDataSeries = [firstLegendItem.value];
     store.toggleSeriesVisibility(firstLegendItem.key);
-    expect(store.selectedDataSeries).toEqual([]);
+    expect(store.deselectedDataSeries).toEqual([]);
   });
 
   test('can toggle single series visibility', () => {
@@ -292,18 +273,18 @@ describe('Chart Store', () => {
       [firstLegendItem.key, firstLegendItem],
       [secondLegendItem.key, secondLegendItem],
     ]);
-    store.selectedDataSeries = null;
+    store.deselectedDataSeries = null;
     store.computeChart = computeChart;
 
     store.toggleSingleSeries('other');
-    expect(store.selectedDataSeries).toEqual(null);
+    expect(store.deselectedDataSeries).toEqual(null);
     expect(computeChart).not.toBeCalled();
 
     store.toggleSingleSeries(firstLegendItem.key);
-    expect(store.selectedDataSeries).toEqual([firstLegendItem.value]);
+    expect(store.deselectedDataSeries).toEqual([firstLegendItem.value]);
 
     store.toggleSingleSeries(firstLegendItem.key);
-    expect(store.selectedDataSeries).toEqual([secondLegendItem.value]);
+    expect(store.deselectedDataSeries).toEqual([secondLegendItem.value]);
   });
 
   test('can set an element click listener', () => {
@@ -500,9 +481,9 @@ describe('Chart Store', () => {
   });
 
   test('can reset selectedDataSeries', () => {
-    store.selectedDataSeries = [firstLegendItem.value];
-    store.resetSelectedDataSeries();
-    expect(store.selectedDataSeries).toBe(null);
+    store.deselectedDataSeries = [firstLegendItem.value];
+    store.resetDeselectedDataSeries();
+    expect(store.deselectedDataSeries).toBe(null);
   });
   test('can update the crosshair visibility', () => {
     store.cursorPosition.x = -1;

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -18,7 +18,7 @@ describe('Chart Store', () => {
     groupId: GROUP_ID,
     seriesType: 'bar',
     yScaleToDataExtent: false,
-    data: [{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }],
+    data: [{ x: 1, y: 1, g: 0 }, { x: 2, y: 2, g: 1 }, { x: 3, y: 3, g: 3 }],
     xAccessor: 'x',
     yAccessors: ['y'],
     xScaleType: ScaleType.Linear,
@@ -51,6 +51,18 @@ describe('Chart Store', () => {
     store.computeChart();
     const { seriesDomainsAndData } = store;
     expect(seriesDomainsAndData).not.toBeUndefined();
+  });
+
+  test('resets selectedDataSeries in state if series colors change on addSeriesSpec', () => {
+    const localStore = new ChartStore();
+    localStore.seriesSpecs = new Map();
+    localStore.addSeriesSpec(spec);
+    localStore.updateParentDimensions(600, 600, 0, 0);
+    localStore.computeChart();
+
+    const updatedSpec = { ...spec, splitSeriesAccessors: ['g'] };
+    localStore.addSeriesSpec(updatedSpec);
+    expect(localStore.selectedDataSeries).toBe(null);
   });
 
   test('can initialize selectedDataSeries depending on previous state', () => {

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -66,14 +66,12 @@ import {
   computeChartTransform,
   computeSeriesDomains,
   computeSeriesGeometries,
-  findSelectedDataSeries,
-  getAllDataSeriesColorValues,
+  findDataSeriesByColorValues,
   getAxesSpecForSpecId,
   getUpdatedCustomSeriesColors,
-  hasSeriesColorsChanged,
   isLineAreaOnlyChart,
   Transform,
-  updateSelectedDataSeries,
+  updateDeselectedDataSeries,
 } from './utils';
 
 export interface Point {
@@ -145,7 +143,7 @@ export class ChartStore {
   legendItems: Map<string, LegendItem> = new Map();
   highlightedLegendItemKey: IObservableValue<string | null> = observable.box(null);
   selectedLegendItemKey: IObservableValue<string | null> = observable.box(null);
-  selectedDataSeries: DataSeriesColorsValues[] | null = null;
+  deselectedDataSeries: DataSeriesColorsValues[] | null = null;
   customSeriesColors: Map<string, string> = new Map();
   seriesColorMap: Map<string, string> = new Map();
   totalBarsInCluster?: number;
@@ -480,12 +478,12 @@ export class ChartStore {
     const legendItem = this.legendItems.get(legendItemKey);
 
     if (legendItem) {
-      if (findSelectedDataSeries(this.selectedDataSeries, legendItem.value) > -1) {
-        this.selectedDataSeries = [...this.legendItems.values()]
+      if (findDataSeriesByColorValues(this.deselectedDataSeries, legendItem.value) > -1) {
+        this.deselectedDataSeries = [...this.legendItems.values()]
           .filter((item: LegendItem) => item.key !== legendItemKey)
           .map((item: LegendItem) => item.value);
       } else {
-        this.selectedDataSeries = [legendItem.value];
+        this.deselectedDataSeries = [legendItem.value];
       }
 
       this.computeChart();
@@ -496,7 +494,7 @@ export class ChartStore {
     const legendItem = this.legendItems.get(legendItemKey);
 
     if (legendItem) {
-      this.selectedDataSeries = updateSelectedDataSeries(this.selectedDataSeries, legendItem.value);
+      this.deselectedDataSeries = updateDeselectedDataSeries(this.deselectedDataSeries, legendItem.value);
       this.computeChart();
     }
   });
@@ -528,8 +526,8 @@ export class ChartStore {
     }
   }
 
-  resetSelectedDataSeries() {
-    this.selectedDataSeries = null;
+  resetDeselectedDataSeries() {
+    this.deselectedDataSeries = null;
   }
 
   setOnElementClickListener(listener: ElementClickListener) {
@@ -625,19 +623,6 @@ export class ChartStore {
     }
   }
   addSeriesSpec(seriesSpec: BasicSeriesSpec | LineSeriesSpec | AreaSeriesSpec | BarSeriesSpec) {
-    if (this.seriesDomainsAndData) {
-      const hasChanged = hasSeriesColorsChanged(
-        this.seriesDomainsAndData.seriesColors,
-        this.seriesSpecs,
-        this.selectedDataSeries,
-        seriesSpec,
-      );
-
-      if (hasChanged) {
-        this.resetSelectedDataSeries();
-      }
-    }
-
     this.seriesSpecs.set(seriesSpec.id, seriesSpec);
   }
   removeSeriesSpec(specId: SpecId) {
@@ -667,26 +652,21 @@ export class ChartStore {
 
     // When specs are not initialized, reset selectedDataSeries to null
     if (!this.specsInitialized.get()) {
-      this.selectedDataSeries = null;
+      this.deselectedDataSeries = null;
     }
 
     const domainsByGroupId = mergeDomainsByGroupId(this.axesSpecs, this.chartRotation);
 
     // The last argument is optional; if not supplied, then all series will be factored into computations
-    // Otherwise, selectedDataSeries is used to restrict the computation for just the selected series
+    // Otherwise, deselectedDataSeries is used to restrict the computation excluding the deselected series
     const seriesDomains = computeSeriesDomains(
       this.seriesSpecs,
       domainsByGroupId,
       this.xDomain,
-      this.selectedDataSeries,
+      this.deselectedDataSeries,
     );
 
     this.seriesDomainsAndData = seriesDomains;
-
-    // If this.selectedDataSeries is null, initialize with all series
-    if (!this.selectedDataSeries) {
-      this.selectedDataSeries = getAllDataSeriesColorValues(seriesDomains.seriesColors);
-    }
 
     // Merge all series spec custom colors with state custom colors map
     const updatedCustomSeriesColors = getUpdatedCustomSeriesColors(this.seriesSpecs);
@@ -708,7 +688,7 @@ export class ChartStore {
       this.seriesColorMap,
       this.seriesSpecs,
       this.chartTheme.colors.defaultVizColor,
-      this.selectedDataSeries,
+      this.deselectedDataSeries,
     );
     // tslint:disable-next-line:no-console
     // console.log({ legendItems: this.legendItems });

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -25,6 +25,7 @@ import {
   DataSeriesColorsValues,
   FormattedDataSeries,
   getSeriesColorMap,
+  getSplittedSeries,
   RawDataSeries,
 } from '../lib/series/series';
 import {
@@ -624,6 +625,24 @@ export class ChartStore {
     }
   }
   addSeriesSpec(seriesSpec: BasicSeriesSpec | LineSeriesSpec | AreaSeriesSpec | BarSeriesSpec) {
+    if (this.seriesDomainsAndData) {
+      const prevSeriesColors = this.seriesDomainsAndData.seriesColors;
+      const nextSeriesSpecs = new Map([...this.seriesSpecs]);
+      nextSeriesSpecs.set(seriesSpec.id, seriesSpec);
+
+      const nextSeriesColors = getSplittedSeries(nextSeriesSpecs, this.selectedDataSeries).seriesColors;
+      if (prevSeriesColors.size !== nextSeriesColors.size) {
+        this.resetSelectedDataSeries();
+      } else {
+        for (const [seriesKey] of prevSeriesColors) {
+          if (!nextSeriesColors.get(seriesKey)) {
+            this.resetSelectedDataSeries();
+            break;
+          }
+        }
+      }
+    }
+
     this.seriesSpecs.set(seriesSpec.id, seriesSpec);
   }
   removeSeriesSpec(specId: SpecId) {
@@ -666,6 +685,7 @@ export class ChartStore {
       this.xDomain,
       this.selectedDataSeries,
     );
+
     this.seriesDomainsAndData = seriesDomains;
 
     // If this.selectedDataSeries is null, initialize with all series

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -25,7 +25,6 @@ import {
   DataSeriesColorsValues,
   FormattedDataSeries,
   getSeriesColorMap,
-  getSplittedSeries,
   RawDataSeries,
 } from '../lib/series/series';
 import {
@@ -71,6 +70,7 @@ import {
   getAllDataSeriesColorValues,
   getAxesSpecForSpecId,
   getUpdatedCustomSeriesColors,
+  hasSeriesColorsChanged,
   isLineAreaOnlyChart,
   Transform,
   updateSelectedDataSeries,
@@ -626,20 +626,15 @@ export class ChartStore {
   }
   addSeriesSpec(seriesSpec: BasicSeriesSpec | LineSeriesSpec | AreaSeriesSpec | BarSeriesSpec) {
     if (this.seriesDomainsAndData) {
-      const prevSeriesColors = this.seriesDomainsAndData.seriesColors;
-      const nextSeriesSpecs = new Map([...this.seriesSpecs]);
-      nextSeriesSpecs.set(seriesSpec.id, seriesSpec);
+      const hasChanged = hasSeriesColorsChanged(
+        this.seriesDomainsAndData.seriesColors,
+        this.seriesSpecs,
+        this.selectedDataSeries,
+        seriesSpec,
+      );
 
-      const nextSeriesColors = getSplittedSeries(nextSeriesSpecs, this.selectedDataSeries).seriesColors;
-      if (prevSeriesColors.size !== nextSeriesColors.size) {
+      if (hasChanged) {
         this.resetSelectedDataSeries();
-      } else {
-        for (const [seriesKey] of prevSeriesColors) {
-          if (!nextSeriesColors.get(seriesKey)) {
-            this.resetSelectedDataSeries();
-            break;
-          }
-        }
       }
     }
 

--- a/src/state/utils.test.ts
+++ b/src/state/utils.test.ts
@@ -6,7 +6,7 @@ import {
   LineSeriesSpec,
 } from '../lib/series/specs';
 
-import { BARCHART_1Y0G, BARCHART_1Y1G } from '../lib/series/utils/test_dataset';
+import { BARCHART_1Y0G, BARCHART_1Y1G, BARCHART_2Y2G } from '../lib/series/utils/test_dataset';
 
 import { getGroupId, getSpecId, SpecId } from '../lib/utils/ids';
 import { ScaleType } from '../lib/utils/scales/scales';
@@ -15,6 +15,7 @@ import {
   findSelectedDataSeries,
   getAllDataSeriesColorValues,
   getUpdatedCustomSeriesColors,
+  hasSeriesColorsChanged,
   isHorizontalRotation,
   isLineAreaOnlyChart,
   isVerticalRotation,
@@ -303,5 +304,95 @@ describe('Chart State utils', () => {
     expect(isLineAreaOnlyChart(seriesMap)).toBe(true);
     seriesMap = new Map<SpecId, BasicSeriesSpec>([[bar.id, bar], [getSpecId('bar2'), bar]]);
     expect(isLineAreaOnlyChart(seriesMap)).toBe(false);
+  });
+  test('should detect when series colors have changed', () => {
+    const specId = getSpecId('spec_1');
+    const groupId = getGroupId('group_1');
+
+    const spec1: BarSeriesSpec = {
+      id: specId,
+      groupId,
+      seriesType: 'bar',
+      yScaleToDataExtent: false,
+      data: BARCHART_2Y2G,
+      xAccessor: 'x',
+      yAccessors: ['y1', 'y2'],
+      splitSeriesAccessors: ['g1'],
+      xScaleType: ScaleType.Linear,
+      yScaleType: ScaleType.Linear,
+    };
+
+    const prevSeriesSpecs = new Map();
+    const prevSeriesColors = new Map();
+
+    const hasChangedSize = hasSeriesColorsChanged(
+      prevSeriesColors,
+      prevSeriesSpecs,
+      null,
+      spec1,
+    );
+    expect(hasChangedSize).toBe(true);
+
+    prevSeriesSpecs.set(spec1.id, spec1);
+    const seriesColors1 = {
+      specId,
+      colorValues: ['cdn.google.com', 'y1'],
+    };
+    prevSeriesColors.set('specId:{spec_1},colors:{cdn.google.com,y1}', seriesColors1);
+
+    const seriesColors2 = {
+      specId,
+      colorValues: ['cloudflare.com', 'y1'],
+    };
+    prevSeriesColors.set('specId:{spec_1},colors:{cloudflare.com,y1}', seriesColors2);
+
+    const seriesColors3 = {
+      specId,
+      colorValues: ['cdn.google.com', 'y2'],
+    };
+    prevSeriesColors.set('specId:{spec_1},colors:{cdn.google.com,y2}', seriesColors3);
+
+    const seriesColors4 = {
+      specId,
+      colorValues: ['cloudflare.com', 'y2'],
+    };
+    prevSeriesColors.set('specId:{spec_1},colors:{cloudflare.com,y2}', seriesColors4);
+
+    const changedXAccessorSpec: BarSeriesSpec = { ...spec1, xAccessor: 'y2' };
+    const hasChangedXAccessor = hasSeriesColorsChanged(
+      prevSeriesColors,
+      prevSeriesSpecs,
+      null,
+      changedXAccessorSpec,
+    );
+    expect(hasChangedXAccessor).toBe(false);
+
+    const changedYAccessorSpec: BarSeriesSpec = { ...spec1, yAccessors: ['y2'] };
+    const hasChangedYAccessor = hasSeriesColorsChanged(
+      prevSeriesColors,
+      prevSeriesSpecs,
+      null,
+      changedYAccessorSpec,
+    );
+    expect(hasChangedYAccessor).toBe(true);
+
+    const changedSplitAccessorSpec: BarSeriesSpec = { ...spec1, splitSeriesAccessors: ['g2'] };
+    const hasChangedSplitAccessor = hasSeriesColorsChanged(
+      prevSeriesColors,
+      prevSeriesSpecs,
+      null,
+      changedSplitAccessorSpec,
+    );
+    expect(hasChangedSplitAccessor).toBe(true);
+
+    const additionalSplitData = [...BARCHART_2Y2G, { x: 0, g1: 'foo', g2: 'direct-cdn', y1: 1, y2: 4 }];
+    const changedDataValuesSpec: BarSeriesSpec = { ...spec1, data: additionalSplitData };
+    const hasChangedDataValues = hasSeriesColorsChanged(
+      prevSeriesColors,
+      prevSeriesSpecs,
+      null,
+      changedDataValuesSpec,
+    );
+    expect(hasChangedDataValues).toBe(true);
   });
 });

--- a/src/state/utils.test.ts
+++ b/src/state/utils.test.ts
@@ -6,20 +6,18 @@ import {
   LineSeriesSpec,
 } from '../lib/series/specs';
 
-import { BARCHART_1Y0G, BARCHART_1Y1G, BARCHART_2Y2G } from '../lib/series/utils/test_dataset';
+import { BARCHART_1Y0G, BARCHART_1Y1G } from '../lib/series/utils/test_dataset';
 
 import { getGroupId, getSpecId, SpecId } from '../lib/utils/ids';
 import { ScaleType } from '../lib/utils/scales/scales';
 import {
   computeSeriesDomains,
-  findSelectedDataSeries,
-  getAllDataSeriesColorValues,
+  findDataSeriesByColorValues,
   getUpdatedCustomSeriesColors,
-  hasSeriesColorsChanged,
   isHorizontalRotation,
   isLineAreaOnlyChart,
   isVerticalRotation,
-  updateSelectedDataSeries,
+  updateDeselectedDataSeries,
 } from './utils';
 
 describe('Chart State utils', () => {
@@ -148,11 +146,11 @@ describe('Chart State utils', () => {
       colorValues: ['a', 'b', 'd'],
     };
 
-    const selectedSeries = [dataSeriesValuesA, dataSeriesValuesB];
+    const deselectedSeries = [dataSeriesValuesA, dataSeriesValuesB];
 
-    expect(findSelectedDataSeries(selectedSeries, dataSeriesValuesA)).toBe(0);
-    expect(findSelectedDataSeries(selectedSeries, dataSeriesValuesC)).toBe(-1);
-    expect(findSelectedDataSeries(null, dataSeriesValuesA)).toBe(-1);
+    expect(findDataSeriesByColorValues(deselectedSeries, dataSeriesValuesA)).toBe(0);
+    expect(findDataSeriesByColorValues(deselectedSeries, dataSeriesValuesC)).toBe(-1);
+    expect(findDataSeriesByColorValues(null, dataSeriesValuesA)).toBe(-1);
   });
   it('should update a list of DataSeriesColorsValues given a selected DataSeriesColorValues item', () => {
     const dataSeriesValuesA: DataSeriesColorsValues = {
@@ -174,32 +172,13 @@ describe('Chart State utils', () => {
     const addedSelectedSeries = [dataSeriesValuesA, dataSeriesValuesB, dataSeriesValuesC];
     const removedSelectedSeries = [dataSeriesValuesB];
 
-    expect(updateSelectedDataSeries(selectedSeries, dataSeriesValuesC)).toEqual(
+    expect(updateDeselectedDataSeries(selectedSeries, dataSeriesValuesC)).toEqual(
       addedSelectedSeries,
     );
-    expect(updateSelectedDataSeries(selectedSeries, dataSeriesValuesA)).toEqual(
+    expect(updateDeselectedDataSeries(selectedSeries, dataSeriesValuesA)).toEqual(
       removedSelectedSeries,
     );
-    expect(updateSelectedDataSeries(null, dataSeriesValuesA)).toEqual([dataSeriesValuesA]);
-  });
-  it('should return all of the DataSeriesColorValues on initialization', () => {
-    const dataSeriesValuesA: DataSeriesColorsValues = {
-      specId: getSpecId('a'),
-      colorValues: ['a', 'b', 'c'],
-    };
-
-    const dataSeriesValuesB: DataSeriesColorsValues = {
-      specId: getSpecId('b'),
-      colorValues: ['a', 'b', 'c'],
-    };
-
-    const colorMap = new Map();
-    colorMap.set('a', dataSeriesValuesA);
-    colorMap.set('b', dataSeriesValuesB);
-
-    const expected = [dataSeriesValuesA, dataSeriesValuesB];
-
-    expect(getAllDataSeriesColorValues(colorMap)).toEqual(expected);
+    expect(updateDeselectedDataSeries(null, dataSeriesValuesA)).toEqual([dataSeriesValuesA]);
   });
   it('should get an updated customSeriesColor based on specs', () => {
     const spec1: BasicSeriesSpec = {
@@ -304,95 +283,5 @@ describe('Chart State utils', () => {
     expect(isLineAreaOnlyChart(seriesMap)).toBe(true);
     seriesMap = new Map<SpecId, BasicSeriesSpec>([[bar.id, bar], [getSpecId('bar2'), bar]]);
     expect(isLineAreaOnlyChart(seriesMap)).toBe(false);
-  });
-  test('should detect when series colors have changed', () => {
-    const specId = getSpecId('spec_1');
-    const groupId = getGroupId('group_1');
-
-    const spec1: BarSeriesSpec = {
-      id: specId,
-      groupId,
-      seriesType: 'bar',
-      yScaleToDataExtent: false,
-      data: BARCHART_2Y2G,
-      xAccessor: 'x',
-      yAccessors: ['y1', 'y2'],
-      splitSeriesAccessors: ['g1'],
-      xScaleType: ScaleType.Linear,
-      yScaleType: ScaleType.Linear,
-    };
-
-    const prevSeriesSpecs = new Map();
-    const prevSeriesColors = new Map();
-
-    const hasChangedSize = hasSeriesColorsChanged(
-      prevSeriesColors,
-      prevSeriesSpecs,
-      null,
-      spec1,
-    );
-    expect(hasChangedSize).toBe(true);
-
-    prevSeriesSpecs.set(spec1.id, spec1);
-    const seriesColors1 = {
-      specId,
-      colorValues: ['cdn.google.com', 'y1'],
-    };
-    prevSeriesColors.set('specId:{spec_1},colors:{cdn.google.com,y1}', seriesColors1);
-
-    const seriesColors2 = {
-      specId,
-      colorValues: ['cloudflare.com', 'y1'],
-    };
-    prevSeriesColors.set('specId:{spec_1},colors:{cloudflare.com,y1}', seriesColors2);
-
-    const seriesColors3 = {
-      specId,
-      colorValues: ['cdn.google.com', 'y2'],
-    };
-    prevSeriesColors.set('specId:{spec_1},colors:{cdn.google.com,y2}', seriesColors3);
-
-    const seriesColors4 = {
-      specId,
-      colorValues: ['cloudflare.com', 'y2'],
-    };
-    prevSeriesColors.set('specId:{spec_1},colors:{cloudflare.com,y2}', seriesColors4);
-
-    const changedXAccessorSpec: BarSeriesSpec = { ...spec1, xAccessor: 'y2' };
-    const hasChangedXAccessor = hasSeriesColorsChanged(
-      prevSeriesColors,
-      prevSeriesSpecs,
-      null,
-      changedXAccessorSpec,
-    );
-    expect(hasChangedXAccessor).toBe(false);
-
-    const changedYAccessorSpec: BarSeriesSpec = { ...spec1, yAccessors: ['y2'] };
-    const hasChangedYAccessor = hasSeriesColorsChanged(
-      prevSeriesColors,
-      prevSeriesSpecs,
-      null,
-      changedYAccessorSpec,
-    );
-    expect(hasChangedYAccessor).toBe(true);
-
-    const changedSplitAccessorSpec: BarSeriesSpec = { ...spec1, splitSeriesAccessors: ['g2'] };
-    const hasChangedSplitAccessor = hasSeriesColorsChanged(
-      prevSeriesColors,
-      prevSeriesSpecs,
-      null,
-      changedSplitAccessorSpec,
-    );
-    expect(hasChangedSplitAccessor).toBe(true);
-
-    const additionalSplitData = [...BARCHART_2Y2G, { x: 0, g1: 'foo', g2: 'direct-cdn', y1: 1, y2: 4 }];
-    const changedDataValuesSpec: BarSeriesSpec = { ...spec1, data: additionalSplitData };
-    const hasChangedDataValues = hasSeriesColorsChanged(
-      prevSeriesColors,
-      prevSeriesSpecs,
-      null,
-      changedDataValuesSpec,
-    );
-    expect(hasChangedDataValues).toBe(true);
   });
 });

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -26,7 +26,6 @@ import { isEqualSeriesKey } from '../lib/series/series_utils';
 import {
   AreaSeriesSpec,
   AxisSpec,
-  BarSeriesSpec,
   BasicSeriesSpec,
   DomainRange,
   LineSeriesSpec,
@@ -51,7 +50,7 @@ export interface BrushExtent {
   maxY: number;
 }
 
-export function findSelectedDataSeries(
+export function findDataSeriesByColorValues(
   series: DataSeriesColorsValues[] | null,
   value: DataSeriesColorsValues,
 ): number {
@@ -64,41 +63,11 @@ export function findSelectedDataSeries(
   });
 }
 
-export function hasSeriesColorsChanged(
-  prevSeriesColors: Map<string, DataSeriesColorsValues>,
-  prevSeriesSpecs: Map<SpecId, BasicSeriesSpec>,
-  prevSelectedDataSeries: DataSeriesColorsValues[] | null,
-  nextSeriesSpec: BasicSeriesSpec | LineSeriesSpec | AreaSeriesSpec | BarSeriesSpec,
-
-): boolean {
-  const nextSeriesSpecs = new Map([...prevSeriesSpecs]);
-  nextSeriesSpecs.set(nextSeriesSpec.id, nextSeriesSpec);
-
-  const nextSeriesColors = getSplittedSeries(nextSeriesSpecs, prevSelectedDataSeries).seriesColors;
-  if (prevSeriesColors.size !== nextSeriesColors.size) {
-    return true;
-  }
-
-  for (const [seriesKey] of prevSeriesColors) {
-    if (!nextSeriesColors.get(seriesKey)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-export function getAllDataSeriesColorValues(
-  seriesColors: Map<string, DataSeriesColorsValues>,
-): DataSeriesColorsValues[] {
-  return Array.from(seriesColors.values());
-}
-
-export function updateSelectedDataSeries(
+export function updateDeselectedDataSeries(
   series: DataSeriesColorsValues[] | null,
   value: DataSeriesColorsValues,
 ): DataSeriesColorsValues[] {
-  const seriesIndex = findSelectedDataSeries(series, value);
+  const seriesIndex = findDataSeriesByColorValues(series, value);
   const updatedSeries = series ? [...series] : [];
 
   if (seriesIndex > -1) {
@@ -139,11 +108,11 @@ export function computeSeriesDomains(
   seriesSpecs: Map<SpecId, BasicSeriesSpec>,
   domainsByGroupId: Map<GroupId, DomainRange>,
   customXDomain?: DomainRange | Domain,
-  selectedDataSeries?: DataSeriesColorsValues[] | null,
+  deselectedDataSeries?: DataSeriesColorsValues[] | null,
 ): SeriesDomainsAndData {
   const { splittedSeries, xValues, seriesColors } = getSplittedSeries(
     seriesSpecs,
-    selectedDataSeries,
+    deselectedDataSeries,
   );
   // tslint:disable-next-line:no-console
   // console.log({ splittedSeries, xValues, seriesColors });

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -26,6 +26,7 @@ import { isEqualSeriesKey } from '../lib/series/series_utils';
 import {
   AreaSeriesSpec,
   AxisSpec,
+  BarSeriesSpec,
   BasicSeriesSpec,
   DomainRange,
   LineSeriesSpec,
@@ -61,6 +62,30 @@ export function findSelectedDataSeries(
   return series.findIndex((item: DataSeriesColorsValues) => {
     return isEqualSeriesKey(item.colorValues, value.colorValues) && item.specId === value.specId;
   });
+}
+
+export function hasSeriesColorsChanged(
+  prevSeriesColors: Map<string, DataSeriesColorsValues>,
+  prevSeriesSpecs: Map<SpecId, BasicSeriesSpec>,
+  prevSelectedDataSeries: DataSeriesColorsValues[] | null,
+  nextSeriesSpec: BasicSeriesSpec | LineSeriesSpec | AreaSeriesSpec | BarSeriesSpec,
+
+): boolean {
+  const nextSeriesSpecs = new Map([...prevSeriesSpecs]);
+  nextSeriesSpecs.set(nextSeriesSpec.id, nextSeriesSpec);
+
+  const nextSeriesColors = getSplittedSeries(nextSeriesSpecs, prevSelectedDataSeries).seriesColors;
+  if (prevSeriesColors.size !== nextSeriesColors.size) {
+    return true;
+  }
+
+  for (const [seriesKey] of prevSeriesColors) {
+    if (!nextSeriesColors.get(seriesKey)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function getAllDataSeriesColorValues(

--- a/stories/interactions.tsx
+++ b/stories/interactions.tsx
@@ -19,9 +19,10 @@ import {
   TooltipType,
 } from '../src/';
 
-import { array, boolean, number, select, text } from '@storybook/addon-knobs';
+import { array, boolean, number, select } from '@storybook/addon-knobs';
 import { DateTime } from 'luxon';
 import { switchTheme } from '../.storybook/theme_service';
+import { BARCHART_2Y2G } from '../src/lib/series/utils/test_dataset';
 import { KIBANA_METRICS } from '../src/lib/series/utils/test_dataset_kibana';
 import { niceTimeFormatByDay, timeFormatter } from '../src/utils/data/formatters';
 
@@ -38,23 +39,6 @@ const onLegendItemListeners = {
   onLegendItemPlusClick: action('onLegendItemPlusClick'),
   onLegendItemMinusClick: action('onLegendItemMinusClick'),
 };
-
-function setG1ValueData(value: string): any[] {
-  return [
-    { x: 0, g1: value, g2: 'direct-cdn', y1: 1, y2: 4 },
-    { x: 0, g1: value, g2: 'indirect-cdn', y1: 1, y2: 4 },
-    { x: 0, g1: 'cloudflare.com', g2: 'direct-cdn', y1: 3, y2: 6 },
-    { x: 0, g1: 'cloudflare.com', g2: 'indirect-cdn', y1: 3, y2: 6 },
-    { x: 1, g1: value, g2: 'direct-cdn', y1: 7, y2: 3 },
-    { x: 1, g1: value, g2: 'indirect-cdn', y1: 7, y2: 3 },
-    { x: 3, g1: 'cloudflare.com', g2: 'direct-cdn', y1: 6, y2: 4 },
-    { x: 3, g1: 'cloudflare.com', g2: 'indirect-cdn', y1: 6, y2: 4 },
-    { x: 6, g1: value, g2: 'direct-cdn', y1: 7, y2: 3 },
-    { x: 6, g1: value, g2: 'indirect-cdn', y1: 7, y2: 3 },
-    { x: 6, g1: 'cloudflare.com', g2: 'direct-cdn', y1: 6, y2: 4 },
-    { x: 6, g1: 'cloudflare.com', g2: 'indirect-cdn', y1: 6, y2: 4 },
-  ];
-}
 
 storiesOf('Interactions', module)
   .add('bar clicks and hovers', () => {
@@ -193,17 +177,17 @@ storiesOf('Interactions', module)
     );
   })
   .add('click/hovers on legend items [bar chart]', () => {
-    const doesNotTriggerReset = 'does not trigger reset';
-    const doesTriggerReset = 'does trigger reset';
+    const notSpecChange = 'not spec change';
+    const specChange = 'spec change';
 
     const xDomain = {
-      min: number('xDomain min', 0, {}, doesNotTriggerReset),
-      max: number('xDomain max', 6, {}, doesNotTriggerReset),
+      min: number('xDomain min', 0, {}, notSpecChange),
+      max: number('xDomain max', 6, {}, notSpecChange),
     };
 
     const yDomain = {
-      min: number('yDomain min', 0, {}, doesNotTriggerReset),
-      max: number('yDomain max', 10, {}, doesNotTriggerReset),
+      min: number('yDomain min', 0, {}, notSpecChange),
+      max: number('yDomain max', 10, {}, notSpecChange),
     };
 
     const scaleTypeOptions: { [key: string]: ScaleType.Linear | ScaleType.Log } = {
@@ -211,27 +195,25 @@ storiesOf('Interactions', module)
       log: ScaleType.Log,
     };
 
-    const xScaleType = select('xScaleType', scaleTypeOptions, ScaleType.Linear, doesNotTriggerReset);
-    const yScaleType = select('yScaleType', scaleTypeOptions, ScaleType.Linear, doesNotTriggerReset);
+    const xScaleType = select('xScaleType', scaleTypeOptions, ScaleType.Linear, specChange);
+    const yScaleType = select('yScaleType', scaleTypeOptions, ScaleType.Linear, specChange);
 
     const xAccessorOptions = { x: 'x', y1: 'y1', y2: 'y2' };
-    const xAccessor = select('xAccessor', xAccessorOptions, 'x', doesNotTriggerReset);
+    const xAccessor = select('xAccessor', xAccessorOptions, 'x', notSpecChange);
 
-    const yScaleToDataExtent = boolean('yScaleDataToExtent', false, doesNotTriggerReset);
+    const yScaleToDataExtent = boolean('yScaleDataToExtent', false, specChange);
 
-    const splitSeriesAccessors = array('split series accessors', ['g1', 'g2'], ',', doesTriggerReset);
+    const splitSeriesAccessors = array('split series accessors', ['g1', 'g2'], ',', specChange);
 
-    const hasY2 = boolean('has y2 yAccessor', true, doesTriggerReset);
+    const hasY2 = boolean('has y2 yAccessor', true, specChange);
     const yAccessors = hasY2 ? ['y1', 'y2'] : ['y1'];
 
-    const g1Value = text('g1 value', 'cdn.google.com', doesTriggerReset);
-
     const additionalG1Value = { x: 4, g1: '$$$$$$$$', g2: 'indirect-cdn', y1: 7, y2: 3 };
-    const hasAdditionalG1Value = boolean('has additional g1 value', false, doesTriggerReset);
+    const hasAdditionalG1Value = boolean('has additional g1 value', false, specChange);
 
-    const generatedData = setG1ValueData(g1Value);
+    const seriesData = BARCHART_2Y2G;
 
-    const data = hasAdditionalG1Value ? [...generatedData, additionalG1Value] : generatedData;
+    const data = hasAdditionalG1Value ? [...seriesData, additionalG1Value] : seriesData;
 
     const barSeriesProps = {
       xScaleType,

--- a/stories/interactions.tsx
+++ b/stories/interactions.tsx
@@ -19,10 +19,9 @@ import {
   TooltipType,
 } from '../src/';
 
-import { array, boolean, number, select } from '@storybook/addon-knobs';
+import { array, boolean, number, select, text } from '@storybook/addon-knobs';
 import { DateTime } from 'luxon';
 import { switchTheme } from '../.storybook/theme_service';
-import * as TestDatasets from '../src/lib/series/utils/test_dataset';
 import { KIBANA_METRICS } from '../src/lib/series/utils/test_dataset_kibana';
 import { niceTimeFormatByDay, timeFormatter } from '../src/utils/data/formatters';
 
@@ -39,6 +38,23 @@ const onLegendItemListeners = {
   onLegendItemPlusClick: action('onLegendItemPlusClick'),
   onLegendItemMinusClick: action('onLegendItemMinusClick'),
 };
+
+function setG1ValueData(value: string): any[] {
+  return [
+    { x: 0, g1: value, g2: 'direct-cdn', y1: 1, y2: 4 },
+    { x: 0, g1: value, g2: 'indirect-cdn', y1: 1, y2: 4 },
+    { x: 0, g1: 'cloudflare.com', g2: 'direct-cdn', y1: 3, y2: 6 },
+    { x: 0, g1: 'cloudflare.com', g2: 'indirect-cdn', y1: 3, y2: 6 },
+    { x: 1, g1: value, g2: 'direct-cdn', y1: 7, y2: 3 },
+    { x: 1, g1: value, g2: 'indirect-cdn', y1: 7, y2: 3 },
+    { x: 3, g1: 'cloudflare.com', g2: 'direct-cdn', y1: 6, y2: 4 },
+    { x: 3, g1: 'cloudflare.com', g2: 'indirect-cdn', y1: 6, y2: 4 },
+    { x: 6, g1: value, g2: 'direct-cdn', y1: 7, y2: 3 },
+    { x: 6, g1: value, g2: 'indirect-cdn', y1: 7, y2: 3 },
+    { x: 6, g1: 'cloudflare.com', g2: 'direct-cdn', y1: 6, y2: 4 },
+    { x: 6, g1: 'cloudflare.com', g2: 'indirect-cdn', y1: 6, y2: 4 },
+  ];
+}
 
 storiesOf('Interactions', module)
   .add('bar clicks and hovers', () => {
@@ -201,14 +217,21 @@ storiesOf('Interactions', module)
     const xAccessorOptions = { x: 'x', y1: 'y1', y2: 'y2' };
     const xAccessor = select('xAccessor', xAccessorOptions, 'x', doesNotTriggerReset);
 
-    const yScaleToDataExtent = boolean('yScaleDataToExtent', false, doesNotTriggerReset)
+    const yScaleToDataExtent = boolean('yScaleDataToExtent', false, doesNotTriggerReset);
 
     const splitSeriesAccessors = array('split series accessors', ['g1', 'g2'], ',', doesTriggerReset);
-    const yAccessors = array('y accessors', ['y1', 'y2'], ',', doesTriggerReset);
-    const additionalG1Value = boolean('additional split accessors group (g1)', false, doesTriggerReset);
 
-    const additionalDataRow = { x: 0, g1: 'foo', g2: 'direct-cdn', y1: 1, y2: 4 };
-    const data = additionalG1Value ? [...TestDatasets.BARCHART_2Y2G, additionalDataRow] : TestDatasets.BARCHART_2Y2G;
+    const hasY2 = boolean('has y2 yAccessor', true, doesTriggerReset);
+    const yAccessors = hasY2 ? ['y1', 'y2'] : ['y1'];
+
+    const g1Value = text('g1 value', 'cdn.google.com', doesTriggerReset);
+
+    const additionalG1Value = { x: 4, g1: '$$$$$$$$', g2: 'indirect-cdn', y1: 7, y2: 3 };
+    const hasAdditionalG1Value = boolean('has additional g1 value', false, doesTriggerReset);
+
+    const generatedData = setG1ValueData(g1Value);
+
+    const data = hasAdditionalG1Value ? [...generatedData, additionalG1Value] : generatedData;
 
     const barSeriesProps = {
       xScaleType,

--- a/stories/interactions.tsx
+++ b/stories/interactions.tsx
@@ -190,13 +190,13 @@ storiesOf('Interactions', module)
       max: number('yDomain max', 10, {}, notSpecChange),
     };
 
-    const scaleTypeOptions: { [key: string]: ScaleType.Linear | ScaleType.Log } = {
+    const yScaleTypeOptions: { [key: string]: ScaleType.Linear | ScaleType.Log } = {
       linear: ScaleType.Linear,
       log: ScaleType.Log,
     };
 
-    const xScaleType = select('xScaleType', scaleTypeOptions, ScaleType.Linear, specChange);
-    const yScaleType = select('yScaleType', scaleTypeOptions, ScaleType.Linear, specChange);
+    const xScaleType = ScaleType.Linear;
+    const yScaleType = select('yScaleType', yScaleTypeOptions, ScaleType.Linear, specChange);
 
     const xAccessorOptions = { x: 'x', y1: 'y1', y2: 'y2' };
     const xAccessor = select('xAccessor', xAccessorOptions, 'x', notSpecChange);


### PR DESCRIPTION
## Summary

fix #113 

This PR fixes the issue where the visibility of the data series would reset on every state change.

Previously, `resetSelectedDataSeries` was being called in `componentDidUpdate` on `SpecsParser`.  Instead of keeping track of `selectedDataSeries` (and assuming `isVisible: false` as the default), we now assume visibility as the default and keep track of `deselectedDataSeries`.  This has the advantage that we do not need to reset any kind of visibility and visibility state can be better preserved as specs are being updated & added.

- splitAccessors change
![visibility_split_change](https://user-images.githubusercontent.com/452850/54948447-e5c18900-4ef9-11e9-9725-3e17a4979b16.gif)

- yAccessors change
![visibility_y_change](https://user-images.githubusercontent.com/452850/54948435-dd694e00-4ef9-11e9-9a10-ec0628521a0f.gif)

- changes in split accessor values in data
![visibility_data_change](https://user-images.githubusercontent.com/452850/54948431-db9f8a80-4ef9-11e9-9bbf-33f6ce4fe463.gif)

- removing a series that is the only selected visible series (this is the same as the functionality in current kibana)
![visibility_remove_data](https://user-images.githubusercontent.com/452850/54948884-f9b9ba80-4efa-11e9-98fb-74500df13f09.gif)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
