### PR TITLE
fix(animation): re-enabled animateData prop to disable animation

### DIFF
--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -69,6 +69,7 @@ import {
   findDataSeriesByColorValues,
   getAxesSpecForSpecId,
   getUpdatedCustomSeriesColors,
+  isChartAnimatable,
   isLineAreaOnlyChart,
   Transform,
   updateDeselectedDataSeries,
@@ -93,7 +94,6 @@ export type ElementClickListener = (values: GeometryValue[]) => void;
 export type ElementOverListener = (values: GeometryValue[]) => void;
 export type BrushEndListener = (min: number, max: number) => void;
 export type LegendItemListener = (dataSeriesIdentifiers: DataSeriesColorsValues | null) => void;
-// const MAX_ANIMATABLE_GLYPHS = 500;
 
 export class ChartStore {
   debug = false;
@@ -497,7 +497,10 @@ export class ChartStore {
     const legendItem = this.legendItems.get(legendItemKey);
 
     if (legendItem) {
-      this.deselectedDataSeries = updateDeselectedDataSeries(this.deselectedDataSeries, legendItem.value);
+      this.deselectedDataSeries = updateDeselectedDataSeries(
+        this.deselectedDataSeries,
+        legendItem.value,
+      );
       this.computeChart();
     }
   });
@@ -789,13 +792,8 @@ export class ChartStore {
     this.axesTicks = axisTicksPositions.axisTicks;
     this.axesVisibleTicks = axisTicksPositions.axisVisibleTicks;
     this.axesGridLinesPositions = axisTicksPositions.axisGridLinesPositions;
-    // if (glyphsCount > MAX_ANIMATABLE_GLYPHS) {
-    //   this.canDataBeAnimated = false;
-    // } else {
-    //   this.canDataBeAnimated = this.animateData;
-    // }
-    this.canDataBeAnimated = true;
 
+    this.canDataBeAnimated = isChartAnimatable(seriesGeometries.geometriesCounts, this.animateData);
     this.initialized.set(true);
   }
 }

--- a/src/state/utils.test.ts
+++ b/src/state/utils.test.ts
@@ -14,6 +14,7 @@ import {
   computeSeriesDomains,
   findDataSeriesByColorValues,
   getUpdatedCustomSeriesColors,
+  isChartAnimatable,
   isHorizontalRotation,
   isLineAreaOnlyChart,
   isVerticalRotation,
@@ -283,5 +284,26 @@ describe('Chart State utils', () => {
     expect(isLineAreaOnlyChart(seriesMap)).toBe(true);
     seriesMap = new Map<SpecId, BasicSeriesSpec>([[bar.id, bar], [getSpecId('bar2'), bar]]);
     expect(isLineAreaOnlyChart(seriesMap)).toBe(false);
+  });
+  test('can enable the chart animation if we have a valid number of elements', () => {
+    const geometriesCounts = {
+      points: 0,
+      bars: 0,
+      areas: 0,
+      areasPoints: 0,
+      lines: 0,
+      linePoints: 0,
+    };
+    expect(isChartAnimatable(geometriesCounts, false)).toBe(false);
+    expect(isChartAnimatable(geometriesCounts, true)).toBe(true);
+    geometriesCounts.bars = 300;
+    expect(isChartAnimatable(geometriesCounts, true)).toBe(true);
+    geometriesCounts.areasPoints = 300;
+    expect(isChartAnimatable(geometriesCounts, true)).toBe(true);
+    geometriesCounts.linePoints = 300;
+    expect(isChartAnimatable(geometriesCounts, true)).toBe(true);
+    expect(isChartAnimatable(geometriesCounts, false)).toBe(false);
+    geometriesCounts.linePoints = 301;
+    expect(isChartAnimatable(geometriesCounts, true)).toBe(false);
   });
 });

--- a/src/state/utils.test.ts
+++ b/src/state/utils.test.ts
@@ -1,17 +1,18 @@
-import { DataSeriesColorsValues } from '../lib/series/series';
+import { mergeDomainsByGroupId } from '../lib/axes/axis_utils';
+import { DataSeriesColorsValues, getSeriesColorMap } from '../lib/series/series';
 import {
   AreaSeriesSpec,
+  AxisSpec,
   BarSeriesSpec,
   BasicSeriesSpec,
   LineSeriesSpec,
 } from '../lib/series/specs';
