### PR TITLE
feat(legend): hide legend item if hideLegendItem on series spec is true

### DIFF
--- a/src/components/_legend.scss
+++ b/src/components/_legend.scss
@@ -97,6 +97,10 @@ $elasticChartsLegendMaxHeight: $euiSize * 4;
       text-decoration: underline;
     }
   }
+
+  &.elasticChartsLegendList__item--hidden {
+    display: none;
+  }
 }
 
 .elasticChartsLegendListItem__title {

--- a/src/components/legend.tsx
+++ b/src/components/legend.tsx
@@ -75,11 +75,11 @@ class LegendComponent extends React.Component<ReactiveChartProps> {
                 onMouseLeave: this.onLegendItemMouseout,
               };
 
-              const { color, label, isVisible } = item;
+              const { color, label, isSeriesVisible } = item;
 
               return (
                 <EuiFlexItem {...legendItemProps}>
-                  {this.renderLegendElement({ color, label, isVisible }, item.key)}
+                  {this.renderLegendElement({ color, label, isSeriesVisible }, item.key)}
                 </EuiFlexItem>
               );
             })}
@@ -98,10 +98,10 @@ class LegendComponent extends React.Component<ReactiveChartProps> {
   }
 
   private renderLegendElement = (
-    { color, label, isVisible }: Partial<LegendItem>,
+    { color, label, isSeriesVisible }: Partial<LegendItem>,
     legendItemKey: string,
   ) => {
-    const props = { color, label, isVisible, legendItemKey };
+    const props = { color, label, isSeriesVisible, legendItemKey };
 
     return <LegendElement {...props} />;
   }

