### PR TITLE
feat(line_annotation): add hideLines and hideTooltips props to spec

### DIFF
--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -199,6 +199,10 @@ export interface LineAnnotationSpec {
     width: number;
     height: number;
   };
+  /** Annotation lines are hidden */
+  hideLines?: boolean;
+  /** Annotation tooltips are hidden */
+  hideTooltips?: boolean;
 }
 
 // TODO: RectangleAnnotationSpec & TextAnnotationSpec

--- a/src/specs/line_annotation.tsx
+++ b/src/specs/line_annotation.tsx
@@ -12,6 +12,8 @@ export class LineAnnotationSpecComponent extends PureComponent<LineAnnotationPro
     groupId: getGroupId('__global__'),
     annotationType: AnnotationTypes.Line,
     style: DEFAULT_ANNOTATION_LINE_STYLE,
+    hideLines: false,
+    hideTooltips: false,
   };
 
   private markerRef = createRef<HTMLDivElement>();

--- a/src/state/annotation_utils.ts
+++ b/src/state/annotation_utils.ts
@@ -249,7 +249,11 @@ export function computeLineAnnotationDimensions(
   xScale: Scale,
   axisPosition: Position,
 ): AnnotationLineProps[] | null {
-  const { domainType, dataValues, marker, markerDimensions } = annotationSpec;
+  const { domainType, dataValues, marker, markerDimensions, hideLines } = annotationSpec;
+
+  if (hideLines) {
+    return null;
+  }
 
   // TODO : make line overflow configurable via prop
   const lineOverflow = DEFAULT_LINE_OVERFLOW;

--- a/src/state/annotation_utils.ts
+++ b/src/state/annotation_utils.ts
@@ -579,7 +579,7 @@ export function computeAnnotationTooltipState(
 ): AnnotationTooltipState | null {
   for (const [annotationId, annotationDimension] of annotationDimensions) {
     const spec = annotationSpecs.get(annotationId);
-    if (!spec) {
+    if (!spec || spec.hideTooltips || spec.hideLines) {
       continue;
     }
 

--- a/stories/annotations.tsx
+++ b/stories/annotations.tsx
@@ -258,6 +258,9 @@ storiesOf('Annotations', module)
       questionInCircle: 'questionInCircle',
     }, 'alert');
 
+    const hideLines = boolean('annotation lines hidden', false);
+    const hideTooltips = boolean('annotation tooltips hidden', false);
+
     return (
       <Chart renderer="canvas" className={'story-chart'}>
         <Settings debug={boolean('debug', false)} rotation={chartRotation} />
@@ -267,6 +270,8 @@ storiesOf('Annotations', module)
           dataValues={dataValues}
           style={style}
           marker={(<EuiIcon type={marker} />)}
+          hideLines={hideLines}
+          hideTooltips={hideTooltips}
         />
         <Axis
           id={getAxisId('horizontal')}


### PR DESCRIPTION
## Summary

re: #150 

This PR introduces two props to LineAnnotationSpec: `hideLines` and `hideTooltips` which can be used to toggle visibility of annotation lines and their tooltips when set to true.

![annotation_hide_props](https://user-images.githubusercontent.com/452850/55661287-e8589400-57bf-11e9-9dd9-8e84b880a125.gif)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
