### PR TITLE
fix: apply transform.x to area & line geometries

### DIFF
--- a/src/components/react_canvas/area_geometries.tsx
+++ b/src/components/react_canvas/area_geometries.tsx
@@ -113,6 +113,7 @@ export class AreaGeometries extends React.PureComponent<
                 const areaProps = buildAreaProps({
                   index: i,
                   areaPath: props.area,
+                  xTransform: 0,
                   color,
                   opacity,
                 });
@@ -125,10 +126,11 @@ export class AreaGeometries extends React.PureComponent<
         const areaProps = buildAreaProps({
           index: i,
           areaPath: area,
+          xTransform: transform.x,
           color,
           opacity,
         });
-        return <Path {...areaProps} x={transform.x} />;
+        return <Path {...areaProps} />;
       }
     });
   }
@@ -149,12 +151,13 @@ export class AreaGeometries extends React.PureComponent<
         const lineProps = buildAreaLineProps({
           areaIndex,
           lineIndex,
+          xTransform: transform.x,
           linePath,
           color,
           strokeWidth,
           geometryStyle,
         });
-        linesToRender.push(<Path {...lineProps} x={transform.x} />);
+        linesToRender.push(<Path {...lineProps} />);
       });
     });
     return linesToRender;

--- a/src/components/react_canvas/area_geometries.tsx
+++ b/src/components/react_canvas/area_geometries.tsx
@@ -24,7 +24,7 @@ interface AreaGeometriesDataState {
 export class AreaGeometries extends React.PureComponent<
   AreaGeometriesDataProps,
   AreaGeometriesDataState
-> {
+  > {
   static defaultProps: Partial<AreaGeometriesDataProps> = {
     animated: false,
   };
@@ -128,7 +128,7 @@ export class AreaGeometries extends React.PureComponent<
           color,
           opacity,
         });
-        return <Path {...areaProps} />;
+        return <Path {...areaProps} x={transform.x} />;
       }
     });
   }
@@ -137,7 +137,7 @@ export class AreaGeometries extends React.PureComponent<
     const { strokeWidth } = this.props.style.line;
     const linesToRender: JSX.Element[] = [];
     areas.forEach((glyph, areaIndex) => {
-      const { lines, color, geometryId } = glyph;
+      const { lines, color, geometryId, transform } = glyph;
 
       const geometryStyle = getGeometryStyle(
         geometryId,
@@ -154,7 +154,7 @@ export class AreaGeometries extends React.PureComponent<
           strokeWidth,
           geometryStyle,
         });
-        linesToRender.push(<Path {...lineProps} />);
+        linesToRender.push(<Path {...lineProps} x={transform.x} />);
       });
     });
     return linesToRender;

--- a/src/components/react_canvas/line_geometries.tsx
+++ b/src/components/react_canvas/line_geometries.tsx
@@ -115,6 +115,7 @@ export class LineGeometries extends React.PureComponent<
               {(props: { opacity: number }) => {
                 const lineProps = buildLineProps({
                   index,
+                  xTransform: 0,
                   linePath: line,
                   color,
                   strokeWidth,
@@ -129,13 +130,14 @@ export class LineGeometries extends React.PureComponent<
       } else {
         const lineProps = buildLineProps({
           index,
+          xTransform: transform.x,
           linePath: line,
           color,
           strokeWidth,
           opacity: 1,
           geometryStyle,
         });
-        return <Path {...lineProps} x={transform.x} />;
+        return <Path {...lineProps} />;
       }
     });
   }

--- a/src/components/react_canvas/line_geometries.tsx
+++ b/src/components/react_canvas/line_geometries.tsx
@@ -20,7 +20,7 @@ interface LineGeometriesDataState {
 export class LineGeometries extends React.PureComponent<
   LineGeometriesDataProps,
   LineGeometriesDataState
-> {
+  > {
   static defaultProps: Partial<LineGeometriesDataProps> = {
     animated: false,
   };
@@ -135,7 +135,7 @@ export class LineGeometries extends React.PureComponent<
           opacity: 1,
           geometryStyle,
         });
-        return <Path {...lineProps} />;
+        return <Path {...lineProps} x={transform.x} />;
       }
     });
   }

