### PR TITLE
feat: allow individual series styling

### DIFF
--- a/src/components/react_canvas/area_geometries.tsx
+++ b/src/components/react_canvas/area_geometries.tsx
@@ -24,7 +24,7 @@ interface AreaGeometriesDataState {
 export class AreaGeometries extends React.PureComponent<
   AreaGeometriesDataProps,
   AreaGeometriesDataState
-> {
+  > {
   static defaultProps: Partial<AreaGeometriesDataProps> = {
     animated: false,
   };
@@ -41,29 +41,35 @@ export class AreaGeometries extends React.PureComponent<
 
     return (
       <Group ref={this.barSeriesRef} key={'bar_series'}>
-        {area.visible && this.renderAreaGeoms()}
-        {line.visible && this.renderAreaLines()}
-        {point.visible && this.renderAreaPoints()}
+        {this.renderAreaGeoms(area.visible)}
+        {this.renderAreaLines(line.visible)}
+        {this.renderAreaPoints(point.visible)}
       </Group>
     );
   }
-  private renderAreaPoints = (): JSX.Element[] => {
+  private renderAreaPoints = (themeIsVisible: boolean): JSX.Element[] => {
     const { areas } = this.props;
     return areas.reduce(
       (acc, glyph, i) => {
         const { points } = glyph;
-        return [...acc, ...this.renderPoints(points, i)];
+        return [...acc, ...this.renderPoints(points, i, themeIsVisible)];
       },
       [] as JSX.Element[],
     );
   }
-  private renderPoints = (areaPoints: PointGeometry[], areaIndex: number): JSX.Element[] => {
+  private renderPoints = (areaPoints: PointGeometry[], areaIndex: number, themeIsVisible: boolean): JSX.Element[] => {
     const { radius, strokeWidth, opacity } = this.props.style.point;
 
-    return areaPoints.map((areaPoint, pointIndex) => {
-      const { x, y, color, transform } = areaPoint;
+    const areaPointElements: JSX.Element[] = [];
+    areaPoints.forEach((areaPoint, pointIndex) => {
+      const { x, y, color, transform, seriesPointStyle } = areaPoint;
+      const isVisible = seriesPointStyle ? seriesPointStyle.visible : themeIsVisible;
+      if (!isVisible) {
+        return;
+      }
+
       if (this.props.animated) {
-        return (
+        areaPointElements.push(
           <Group key={`area-point-group-${areaIndex}-${pointIndex}`} x={transform.x}>
             <Spring native from={{ y }} to={{ y }}>
               {(props: { y: number }) => {
@@ -76,12 +82,12 @@ export class AreaGeometries extends React.PureComponent<
                   strokeWidth,
                   color,
                   opacity,
+                  seriesPointStyle,
                 });
                 return <animated.Circle {...pointProps} />;
               }}
             </Spring>
-          </Group>
-        );
+          </Group>);
       } else {
         const pointProps = buildAreaPointProps({
           areaIndex,
@@ -92,21 +98,28 @@ export class AreaGeometries extends React.PureComponent<
           strokeWidth,
           color,
           opacity,
+          seriesPointStyle,
         });
-        return <Circle {...pointProps} />;
+        areaPointElements.push(<Circle {...pointProps} />);
       }
     });
+    return areaPointElements;
   }
 
-  private renderAreaGeoms = (): JSX.Element[] => {
+  private renderAreaGeoms = (themeIsVisible: boolean): JSX.Element[] => {
     const { areas } = this.props;
     const { opacity } = this.props.style.area;
+    const areasToRender: JSX.Element[] = [];
 
-    return areas.map((glyph, i) => {
-      const { area, color, transform } = glyph;
+    areas.forEach((glyph, i) => {
+      const { area, color, transform, seriesAreaStyle } = glyph;
+      const isVisible = seriesAreaStyle ? seriesAreaStyle.visible : themeIsVisible;
+      if (!isVisible) {
+        return;
+      }
 
       if (this.props.animated) {
-        return (
+        areasToRender.push(
           <Group key={`area-group-${i}`} x={transform.x}>
             <Spring native from={{ area }} to={{ area }}>
               {(props: { area: string }) => {
@@ -115,34 +128,43 @@ export class AreaGeometries extends React.PureComponent<
                   areaPath: props.area,
                   color,
                   opacity,
+                  seriesAreaStyle,
                 });
                 return <animated.Path {...areaProps} />;
               }}
             </Spring>
-          </Group>
-        );
+          </Group>);
       } else {
         const areaProps = buildAreaProps({
           index: i,
           areaPath: area,
           color,
           opacity,
+          seriesAreaStyle,
         });
-        return <Path {...areaProps} />;
+        areasToRender.push(<Path {...areaProps} />);
       }
     });
+    return areasToRender;
   }
-  private renderAreaLines = (): JSX.Element[] => {
+  private renderAreaLines = (themeIsVisible: boolean): JSX.Element[] => {
     const { areas, sharedStyle } = this.props;
     const { strokeWidth } = this.props.style.line;
     const linesToRender: JSX.Element[] = [];
     areas.forEach((glyph, areaIndex) => {
-      const { lines, color, geometryId } = glyph;
+      const { lines, color, geometryId, seriesAreaLineStyle } = glyph;
+      const isVisible = seriesAreaLineStyle ? seriesAreaLineStyle.visible : themeIsVisible;
+      if (!isVisible) {
+        return;
+      }
+
+      const customOpacity = seriesAreaLineStyle ? seriesAreaLineStyle.opacity : undefined;
 
       const geometryStyle = getGeometryStyle(
         geometryId,
         this.props.highlightedLegendItem,
         sharedStyle,
+        customOpacity,
       );
 
       lines.forEach((linePath, lineIndex) => {
@@ -153,6 +175,7 @@ export class AreaGeometries extends React.PureComponent<
           color,
           strokeWidth,
           geometryStyle,
+          seriesAreaLineStyle,
         });
         linesToRender.push(<Path {...lineProps} />);
       });

--- a/src/components/react_canvas/area_geometries.tsx
+++ b/src/components/react_canvas/area_geometries.tsx
@@ -9,6 +9,7 @@ import {
   buildAreaLineProps,
   buildAreaPointProps,
   buildAreaProps,
+  buildPointStyleProps,
 } from './utils/rendering_props_utils';
 
 interface AreaGeometriesDataProps {
@@ -51,22 +52,34 @@ export class AreaGeometries extends React.PureComponent<
     const { areas } = this.props;
     return areas.reduce(
       (acc, glyph, i) => {
-        const { points } = glyph;
-        return [...acc, ...this.renderPoints(points, i, themeIsVisible)];
+        const { points, seriesPointStyle } = glyph;
+
+        const isVisible = seriesPointStyle ? seriesPointStyle.visible : themeIsVisible;
+        if (!isVisible) {
+          return acc;
+        }
+
+        const { radius, strokeWidth, opacity } = this.props.style.point;
+        const pointStyleProps = buildPointStyleProps({
+          radius,
+          strokeWidth,
+          opacity,
+          seriesPointStyle,
+        });
+
+        return [...acc, ...this.renderPoints(points, i, pointStyleProps)];
       },
       [] as JSX.Element[],
     );
   }
-  private renderPoints = (areaPoints: PointGeometry[], areaIndex: number, themeIsVisible: boolean): JSX.Element[] => {
-    const { radius, strokeWidth, opacity } = this.props.style.point;
-
+  private renderPoints = (
+    areaPoints: PointGeometry[],
+    areaIndex: number,
+    pointStyleProps: any,
+  ): JSX.Element[] => {
     const areaPointElements: JSX.Element[] = [];
     areaPoints.forEach((areaPoint, pointIndex) => {
-      const { x, y, color, transform, seriesPointStyle } = areaPoint;
-      const isVisible = seriesPointStyle ? seriesPointStyle.visible : themeIsVisible;
-      if (!isVisible) {
-        return;
-      }
+      const { x, y, color, transform } = areaPoint;
 
       if (this.props.animated) {
         areaPointElements.push(
@@ -78,11 +91,8 @@ export class AreaGeometries extends React.PureComponent<
                   pointIndex,
                   x,
                   y,
-                  radius,
-                  strokeWidth,
                   color,
-                  opacity,
-                  seriesPointStyle,
+                  pointStyleProps,
                 });
                 return <animated.Circle {...pointProps} />;
               }}
@@ -94,11 +104,8 @@ export class AreaGeometries extends React.PureComponent<
           pointIndex,
           x: transform.x + x,
           y,
-          radius,
-          strokeWidth,
           color,
-          opacity,
-          seriesPointStyle,
+          pointStyleProps,
         });
         areaPointElements.push(<Circle {...pointProps} />);
       }

--- a/src/components/react_canvas/bar_geometries.tsx
+++ b/src/components/react_canvas/bar_geometries.tsx
@@ -20,7 +20,7 @@ interface BarGeometriesDataState {
 export class BarGeometries extends React.PureComponent<
   BarGeometriesDataProps,
   BarGeometriesDataState
-> {
+  > {
   static defaultProps: Partial<BarGeometriesDataProps> = {
     animated: false,
   };
@@ -44,11 +44,12 @@ export class BarGeometries extends React.PureComponent<
   private renderBarGeoms = (bars: BarGeometry[]): JSX.Element[] => {
     const { overBar } = this.state;
     const {
-      style: { border },
+      style,
       sharedStyle,
     } = this.props;
     return bars.map((bar, index) => {
-      const { x, y, width, height, color } = bar;
+      const { x, y, width, height, color, seriesStyle } = bar;
+      const border = seriesStyle ? seriesStyle.border : style.border;
 
       // Properties to determine if we need to highlight individual bars depending on hover state
       const hasGeometryHover = overBar != null;

--- a/src/components/react_canvas/bar_geometries.tsx
+++ b/src/components/react_canvas/bar_geometries.tsx
@@ -50,6 +50,7 @@ export class BarGeometries extends React.PureComponent<
     return bars.map((bar, index) => {
       const { x, y, width, height, color, seriesStyle } = bar;
       const border = seriesStyle ? seriesStyle.border : style.border;
+      const customOpacity = seriesStyle ? seriesStyle.opacity : undefined;
 
       // Properties to determine if we need to highlight individual bars depending on hover state
       const hasGeometryHover = overBar != null;
@@ -63,6 +64,7 @@ export class BarGeometries extends React.PureComponent<
         bar.geometryId,
         this.props.highlightedLegendItem,
         sharedStyle,
+        customOpacity,
         individualHighlight,
       );
 

--- a/src/components/react_canvas/utils/rendering_props_utils.test.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.test.ts
@@ -156,6 +156,38 @@ describe('[canvas] Line Geometries', () => {
       perfectDrawEnabled: false,
       listening: false,
     });
+
+    const seriesPointStyle = buildLinePointProps({
+      lineIndex: 1,
+      pointIndex: 2,
+      x: 10,
+      y: 20,
+      radius: 30,
+      strokeWidth: 2,
+      color: 'red',
+      opacity: 0.5,
+      seriesPointStyle: {
+        stroke: 'series-stroke',
+        strokeWidth: 6,
+        visible: true,
+        radius: 12,
+        opacity: 18,
+      },
+    });
+    expect(seriesPointStyle).toEqual({
+      key: 'line-point-1-2',
+      x: 10,
+      y: 20,
+      radius: 12,
+      strokeWidth: 2,
+      strokeEnabled: true,
+      stroke: 'red',
+      fill: 'white',
+      opacity: 18,
+      strokeHitEnabled: false,
+      perfectDrawEnabled: false,
+      listening: false,
+    });
   });
   test('can build line path props', () => {
     const props = buildLineProps({
@@ -163,7 +195,6 @@ describe('[canvas] Line Geometries', () => {
       linePath: 'M0,0L10,10Z',
       color: 'red',
       strokeWidth: 1,
-      opacity: 0.3,
       geometryStyle: {
         opacity: 0.5,
       },
@@ -181,6 +212,33 @@ describe('[canvas] Line Geometries', () => {
       listening: false,
     });
     expect(props.fill).toBeFalsy();
+
+    const seriesLineStyleProps = buildLineProps({
+      index: 1,
+      linePath: 'M0,0L10,10Z',
+      color: 'red',
+      strokeWidth: 1,
+      geometryStyle: {
+        opacity: 0.5,
+      },
+      seriesLineStyle: {
+        stroke: 'series-stroke',
+        strokeWidth: 66,
+        visible: true,
+      },
+    });
+    expect(seriesLineStyleProps).toEqual({
+      key: `line-1`,
+      data: 'M0,0L10,10Z',
+      stroke: 'red',
+      strokeWidth: 66,
+      lineCap: 'round',
+      lineJoin: 'round',
+      opacity: 0.5,
+      strokeHitEnabled: false,
+      perfectDrawEnabled: false,
+      listening: false,
+    });
   });
 });
 

--- a/src/components/react_canvas/utils/rendering_props_utils.test.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.test.ts
@@ -58,6 +58,38 @@ describe('[canvas] Area Geometries props', () => {
       perfectDrawEnabled: false,
       listening: false,
     });
+
+    const seriesPointStyle = buildAreaPointProps({
+      areaIndex: 1,
+      pointIndex: 2,
+      x: 10,
+      y: 20,
+      radius: 30,
+      strokeWidth: 2,
+      color: 'red',
+      opacity: 0.5,
+      seriesPointStyle: {
+        radius: 123,
+        stroke: 'series-stroke',
+        strokeWidth: 456,
+        opacity: 789,
+        visible: true,
+      },
+    });
+    expect(seriesPointStyle).toEqual({
+      key: 'area-point-1-2',
+      x: 10,
+      y: 20,
+      radius: 123,
+      strokeWidth: 456,
+      strokeEnabled: true,
+      stroke: 'red',
+      fill: 'white',
+      opacity: 789,
+      strokeHitEnabled: false,
+      perfectDrawEnabled: false,
+      listening: false,
+    });
   });
   test('can build area path props', () => {
     const props = buildAreaProps({
@@ -73,6 +105,29 @@ describe('[canvas] Area Geometries props', () => {
       lineCap: 'round',
       lineJoin: 'round',
       opacity: 0.5,
+      strokeHitEnabled: false,
+      perfectDrawEnabled: false,
+      listening: false,
+    });
+
+    const seriesAreaStyle = buildAreaProps({
+      index: 1,
+      areaPath: 'M0,0L10,10Z',
+      color: 'red',
+      opacity: 0.5,
+      seriesAreaStyle: {
+        opacity: 123,
+        fill: '',
+        visible: true,
+      },
+    });
+    expect(seriesAreaStyle).toEqual({
+      key: 'area-1',
+      data: 'M0,0L10,10Z',
+      fill: 'red',
+      lineCap: 'round',
+      lineJoin: 'round',
+      opacity: 123,
       strokeHitEnabled: false,
       perfectDrawEnabled: false,
       listening: false,
@@ -102,6 +157,35 @@ describe('[canvas] Area Geometries props', () => {
       listening: false,
     });
     expect(props.fill).toBeFalsy();
+
+    const seriesLineStyle = buildAreaLineProps({
+      areaIndex: 1,
+      lineIndex: 2,
+      linePath: 'M0,0L10,10Z',
+      color: 'red',
+      strokeWidth: 1,
+      geometryStyle: {
+        opacity: 0.5,
+      },
+      seriesAreaLineStyle: {
+        opacity: 0.5,
+        stroke: 'series-stroke',
+        strokeWidth: 66,
+        visible: true,
+      },
+    });
+    expect(seriesLineStyle).toEqual({
+      key: `area-1-line-2`,
+      data: 'M0,0L10,10Z',
+      stroke: 'red',
+      strokeWidth: 66,
+      lineCap: 'round',
+      lineJoin: 'round',
+      opacity: 0.5,
+      strokeHitEnabled: false,
+      perfectDrawEnabled: false,
+      listening: false,
+    });
   });
 });
 

--- a/src/components/react_canvas/utils/rendering_props_utils.test.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.test.ts
@@ -5,19 +5,24 @@ import {
   buildBarProps,
   buildLinePointProps,
   buildLineProps,
+  buildPointStyleProps,
 } from './rendering_props_utils';
 
 describe('[canvas] Area Geometries props', () => {
   test('can build area point props', () => {
+    const pointStyleProps = buildPointStyleProps({
+      radius: 30,
+      strokeWidth: 2,
+      opacity: 0.5,
+    });
+
     const props = buildAreaPointProps({
       areaIndex: 1,
       pointIndex: 2,
       x: 10,
       y: 20,
-      radius: 30,
-      strokeWidth: 2,
       color: 'red',
-      opacity: 0.5,
+      pointStyleProps,
     });
     expect(props).toEqual({
       key: 'area-point-1-2',
@@ -34,15 +39,19 @@ describe('[canvas] Area Geometries props', () => {
       listening: false,
     });
 
+    const noStrokePointStyleProps = buildPointStyleProps({
+      radius: 30,
+      strokeWidth: 0,
+      opacity: 0.5,
+    });
+
     const propsNoStroke = buildAreaPointProps({
       areaIndex: 1,
       pointIndex: 2,
       x: 10,
       y: 20,
-      radius: 30,
-      strokeWidth: 0,
       color: 'red',
-      opacity: 0.5,
+      pointStyleProps: noStrokePointStyleProps,
     });
     expect(propsNoStroke).toEqual({
       key: 'area-point-1-2',
@@ -59,14 +68,9 @@ describe('[canvas] Area Geometries props', () => {
       listening: false,
     });
 
-    const seriesPointStyle = buildAreaPointProps({
-      areaIndex: 1,
-      pointIndex: 2,
-      x: 10,
-      y: 20,
+    const seriesPointStyleProps = buildPointStyleProps({
       radius: 30,
       strokeWidth: 2,
-      color: 'red',
       opacity: 0.5,
       seriesPointStyle: {
         radius: 123,
@@ -75,6 +79,14 @@ describe('[canvas] Area Geometries props', () => {
         opacity: 789,
         visible: true,
       },
+    });
+    const seriesPointStyle = buildAreaPointProps({
+      areaIndex: 1,
+      pointIndex: 2,
+      x: 10,
+      y: 20,
+      color: 'red',
+      pointStyleProps: seriesPointStyleProps,
     });
     expect(seriesPointStyle).toEqual({
       key: 'area-point-1-2',
@@ -191,15 +203,19 @@ describe('[canvas] Area Geometries props', () => {
 
 describe('[canvas] Line Geometries', () => {
   test('can build line point props', () => {
+    const pointStyleProps = buildPointStyleProps({
+      radius: 30,
+      strokeWidth: 2,
+      opacity: 0.5,
+    });
+
     const props = buildLinePointProps({
       lineIndex: 1,
       pointIndex: 2,
       x: 10,
       y: 20,
-      radius: 30,
-      strokeWidth: 2,
       color: 'red',
-      opacity: 0.5,
+      pointStyleProps,
     });
     expect(props).toEqual({
       key: 'line-point-1-2',
@@ -216,15 +232,18 @@ describe('[canvas] Line Geometries', () => {
       listening: false,
     });
 
+    const noStrokeStyleProps = buildPointStyleProps({
+      radius: 30,
+      strokeWidth: 0,
+      opacity: 0.5,
+    });
     const propsNoStroke = buildLinePointProps({
       lineIndex: 1,
       pointIndex: 2,
       x: 10,
       y: 20,
-      radius: 30,
-      strokeWidth: 0,
       color: 'red',
-      opacity: 0.5,
+      pointStyleProps: noStrokeStyleProps,
     });
     expect(propsNoStroke).toEqual({
       key: 'line-point-1-2',
@@ -241,14 +260,9 @@ describe('[canvas] Line Geometries', () => {
       listening: false,
     });
 
-    const seriesPointStyle = buildLinePointProps({
-      lineIndex: 1,
-      pointIndex: 2,
-      x: 10,
-      y: 20,
+    const seriesPointStyleProps = buildPointStyleProps({
       radius: 30,
       strokeWidth: 2,
-      color: 'red',
       opacity: 0.5,
       seriesPointStyle: {
         stroke: 'series-stroke',
@@ -258,12 +272,20 @@ describe('[canvas] Line Geometries', () => {
         opacity: 18,
       },
     });
+    const seriesPointStyle = buildLinePointProps({
+      lineIndex: 1,
+      pointIndex: 2,
+      x: 10,
+      y: 20,
+      color: 'red',
+      pointStyleProps: seriesPointStyleProps,
+    });
     expect(seriesPointStyle).toEqual({
       key: 'line-point-1-2',
       x: 10,
       y: 20,
       radius: 12,
-      strokeWidth: 2,
+      strokeWidth: 6,
       strokeEnabled: true,
       stroke: 'red',
       fill: 'white',

--- a/src/components/react_canvas/utils/rendering_props_utils.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.ts
@@ -1,5 +1,5 @@
 import { GeometryStyle } from '../../../lib/series/rendering';
-import { LineStyle, PointStyle } from '../../../lib/themes/theme';
+import { AreaStyle, LineStyle, PointStyle } from '../../../lib/themes/theme';
 import { GlobalKonvaElementProps } from '../globals';
 
 export function buildAreaPointProps({
@@ -11,6 +11,7 @@ export function buildAreaPointProps({
   strokeWidth,
   color,
   opacity,
+  seriesPointStyle,
 }: {
   areaIndex: number;
   pointIndex: number;
@@ -20,17 +21,19 @@ export function buildAreaPointProps({
   strokeWidth: number;
   color: string;
   opacity: number;
+  seriesPointStyle?: PointStyle;
 }) {
+  const pointStrokeWidth = seriesPointStyle ? seriesPointStyle.strokeWidth : strokeWidth;
   return {
     key: `area-point-${areaIndex}-${pointIndex}`,
     x,
     y,
-    radius,
-    strokeWidth,
-    strokeEnabled: strokeWidth !== 0,
+    radius: seriesPointStyle ? seriesPointStyle.radius : radius,
+    strokeWidth: pointStrokeWidth,
+    strokeEnabled: pointStrokeWidth !== 0,
     stroke: color,
     fill: 'white',
-    opacity,
+    opacity: seriesPointStyle ? seriesPointStyle.opacity : opacity,
     ...GlobalKonvaElementProps,
   };
 }
@@ -40,11 +43,13 @@ export function buildAreaProps({
   areaPath,
   color,
   opacity,
+  seriesAreaStyle,
 }: {
   index: number;
   areaPath: string;
   color: string;
   opacity: number;
+  seriesAreaStyle?: AreaStyle,
 }) {
   return {
     key: `area-${index}`,
@@ -52,7 +57,7 @@ export function buildAreaProps({
     fill: color,
     lineCap: 'round',
     lineJoin: 'round',
-    opacity,
+    opacity: seriesAreaStyle ? seriesAreaStyle.opacity : opacity,
     ...GlobalKonvaElementProps,
   };
 }
@@ -64,6 +69,7 @@ export function buildAreaLineProps({
   color,
   strokeWidth,
   geometryStyle,
+  seriesAreaLineStyle,
 }: {
   areaIndex: number;
   lineIndex: number;
@@ -71,12 +77,13 @@ export function buildAreaLineProps({
   color: string;
   strokeWidth: number;
   geometryStyle: GeometryStyle;
+  seriesAreaLineStyle?: LineStyle;
 }) {
   return {
     key: `area-${areaIndex}-line-${lineIndex}`,
     data: linePath,
     stroke: color,
-    strokeWidth,
+    strokeWidth: seriesAreaLineStyle ? seriesAreaLineStyle.strokeWidth : strokeWidth,
     lineCap: 'round',
     lineJoin: 'round',
     ...geometryStyle,

--- a/src/components/react_canvas/utils/rendering_props_utils.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.ts
@@ -2,39 +2,57 @@ import { GeometryStyle } from '../../../lib/series/rendering';
 import { AreaStyle, LineStyle, PointStyle } from '../../../lib/themes/theme';
 import { GlobalKonvaElementProps } from '../globals';
 
+export interface PointStyleProps {
+  radius: number;
+  strokeWidth: number;
+  strokeEnabled: boolean;
+  fill: string;
+  opacity: number;
+}
+
 export function buildAreaPointProps({
   areaIndex,
   pointIndex,
   x,
   y,
-  radius,
-  strokeWidth,
   color,
-  opacity,
-  seriesPointStyle,
+  pointStyleProps,
 }: {
   areaIndex: number;
   pointIndex: number;
   x: number;
   y: number;
-  radius: number;
-  strokeWidth: number;
   color: string;
-  opacity: number;
-  seriesPointStyle?: PointStyle;
+  pointStyleProps: PointStyleProps;
 }) {
-  const pointStrokeWidth = seriesPointStyle ? seriesPointStyle.strokeWidth : strokeWidth;
   return {
     key: `area-point-${areaIndex}-${pointIndex}`,
     x,
     y,
+    stroke: color,
+    ...pointStyleProps,
+    ...GlobalKonvaElementProps,
+  };
+}
+
+export function buildPointStyleProps({
+  radius,
+  strokeWidth,
+  opacity,
+  seriesPointStyle,
+}: {
+  radius: number;
+  strokeWidth: number;
+  opacity: number;
+  seriesPointStyle?: PointStyle;
+}): PointStyleProps {
+  const pointStrokeWidth = seriesPointStyle ? seriesPointStyle.strokeWidth : strokeWidth;
+  return {
     radius: seriesPointStyle ? seriesPointStyle.radius : radius,
     strokeWidth: pointStrokeWidth,
     strokeEnabled: pointStrokeWidth !== 0,
-    stroke: color,
     fill: 'white',
     opacity: seriesPointStyle ? seriesPointStyle.opacity : opacity,
-    ...GlobalKonvaElementProps,
   };
 }
 
@@ -134,32 +152,22 @@ export function buildLinePointProps({
   pointIndex,
   x,
   y,
-  radius,
-  strokeWidth,
   color,
-  opacity,
-  seriesPointStyle,
+  pointStyleProps,
 }: {
   lineIndex: number;
   pointIndex: number;
   x: number;
   y: number;
-  radius: number;
-  strokeWidth: number;
   color: string;
-  opacity: number;
-  seriesPointStyle?: PointStyle;
+  pointStyleProps: PointStyleProps;
 }) {
   return {
     key: `line-point-${lineIndex}-${pointIndex}`,
     x,
     y,
-    radius: seriesPointStyle ? seriesPointStyle.radius : radius,
     stroke: color,
-    strokeWidth,
-    strokeEnabled: strokeWidth !== 0,
-    fill: 'white',
-    opacity: seriesPointStyle ? seriesPointStyle.opacity : opacity,
+    ...pointStyleProps,
     ...GlobalKonvaElementProps,
   };
 }

--- a/src/components/react_canvas/utils/rendering_props_utils.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.ts
@@ -1,4 +1,5 @@
 import { GeometryStyle } from '../../../lib/series/rendering';
+import { LineStyle, PointStyle } from '../../../lib/themes/theme';
 import { GlobalKonvaElementProps } from '../globals';
 
 export function buildAreaPointProps({
@@ -130,6 +131,7 @@ export function buildLinePointProps({
   strokeWidth,
   color,
   opacity,
+  seriesPointStyle,
 }: {
   lineIndex: number;
   pointIndex: number;
@@ -139,17 +141,18 @@ export function buildLinePointProps({
   strokeWidth: number;
   color: string;
   opacity: number;
+  seriesPointStyle?: PointStyle;
 }) {
   return {
     key: `line-point-${lineIndex}-${pointIndex}`,
     x,
     y,
-    radius,
+    radius: seriesPointStyle ? seriesPointStyle.radius : radius,
     stroke: color,
     strokeWidth,
     strokeEnabled: strokeWidth !== 0,
     fill: 'white',
-    opacity,
+    opacity: seriesPointStyle ? seriesPointStyle.opacity : opacity,
     ...GlobalKonvaElementProps,
   };
 }
@@ -159,22 +162,21 @@ export function buildLineProps({
   linePath,
   color,
   strokeWidth,
-  opacity,
   geometryStyle,
+  seriesLineStyle,
 }: {
   index: number;
   linePath: string;
   color: string;
   strokeWidth: number;
-  opacity: number;
   geometryStyle: GeometryStyle;
+  seriesLineStyle?: LineStyle;
 }) {
   return {
     key: `line-${index}`,
     data: linePath,
     stroke: color,
-    strokeWidth,
-    opacity,
+    strokeWidth: seriesLineStyle ? seriesLineStyle.strokeWidth : strokeWidth,
     lineCap: 'round',
     lineJoin: 'round',
     ...geometryStyle,

--- a/src/lib/series/rendering.test.ts
+++ b/src/lib/series/rendering.test.ts
@@ -1,5 +1,6 @@
+import { DEFAULT_GEOMETRY_STYLES } from '../themes/theme_commons';
 import { getSpecId } from '../utils/ids';
-import { BarGeometry, isPointOnGeometry, PointGeometry } from './rendering';
+import { BarGeometry, getGeometryStyle, isPointOnGeometry, PointGeometry } from './rendering';
 
 describe('Rendering utils', () => {
   test('check if point is in geometry', () => {
@@ -55,5 +56,129 @@ describe('Rendering utils', () => {
     expect(isPointOnGeometry(-10, 0, geometry)).toBe(true);
     expect(isPointOnGeometry(-11, 0, geometry)).toBe(false);
     expect(isPointOnGeometry(11, 11, geometry)).toBe(false);
+  });
+
+  test('should get common geometry style dependent on legend item highlight state', () => {
+    const geometryId = {
+      seriesKey: [],
+      specId: getSpecId('id'),
+    };
+    const highlightedLegendItem = {
+      key: '',
+      color: '',
+      label: '',
+      value: {
+        colorValues: [],
+        specId: getSpecId('id'),
+      },
+      isSeriesVisible: true,
+      isLegendItemVisible: true,
+      displayValue: {
+        raw: '',
+        formatted: '',
+      },
+    };
+
+    const unhighlightedLegendItem = {
+      ...highlightedLegendItem,
+      value: {
+        colorValues: [],
+        specId: getSpecId('foo'),
+      },
+    };
+
+    const sharedThemeStyle = DEFAULT_GEOMETRY_STYLES;
+    const specOpacity = 0.66;
+
+    const defaultStyle = getGeometryStyle(
+      geometryId,
+      null,
+      sharedThemeStyle,
+    );
+
+    // no highlighted elements
+    expect(defaultStyle).toEqual({ opacity: 1 });
+
+
+    const customDefaultStyle = getGeometryStyle(
+      geometryId,
+      null,
+      sharedThemeStyle,
+      specOpacity,
+    );
+
+    // no highlighted elements with custom spec opacity
+    expect(customDefaultStyle).toEqual({ opacity: 0.66 });
+
+    const highlightedStyle = getGeometryStyle(
+      geometryId,
+      highlightedLegendItem,
+      sharedThemeStyle,
+    );
+
+    // should equal highlighted opacity
+    expect(highlightedStyle).toEqual({ opacity: 1 });
+
+    const unhighlightedStyle = getGeometryStyle(
+      geometryId,
+      unhighlightedLegendItem,
+      sharedThemeStyle,
+    );
+
+    // should equal unhighlighted opacity
+    expect(unhighlightedStyle).toEqual({ opacity: 0.25 });
+
+    const customHighlightedStyle = getGeometryStyle(
+      geometryId,
+      highlightedLegendItem,
+      sharedThemeStyle,
+      specOpacity,
+    );
+
+    // should equal custom spec highlighted opacity
+    expect(customHighlightedStyle).toEqual({ opacity: 0.66 });
+
+    const customUnhighlightedStyle = getGeometryStyle(
+      geometryId,
+      unhighlightedLegendItem,
+      sharedThemeStyle,
+      specOpacity,
+    );
+
+    // unhighlighted elements remain unchanged with custom opacity
+    expect(customUnhighlightedStyle).toEqual({ opacity: 0.25 });
+
+    // has individual highlight
+    const hasIndividualHighlight = getGeometryStyle(
+      geometryId,
+      null,
+      sharedThemeStyle,
+      undefined,
+      { hasHighlight: true, hasGeometryHover: true },
+    );
+
+    expect(hasIndividualHighlight).toEqual({ opacity: 1 });
+
+    // no highlight
+    const noHighlight = getGeometryStyle(
+      geometryId,
+      null,
+      sharedThemeStyle,
+      undefined,
+      { hasHighlight: false, hasGeometryHover: true },
+    );
+
+    expect(noHighlight).toEqual({ opacity: 0.25 });
+
+    // no geometry hover
+    const noHover = getGeometryStyle(
+      geometryId,
+      null,
+      sharedThemeStyle,
+      undefined,
+      { hasHighlight: true, hasGeometryHover: false },
+    );
+
+    expect(noHover).toEqual({ opacity: 1 });
   });
 });

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -1,6 +1,14 @@
 import { area, line } from 'd3-shape';
 import { mutableIndexedGeometryMapUpsert } from '../../state/utils';
-import { CustomBarSeriesStyle, LineSeriesStyle, LineStyle, PointStyle, SharedGeometryStyle } from '../themes/theme';
+import {
+  AreaSeriesStyle,
+  AreaStyle,
+  CustomBarSeriesStyle,
+  LineSeriesStyle,
+  LineStyle,
+  PointStyle,
+  SharedGeometryStyle,
+} from '../themes/theme';
 import { SpecId } from '../utils/ids';
 import { isLogarithmicScale } from '../utils/scales/scale_continuous';
 import { Scale, ScaleType } from '../utils/scales/scales';
@@ -71,6 +79,8 @@ export interface AreaGeometry {
     y: number;
   };
   geometryId: GeometryId;
+  seriesAreaStyle?: AreaStyle;
+  seriesAreaLineStyle?: LineStyle;
 }
 
 export function isPointGeometry(ig: IndexedGeometry): ig is PointGeometry {
@@ -296,6 +306,7 @@ export function renderArea(
   specId: SpecId,
   hasY0Accessors: boolean,
   seriesKey: any[],
+  seriesStyle?: AreaSeriesStyle,
 ): {
   areaGeometry: AreaGeometry;
   indexedGeometries: Map<any, IndexedGeometry[]>;
@@ -327,6 +338,10 @@ export function renderArea(
     }
   }
 
+  const seriesPointStyle = seriesStyle ? seriesStyle.point : undefined;
+  const seriesAreaStyle = seriesStyle ? seriesStyle.area : undefined;
+  const seriesAreaLineStyle = seriesStyle ? seriesStyle.line : undefined;
+
   const { pointGeometries, indexedGeometries } = renderPoints(
     shift,
     dataset,
@@ -336,6 +351,7 @@ export function renderArea(
     specId,
     hasY0Accessors,
     seriesKey,
+    seriesPointStyle,
   );
 
   const areaGeometry = {
@@ -351,6 +367,8 @@ export function renderArea(
       specId,
       seriesKey,
     },
+    seriesAreaStyle,
+    seriesAreaLineStyle,
   };
   return {
     areaGeometry,

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -1,6 +1,6 @@
 import { area, line } from 'd3-shape';
 import { mutableIndexedGeometryMapUpsert } from '../../state/utils';
-import { SharedGeometryStyle } from '../themes/theme';
+import { BarSeriesStyle, SharedGeometryStyle } from '../themes/theme';
 import { SpecId } from '../utils/ids';
 import { isLogarithmicScale } from '../utils/scales/scale_continuous';
 import { Scale, ScaleType } from '../utils/scales/scales';
@@ -47,6 +47,7 @@ export interface BarGeometry {
   color: string;
   geometryId: GeometryId;
   value: GeometryValue;
+  seriesStyle?: BarSeriesStyle;
 }
 export interface LineGeometry {
   line: string;
@@ -159,6 +160,7 @@ export function renderBars(
   color: string,
   specId: SpecId,
   seriesKey: any[],
+  seriesStyle?: BarSeriesStyle,
 ): {
   barGeometries: BarGeometry[];
   indexedGeometries: Map<any, IndexedGeometry[]>;
@@ -210,6 +212,7 @@ export function renderBars(
         specId,
         seriesKey,
       },
+      seriesStyle,
     };
     mutableIndexedGeometryMapUpsert(indexedGeometries, datum.x, barGeometry);
     barGeometries.push(barGeometry);

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -46,7 +46,6 @@ export interface PointGeometry {
   };
   geometryId: GeometryId;
   value: GeometryValue;
-  seriesPointStyle?: PointStyle;
 }
 export interface BarGeometry {
   x: number;
@@ -68,6 +67,7 @@ export interface LineGeometry {
   };
   geometryId: GeometryId;
   seriesLineStyle?: LineStyle;
+  seriesPointStyle?: PointStyle;
 }
 export interface AreaGeometry {
   area: string;
@@ -81,6 +81,7 @@ export interface AreaGeometry {
   geometryId: GeometryId;
   seriesAreaStyle?: AreaStyle;
   seriesAreaLineStyle?: LineStyle;
+  seriesPointStyle?: PointStyle;
 }
 
 export function isPointGeometry(ig: IndexedGeometry): ig is PointGeometry {
@@ -99,7 +100,6 @@ export function renderPoints(
   specId: SpecId,
   hasY0Accessors: boolean,
   seriesKey: any[],
-  seriesPointStyle?: PointStyle,
 ): {
   pointGeometries: PointGeometry[];
   indexedGeometries: Map<any, IndexedGeometry[]>;
@@ -149,7 +149,6 @@ export function renderPoints(
             specId,
             seriesKey,
           },
-          seriesPointStyle,
         };
         mutableIndexedGeometryMapUpsert(indexedGeometries, datum.x, pointGeometry);
         if (!isHidden) {
@@ -262,7 +261,7 @@ export function renderLine(
   const y = 0;
   const x = shift;
 
-  const pointStyle = seriesStyle ? seriesStyle.point : undefined;
+  const seriesPointStyle = seriesStyle ? seriesStyle.point : undefined;
   const seriesLineStyle = seriesStyle ? seriesStyle.line : undefined;
 
   const { pointGeometries, indexedGeometries } = renderPoints(
@@ -274,7 +273,6 @@ export function renderLine(
     specId,
     hasY0Accessors,
     seriesKey,
-    pointStyle,
   );
   const lineGeometry = {
     line: pathGenerator(dataset) || '',
@@ -289,6 +287,7 @@ export function renderLine(
       seriesKey,
     },
     seriesLineStyle,
+    seriesPointStyle,
   };
   return {
     lineGeometry,
@@ -351,7 +350,6 @@ export function renderArea(
     specId,
     hasY0Accessors,
     seriesKey,
-    seriesPointStyle,
   );
 
   const areaGeometry = {
@@ -369,6 +367,7 @@ export function renderArea(
     },
     seriesAreaStyle,
     seriesAreaLineStyle,
+    seriesPointStyle,
   };
   return {
     areaGeometry,

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -1,6 +1,6 @@
 import { area, line } from 'd3-shape';
 import { mutableIndexedGeometryMapUpsert } from '../../state/utils';
-import { BarSeriesStyle, SharedGeometryStyle } from '../themes/theme';
+import { CustomBarSeriesStyle, SharedGeometryStyle } from '../themes/theme';
 import { SpecId } from '../utils/ids';
 import { isLogarithmicScale } from '../utils/scales/scale_continuous';
 import { Scale, ScaleType } from '../utils/scales/scales';
@@ -47,7 +47,7 @@ export interface BarGeometry {
   color: string;
   geometryId: GeometryId;
   value: GeometryValue;
-  seriesStyle?: BarSeriesStyle;
+  seriesStyle?: CustomBarSeriesStyle;
 }
 export interface LineGeometry {
   line: string;
@@ -160,7 +160,7 @@ export function renderBars(
   color: string,
   specId: SpecId,
   seriesKey: any[],
-  seriesStyle?: BarSeriesStyle,
+  seriesStyle?: CustomBarSeriesStyle,
 ): {
   barGeometries: BarGeometry[];
   indexedGeometries: Map<any, IndexedGeometry[]>;
@@ -350,9 +350,19 @@ export function renderArea(
 export function getGeometryStyle(
   geometryId: GeometryId,
   highlightedLegendItem: LegendItem | null,
-  sharedStyle: SharedGeometryStyle,
+  sharedThemeStyle: SharedGeometryStyle,
+  specOpacity?: number,
   individualHighlight?: { [key: string]: boolean },
 ): GeometryStyle {
+
+  const sharedStyle = specOpacity == null ?
+    sharedThemeStyle :
+    {
+      ...sharedThemeStyle,
+      highlighted: { opacity: specOpacity },
+      default: { opacity: specOpacity },
+    };
+
   if (highlightedLegendItem != null) {
     const isPartOfHighlightedSeries = belongsToDataSeries(geometryId, highlightedLegendItem.value);
 

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -1,6 +1,6 @@
 import { area, line } from 'd3-shape';
 import { mutableIndexedGeometryMapUpsert } from '../../state/utils';
-import { CustomBarSeriesStyle, SharedGeometryStyle } from '../themes/theme';
+import { CustomBarSeriesStyle, LineSeriesStyle, LineStyle, PointStyle, SharedGeometryStyle } from '../themes/theme';
 import { SpecId } from '../utils/ids';
 import { isLogarithmicScale } from '../utils/scales/scale_continuous';
 import { Scale, ScaleType } from '../utils/scales/scales';
@@ -38,6 +38,7 @@ export interface PointGeometry {
   };
   geometryId: GeometryId;
   value: GeometryValue;
+  seriesPointStyle?: PointStyle;
 }
 export interface BarGeometry {
   x: number;
@@ -58,6 +59,7 @@ export interface LineGeometry {
     y: number;
   };
   geometryId: GeometryId;
+  seriesLineStyle?: LineStyle;
 }
 export interface AreaGeometry {
   area: string;
@@ -87,6 +89,7 @@ export function renderPoints(
   specId: SpecId,
   hasY0Accessors: boolean,
   seriesKey: any[],
+  seriesPointStyle?: PointStyle,
 ): {
   pointGeometries: PointGeometry[];
   indexedGeometries: Map<any, IndexedGeometry[]>;
@@ -136,6 +139,7 @@ export function renderPoints(
             specId,
             seriesKey,
           },
+          seriesPointStyle,
         };
         mutableIndexedGeometryMapUpsert(indexedGeometries, datum.x, pointGeometry);
         if (!isHidden) {
@@ -233,6 +237,7 @@ export function renderLine(
   specId: SpecId,
   hasY0Accessors: boolean,
   seriesKey: any[],
+  seriesStyle?: LineSeriesStyle,
 ): {
   lineGeometry: LineGeometry;
   indexedGeometries: Map<any, IndexedGeometry[]>;
@@ -246,6 +251,10 @@ export function renderLine(
     .curve(getCurveFactory(curve));
   const y = 0;
   const x = shift;
+
+  const pointStyle = seriesStyle ? seriesStyle.point : undefined;
+  const seriesLineStyle = seriesStyle ? seriesStyle.line : undefined;
+
   const { pointGeometries, indexedGeometries } = renderPoints(
     shift,
     dataset,
@@ -255,6 +264,7 @@ export function renderLine(
     specId,
     hasY0Accessors,
     seriesKey,
+    pointStyle,
   );
   const lineGeometry = {
     line: pathGenerator(dataset) || '',
@@ -268,6 +278,7 @@ export function renderLine(
       specId,
       seriesKey,
     },
+    seriesLineStyle,
   };
   return {
     lineGeometry,

--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -4,7 +4,7 @@ import {
   BarSeriesStyle,
   GridLineConfig,
   LineSeriesStyle,
-  Opacity,
+  SharedGeometryStyle,
 } from '../themes/theme';
 import { Accessor } from '../utils/accessor';
 import { AnnotationId, AxisId, GroupId, SpecId } from '../utils/ids';
@@ -93,7 +93,12 @@ export interface SeriesScales {
   yScaleToDataExtent: boolean;
 }
 
-export type BasicSeriesSpec = SeriesSpec & SeriesAccessors & SeriesScales;
+export type BasicSeriesSpec = SeriesSpec & SeriesAccessors & SeriesScales & {
+  barSeriesStyle?: BarSeriesStyle;
+  lineSeriesStyle?: LineSeriesStyle;
+  areaSeriesStyle?: AreaSeriesStyle;
+  sharedGeometryStyle?: SharedGeometryStyle;
+};
 
 /**
  * This spec describe the dataset configuration used to display a bar series.
@@ -101,8 +106,6 @@ export type BasicSeriesSpec = SeriesSpec & SeriesAccessors & SeriesScales;
 export type BarSeriesSpec = BasicSeriesSpec & {
   /** @default bar */
   seriesType: 'bar';
-  /** Custom series style (takes precedence over custom theme style) */
-  seriesStyle?: BarSeriesStyle & Opacity;
 };
 
 /**
@@ -111,8 +114,6 @@ export type BarSeriesSpec = BasicSeriesSpec & {
 export type LineSeriesSpec = BasicSeriesSpec & {
   /** @default line */
   seriesType: 'line';
-  /** Custom series style (takes precedence over custom theme style) */
-  seriesStyle?: LineSeriesStyle & Opacity;
   curve?: CurveType;
 };
 
@@ -122,8 +123,6 @@ export type LineSeriesSpec = BasicSeriesSpec & {
 export type AreaSeriesSpec = BasicSeriesSpec & {
   /** @default area */
   seriesType: 'area';
-  /** Custom series style (takes precedence over custom theme style) */
-  seriesStyle?: AreaSeriesStyle & Opacity;
   /** The type of interpolator to be used to interpolate values between points */
   curve?: CurveType;
 };

--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -1,4 +1,11 @@
-import { AnnotationLineStyle, GridLineConfig } from '../themes/theme';
+import {
+  AnnotationLineStyle,
+  AreaSeriesStyle,
+  BarSeriesStyle,
+  GridLineConfig,
+  LineSeriesStyle,
+  SharedGeometryStyle,
+} from '../themes/theme';
 import { Accessor } from '../utils/accessor';
 import { AnnotationId, AxisId, GroupId, SpecId } from '../utils/ids';
 import { ScaleContinuousType, ScaleType } from '../utils/scales/scales';
@@ -94,6 +101,8 @@ export type BasicSeriesSpec = SeriesSpec & SeriesAccessors & SeriesScales;
 export type BarSeriesSpec = BasicSeriesSpec & {
   /** @default bar */
   seriesType: 'bar';
+  /** Custom series style (takes precedence over custom theme style) */
+  seriesStyle?: BarSeriesStyle & SharedGeometryStyle;
 };
 
 /**
@@ -102,6 +111,8 @@ export type BarSeriesSpec = BasicSeriesSpec & {
 export type LineSeriesSpec = BasicSeriesSpec & {
   /** @default line */
   seriesType: 'line';
+  /** Custom series style (takes precedence over custom theme style) */
+  seriesStyle?: LineSeriesStyle & SharedGeometryStyle;
   curve?: CurveType;
 };
 
@@ -111,6 +122,8 @@ export type LineSeriesSpec = BasicSeriesSpec & {
 export type AreaSeriesSpec = BasicSeriesSpec & {
   /** @default area */
   seriesType: 'area';
+  /** Custom series style (takes precedence over custom theme style) */
+  seriesStyle?: AreaSeriesStyle & SharedGeometryStyle;
   /** The type of interpolator to be used to interpolate values between points */
   curve?: CurveType;
 };

--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -1,10 +1,9 @@
 import {
   AnnotationLineStyle,
   AreaSeriesStyle,
-  BarSeriesStyle,
+  CustomBarSeriesStyle,
   GridLineConfig,
   LineSeriesStyle,
-  SharedGeometryStyle,
 } from '../themes/theme';
 import { Accessor } from '../utils/accessor';
 import { AnnotationId, AxisId, GroupId, SpecId } from '../utils/ids';
@@ -94,10 +93,9 @@ export interface SeriesScales {
 }
 
 export type BasicSeriesSpec = SeriesSpec & SeriesAccessors & SeriesScales & {
-  barSeriesStyle?: BarSeriesStyle;
+  barSeriesStyle?: CustomBarSeriesStyle;
   lineSeriesStyle?: LineSeriesStyle;
   areaSeriesStyle?: AreaSeriesStyle;
-  sharedGeometryStyle?: SharedGeometryStyle;
 };
 
 /**

--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -4,7 +4,7 @@ import {
   BarSeriesStyle,
   GridLineConfig,
   LineSeriesStyle,
-  SharedGeometryStyle,
+  Opacity,
 } from '../themes/theme';
 import { Accessor } from '../utils/accessor';
 import { AnnotationId, AxisId, GroupId, SpecId } from '../utils/ids';
@@ -102,7 +102,7 @@ export type BarSeriesSpec = BasicSeriesSpec & {
   /** @default bar */
   seriesType: 'bar';
   /** Custom series style (takes precedence over custom theme style) */
-  seriesStyle?: BarSeriesStyle & SharedGeometryStyle;
+  seriesStyle?: BarSeriesStyle & Opacity;
 };
 
 /**
@@ -112,7 +112,7 @@ export type LineSeriesSpec = BasicSeriesSpec & {
   /** @default line */
   seriesType: 'line';
   /** Custom series style (takes precedence over custom theme style) */
-  seriesStyle?: LineSeriesStyle & SharedGeometryStyle;
+  seriesStyle?: LineSeriesStyle & Opacity;
   curve?: CurveType;
 };
 
@@ -123,7 +123,7 @@ export type AreaSeriesSpec = BasicSeriesSpec & {
   /** @default area */
   seriesType: 'area';
   /** Custom series style (takes precedence over custom theme style) */
-  seriesStyle?: AreaSeriesStyle & SharedGeometryStyle;
+  seriesStyle?: AreaSeriesStyle & Opacity;
   /** The type of interpolator to be used to interpolate values between points */
   curve?: CurveType;
 };

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -185,6 +185,20 @@ export function mergeWithDefaultAnnotationLine(config?: Partial<AnnotationLineSt
   return mergedConfig;
 }
 
+export function mergeWithBarSeriesStyles(
+  defaultStyle: BarSeriesStyle,
+  seriesStyle?: BarSeriesStyle,
+): BarSeriesStyle | undefined {
+  if (!seriesStyle) {
+    return undefined;
+  }
+
+  return {
+    ...defaultStyle,
+    ...seriesStyle,
+  };
+}
+
 export function mergeWithDefaultTheme(
   theme: PartialTheme,
   defaultTheme: Theme = LIGHT_THEME,

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -101,12 +101,13 @@ export interface LineSeriesStyle {
 
 export type PointStyle = StrokeStyle & Opacity & Visible & Radius;
 export type LineStyle = StrokeStyle & Visible & Partial<Opacity>;
+export type AreaStyle = FillStyle & Opacity & Visible;
 
 export interface AreaSeriesStyle {
-  area: FillStyle & Opacity & Visible;
-  line: StrokeStyle & Visible;
+  area: AreaStyle;
+  line: LineStyle;
   border: StrokeStyle & Visible;
-  point: StrokeStyle & Opacity & Visible & Radius;
+  point: PointStyle;
 }
 export interface CrosshairStyle {
   band: FillStyle & Visible;

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -90,6 +90,9 @@ export interface Theme {
 export interface BarSeriesStyle {
   border: StrokeStyle & Visible;
 }
+
+export type CustomBarSeriesStyle = BarSeriesStyle & Partial<Opacity>;
+
 export interface LineSeriesStyle {
   line: StrokeStyle & Visible;
   border: StrokeStyle & Visible;
@@ -183,20 +186,6 @@ export function mergeWithDefaultAnnotationLine(config?: Partial<AnnotationLineSt
   }
 
   return mergedConfig;
-}
-
-export function mergeWithBarSeriesStyles(
-  defaultStyle: BarSeriesStyle,
-  seriesStyle?: BarSeriesStyle,
-): BarSeriesStyle | undefined {
-  if (!seriesStyle) {
-    return undefined;
-  }
-
-  return {
-    ...defaultStyle,
-    ...seriesStyle,
-  };
 }
 
 export function mergeWithDefaultTheme(

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -94,10 +94,14 @@ export interface BarSeriesStyle {
 export type CustomBarSeriesStyle = BarSeriesStyle & Partial<Opacity>;
 
 export interface LineSeriesStyle {
-  line: StrokeStyle & Visible;
+  line: LineStyle;
   border: StrokeStyle & Visible;
-  point: StrokeStyle & Opacity & Visible & Radius;
+  point: PointStyle;
 }
+
+export type PointStyle = StrokeStyle & Opacity & Visible & Radius;
+export type LineStyle = StrokeStyle & Visible & Partial<Opacity>;
+
 export interface AreaSeriesStyle {
   area: FillStyle & Opacity & Visible;
   line: StrokeStyle & Visible;

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -351,8 +351,8 @@ export function renderGeometries(
         break;
       case 'bar':
         const shift = isStacked ? indexOffset : indexOffset + i;
-        const barStyle = spec.barSeriesStyle;
-        const renderedBars = renderBars(shift, ds.data, xScale, yScale, color, ds.specId, ds.key, barStyle);
+        const barSeriesStyle = spec.barSeriesStyle;
+        const renderedBars = renderBars(shift, ds.data, xScale, yScale, color, ds.specId, ds.key, barSeriesStyle);
         barGeometriesIndex = mergeGeometriesIndexes(
           barGeometriesIndex,
           renderedBars.indexedGeometries,
@@ -362,7 +362,7 @@ export function renderGeometries(
         break;
       case 'line':
         const lineShift = clusteredCount > 0 ? clusteredCount : 1;
-        const lineStyle = spec.lineSeriesStyle;
+        const lineSeriesStyle = spec.lineSeriesStyle;
         const renderedLines = renderLine(
           // move the point on half of the bandwidth if we have mixed bars/lines
           (xScale.bandwidth * lineShift) / 2,
@@ -374,7 +374,7 @@ export function renderGeometries(
           ds.specId,
           Boolean(spec.y0Accessors),
           ds.key,
-          lineStyle,
+          lineSeriesStyle,
         );
         lineGeometriesIndex = mergeGeometriesIndexes(
           lineGeometriesIndex,
@@ -386,6 +386,7 @@ export function renderGeometries(
         break;
       case 'area':
         const areaShift = clusteredCount > 0 ? clusteredCount : 1;
+        const areaSeriesStyle = spec.areaSeriesStyle;
         const renderedAreas = renderArea(
           // move the point on half of the bandwidth if we have mixed bars/lines
           (xScale.bandwidth * areaShift) / 2,
@@ -397,6 +398,7 @@ export function renderGeometries(
           ds.specId,
           Boolean(spec.y0Accessors),
           ds.key,
+          areaSeriesStyle,
         );
         areaGeometriesIndex = mergeGeometriesIndexes(
           areaGeometriesIndex,

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -351,7 +351,8 @@ export function renderGeometries(
         break;
       case 'bar':
         const shift = isStacked ? indexOffset : indexOffset + i;
-        const renderedBars = renderBars(shift, ds.data, xScale, yScale, color, ds.specId, ds.key);
+        const barStyle = spec.barSeriesStyle;
+        const renderedBars = renderBars(shift, ds.data, xScale, yScale, color, ds.specId, ds.key, barStyle);
         barGeometriesIndex = mergeGeometriesIndexes(
           barGeometriesIndex,
           renderedBars.indexedGeometries,

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -362,6 +362,7 @@ export function renderGeometries(
         break;
       case 'line':
         const lineShift = clusteredCount > 0 ? clusteredCount : 1;
+        const lineStyle = spec.lineSeriesStyle;
         const renderedLines = renderLine(
           // move the point on half of the bandwidth if we have mixed bars/lines
           (xScale.bandwidth * lineShift) / 2,
@@ -373,6 +374,7 @@ export function renderGeometries(
           ds.specId,
           Boolean(spec.y0Accessors),
           ds.key,
+          lineStyle,
         );
         lineGeometriesIndex = mergeGeometriesIndexes(
           lineGeometriesIndex,

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -417,6 +417,7 @@ storiesOf('Stylings', module)
         strokeWidth: range('strokeWidth 1', 0, 10, 1, 'group1'),
         visible: boolean('borderVisible 1', true, 'group1'),
       },
+      opacity: range('opacity 1', 0, 1, 1, 'group1', 0.1),
     };
 
     const barSeriesStyle2 = {
@@ -425,6 +426,7 @@ storiesOf('Stylings', module)
         strokeWidth: range('strokeWidth 2', 0, 10, 1, 'group2'),
         visible: boolean('borderVisible 2', true, 'group2'),
       },
+      opacity: range('opacity 2', 0, 1, 1, 'group2', 0.1),
     };
 
     const chartTheme = {

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -51,9 +51,9 @@ function generateLineSeriesStyleKnobs(groupName: string) {
   return {
     line: {
       stroke: DEFAULT_MISSING_COLOR,
-      strokeWidth: range(`lineStrokeWidth (${groupName})`, 0, 10, 1, groupName),
-      visible: boolean(`lineVisible (${groupName})`, true, groupName),
-      opacity: range(`lineOpacity (${groupName})`, 0, 1, 1, groupName, 0.01),
+      strokeWidth: range(`line.strokeWidth (${groupName})`, 0, 10, 1, groupName),
+      visible: boolean(`line.visible (${groupName})`, true, groupName),
+      opacity: range(`line.opacity (${groupName})`, 0, 1, 1, groupName, 0.01),
     },
     border: {
       stroke: 'gray',
@@ -61,12 +61,22 @@ function generateLineSeriesStyleKnobs(groupName: string) {
       visible: false,
     },
     point: {
-      visible: boolean(`linePointVisible (${groupName})`, true, groupName),
-      radius: range(`linePointRadius (${groupName})`, 0, 20, 1, groupName, 0.5),
-      // not customizable
-      stroke: 'red',
+      visible: boolean(`point.visible (${groupName})`, true, groupName),
+      radius: range(`point.radius (${groupName})`, 0, 20, 1, groupName, 0.5),
+      opacity: range(`point.opacity (${groupName})`, 0, 1, 1, groupName, 0.01),
+      stroke: '',
       strokeWidth: 0.5,
-      opacity: range(`linePointOpacity (${groupName})`, 0, 1, 1, groupName, 0.01),
+    },
+  };
+}
+
+function generateAreaSeriesStyleKnobs(groupName: string) {
+  return {
+    ...generateLineSeriesStyleKnobs(groupName),
+    area: {
+      fill: DEFAULT_MISSING_COLOR,
+      visible: boolean(`area.visible (${groupName})`, true, groupName),
+      opacity: range(`area.opacity ${groupName}`, 0, 1, 1, groupName, 0.01),
     },
   };
 }
@@ -581,13 +591,27 @@ storiesOf('Stylings', module)
     );
   })
   .add('custom series styles: area', () => {
+    const chartTheme = {
+      ...LIGHT_THEME,
+      areaSeriesStyle: generateAreaSeriesStyleKnobs('chartTheme'),
+    };
+
+    const useOnlyChartTheme = boolean('ignore series style (use only chart theme)', false, 'chartTheme');
+
+    const dataset1 = [{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }];
+    const dataset2 = dataset1.map((datum) => ({ ...datum, y: datum.y - 1 }));
+    const dataset3 = dataset1.map((datum) => ({ ...datum, y: datum.y - 2 }));
+
+    const areaStyle1 = useOnlyChartTheme ? undefined : generateAreaSeriesStyleKnobs('area1');
+    const areaStyle2 = useOnlyChartTheme ? undefined : generateAreaSeriesStyleKnobs('area2');
+
     return (
       <Chart renderer="canvas" className={'story-chart'}>
-        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Settings showLegend={true} legendPosition={Position.Right} theme={chartTheme} />
         <Axis
           id={getAxisId('bottom')}
           position={Position.Bottom}
-          // title={'Bottom axis'}
+          title={'Bottom axis'}
           showOverlappingTicks={true}
         />
         <Axis
@@ -597,12 +621,32 @@ storiesOf('Stylings', module)
           tickFormat={(d) => Number(d).toFixed(2)}
         />
         <AreaSeries
-          id={getSpecId('lines')}
+          id={getSpecId('area1')}
           xScaleType={ScaleType.Linear}
           yScaleType={ScaleType.Linear}
           xAccessor="x"
           yAccessors={['y']}
-          data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
+          data={dataset1}
+          yScaleToDataExtent={false}
+          areaSeriesStyle={areaStyle1}
+        />
+        <AreaSeries
+          id={getSpecId('area2')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={dataset2}
+          yScaleToDataExtent={false}
+          areaSeriesStyle={areaStyle2}
+        />
+        <AreaSeries
+          id={getSpecId('area3')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={dataset3}
           yScaleToDataExtent={false}
         />
       </Chart>

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -48,6 +48,31 @@ function range(
   );
 }
 
+function generateLineSeriesStyleKnobs(index: number) {
+  const groupName = `lines${index}`;
+  return {
+    line: {
+      stroke: DEFAULT_MISSING_COLOR,
+      strokeWidth: range(`lineStrokeWidth ${index}`, 0, 10, 1, groupName),
+      visible: boolean(`lineVisible ${index}`, true, groupName),
+      opacity: range(`lineOpacity ${index}`, 0, 1, 1, groupName, 0.01),
+    },
+    border: {
+      stroke: 'gray',
+      strokeWidth: 2,
+      visible: false,
+    },
+    point: {
+      visible: boolean(`linePointVisible ${index}`, true, groupName),
+      radius: range(`linePointRadius ${index}`, 0, 20, 1, groupName, 0.5),
+      // not customizable
+      stroke: 'red',
+      strokeWidth: 0.5,
+      opacity: range(`linePointOpacity ${index}`, 0, 1, 1, groupName, 0.01),
+    },
+  };
+}
+
 const dg = new DataGenerator();
 const data1 = dg.generateGroupedSeries(40, 4);
 const data2 = dg.generateSimpleSeries(40);
@@ -497,6 +522,12 @@ storiesOf('Stylings', module)
     );
   })
   .add('custom series styles: lines', () => {
+    const lineSeriesStyle1 = generateLineSeriesStyleKnobs(1);
+    const lineSeriesStyle2 = generateLineSeriesStyleKnobs(2);
+
+    const dataset1 = [{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }];
+    const dataset2 = dataset1.map((datum) => ({ ...datum, y: datum.y - 1 }));
+
     return (
       <Chart renderer="canvas" className={'story-chart'}>
         <Settings showLegend={true} legendPosition={Position.Right} />
@@ -513,13 +544,24 @@ storiesOf('Stylings', module)
           tickFormat={(d) => Number(d).toFixed(2)}
         />
         <LineSeries
-          id={getSpecId('lines')}
+          id={getSpecId('lines1')}
           xScaleType={ScaleType.Linear}
           yScaleType={ScaleType.Linear}
           xAccessor="x"
           yAccessors={['y']}
-          data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
+          data={dataset1}
           yScaleToDataExtent={false}
+          lineSeriesStyle={lineSeriesStyle1}
+        />
+        <LineSeries
+          id={getSpecId('lines2')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={dataset2}
+          yScaleToDataExtent={false}
+          lineSeriesStyle={lineSeriesStyle2}
         />
       </Chart>
     );

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -25,6 +25,7 @@ import {
   Settings,
 } from '../src/';
 import * as TestDatasets from '../src/lib/series/utils/test_dataset';
+// import { GeometryStyle } from '../src/lib/series/rendering';
 
 function range(
   title: string,
@@ -351,23 +352,25 @@ storiesOf('Stylings', module)
       </Chart>
     );
   })
-  .add('custom series colors through spec props', () => {
+  .add('custom series styles: bars', () => {
     const barCustomSeriesColors: CustomSeriesColorsMap = new Map();
     const barDataSeriesColorValues: DataSeriesColorsValues = {
       colorValues: ['cloudflare.com', 'direct-cdn', 'y2'],
       specId: getSpecId('bars'),
     };
 
-    const lineCustomSeriesColors: CustomSeriesColorsMap = new Map();
-    const lineDataSeriesColorValues: DataSeriesColorsValues = {
-      colorValues: [],
-      specId: getSpecId('lines'),
-    };
-
     const customBarColorKnob = color('barDataSeriesColor', '#000');
-    const customLineColorKnob = color('lineDataSeriesColor', '#ff0');
     barCustomSeriesColors.set(barDataSeriesColorValues, customBarColorKnob);
-    lineCustomSeriesColors.set(lineDataSeriesColorValues, customLineColorKnob);
+
+    // const barSeriesStyle: BarSeriesStyle & GeometryStyle = {
+    //   border: {
+    //     stroke: color('borderStroke', 'white', 'bar'),
+    //     strokeWidth: range('strokeWidth', 0, 10, 1, 'bar'),
+    //     visible: boolean('borderVisible', true, 'bar'),
+    //   },
+    //   opacity: range('opacity', 0, 1, 1, 'Shared', 0.05),
+    //   fill:
+    // },
 
     return (
       <Chart renderer="canvas" className={'story-chart'}>
@@ -375,7 +378,6 @@ storiesOf('Stylings', module)
         <Axis
           id={getAxisId('bottom')}
           position={Position.Bottom}
-          // title={'Bottom axis'}
           showOverlappingTicks={true}
         />
         <Axis
@@ -395,6 +397,72 @@ storiesOf('Stylings', module)
           customSeriesColors={barCustomSeriesColors}
           data={TestDatasets.BARCHART_2Y2G}
           yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('custom series styles: lines', () => {
+    const lineCustomSeriesColors: CustomSeriesColorsMap = new Map();
+    const lineDataSeriesColorValues: DataSeriesColorsValues = {
+      colorValues: [],
+      specId: getSpecId('lines'),
+    };
+
+    const customLineColorKnob = color('lineDataSeriesColor', '#9F2C8A');
+    lineCustomSeriesColors.set(lineDataSeriesColorValues, customLineColorKnob);
+
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          // title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+        <LineSeries
+          id={getSpecId('lines')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          customSeriesColors={lineCustomSeriesColors}
+          data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('custom series styles: area', () => {
+    const lineCustomSeriesColors: CustomSeriesColorsMap = new Map();
+    const lineDataSeriesColorValues: DataSeriesColorsValues = {
+      colorValues: [],
+      specId: getSpecId('lines'),
+    };
+
+    const customLineColorKnob = color('lineDataSeriesColor', '#9F2C8A');
+    lineCustomSeriesColors.set(lineDataSeriesColorValues, customLineColorKnob);
+
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          // title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
         />
         <LineSeries
           id={getSpecId('lines')}

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -444,7 +444,9 @@ storiesOf('Stylings', module)
     );
   })
   .add('custom series styles: bars', () => {
-    const barSeriesStyle1 = {
+    const useOnlyChartTheme = boolean('ignore series style (use only chart theme)', false, 'chartTheme');
+
+    const barSeriesStyle1 = useOnlyChartTheme ? undefined : {
       border: {
         stroke: color('borderStroke 1', 'white', 'group1'),
         strokeWidth: range('strokeWidth 1', 0, 10, 1, 'group1'),
@@ -453,7 +455,7 @@ storiesOf('Stylings', module)
       opacity: range('opacity 1', 0, 1, 1, 'group1', 0.1),
     };
 
-    const barSeriesStyle2 = {
+    const barSeriesStyle2 = useOnlyChartTheme ? undefined : {
       border: {
         stroke: color('borderStroke 2', 'white', 'group2'),
         strokeWidth: range('strokeWidth 2', 0, 10, 1, 'group2'),
@@ -466,9 +468,9 @@ storiesOf('Stylings', module)
       ...LIGHT_THEME,
       barSeriesStyle: {
         border: {
-          stroke: color('theme borderStroke', 'white', 'theme'),
-          strokeWidth: range('theme strokeWidth', 0, 10, 1, 'theme'),
-          visible: boolean('theme borderVisible', true, 'theme'),
+          stroke: color('theme borderStroke', 'white', 'chartTheme'),
+          strokeWidth: range('theme strokeWidth', 0, 10, 1, 'chartTheme'),
+          visible: boolean('theme borderVisible', true, 'chartTheme'),
         },
       },
     };

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -25,7 +25,6 @@ import {
   Settings,
 } from '../src/';
 import * as TestDatasets from '../src/lib/series/utils/test_dataset';
-// import { GeometryStyle } from '../src/lib/series/rendering';
 
 function range(
   title: string,
@@ -48,14 +47,13 @@ function range(
   );
 }
 
-function generateLineSeriesStyleKnobs(index: number) {
-  const groupName = `lines${index}`;
+function generateLineSeriesStyleKnobs(groupName: string) {
   return {
     line: {
       stroke: DEFAULT_MISSING_COLOR,
-      strokeWidth: range(`lineStrokeWidth ${index}`, 0, 10, 1, groupName),
-      visible: boolean(`lineVisible ${index}`, true, groupName),
-      opacity: range(`lineOpacity ${index}`, 0, 1, 1, groupName, 0.01),
+      strokeWidth: range(`lineStrokeWidth (${groupName})`, 0, 10, 1, groupName),
+      visible: boolean(`lineVisible (${groupName})`, true, groupName),
+      opacity: range(`lineOpacity (${groupName})`, 0, 1, 1, groupName, 0.01),
     },
     border: {
       stroke: 'gray',
@@ -63,12 +61,12 @@ function generateLineSeriesStyleKnobs(index: number) {
       visible: false,
     },
     point: {
-      visible: boolean(`linePointVisible ${index}`, true, groupName),
-      radius: range(`linePointRadius ${index}`, 0, 20, 1, groupName, 0.5),
+      visible: boolean(`linePointVisible (${groupName})`, true, groupName),
+      radius: range(`linePointRadius (${groupName})`, 0, 20, 1, groupName, 0.5),
       // not customizable
       stroke: 'red',
       strokeWidth: 0.5,
-      opacity: range(`linePointOpacity ${index}`, 0, 1, 1, groupName, 0.01),
+      opacity: range(`linePointOpacity (${groupName})`, 0, 1, 1, groupName, 0.01),
     },
   };
 }
@@ -522,15 +520,22 @@ storiesOf('Stylings', module)
     );
   })
   .add('custom series styles: lines', () => {
-    const lineSeriesStyle1 = generateLineSeriesStyleKnobs(1);
-    const lineSeriesStyle2 = generateLineSeriesStyleKnobs(2);
+    const useOnlyChartTheme = boolean('ignore series style (use only chart theme)', false, 'chartTheme');
+    const lineSeriesStyle1 = useOnlyChartTheme ? undefined : generateLineSeriesStyleKnobs('lines1');
+    const lineSeriesStyle2 = useOnlyChartTheme ? undefined : generateLineSeriesStyleKnobs('lines2');
+
+    const chartTheme = {
+      ...LIGHT_THEME,
+      lineSeriesStyle: generateLineSeriesStyleKnobs('chartTheme'),
+    };
 
     const dataset1 = [{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }];
     const dataset2 = dataset1.map((datum) => ({ ...datum, y: datum.y - 1 }));
+    const dataset3 = dataset1.map((datum) => ({ ...datum, y: datum.y - 2 }));
 
     return (
       <Chart renderer="canvas" className={'story-chart'}>
-        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Settings showLegend={true} legendPosition={Position.Right} theme={chartTheme} />
         <Axis
           id={getAxisId('bottom')}
           position={Position.Bottom}
@@ -562,6 +567,15 @@ storiesOf('Stylings', module)
           data={dataset2}
           yScaleToDataExtent={false}
           lineSeriesStyle={lineSeriesStyle2}
+        />
+        <LineSeries
+          id={getSpecId('lines3')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={dataset3}
+          yScaleToDataExtent={false}
         />
       </Chart>
     );

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -411,18 +411,40 @@ storiesOf('Stylings', module)
     );
   })
   .add('custom series styles: bars', () => {
-    const barSeriesStyle = {
+    const barSeriesStyle1 = {
       border: {
-        stroke: color('borderStroke', 'white'),
-        strokeWidth: range('strokeWidth', 0, 10, 1),
-        visible: boolean('borderVisible', true),
+        stroke: color('borderStroke 1', 'white', 'group1'),
+        strokeWidth: range('strokeWidth 1', 0, 10, 1, 'group1'),
+        visible: boolean('borderVisible 1', true, 'group1'),
       },
-      opacity: range('opacity', 0, 1, 1),
     };
+
+    const barSeriesStyle2 = {
+      border: {
+        stroke: color('borderStroke 2', 'white', 'group2'),
+        strokeWidth: range('strokeWidth 2', 0, 10, 1, 'group2'),
+        visible: boolean('borderVisible 2', true, 'group2'),
+      },
+    };
+
+    const chartTheme = {
+      ...LIGHT_THEME,
+      barSeriesStyle: {
+        border: {
+          stroke: color('theme borderStroke', 'white', 'theme'),
+          strokeWidth: range('theme strokeWidth', 0, 10, 1, 'theme'),
+          visible: boolean('theme borderVisible', true, 'theme'),
+        },
+      },
+    };
+
+    const dataset1 = TestDatasets.BARCHART_2Y2G.filter((data) => data.g1 === 'cdn.google.com');
+    const dataset2 = TestDatasets.BARCHART_2Y2G.filter((data) => data.g1 === 'cloudflare.com');
+    const dataset3 = TestDatasets.BARCHART_2Y2G.filter((data) => data.g2 === 'indirect-cdn');
 
     return (
       <Chart renderer="canvas" className={'story-chart'}>
-        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Settings showLegend={true} legendPosition={Position.Right} theme={chartTheme} />
         <Axis
           id={getAxisId('bottom')}
           position={Position.Bottom}
@@ -442,9 +464,32 @@ storiesOf('Stylings', module)
           xAccessor="x"
           yAccessors={['y1', 'y2']}
           splitSeriesAccessors={['g1', 'g2']}
-          data={TestDatasets.BARCHART_2Y2G}
+          data={dataset1}
           yScaleToDataExtent={false}
-          seriesStyle={barSeriesStyle}
+          barSeriesStyle={barSeriesStyle1}
+          name={'bars 1'}
+        />
+        <BarSeries
+          id={getSpecId('bars2')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y1', 'y2']}
+          splitSeriesAccessors={['g1', 'g2']}
+          data={dataset2}
+          yScaleToDataExtent={false}
+          barSeriesStyle={barSeriesStyle2}
+          name={'bars 2'}
+        />
+        <BarSeries
+          id={getSpecId('bars3')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y1', 'y2']}
+          splitSeriesAccessors={['g1', 'g2']}
+          data={dataset3}
+          yScaleToDataExtent={false}
         />
       </Chart>
     );

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -352,25 +352,73 @@ storiesOf('Stylings', module)
       </Chart>
     );
   })
-  .add('custom series styles: bars', () => {
+  .add('custom series colors through spec props', () => {
     const barCustomSeriesColors: CustomSeriesColorsMap = new Map();
     const barDataSeriesColorValues: DataSeriesColorsValues = {
       colorValues: ['cloudflare.com', 'direct-cdn', 'y2'],
       specId: getSpecId('bars'),
     };
 
-    const customBarColorKnob = color('barDataSeriesColor', '#000');
-    barCustomSeriesColors.set(barDataSeriesColorValues, customBarColorKnob);
+    const lineCustomSeriesColors: CustomSeriesColorsMap = new Map();
+    const lineDataSeriesColorValues: DataSeriesColorsValues = {
+      colorValues: [],
+      specId: getSpecId('lines'),
+    };
 
-    // const barSeriesStyle: BarSeriesStyle & GeometryStyle = {
-    //   border: {
-    //     stroke: color('borderStroke', 'white', 'bar'),
-    //     strokeWidth: range('strokeWidth', 0, 10, 1, 'bar'),
-    //     visible: boolean('borderVisible', true, 'bar'),
-    //   },
-    //   opacity: range('opacity', 0, 1, 1, 'Shared', 0.05),
-    //   fill:
-    // },
+    const customBarColorKnob = color('barDataSeriesColor', '#000');
+    const customLineColorKnob = color('lineDataSeriesColor', '#ff0');
+    barCustomSeriesColors.set(barDataSeriesColorValues, customBarColorKnob);
+    lineCustomSeriesColors.set(lineDataSeriesColorValues, customLineColorKnob);
+
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          // title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y1', 'y2']}
+          splitSeriesAccessors={['g1', 'g2']}
+          customSeriesColors={barCustomSeriesColors}
+          data={TestDatasets.BARCHART_2Y2G}
+          yScaleToDataExtent={false}
+        />
+        <LineSeries
+          id={getSpecId('lines')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          customSeriesColors={lineCustomSeriesColors}
+          data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('custom series styles: bars', () => {
+    const barSeriesStyle = {
+      border: {
+        stroke: color('borderStroke', 'white'),
+        strokeWidth: range('strokeWidth', 0, 10, 1),
+        visible: boolean('borderVisible', true),
+      },
+      opacity: range('opacity', 0, 1, 1),
+    };
 
     return (
       <Chart renderer="canvas" className={'story-chart'}>
@@ -394,23 +442,14 @@ storiesOf('Stylings', module)
           xAccessor="x"
           yAccessors={['y1', 'y2']}
           splitSeriesAccessors={['g1', 'g2']}
-          customSeriesColors={barCustomSeriesColors}
           data={TestDatasets.BARCHART_2Y2G}
           yScaleToDataExtent={false}
+          seriesStyle={barSeriesStyle}
         />
       </Chart>
     );
   })
   .add('custom series styles: lines', () => {
-    const lineCustomSeriesColors: CustomSeriesColorsMap = new Map();
-    const lineDataSeriesColorValues: DataSeriesColorsValues = {
-      colorValues: [],
-      specId: getSpecId('lines'),
-    };
-
-    const customLineColorKnob = color('lineDataSeriesColor', '#9F2C8A');
-    lineCustomSeriesColors.set(lineDataSeriesColorValues, customLineColorKnob);
-
     return (
       <Chart renderer="canvas" className={'story-chart'}>
         <Settings showLegend={true} legendPosition={Position.Right} />
@@ -432,7 +471,6 @@ storiesOf('Stylings', module)
           yScaleType={ScaleType.Linear}
           xAccessor="x"
           yAccessors={['y']}
-          customSeriesColors={lineCustomSeriesColors}
           data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
           yScaleToDataExtent={false}
         />
@@ -440,15 +478,6 @@ storiesOf('Stylings', module)
     );
   })
   .add('custom series styles: area', () => {
-    const lineCustomSeriesColors: CustomSeriesColorsMap = new Map();
-    const lineDataSeriesColorValues: DataSeriesColorsValues = {
-      colorValues: [],
-      specId: getSpecId('lines'),
-    };
-
-    const customLineColorKnob = color('lineDataSeriesColor', '#9F2C8A');
-    lineCustomSeriesColors.set(lineDataSeriesColorValues, customLineColorKnob);
-
     return (
       <Chart renderer="canvas" className={'story-chart'}>
         <Settings showLegend={true} legendPosition={Position.Right} />
@@ -464,13 +493,12 @@ storiesOf('Stylings', module)
           position={Position.Left}
           tickFormat={(d) => Number(d).toFixed(2)}
         />
-        <LineSeries
+        <AreaSeries
           id={getSpecId('lines')}
           xScaleType={ScaleType.Linear}
           yScaleType={ScaleType.Linear}
           xAccessor="x"
           yAccessors={['y']}
-          customSeriesColors={lineCustomSeriesColors}
           data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
           yScaleToDataExtent={false}
         />


### PR DESCRIPTION
## Summary

close #138 

This PR introduces the ability to customize the styles for a series independently from the main chart theme (which is shared across all series).  If both a custom individual series style and custom chart theme are defined, precedence will be given to the custom series style (though the chart theme can still be used to change styles for the series which do not have their own custom series styles).

Currently, this supports the same set of customizable styling options as the main chart theme, but can be extended to cover additional styles currently not implemented as customizable.

The following examples can be found under `Styling` in storybook:

### Bars
currently supported customizable options:
- border stroke width
- border stroke color
- border visibility
- bars opacity (currrently not configurable from chart theme, but seems something that TSVB allows as a series-specific customization)

![bar_style](https://user-images.githubusercontent.com/452850/56055719-159cc900-5d0f-11e9-9d17-e2bc709d7062.gif)

### Lines
currently supported customizable options:
- line stroke width
- line visibility
- line opacity 
- point visibility
- point radius
- point opacity

![line_style](https://user-images.githubusercontent.com/452850/56055897-952a9800-5d0f-11e9-8b54-a843bd21068f.gif)

### Areas
currently supported customizable options:
- line stroke width
- line visibility
- line opacity 
- point visibility
- point radius
- point opacity
- area visibility
- area opacity

![area_style](https://user-images.githubusercontent.com/452850/56055963-bc816500-5d0f-11e9-8d1c-682045a82be5.gif)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
