### PR TITLE
fix(domain): set domain bounds dependent on negative/positive values

### DIFF
--- a/src/lib/utils/domain.test.ts
+++ b/src/lib/utils/domain.test.ts
@@ -1,5 +1,10 @@
 import { AccessorFn } from './accessor';
-import { computeContinuousDataDomain, computeOrdinalDataDomain, computeStackedContinuousDomain } from './domain';
+import {
+  computeContinuousDataDomain,
+  computeDomainExtent,
+  computeOrdinalDataDomain,
+  computeStackedContinuousDomain,
+} from './domain';
 
 describe('utils/domain', () => {
   test('should compute ordinal data domain: sort & remove nulls', () => {
@@ -150,5 +155,19 @@ describe('utils/domain', () => {
     const expectedStackedDomain = [0, 20];
 
     expect(stackedDataDomain).toEqual(expectedStackedDomain);
+  });
+
+  test('should compute domain based on scaleToExtent', () => {
+    // start & end are positive
+    expect(computeDomainExtent([5, 10], true)).toEqual([5, 10]);
+    expect(computeDomainExtent([5, 10], false)).toEqual([0, 10]);
+
+    // start & end are negative
+    expect(computeDomainExtent([-15, -10], true)).toEqual([-15, -10]);
+    expect(computeDomainExtent([-15, -10], false)).toEqual([-15, 0]);
+
+    // start is negative, end is positive
+    expect(computeDomainExtent([-15, 10], true)).toEqual([-15, 10]);
+    expect(computeDomainExtent([-15, 10], false)).toEqual([-15, 10]);
   });
 });

--- a/src/lib/utils/domain.ts
+++ b/src/lib/utils/domain.ts
@@ -40,9 +40,28 @@ export function computeOrdinalDataDomain(
   const uniqueValues = [...new Set(domain)];
   return sorted
     ? uniqueValues.sort((a, b) => {
-        return `${a}`.localeCompare(`${b}`);
-      })
+      return `${a}`.localeCompare(`${b}`);
+    })
     : uniqueValues;
+}
+
+export function computeDomainExtent(
+  computedDomain: [number, number] | [undefined, undefined],
+  scaleToExtent: boolean,
+): [number, number] {
+  const [start, end] = computedDomain;
+
+  if (start != null && end != null) {
+    if (start >= 0 && end >= 0) {
+      return scaleToExtent ? [start, end] : [0, end];
+    } else if (start < 0 && end < 0) {
+      return scaleToExtent ? [start, end] : [start, 0];
+    }
+    return [start, end];
+  }
+
+  // if any of the values are null
+  return [0, 0];
 }
 
 export function computeContinuousDataDomain(
@@ -51,7 +70,7 @@ export function computeContinuousDataDomain(
   scaleToExtent = false,
 ): number[] {
   const range = extent(data, accessor);
-  return scaleToExtent ? range : [0, range[1] || 0];
+  return computeDomainExtent(range, scaleToExtent);
 }
 
 export function computeStackedContinuousDomain(

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -1,4 +1,4 @@
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import { DateTime } from 'luxon';
 import React from 'react';
@@ -827,6 +827,61 @@ storiesOf('Bar Chart', module)
             { x: 3, y: 1 },
           ]}
           yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('scale to extent', () => {
+    const yScaleToDataExtent = boolean('yScaleDataToExtent', false);
+    const mixed = [
+      { x: 3, y: 1 },
+      { x: 0, y: -4 },
+      { x: 2, y: 2 },
+      { x: 1, y: -3 },
+      { x: 2, y: 2 },
+      { x: 1, y: -3 },
+      { x: 3, y: 1 },
+    ];
+
+    const allPositive = mixed.map((datum) => ({ x: datum.x, y: Math.abs(datum.y) }));
+    const allNegative = mixed.map((datum) => ({ x: datum.x, y: Math.abs(datum.y) * -1 }));
+
+    const dataChoice = select('data', {
+      mixed: 'mixed',
+      allPositive: 'all positive',
+      allNegative: 'all negative',
+    }, 'mixed');
+
+    let data = mixed;
+    switch (dataChoice) {
+      case 'all positive':
+        data = allPositive;
+        break;
+      case 'all negative':
+        data = allNegative;
+        break;
+    }
+
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Axis id={getAxisId('top')} position={Position.Top} title={'Top axis'} />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          splitSeriesAccessors={['g']}
+          stackAccessors={['x']}
+          data={data}
+          yScaleToDataExtent={yScaleToDataExtent}
         />
       </Chart>
     );


### PR DESCRIPTION
## Summary

close #135

This PR addresses the issues with the previous `scaleToExtent` logic assuming a domain with only positive values.  Now, when `scaleToExtent` is false, we return a domain dependent on whether the domain has positive or negative values.  Previously, a chart with only negative values would only see the values rendering if `scaleToExtent` was true; now even when `scaleToExtent` is false, the negative values will render.  For mixed negative & positive values, we return the original domain.

![scale_to_extent](https://user-images.githubusercontent.com/452850/55598855-b684f600-5709-11e9-971e-1ddf35dca123.gif)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