--- a/src/components/react_canvas/utils/rendering_props_utils.test.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.test.ts
@@ -63,12 +63,14 @@ describe('[canvas] Area Geometries props', () => {
     const props = buildAreaProps({
       index: 1,
       areaPath: 'M0,0L10,10Z',
+      xTransform: 40,
       color: 'red',
       opacity: 0.5,
     });
     expect(props).toEqual({
       key: 'area-1',
       data: 'M0,0L10,10Z',
+      x: 40,
       fill: 'red',
       lineCap: 'round',
       lineJoin: 'round',
@@ -82,6 +84,7 @@ describe('[canvas] Area Geometries props', () => {
     const props = buildAreaLineProps({
       areaIndex: 1,
       lineIndex: 2,
+      xTransform: 40,
       linePath: 'M0,0L10,10Z',
       color: 'red',
       strokeWidth: 1,
@@ -92,6 +95,7 @@ describe('[canvas] Area Geometries props', () => {
     expect(props).toEqual({
       key: `area-1-line-2`,
       data: 'M0,0L10,10Z',
+      x: 40,
       stroke: 'red',
       strokeWidth: 1,
       lineCap: 'round',
@@ -161,6 +165,7 @@ describe('[canvas] Line Geometries', () => {
     const props = buildLineProps({
       index: 1,
       linePath: 'M0,0L10,10Z',
+      xTransform: 40,
       color: 'red',
       strokeWidth: 1,
       opacity: 0.3,
@@ -171,6 +176,7 @@ describe('[canvas] Line Geometries', () => {
     expect(props).toEqual({
       key: `line-1`,
       data: 'M0,0L10,10Z',
+      x: 40,
       stroke: 'red',
       strokeWidth: 1,
       lineCap: 'round',

--- a/src/components/react_canvas/utils/rendering_props_utils.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.ts
@@ -37,17 +37,20 @@ export function buildAreaPointProps({
 export function buildAreaProps({
   index,
   areaPath,
+  xTransform,
   color,
   opacity,
 }: {
   index: number;
   areaPath: string;
+  xTransform: number;
   color: string;
   opacity: number;
 }) {
   return {
     key: `area-${index}`,
     data: areaPath,
+    x: xTransform,
     fill: color,
     lineCap: 'round',
     lineJoin: 'round',
@@ -59,6 +62,7 @@ export function buildAreaProps({
 export function buildAreaLineProps({
   areaIndex,
   lineIndex,
+  xTransform,
   linePath,
   color,
   strokeWidth,
@@ -66,6 +70,7 @@ export function buildAreaLineProps({
 }: {
   areaIndex: number;
   lineIndex: number;
+  xTransform: number;
   linePath: string;
   color: string;
   strokeWidth: number;
@@ -74,6 +79,7 @@ export function buildAreaLineProps({
   return {
     key: `area-${areaIndex}-line-${lineIndex}`,
     data: linePath,
+    x: xTransform,
     stroke: color,
     strokeWidth,
     lineCap: 'round',
@@ -156,6 +162,7 @@ export function buildLinePointProps({
 
 export function buildLineProps({
   index,
+  xTransform,
   linePath,
   color,
   strokeWidth,
@@ -163,6 +170,7 @@ export function buildLineProps({
   geometryStyle,
 }: {
   index: number;
+  xTransform: number;
   linePath: string;
   color: string;
   strokeWidth: number;
@@ -171,6 +179,7 @@ export function buildLineProps({
 }) {
   return {
     key: `line-${index}`,
+    x: xTransform,
     data: linePath,
     stroke: color,
     strokeWidth,

--- a/stories/mixed.tsx
+++ b/stories/mixed.tsx
@@ -6,6 +6,7 @@ import {
   Axis,
   BarSeries,
   Chart,
+  CurveType,
   getAxisId,
   getSpecId,
   LineSeries,
@@ -81,6 +82,61 @@ storiesOf('Mixed Charts', module)
           yAccessors={['y']}
           stackAccessors={['x']}
           data={[{ x: 0, y: 2.8 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
+  })
+  .add('areas and bars', () => {
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Settings
+          showLegend={true}
+          legendPosition={Position.Right}
+        />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+        <Axis
+          id={getAxisId('top')}
+          position={Position.Top}
+          title={'Top axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('right')}
+          title={'Right axis'}
+          position={Position.Right}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          splitSeriesAccessors={['g']}
+          stackAccessors={['x']}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+          yScaleToDataExtent={false}
+        />
+        <AreaSeries
+          id={getSpecId('areas')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          curve={CurveType.CURVE_MONOTONE_X}
+          data={[{ x: 0, y: 2.5 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
           yScaleToDataExtent={false}
         />
       </Chart>


### PR DESCRIPTION
## Summary

There were discrepancies between the props applied to animated elements and non-animated elements.  When we disabled animation across the board, this discrepancy surface issues with the non-animated elements not having the correct transform.x applied, leading to misaligned lines & points in area and line series:

![bar_line](https://user-images.githubusercontent.com/452850/56057465-b8efdd00-5d13-11e9-9bc2-4cab10c640ef.gif)

![bar_area](https://user-images.githubusercontent.com/452850/56057464-b8efdd00-5d13-11e9-879a-ae2767c4768f.gif)

![mixed](https://user-images.githubusercontent.com/452850/56057463-b8efdd00-5d13-11e9-9811-935e0f562e57.gif)

This PR applies the transform to the non-animated elements as well, resolving the alignment issues:

![bar_line_fixed](https://user-images.githubusercontent.com/452850/56057628-226feb80-5d14-11e9-9424-6f35a32622ef.gif)

![bar_area_fixed](https://user-images.githubusercontent.com/452850/56057627-21d75500-5d14-11e9-8a3b-310b2b86464d.gif)

![mixed_fixed](https://user-images.githubusercontent.com/452850/56057626-21d75500-5d14-11e9-9982-0abfb70a288f.gif)

We also move this transform into the build props functions to require consistency in handling these values regardless of animation.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
