### PR TITLE
fix(build): fix dependencies for kibana integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@commitlint/cli": "^7.5.2",
     "@commitlint/config-conventional": "^7.5.0",
     "@elastic/datemath": "^5.0.2",
-    "@elastic/eui": "^8.0.0",
+    "@elastic/eui": "9.7.1",
     "@semantic-release/changelog": "^3.0.2",
     "@semantic-release/commit-analyzer": "^6.1.0",
     "@semantic-release/git": "^7.0.8",
@@ -67,12 +67,10 @@
     "@types/d3-collection": "^1.0.8",
     "@types/d3-random": "^1.1.2",
     "@types/d3-scale": "^2.1.1",
-    "@types/d3-shape": "^1.3.1",
     "@types/enzyme": "^3.9.0",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/jest": "^24.0.9",
     "@types/lodash": "^4.14.121",
-    "@types/luxon": "^1.11.1",
     "@types/react": "^16.8.5",
     "@types/react-dom": "^16.8.2",
     "@types/storybook__addon-actions": "^3.4.2",
@@ -108,6 +106,8 @@
     "webpack": "^4.29.5"
   },
   "dependencies": {
+    "@types/d3-shape": "^1.3.1",
+    "@types/luxon": "^1.11.1",
     "classnames": "^2.2.6",
     "d3-array": "^2.0.3",
     "d3-collection": "^1.0.7",
@@ -123,14 +123,14 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "react-konva": "^16.8.3",
+    "react-konva": "16.8.3",
     "react-spring": "^8.0.8",
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
     "@elastic/datemath": "^5.0.2",
-    "@elastic/eui": "^8.0.0",
-    "moment": "^2.24.0"
+    "@elastic/eui": "9.7.1",
+    "moment": "^2.20.1"
   },
   "config": {
     "commitizen": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1048,10 +1048,10 @@
   dependencies:
     tslib "^1.9.3"
 
-"@elastic/eui@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-8.0.0.tgz#36247a32f27b10ad3b3f886378d57aaaaa583064"
-  integrity sha512-XVhoHcDqnI60gct9PiqVwL4rpui7cdjYZf2/n+SAXBhqqYXQIZ5YX6HiVSkN84gcmWGODXbXCA27Oj35lOWW9A==
+"@elastic/eui@9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-9.7.1.tgz#817b5018303a2c6160011e201a8d21fca2f3e47b"
+  integrity sha512-yYTnW1jqv586M8dD4TxTa/9wkj84gJuHeDh9F13z7XGeZ/clUN0XP43Y5Jzv80Q3M80VlEuTpABYMGpPqBAw8w==
   dependencies:
     "@types/lodash" "^4.14.116"
     "@types/numeral" "^0.0.25"
@@ -10347,7 +10347,7 @@ react-is@~16.3.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
   integrity sha512-ybEM7YOr4yBgFd6w8dJqwxegqZGJNBZl6U27HnGKuTZmDvVrD5quWOK/wAnMywiZzW+Qsk+l4X2c70+thp/A8Q==
 
-react-konva@^16.8.3:
+react-konva@16.8.3:
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/react-konva/-/react-konva-16.8.3.tgz#e55390040ea54675a0ef0d40b4fa93731e6d7b03"
   integrity sha512-gU36TBxcPZANQOV5prAFnpRSNp2ikAT7zCICHTBJvOzAfa8Yhcyaey6EIrD+NTT/4y0PyGFBIkmWq6zdrlNrQg==


### PR DESCRIPTION
## Summary

fix #145 

Kibana CI run a type check against the libs imported. We were missing two types, that are not directly exported by the chart package but are subject to typecheck by kibana.
I've moved those dev dependencies to dependencies.

I've also updated the `EUI` dependency and fixed the right `react-konva` version.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- ~~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~~
- ~~[ ] Unit tests were updated or added to match the most common scenarios~~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