--- a/src/components/legend.tsx
+++ b/src/components/legend.tsx
@@ -68,14 +68,16 @@ class LegendComponent extends React.Component<ReactiveChartProps> {
             responsive={false}
           >
             {[...legendItems.values()].map((item) => {
+              const { color, label, isSeriesVisible, isLegendItemVisible } = item;
+
               const legendItemProps = {
                 key: item.key,
-                className: 'elasticChartsLegendList__item',
+                className: classNames('elasticChartsLegendList__item', {
+                  'elasticChartsLegendList__item--hidden': !isLegendItemVisible,
+                }),
                 onMouseEnter: this.onLegendItemMouseover(item.key),
                 onMouseLeave: this.onLegendItemMouseout,
               };
-
-              const { color, label, isSeriesVisible } = item;
 
               return (
                 <EuiFlexItem {...legendItemProps}>

--- a/src/components/legend_element.tsx
+++ b/src/components/legend_element.tsx
@@ -21,7 +21,7 @@ interface LegendElementProps {
   legendItemKey: string;
   color: string | undefined;
   label: string | undefined;
-  isVisible?: boolean;
+  isSeriesVisible?: boolean;
 }
 
 interface LegendElementState {
@@ -52,7 +52,7 @@ class LegendElementComponent extends React.Component<LegendElementProps, LegendE
 
   render() {
     const { legendItemKey } = this.props;
-    const { color, label, isVisible } = this.props;
+    const { color, label, isSeriesVisible } = this.props;
 
     const onTitleClick = this.onLegendTitleClick(legendItemKey);
 
@@ -88,7 +88,7 @@ class LegendElementComponent extends React.Component<LegendElementProps, LegendE
           </EuiPopover>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          {this.renderVisibilityButton(legendItemKey, isVisible)}
+          {this.renderVisibilityButton(legendItemKey, isSeriesVisible)}
         </EuiFlexItem>
         <EuiFlexItem grow={false} className={titleClassNames} onClick={onTitleClick}>
           <EuiPopover
@@ -156,8 +156,8 @@ class LegendElementComponent extends React.Component<LegendElementProps, LegendE
     }
   }
 
-  private renderVisibilityButton = (legendItemKey: string, isVisible: boolean = true) => {
-    const iconType = isVisible ? 'eye' : 'eyeClosed';
+  private renderVisibilityButton = (legendItemKey: string, isSeriesVisible: boolean = true) => {
+    const iconType = isSeriesVisible ? 'eye' : 'eyeClosed';
     return (
       <EuiButtonIcon
         onClick={this.onVisibilityClick(legendItemKey)}

--- a/src/lib/series/legend.test.ts
+++ b/src/lib/series/legend.test.ts
@@ -31,6 +31,7 @@ const spec1: BasicSeriesSpec = {
   yAccessors: ['y'],
   yScaleToDataExtent: false,
   data: [],
+  hideInLegend: false,
 };
 const spec2: BasicSeriesSpec = {
   id: getSpecId('spec2'),
@@ -42,6 +43,7 @@ const spec2: BasicSeriesSpec = {
   yAccessors: ['y'],
   yScaleToDataExtent: false,
   data: [],
+  hideInLegend: false,
 };
 
 describe('Legends', () => {
@@ -65,7 +67,7 @@ describe('Legends', () => {
         color: 'red',
         label: 'Spec 1 title',
         value: { colorValues: [], specId: 'spec1' },
-        isVisible: true,
+        isSeriesVisible: true,
         key: 'colorSeries1a',
       },
     ];
@@ -80,14 +82,14 @@ describe('Legends', () => {
         color: 'red',
         label: 'Spec 1 title',
         value: { colorValues: [], specId: 'spec1' },
-        isVisible: true,
+        isSeriesVisible: true,
         key: 'colorSeries1a',
       },
       {
         color: 'blue',
         label: 'a - b',
         value: { colorValues: ['a', 'b'], specId: 'spec1' },
-        isVisible: true,
+        isSeriesVisible: true,
         key: 'colorSeries1b',
       },
     ];
@@ -102,14 +104,14 @@ describe('Legends', () => {
         color: 'red',
         label: 'Spec 1 title',
         value: { colorValues: [], specId: 'spec1' },
-        isVisible: true,
+        isSeriesVisible: true,
         key: 'colorSeries1a',
       },
       {
         color: 'green',
         label: 'spec2',
         value: { colorValues: [], specId: 'spec2' },
-        isVisible: true,
+        isSeriesVisible: true,
         key: 'colorSeries2a',
       },
     ];
@@ -129,7 +131,7 @@ describe('Legends', () => {
         color: 'violet',
         label: 'Spec 1 title',
         value: { colorValues: [], specId: 'spec1' },
-        isVisible: true,
+        isSeriesVisible: true,
         key: 'colorSeries1a',
       },
     ];
@@ -146,7 +148,7 @@ describe('Legends', () => {
 
     const legend = computeLegend(seriesColor, emptyColorMap, specs, 'violet', deselectedDataSeries);
 
-    const visibility = [...legend.values()].map((item) => item.isVisible);
+    const visibility = [...legend.values()].map((item) => item.isSeriesVisible);
 
     expect(visibility).toEqual([true, true, true, true]);
   });
@@ -161,7 +163,7 @@ describe('Legends', () => {
 
     const legend = computeLegend(seriesColor, emptyColorMap, specs, 'violet', deselectedDataSeries);
 
-    const visibility = [...legend.values()].map((item) => item.isVisible);
+    const visibility = [...legend.values()].map((item) => item.isSeriesVisible);
     expect(visibility).toEqual([false, false, true, true]);
   });
   it('returns the right series label for a color series', () => {

--- a/src/lib/series/legend.test.ts
+++ b/src/lib/series/legend.test.ts
@@ -68,6 +68,7 @@ describe('Legends', () => {
         label: 'Spec 1 title',
         value: { colorValues: [], specId: 'spec1' },
         isSeriesVisible: true,
+        isLegendItemVisible: true,
         key: 'colorSeries1a',
       },
     ];
@@ -83,6 +84,7 @@ describe('Legends', () => {
         label: 'Spec 1 title',
         value: { colorValues: [], specId: 'spec1' },
         isSeriesVisible: true,
+        isLegendItemVisible: true,
         key: 'colorSeries1a',
       },
       {
@@ -90,6 +92,7 @@ describe('Legends', () => {
         label: 'a - b',
         value: { colorValues: ['a', 'b'], specId: 'spec1' },
         isSeriesVisible: true,
+        isLegendItemVisible: true,
         key: 'colorSeries1b',
       },
     ];
@@ -105,6 +108,7 @@ describe('Legends', () => {
         label: 'Spec 1 title',
         value: { colorValues: [], specId: 'spec1' },
         isSeriesVisible: true,
+        isLegendItemVisible: true,
         key: 'colorSeries1a',
       },
       {
@@ -112,6 +116,7 @@ describe('Legends', () => {
         label: 'spec2',
         value: { colorValues: [], specId: 'spec2' },
         isSeriesVisible: true,
+        isLegendItemVisible: true,
         key: 'colorSeries2a',
       },
     ];
@@ -132,6 +137,7 @@ describe('Legends', () => {
         label: 'Spec 1 title',
         value: { colorValues: [], specId: 'spec1' },
         isSeriesVisible: true,
+        isLegendItemVisible: true,
         key: 'colorSeries1a',
       },
     ];
@@ -150,7 +156,7 @@ describe('Legends', () => {
 
     const visibility = [...legend.values()].map((item) => item.isSeriesVisible);
 
-    expect(visibility).toEqual([true, true, true, true]);
+    expect(visibility).toEqual([true, true, true]);
   });
   it('selectively sets series to visible when there are deselectedDataSeries items', () => {
     seriesColor.set('colorSeries1a', colorValues1a);
@@ -164,7 +170,7 @@ describe('Legends', () => {
     const legend = computeLegend(seriesColor, emptyColorMap, specs, 'violet', deselectedDataSeries);
 
     const visibility = [...legend.values()].map((item) => item.isSeriesVisible);
-    expect(visibility).toEqual([false, false, true, true]);
+    expect(visibility).toEqual([false, false, true]);
   });
   it('returns the right series label for a color series', () => {
     let label = getSeriesColorLabel([], true);

--- a/src/lib/series/legend.ts
+++ b/src/lib/series/legend.ts
@@ -9,6 +9,7 @@ export interface LegendItem {
   label: string;
   value: DataSeriesColorsValues;
   isSeriesVisible?: boolean;
+  isLegendItemVisible?: boolean;
 }
 export function computeLegend(
   seriesColor: Map<string, DataSeriesColorsValues>,
@@ -20,6 +21,11 @@ export function computeLegend(
   const legendItems: Map<string, LegendItem> = new Map();
   seriesColor.forEach((series, key) => {
     const spec = specs.get(series.specId);
+
+    if (!spec) {
+      return;
+    }
+    const { hideInLegend } = spec;
 
     const color = seriesColorMap.get(key) || defaultColor;
     const hasSingleSeries = seriesColor.size === 1;
@@ -38,6 +44,7 @@ export function computeLegend(
       label,
       value: series,
       isSeriesVisible,
+      isLegendItemVisible: !hideInLegend,
     });
   });
   return legendItems;

--- a/src/lib/series/legend.ts
+++ b/src/lib/series/legend.ts
@@ -22,11 +22,6 @@ export function computeLegend(
   seriesColor.forEach((series, key) => {
     const spec = specs.get(series.specId);
 
-    if (!spec) {
-      return;
-    }
-    const { hideInLegend } = spec;
-
     const color = seriesColorMap.get(key) || defaultColor;
     const hasSingleSeries = seriesColor.size === 1;
     const label = getSeriesColorLabel(series.colorValues, hasSingleSeries, spec);
@@ -34,9 +29,11 @@ export function computeLegend(
       ? findDataSeriesByColorValues(deselectedDataSeries, series) < 0
       : true;
 
-    if (!label) {
+    if (!label || !spec) {
       return;
     }
+
+    const { hideInLegend } = spec;
 
     legendItems.set(key, {
       key,

--- a/src/lib/series/legend.ts
+++ b/src/lib/series/legend.ts
@@ -8,7 +8,7 @@ export interface LegendItem {
   color: string;
   label: string;
   value: DataSeriesColorsValues;
-  isVisible?: boolean;
+  isSeriesVisible?: boolean;
 }
 export function computeLegend(
   seriesColor: Map<string, DataSeriesColorsValues>,
@@ -24,7 +24,7 @@ export function computeLegend(
     const color = seriesColorMap.get(key) || defaultColor;
     const hasSingleSeries = seriesColor.size === 1;
     const label = getSeriesColorLabel(series.colorValues, hasSingleSeries, spec);
-    const isVisible = deselectedDataSeries
+    const isSeriesVisible = deselectedDataSeries
       ? findDataSeriesByColorValues(deselectedDataSeries, series) < 0
       : true;
 
@@ -37,7 +37,7 @@ export function computeLegend(
       color,
       label,
       value: series,
-      isVisible,
+      isSeriesVisible,
     });
   });
   return legendItems;

--- a/src/lib/series/series.test.ts
+++ b/src/lib/series/series.test.ts
@@ -181,6 +181,7 @@ describe('Series', () => {
       yAccessors: ['y'],
       yScaleToDataExtent: false,
       data: TestDataset.BARCHART_1Y0G,
+      hideInLegend: false,
     };
     const spec2: BasicSeriesSpec = {
       id: getSpecId('spec2'),
@@ -193,6 +194,7 @@ describe('Series', () => {
       stackAccessors: ['x'],
       yScaleToDataExtent: false,
       data: TestDataset.BARCHART_2Y0G,
+      hideInLegend: false,
     };
     seriesSpecs.set(spec1.id, spec1);
     seriesSpecs.set(spec2.id, spec2);
@@ -212,6 +214,7 @@ describe('Series', () => {
       yAccessors: ['y'],
       yScaleToDataExtent: false,
       data: TestDataset.BARCHART_1Y0G,
+      hideInLegend: false,
     };
     const spec2: BasicSeriesSpec = {
       id: getSpecId('spec2'),
@@ -224,6 +227,7 @@ describe('Series', () => {
       stackAccessors: ['x'],
       yScaleToDataExtent: false,
       data: TestDataset.BARCHART_2Y0G,
+      hideInLegend: false,
     };
     seriesSpecs.set(spec1.id, spec1);
     seriesSpecs.set(spec2.id, spec2);
@@ -245,6 +249,7 @@ describe('Series', () => {
       yAccessors: ['y'],
       yScaleToDataExtent: false,
       data: TestDataset.BARCHART_1Y0G,
+      hideInLegend: false,
     };
 
     const specs = new Map();
@@ -293,6 +298,7 @@ describe('Series', () => {
       stackAccessors: ['x'],
       yScaleToDataExtent: false,
       data: TestDataset.BARCHART_2Y0G,
+      hideInLegend: false,
     };
 
     seriesSpecs.set(splitSpec.id, splitSpec);

--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -42,7 +42,7 @@ export interface SeriesSpec {
   /** If the series should appear in the legend
    * @default false
    */
-  hideInLegend: boolean;
+  hideInLegend?: boolean;
 }
 
 export type CustomSeriesColorsMap = Map<DataSeriesColorsValues, string>;

--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -39,6 +39,10 @@ export interface SeriesSpec {
   seriesType: 'bar' | 'line' | 'area' | 'basic';
   /** Custom colors for series */
   customSeriesColors?: CustomSeriesColorsMap;
+  /** If the series should appear in the legend
+   * @default false
+   */
+  hideInLegend: boolean;
 }
 
 export type CustomSeriesColorsMap = Map<DataSeriesColorsValues, string>;

--- a/src/specs/area_series.tsx
+++ b/src/specs/area_series.tsx
@@ -16,6 +16,7 @@ export class AreaSeriesSpecComponent extends PureComponent<AreaSpecProps> {
     xAccessor: 'x',
     yAccessors: ['y'],
     yScaleToDataExtent: false,
+    hideInLegend: false,
   };
   componentDidMount() {
     const { chartStore, children, ...config } = this.props;

--- a/src/specs/bar_series.tsx
+++ b/src/specs/bar_series.tsx
@@ -16,6 +16,7 @@ export class BarSeriesSpecComponent extends PureComponent<BarSpecProps> {
     xAccessor: 'x',
     yAccessors: ['y'],
     yScaleToDataExtent: false,
+    hideInLegend: false,
   };
   componentDidMount() {
     const { chartStore, children, ...config } = this.props;

--- a/src/specs/basic_series.tsx
+++ b/src/specs/basic_series.tsx
@@ -16,6 +16,7 @@ export class BasicSeriesSpecComponent extends PureComponent<BasicSpecProps> {
     xAccessor: 'x',
     yAccessors: ['y'],
     yScaleToDataExtent: false,
+    hideInLegend: false,
   };
   componentDidMount() {
     const { chartStore, children, ...config } = this.props;

--- a/src/specs/line_series.tsx
+++ b/src/specs/line_series.tsx
@@ -16,6 +16,7 @@ export class LineSeriesSpecComponent extends PureComponent<LineSpecProps> {
     xAccessor: 'x',
     yAccessors: ['y'],
     yScaleToDataExtent: false,
+    hideInLegend: false,
   };
   componentDidMount() {
     const { chartStore, children, ...config } = this.props;

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -25,6 +25,7 @@ describe('Chart Store', () => {
     yAccessors: ['y'],
     xScaleType: ScaleType.Linear,
     yScaleType: ScaleType.Linear,
+    hideInLegend: false,
   };
 
   const firstLegendItem = {

--- a/src/state/test/interactions.test.ts
+++ b/src/state/test/interactions.test.ts
@@ -22,6 +22,7 @@ const ordinalBarSeries: BarSeriesSpec = {
   yAccessors: [1],
   xScaleType: ScaleType.Ordinal,
   yScaleType: ScaleType.Linear,
+  hideInLegend: false,
 };
 const linearBarSeries: BarSeriesSpec = {
   id: SPEC_ID,
@@ -33,6 +34,7 @@ const linearBarSeries: BarSeriesSpec = {
   yAccessors: [1],
   xScaleType: ScaleType.Linear,
   yScaleType: ScaleType.Linear,
+  hideInLegend: false,
 };
 const chartTop = 10;
 const chartLeft = 10;

--- a/stories/legend.tsx
+++ b/stories/legend.tsx
@@ -7,6 +7,7 @@ import {
   Chart,
   getAxisId,
   getSpecId,
+  LineSeries,
   Position,
   ScaleType,
   Settings,
@@ -40,6 +41,7 @@ storiesOf('Legend', module)
           splitSeriesAccessors={['g1', 'g2']}
           data={TestDatasets.BARCHART_2Y2G}
           yScaleToDataExtent={false}
+          hideInLegend={false}
         />
       </Chart>
     );
@@ -160,6 +162,46 @@ storiesOf('Legend', module)
           yAccessors={['y1', 'y2']}
           splitSeriesAccessors={splitSeries}
           data={TestDatasets.BARCHART_2Y2G}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('hide legend items by series', () => {
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+          yScaleToDataExtent={false}
+        />
+        <LineSeries
+          id={getSpecId('lines')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          stackAccessors={['x']}
+          splitSeriesAccessors={['g']}
+          data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
           yScaleToDataExtent={false}
         />
       </Chart>

--- a/stories/legend.tsx
+++ b/stories/legend.tsx
@@ -168,6 +168,9 @@ storiesOf('Legend', module)
     );
   })
   .add('hide legend items by series', () => {
+    const hideBarSeriesInLegend = boolean('hide bar series in legend', false);
+    const hideLineSeriesInLegend = boolean('hide line series in legend', false);
+
     return (
       <Chart renderer="canvas" className={'story-chart'}>
         <Settings showLegend={true} legendPosition={Position.Right} />
@@ -192,6 +195,7 @@ storiesOf('Legend', module)
           yAccessors={['y']}
           data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
           yScaleToDataExtent={false}
+          hideInLegend={hideBarSeriesInLegend}
         />
         <LineSeries
           id={getSpecId('lines')}
@@ -203,6 +207,7 @@ storiesOf('Legend', module)
           splitSeriesAccessors={['g']}
           data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
           yScaleToDataExtent={false}
+          hideInLegend={hideLineSeriesInLegend}
         />
       </Chart>
     );


### PR DESCRIPTION
## Summary

close #137 

This PR introduces a new property to the series spec `hideInLegend` which, when true, will remove the legend item from being visible in the legend list.

![hide_legend_item](https://user-images.githubusercontent.com/452850/55516831-49973080-5623-11e9-820c-40590b981f95.gif)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