-
 import { BARCHART_1Y0G, BARCHART_1Y1G } from '../lib/series/utils/test_dataset';
-
-import { getGroupId, getSpecId, SpecId } from '../lib/utils/ids';
+import { AxisId, getGroupId, getSpecId, SpecId } from '../lib/utils/ids';
 import { ScaleType } from '../lib/utils/scales/scales';
 import {
   computeSeriesDomains,
+  computeSeriesGeometries,
   findDataSeriesByColorValues,
   getUpdatedCustomSeriesColors,
   isChartAnimatable,
@@ -305,5 +306,349 @@ describe('Chart State utils', () => {
     expect(isChartAnimatable(geometriesCounts, false)).toBe(false);
     geometriesCounts.linePoints = 301;
     expect(isChartAnimatable(geometriesCounts, true)).toBe(false);
+  });
+  describe('Geometries counts', () => {
+    test('can compute stacked geometries counts', () => {
+      const area: AreaSeriesSpec = {
+        id: getSpecId('area'),
+        groupId: getGroupId('group1'),
+        seriesType: 'area',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const line: LineSeriesSpec = {
+        id: getSpecId('line'),
+        groupId: getGroupId('group2'),
+        seriesType: 'line',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        stackAccessors: ['x'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const bar: BarSeriesSpec = {
+        id: getSpecId('bar'),
+        groupId: getGroupId('group2'),
+        seriesType: 'bar',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        stackAccessors: ['x'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const seriesSpecs = new Map<SpecId, BasicSeriesSpec>([
+        [area.id, area],
+        [line.id, line],
+        [bar.id, bar],
+      ]);
+      const axesSpecs = new Map<AxisId, AxisSpec>();
+      const chartRotation = 0;
+      const chartDimensions = { width: 100, height: 100, top: 0, left: 0 };
+      const chartColors = {
+        vizColors: ['violet', 'green', 'blue'],
+        defaultVizColor: 'red',
+      };
+      const domainsByGroupId = mergeDomainsByGroupId(axesSpecs, chartRotation);
+      const seriesDomains = computeSeriesDomains(seriesSpecs, domainsByGroupId);
+      const seriesColorMap = getSeriesColorMap(seriesDomains.seriesColors, chartColors, new Map());
+      const geometries = computeSeriesGeometries(
+        seriesSpecs,
+        seriesDomains.xDomain,
+        seriesDomains.yDomain,
+        seriesDomains.formattedDataSeries,
+        seriesColorMap,
+        chartColors,
+        chartDimensions,
+        chartRotation,
+      );
+      expect(geometries.geometriesCounts.bars).toBe(8);
+      expect(geometries.geometriesCounts.linePoints).toBe(8);
+      expect(geometries.geometriesCounts.areasPoints).toBe(8);
+      expect(geometries.geometriesCounts.lines).toBe(2);
+      expect(geometries.geometriesCounts.areas).toBe(2);
+    });
+    test('can compute non stacked geometries counts', () => {
+      const area: AreaSeriesSpec = {
+        id: getSpecId('area'),
+        groupId: getGroupId('group1'),
+        seriesType: 'area',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const line: LineSeriesSpec = {
+        id: getSpecId('line'),
+        groupId: getGroupId('group2'),
+        seriesType: 'line',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const bar: BarSeriesSpec = {
+        id: getSpecId('bar'),
+        groupId: getGroupId('group2'),
+        seriesType: 'bar',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const seriesSpecs = new Map<SpecId, BasicSeriesSpec>([
+        [area.id, area],
+        [line.id, line],
+        [bar.id, bar],
+      ]);
+      const axesSpecs = new Map<AxisId, AxisSpec>();
+      const chartRotation = 0;
+      const chartDimensions = { width: 100, height: 100, top: 0, left: 0 };
+      const chartColors = {
+        vizColors: ['violet', 'green', 'blue'],
+        defaultVizColor: 'red',
+      };
+      const domainsByGroupId = mergeDomainsByGroupId(axesSpecs, chartRotation);
+      const seriesDomains = computeSeriesDomains(seriesSpecs, domainsByGroupId);
+      const seriesColorMap = getSeriesColorMap(seriesDomains.seriesColors, chartColors, new Map());
+      const geometries = computeSeriesGeometries(
+        seriesSpecs,
+        seriesDomains.xDomain,
+        seriesDomains.yDomain,
+        seriesDomains.formattedDataSeries,
+        seriesColorMap,
+        chartColors,
+        chartDimensions,
+        chartRotation,
+      );
+      expect(geometries.geometriesCounts.bars).toBe(8);
+      expect(geometries.geometriesCounts.linePoints).toBe(8);
+      expect(geometries.geometriesCounts.areasPoints).toBe(8);
+      expect(geometries.geometriesCounts.lines).toBe(2);
+      expect(geometries.geometriesCounts.areas).toBe(2);
+    });
+    test('can compute line geometries counts', () => {
+      const line1: LineSeriesSpec = {
+        id: getSpecId('line1'),
+        groupId: getGroupId('group2'),
+        seriesType: 'line',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const line2: LineSeriesSpec = {
+        id: getSpecId('line2'),
+        groupId: getGroupId('group2'),
+        seriesType: 'line',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const line3: LineSeriesSpec = {
+        id: getSpecId('line3'),
+        groupId: getGroupId('group2'),
+        seriesType: 'line',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const seriesSpecs = new Map<SpecId, BasicSeriesSpec>([
+        [line1.id, line1],
+        [line2.id, line2],
+        [line3.id, line3],
+      ]);
+      const axesSpecs = new Map<AxisId, AxisSpec>();
+      const chartRotation = 0;
+      const chartDimensions = { width: 100, height: 100, top: 0, left: 0 };
+      const chartColors = {
+        vizColors: ['violet', 'green', 'blue'],
+        defaultVizColor: 'red',
+      };
+      const domainsByGroupId = mergeDomainsByGroupId(axesSpecs, chartRotation);
+      const seriesDomains = computeSeriesDomains(seriesSpecs, domainsByGroupId);
+      const seriesColorMap = getSeriesColorMap(seriesDomains.seriesColors, chartColors, new Map());
+      const geometries = computeSeriesGeometries(
+        seriesSpecs,
+        seriesDomains.xDomain,
+        seriesDomains.yDomain,
+        seriesDomains.formattedDataSeries,
+        seriesColorMap,
+        chartColors,
+        chartDimensions,
+        chartRotation,
+      );
+      expect(geometries.geometriesCounts.bars).toBe(0);
+      expect(geometries.geometriesCounts.linePoints).toBe(24);
+      expect(geometries.geometriesCounts.areasPoints).toBe(0);
+      expect(geometries.geometriesCounts.lines).toBe(6);
+      expect(geometries.geometriesCounts.areas).toBe(0);
+    });
+    test('can compute area geometries counts', () => {
+      const area1: AreaSeriesSpec = {
+        id: getSpecId('area1'),
+        groupId: getGroupId('group2'),
+        seriesType: 'area',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const area2: AreaSeriesSpec = {
+        id: getSpecId('area2'),
+        groupId: getGroupId('group2'),
+        seriesType: 'area',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const area3: AreaSeriesSpec = {
+        id: getSpecId('area3'),
+        groupId: getGroupId('group2'),
+        seriesType: 'area',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const seriesSpecs = new Map<SpecId, BasicSeriesSpec>([
+        [area1.id, area1],
+        [area2.id, area2],
+        [area3.id, area3],
+      ]);
+      const axesSpecs = new Map<AxisId, AxisSpec>();
+      const chartRotation = 0;
+      const chartDimensions = { width: 100, height: 100, top: 0, left: 0 };
+      const chartColors = {
+        vizColors: ['violet', 'green', 'blue'],
+        defaultVizColor: 'red',
+      };
+      const domainsByGroupId = mergeDomainsByGroupId(axesSpecs, chartRotation);
+      const seriesDomains = computeSeriesDomains(seriesSpecs, domainsByGroupId);
+      const seriesColorMap = getSeriesColorMap(seriesDomains.seriesColors, chartColors, new Map());
+      const geometries = computeSeriesGeometries(
+        seriesSpecs,
+        seriesDomains.xDomain,
+        seriesDomains.yDomain,
+        seriesDomains.formattedDataSeries,
+        seriesColorMap,
+        chartColors,
+        chartDimensions,
+        chartRotation,
+      );
+      expect(geometries.geometriesCounts.bars).toBe(0);
+      expect(geometries.geometriesCounts.linePoints).toBe(0);
+      expect(geometries.geometriesCounts.areasPoints).toBe(24);
+      expect(geometries.geometriesCounts.lines).toBe(0);
+      expect(geometries.geometriesCounts.areas).toBe(6);
+    });
+    test('can compute bars geometries counts', () => {
+      const bars1: BarSeriesSpec = {
+        id: getSpecId('bars1'),
+        groupId: getGroupId('group2'),
+        seriesType: 'bar',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const bars2: BarSeriesSpec = {
+        id: getSpecId('bars2'),
+        groupId: getGroupId('group2'),
+        seriesType: 'bar',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const bars3: BarSeriesSpec = {
+        id: getSpecId('bars3'),
+        groupId: getGroupId('group2'),
+        seriesType: 'bar',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const seriesSpecs = new Map<SpecId, BasicSeriesSpec>([
+        [bars1.id, bars1],
+        [bars2.id, bars2],
+        [bars3.id, bars3],
+      ]);
+      const axesSpecs = new Map<AxisId, AxisSpec>();
+      const chartRotation = 0;
+      const chartDimensions = { width: 100, height: 100, top: 0, left: 0 };
+      const chartColors = {
+        vizColors: ['violet', 'green', 'blue'],
+        defaultVizColor: 'red',
+      };
+      const domainsByGroupId = mergeDomainsByGroupId(axesSpecs, chartRotation);
+      const seriesDomains = computeSeriesDomains(seriesSpecs, domainsByGroupId);
+      const seriesColorMap = getSeriesColorMap(seriesDomains.seriesColors, chartColors, new Map());
+      const geometries = computeSeriesGeometries(
+        seriesSpecs,
+        seriesDomains.xDomain,
+        seriesDomains.yDomain,
+        seriesDomains.formattedDataSeries,
+        seriesColorMap,
+        chartColors,
+        chartDimensions,
+        chartRotation,
+      );
+      expect(geometries.geometriesCounts.bars).toBe(24);
+      expect(geometries.geometriesCounts.linePoints).toBe(0);
+      expect(geometries.geometriesCounts.areasPoints).toBe(0);
+      expect(geometries.geometriesCounts.lines).toBe(0);
+      expect(geometries.geometriesCounts.areas).toBe(0);
+    });
   });
 });

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -38,6 +38,9 @@ import { AxisId, GroupId, SpecId } from '../lib/utils/ids';
 import { Scale } from '../lib/utils/scales/scales';
 import { SeriesDomainsAndData } from './chart_state';
 
+const MAX_ANIMATABLE_BARS = 300;
+const MAX_ANIMATABLE_LINES_AREA_POINTS = 600;
+
 export interface Transform {
   x: number;
   y: number;
@@ -48,6 +51,15 @@ export interface BrushExtent {
   minY: number;
   maxX: number;
   maxY: number;
+}
+
+export interface GeometrisCounts {
+  points: number;
+  bars: number;
+  areas: number;
+  areasPoints: number;
+  lines: number;
+  linePoints: number;
 }
 
 export function findDataSeriesByColorValues(
@@ -159,6 +171,7 @@ export function computeSeriesGeometries(
     lines: LineGeometry[];
   };
   geometriesIndex: Map<any, IndexedGeometry[]>;
+  geometriesCounts: GeometrisCounts;
 } {
   const width = [0, 180].includes(chartRotation) ? chartDims.width : chartDims.height;
   const height = [0, 180].includes(chartRotation) ? chartDims.height : chartDims.width;
@@ -182,6 +195,14 @@ export function computeSeriesGeometries(
   let stackedGeometriesIndex: Map<any, IndexedGeometry[]> = new Map();
   let nonStackedGeometriesIndex: Map<any, IndexedGeometry[]> = new Map();
   let orderIndex = 0;
+  const geometriesCounts = {
+    points: 0,
+    bars: 0,
+    areas: 0,
+    areasPoints: 0,
+    lines: 0,
+    linePoints: 0,
+  };
   formattedDataSeries.stacked.forEach((dataSeriesGroup, index) => {
     const { groupId, dataSeries, counts } = dataSeriesGroup;
     const yScale = yScales.get(groupId);
@@ -205,7 +226,15 @@ export function computeSeriesGeometries(
     lines.push(...geometries.lines);
     bars.push(...geometries.bars);
     points.push(...geometries.points);
+
+    // update counts
     stackedGeometriesIndex = geometries.geometriesIndex;
+    geometriesCounts.points += geometries.geometriesCounts.points;
+    geometriesCounts.bars += geometries.geometriesCounts.bars;
+    geometriesCounts.areas += geometries.geometriesCounts.areas;
+    geometriesCounts.areasPoints += geometries.geometriesCounts.areasPoints;
+    geometriesCounts.lines += geometries.geometriesCounts.lines;
+    geometriesCounts.linePoints += geometries.geometriesCounts.linePoints;
   });
   formattedDataSeries.nonStacked.map((dataSeriesGroup, index) => {
     const { groupId, dataSeries } = dataSeriesGroup;
@@ -230,6 +259,14 @@ export function computeSeriesGeometries(
     bars.push(...geometries.bars);
     points.push(...geometries.points);
     nonStackedGeometriesIndex = geometries.geometriesIndex;
+
+    // update counts
+    geometriesCounts.points += geometries.geometriesCounts.points;
+    geometriesCounts.bars += geometries.geometriesCounts.bars;
+    geometriesCounts.areas += geometries.geometriesCounts.areas;
+    geometriesCounts.areasPoints += geometries.geometriesCounts.areasPoints;
+    geometriesCounts.lines += geometries.geometriesCounts.lines;
+    geometriesCounts.linePoints += geometries.geometriesCounts.linePoints;
   });
   const geometriesIndex = mergeGeometriesIndexes(stackedGeometriesIndex, nonStackedGeometriesIndex);
   return {
@@ -244,6 +281,7 @@ export function computeSeriesGeometries(
       lines,
     },
     geometriesIndex,
+    geometriesCounts,
   };
 }
 
@@ -263,6 +301,7 @@ export function renderGeometries(
   areas: AreaGeometry[];
   lines: LineGeometry[];
   geometriesIndex: Map<any, IndexedGeometry[]>;
+  geometriesCounts: GeometrisCounts;
 } {
   const len = dataSeries.length;
   let i;
@@ -274,6 +313,14 @@ export function renderGeometries(
   let barGeometriesIndex: Map<any, IndexedGeometry[]> = new Map();
   let lineGeometriesIndex: Map<any, IndexedGeometry[]> = new Map();
   let areaGeometriesIndex: Map<any, IndexedGeometry[]> = new Map();
+  const geometriesCounts = {
+    points: 0,
+    bars: 0,
+    areas: 0,
+    areasPoints: 0,
+    lines: 0,
+    linePoints: 0,
+  };
   for (i = 0; i < len; i++) {
     const ds = dataSeries[i];
     const spec = getSpecById(seriesSpecs, ds.specId);
@@ -299,6 +346,7 @@ export function renderGeometries(
           pointGeometriesIndex,
           renderedPoints.indexedGeometries,
         );
+        geometriesCounts.points += renderedPoints.pointGeometries.length;
         break;
       case 'bar':
         const shift = isStacked ? indexOffset : indexOffset + i;
@@ -308,6 +356,7 @@ export function renderGeometries(
           renderedBars.indexedGeometries,
         );
         bars.push(...renderedBars.barGeometries);
+        geometriesCounts.bars += renderedBars.barGeometries.length;
         break;
       case 'line':
         const lineShift = clusteredCount > 0 ? clusteredCount : 1;
@@ -327,6 +376,8 @@ export function renderGeometries(
           renderedLines.indexedGeometries,
         );
         lines.push(renderedLines.lineGeometry);
+        geometriesCounts.linePoints += renderedLines.lineGeometry.points.length;
+        geometriesCounts.lines += 1;
         break;
       case 'area':
         const areaShift = clusteredCount > 0 ? clusteredCount : 1;
@@ -346,6 +397,8 @@ export function renderGeometries(
           renderedAreas.indexedGeometries,
         );
         areas.push(renderedAreas.areaGeometry);
+        geometriesCounts.areasPoints += renderedAreas.areaGeometry.points.length;
+        geometriesCounts.areas += 1;
         break;
     }
   }
@@ -361,6 +414,7 @@ export function renderGeometries(
     areas,
     lines,
     geometriesIndex,
+    geometriesCounts,
   };
 }
 
@@ -480,4 +534,19 @@ export function isLineAreaOnlyChart(specs: Map<SpecId, BasicSeriesSpec>) {
   return ![...specs.values()].some((spec) => {
     return spec.seriesType === 'bar';
   });
+}
+
+export function isChartAnimatable(
+  geometriesCounts: GeometrisCounts,
+  animationEnabled: boolean,
+): boolean {
+  if (!animationEnabled) {
+    return false;
+  }
+  const { bars, linePoints, areasPoints } = geometriesCounts;
+  if (bars > MAX_ANIMATABLE_BARS || linePoints + areasPoints > MAX_ANIMATABLE_LINES_AREA_POINTS) {
+    return false;
+  } else {
+    return true;
+  }
 }

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -53,7 +53,7 @@ export interface BrushExtent {
   maxY: number;
 }
 
-export interface GeometrisCounts {
+export interface GeometriesCounts {
   points: number;
   bars: number;
   areas: number;
@@ -171,7 +171,7 @@ export function computeSeriesGeometries(
     lines: LineGeometry[];
   };
   geometriesIndex: Map<any, IndexedGeometry[]>;
-  geometriesCounts: GeometrisCounts;
+  geometriesCounts: GeometriesCounts;
 } {
   const width = [0, 180].includes(chartRotation) ? chartDims.width : chartDims.height;
   const height = [0, 180].includes(chartRotation) ? chartDims.height : chartDims.width;
@@ -301,7 +301,7 @@ export function renderGeometries(
   areas: AreaGeometry[];
   lines: LineGeometry[];
   geometriesIndex: Map<any, IndexedGeometry[]>;
-  geometriesCounts: GeometrisCounts;
+  geometriesCounts: GeometriesCounts;
 } {
   const len = dataSeries.length;
   let i;
@@ -537,16 +537,14 @@ export function isLineAreaOnlyChart(specs: Map<SpecId, BasicSeriesSpec>) {
 }
 
 export function isChartAnimatable(
-  geometriesCounts: GeometrisCounts,
+  geometriesCounts: GeometriesCounts,
   animationEnabled: boolean,
 ): boolean {
   if (!animationEnabled) {
     return false;
   }
   const { bars, linePoints, areasPoints } = geometriesCounts;
-  if (bars > MAX_ANIMATABLE_BARS || linePoints + areasPoints > MAX_ANIMATABLE_LINES_AREA_POINTS) {
-    return false;
-  } else {
-    return true;
-  }
+  const isBarsAnimatable = bars <= MAX_ANIMATABLE_BARS;
+  const isLinesAndAreasAnimatable = linePoints + areasPoints <= MAX_ANIMATABLE_LINES_AREA_POINTS;
+  return isBarsAnimatable && isLinesAndAreasAnimatable;
 }


### PR DESCRIPTION
## Summary

The `animateData` prop was not used. This PR reenable this functionality and add a max thresholds of bars and lines/area points before disabling automatically the animation.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
