### PR TITLE
fix(brushing): enable mouseup event outside chart element

### DIFF
--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -193,6 +193,8 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     return <Rect x={x} y={y} width={width} height={height} fill="gray" opacity={0.6} />;
   }
   onStartBrusing = (event: { evt: MouseEvent }) => {
+    window.addEventListener('mouseup', this.onEndBrushing);
+    this.props.chartStore!.onBrushStart();
     const { brushExtent } = this.props.chartStore!;
     const point = getPoint(event.evt, brushExtent);
     this.setState(() => ({
@@ -202,6 +204,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     }));
   }
   onEndBrushing = () => {
+    window.removeEventListener('mouseup', this.onEndBrushing);
     const { brushStart, brushEnd } = this.state;
     this.props.chartStore!.onBrushEnd(brushStart, brushEnd);
     this.setState(() => ({
@@ -254,7 +257,6 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     if (isBrushEnabled) {
       brushProps = {
         onMouseDown: this.onStartBrusing,
-        onMouseUp: this.onEndBrushing,
         onMouseMove: this.onBrushing,
       };
     }

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -3,6 +3,7 @@ import { DataSeriesColorsValues } from '../lib/series/series';
 import { AxisSpec, BarSeriesSpec, Position } from '../lib/series/specs';
 import { getAxisId, getGroupId, getSpecId } from '../lib/utils/ids';
 import { TooltipType, TooltipValue } from '../lib/utils/interactions';
+import { ScaleContinuous } from '../lib/utils/scales/scale_continuous';
 import { ScaleType } from '../lib/utils/scales/scales';
 import { ChartStore } from './chart_state';
 
@@ -550,6 +551,32 @@ describe('Chart Store', () => {
     store.cursorPosition.x = 1;
     store.tooltipType.set(TooltipType.Crosshairs);
     store.tooltipData.replace([tooltipValue]);
+    expect(store.isTooltipVisible.get()).toBe(true);
+  });
+
+  test('can disable tooltip on brushing', () => {
+    const tooltipValue: TooltipValue = {
+      name: 'a',
+      value: 'a',
+      color: 'a',
+      isHighlighted: false,
+      isXValue: false,
+    };
+    store.xScale = new ScaleContinuous([0, 100], [0, 100], ScaleType.Linear);
+    store.cursorPosition.x = 1;
+    store.cursorPosition.x = 1;
+    store.tooltipType.set(TooltipType.Crosshairs);
+    store.tooltipData.replace([tooltipValue]);
+    store.onBrushStart();
+    expect(store.isBrushing.get()).toBe(true);
+    expect(store.isTooltipVisible.get()).toBe(false);
+
+    store.cursorPosition.x = 1;
+    store.cursorPosition.x = 1;
+    store.tooltipType.set(TooltipType.Crosshairs);
+    store.tooltipData.replace([tooltipValue]);
+    store.onBrushEnd({ x: 0, y: 0 }, { x: 1, y: 1 });
+    expect(store.isBrushing.get()).toBe(false);
     expect(store.isTooltipVisible.get()).toBe(true);
   });
   test('handle click on chart', () => {

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -3,6 +3,7 @@ import { DataSeriesColorsValues } from '../lib/series/series';
 import { AxisSpec, BarSeriesSpec, Position } from '../lib/series/specs';
 import { getAxisId, getGroupId, getSpecId } from '../lib/utils/ids';
 import { TooltipType, TooltipValue } from '../lib/utils/interactions';
+import { ScaleBand } from '../lib/utils/scales/scale_band';
 import { ScaleContinuous } from '../lib/utils/scales/scale_continuous';
 import { ScaleType } from '../lib/utils/scales/scales';
 import { ChartStore } from './chart_state';
@@ -346,11 +347,14 @@ describe('Chart Store', () => {
     store.chartDimensions.left = 10;
 
     store.onBrushEndListener = undefined;
+    store.onBrushStart();
+    expect(store.isBrushing.get()).toBe(false);
     store.onBrushEnd(start, end1);
     expect(brushEndListener).not.toBeCalled();
 
     store.setOnBrushEndListener(brushEndListener);
-
+    store.onBrushStart();
+    expect(store.isBrushing.get()).toBe(true);
     store.onBrushEnd(start, start);
     expect(brushEndListener).not.toBeCalled();
 
@@ -361,13 +365,6 @@ describe('Chart Store', () => {
     store.onBrushEnd(start, end2);
     expect(brushEndListener.mock.calls[1][0]).toBeCloseTo(0.3, 1);
     expect(brushEndListener.mock.calls[1][1]).toBeCloseTo(0.9, 1);
-  });
-
-  test('can determine if brush is enabled', () => {
-    expect(store.isBrushEnabled()).toBe(true);
-
-    store.xScale = undefined;
-    expect(store.isBrushEnabled()).toBe(false);
   });
 
   test('can update parent dimensions', () => {
@@ -552,6 +549,18 @@ describe('Chart Store', () => {
     store.tooltipType.set(TooltipType.Crosshairs);
     store.tooltipData.replace([tooltipValue]);
     expect(store.isTooltipVisible.get()).toBe(true);
+  });
+
+  test('can disable brush based on scale and listener', () => {
+    store.xScale = undefined;
+    expect(store.isBrushEnabled()).toBe(false);
+    store.xScale = new ScaleContinuous([0, 100], [0, 100], ScaleType.Linear);
+    store.onBrushEndListener = undefined;
+    expect(store.isBrushEnabled()).toBe(false);
+    store.setOnBrushEndListener(() => ({}));
+    expect(store.isBrushEnabled()).toBe(true);
+    store.xScale = new ScaleBand([0, 100], [0, 100]);
+    expect(store.isBrushEnabled()).toBe(false);
   });
 
   test('can disable tooltip on brushing', () => {


### PR DESCRIPTION
## Summary

This PR add the mouseup listener on the window element at the mousedown event for bushing.
we remove it after the brush is end. 

We also disabled the tooltip when brushing.

![Mar-25-2019 18-39-33](https://user-images.githubusercontent.com/1421091/54941573-78c7e680-4f2d-11e9-9c32-e3628e4d564e.gif)


fix #119

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
