### PR TITLE
fix: merge multi-group indexed geometry

### DIFF
--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -225,9 +225,11 @@ export function computeSeriesGeometries(
     lines.push(...geometries.lines);
     bars.push(...geometries.bars);
     points.push(...geometries.points);
-
+    stackedGeometriesIndex = mergeGeometriesIndexes(
+      stackedGeometriesIndex,
+      geometries.geometriesIndex,
+    );
     // update counts
-    stackedGeometriesIndex = geometries.geometriesIndex;
     geometriesCounts.points += geometries.geometriesCounts.points;
     geometriesCounts.bars += geometries.geometriesCounts.bars;
     geometriesCounts.areas += geometries.geometriesCounts.areas;
@@ -257,8 +259,11 @@ export function computeSeriesGeometries(
     lines.push(...geometries.lines);
     bars.push(...geometries.bars);
     points.push(...geometries.points);
-    nonStackedGeometriesIndex = geometries.geometriesIndex;
 
+    nonStackedGeometriesIndex = mergeGeometriesIndexes(
+      nonStackedGeometriesIndex,
+      geometries.geometriesIndex,
+    );
     // update counts
     geometriesCounts.points += geometries.geometriesCounts.points;
     geometriesCounts.bars += geometries.geometriesCounts.bars;
@@ -331,7 +336,16 @@ export function renderGeometries(
       case 'bar':
         const shift = isStacked ? indexOffset : indexOffset + i;
         const barSeriesStyle = spec.barSeriesStyle;
-        const renderedBars = renderBars(shift, ds.data, xScale, yScale, color, ds.specId, ds.key, barSeriesStyle);
+        const renderedBars = renderBars(
+          shift,
+          ds.data,
+          xScale,
+          yScale,
+          color,
+          ds.specId,
+          ds.key,
+          barSeriesStyle,
+        );
         barGeometriesIndex = mergeGeometriesIndexes(
           barGeometriesIndex,
           renderedBars.indexedGeometries,
@@ -480,6 +494,12 @@ export function computeBrushExtent(
   };
 }
 
+/**
+ * Merge multiple geometry indexes maps together.
+ * @param iterables a set of maps to be merged
+ * @returns a new Map where each element with the same key are concatenated on a single
+ * IndexedGemoetry array for that key
+ */
 export function mergeGeometriesIndexes(...iterables: Array<Map<any, IndexedGeometry[]>>) {
   const geometriesIndex: Map<any, IndexedGeometry[]> = new Map();
 

--- a/stories/axis.tsx
+++ b/stories/axis.tsx
@@ -273,6 +273,55 @@ storiesOf('Axis', module)
       </Chart>
     );
   })
+  .add('with multi axis different tooltip formats', () => {
+    return (
+      <Chart className={'story-chart'}>
+        <Settings showLegend={false} />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('left')}
+          groupId={getGroupId('group1')}
+          title={'Line 1'}
+          position={Position.Left}
+          tickFormat={(d) => `${Number(d).toFixed(2)} %`}
+        />
+        <Axis
+          id={getAxisId('right')}
+          title={'Line 2'}
+          groupId={getGroupId('group2')}
+          position={Position.Right}
+          tickFormat={(d) => `${Number(d).toFixed(2)}/s`}
+        />
+        <LineSeries
+          id={getSpecId('line1')}
+          groupId={getGroupId('group1')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          stackAccessors={['x']}
+          splitSeriesAccessors={['g']}
+          data={[{ x: 0, y: 5 }, { x: 1, y: 4 }, { x: 2, y: 3 }, { x: 3, y: 2 }]}
+        />
+        <LineSeries
+          id={getSpecId('line2')}
+          groupId={getGroupId('group2')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          stackAccessors={['x']}
+          splitSeriesAccessors={['g']}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 5 }]}
+        />
+      </Chart>
+    );
+  })
   .add('w many tick labels', () => {
     const dg = new DataGenerator();
     const data = dg.generateSimpleSeries(31);


### PR DESCRIPTION
## Summary

This fix correct the wrong behaviour when indexed geometries are not merged on multiple series.
Previously we just rewrote the entire stacked and non stacked map. Now, for each stacked/nonstacked
series we are merging that indexed geometry map.

fix #186

**Before:**
<img width="1191" alt="Screenshot 2019-04-23 at 17 41 10" src="https://user-images.githubusercontent.com/1421091/56596320-a79ab080-65f0-11e9-99dd-b58db98f2787.png">

**After:**
<img width="674" alt="Screenshot 2019-04-23 at 17 37 59" src="https://user-images.githubusercontent.com/1421091/56596326-ab2e3780-65f0-11e9-8248-c3105a40456b.png">


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
