### PR TITLE
feat(scales): add paddings between bars

### DIFF
--- a/src/lib/axes/axis_utils.ts
+++ b/src/lib/axes/axis_utils.ts
@@ -62,6 +62,7 @@ export function computeAxisTicksDimensions(
   bboxCalculator: BBoxCalculator,
   chartRotation: Rotation,
   axisConfig: AxisConfig,
+  barsPadding?: number,
 ): AxisTicksDimensions | null {
   if (axisSpec.hide) {
     return null;
@@ -75,6 +76,7 @@ export function computeAxisTicksDimensions(
     chartRotation,
     0,
     1,
+    barsPadding,
   );
   if (!scale) {
     throw new Error(`Cannot compute scale for axis spec ${axisSpec.id}`);
@@ -111,6 +113,7 @@ export function getScaleForAxisSpec(
   chartRotation: Rotation,
   minRange: number,
   maxRange: number,
+  barsPadding?: number,
 ): Scale | null {
   const axisIsYDomain = isYDomain(axisSpec.position, chartRotation);
 
@@ -121,7 +124,7 @@ export function getScaleForAxisSpec(
     }
     return null;
   } else {
-    return computeXScale(xDomain, totalBarsInCluster, minRange, maxRange);
+    return computeXScale(xDomain, totalBarsInCluster, minRange, maxRange, barsPadding);
   }
 }
 
@@ -505,6 +508,7 @@ export function getAxisTicksPositions(
   yDomain: YDomain[],
   totalGroupsCount: number,
   legendPosition?: Position,
+  barsPadding?: number,
 ) {
   const { chartPaddings, chartMargins } = chartTheme;
   const legendStyle = chartTheme.legend;
@@ -556,8 +560,7 @@ export function getAxisTicksPositions(
       chartRotation,
       minMaxRanges.minRange,
       minMaxRanges.maxRange,
-      // minRange,
-      // maxRange,
+      barsPadding,
     );
 
     if (!scale) {

--- a/src/lib/series/scales.ts
+++ b/src/lib/series/scales.ts
@@ -49,6 +49,7 @@ export function computeXScale(
   totalBarsInCluster: number,
   minRange: number,
   maxRange: number,
+  barsPadding?: number,
 ): Scale {
   const { scaleType, minInterval, domain, isBandScale, timeZone } = xDomain;
   const rangeDiff = Math.abs(maxRange - minRange);
@@ -56,7 +57,7 @@ export function computeXScale(
   if (scaleType === ScaleType.Ordinal) {
     const dividend = totalBarsInCluster > 0 ? totalBarsInCluster : 1;
     const bandwidth = rangeDiff / (domain.length * dividend);
-    return new ScaleBand(domain, [minRange, maxRange], bandwidth);
+    return new ScaleBand(domain, [minRange, maxRange], bandwidth, barsPadding);
   } else {
     if (isBandScale) {
       const intervalCount = (domain[1] - domain[0]) / minInterval;
@@ -70,9 +71,20 @@ export function computeXScale(
         bandwidth / totalBarsInCluster,
         minInterval,
         timeZone,
+        totalBarsInCluster,
+        barsPadding,
       );
     } else {
-      return new ScaleContinuous(scaleType, domain, [minRange, maxRange], 0, minInterval, timeZone);
+      return new ScaleContinuous(
+        scaleType,
+        domain,
+        [minRange, maxRange],
+        0,
+        minInterval,
+        timeZone,
+        totalBarsInCluster,
+        barsPadding,
+      );
     }
   }
 }

--- a/src/lib/series/scales.ts
+++ b/src/lib/series/scales.ts
@@ -1,10 +1,7 @@
 import { GroupId } from '../utils/ids';
-import {
-  createContinuousScale,
-  createOrdinalScale,
-  Scale,
-  ScaleType,
-} from '../utils/scales/scales';
+import { ScaleBand } from '../utils/scales/scale_band';
+import { ScaleContinuous } from '../utils/scales/scale_continuous';
+import { Scale, ScaleType } from '../utils/scales/scales';
 import { XDomain } from './domains/x_domain';
 import { YDomain } from './domains/y_domain';
 import { FormattedDataSeries } from './series';
@@ -59,34 +56,23 @@ export function computeXScale(
   if (scaleType === ScaleType.Ordinal) {
     const dividend = totalBarsInCluster > 0 ? totalBarsInCluster : 1;
     const bandwidth = rangeDiff / (domain.length * dividend);
-    return createOrdinalScale(domain, minRange, maxRange, 0, bandwidth);
+    return new ScaleBand(domain, [minRange, maxRange], bandwidth);
   } else {
     if (isBandScale) {
       const intervalCount = (domain[1] - domain[0]) / minInterval;
       const bandwidth = rangeDiff / (intervalCount + 1);
       const start = isInverse ? minRange - bandwidth : minRange;
       const end = isInverse ? maxRange : maxRange - bandwidth;
-      return createContinuousScale(
+      return new ScaleContinuous(
         scaleType,
         domain,
-        start,
-        end,
+        [start, end],
         bandwidth / totalBarsInCluster,
-        false,
         minInterval,
         timeZone,
       );
     } else {
-      return createContinuousScale(
-        scaleType,
-        domain,
-        minRange,
-        maxRange,
-        0,
-        undefined,
-        minInterval,
-        timeZone,
-      );
+      return new ScaleContinuous(scaleType, domain, [minRange, maxRange], 0, minInterval, timeZone);
     }
   }
 }
@@ -104,7 +90,7 @@ export function computeYScales(
   const yScales: Map<GroupId, Scale> = new Map();
 
   yDomains.forEach((yDomain) => {
-    const yScale = createContinuousScale(yDomain.scaleType, yDomain.domain, minRange, maxRange);
+    const yScale = new ScaleContinuous(yDomain.scaleType, yDomain.domain, [minRange, maxRange]);
     yScales.set(yDomain.groupId, yScale);
   });
 

--- a/src/lib/themes/dark_theme.ts
+++ b/src/lib/themes/dark_theme.ts
@@ -63,9 +63,7 @@ export const DARK_THEME: Theme = {
   },
   sharedStyle: DEFAULT_GEOMETRY_STYLES,
   scales: {
-    ordinal: {
-      padding: 0.25,
-    },
+    barsPadding: 0.25,
   },
   axes: {
     axisTitleStyle: {

--- a/src/lib/themes/light_theme.ts
+++ b/src/lib/themes/light_theme.ts
@@ -63,9 +63,7 @@ export const LIGHT_THEME: Theme = {
   },
   sharedStyle: DEFAULT_GEOMETRY_STYLES,
   scales: {
-    ordinal: {
-      padding: 0.25,
-    },
+    barsPadding: 0.25,
   },
   axes: {
     axisTitleStyle: {

--- a/src/lib/themes/theme.test.ts
+++ b/src/lib/themes/theme.test.ts
@@ -193,9 +193,7 @@ describe('Themes', () => {
 
   it('should merge partial theme: scales', () => {
     const scales: ScalesConfig = {
-      ordinal: {
-        padding: 314571,
-      },
+      barsPadding: 314571,
     };
     const customTheme = mergeWithDefaultTheme({
       scales,

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -60,7 +60,6 @@ export interface ScalesConfig {
    * The proportion of the range that is reserved for blank space between bands.
    * A value of 0 means no blank space between bands, and a value of 1 means a bandwidth of zero.
    * A number between 0 and 1.
-   * @default 0
    */
   barsPadding: number;
 }

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -56,6 +56,12 @@ export interface GridLineConfig {
   dash?: number[];
 }
 export interface ScalesConfig {
+  /**
+   * The proportion of the range that is reserved for blank space between bands.
+   * A value of 0 means no blank space between bands, and a value of 1 means a bandwidth of zero.
+   * A number between 0 and 1.
+   * @default 0
+   */
   barsPadding: number;
 }
 export interface ColorConfig {

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -56,9 +56,7 @@ export interface GridLineConfig {
   dash?: number[];
 }
 export interface ScalesConfig {
-  ordinal: {
-    padding: number;
-  };
+  barsPadding: number;
 }
 export interface ColorConfig {
   vizColors: string[];
@@ -167,7 +165,9 @@ export function mergeWithDefaultGridLineConfig(config: GridLineConfig): GridLine
   };
 }
 
-export function mergeWithDefaultAnnotationLine(config?: Partial<AnnotationLineStyle>): AnnotationLineStyle {
+export function mergeWithDefaultAnnotationLine(
+  config?: Partial<AnnotationLineStyle>,
+): AnnotationLineStyle {
   const defaultLine = DEFAULT_ANNOTATION_LINE_STYLE.line;
   const defaultDetails = DEFAULT_ANNOTATION_LINE_STYLE.details;
   const mergedConfig: AnnotationLineStyle = { ...DEFAULT_ANNOTATION_LINE_STYLE };

--- a/src/lib/utils/commons.test.ts
+++ b/src/lib/utils/commons.test.ts
@@ -1,0 +1,31 @@
+import { clamp, compareByValueAsc, identity } from './commons';
+
+describe('commons utilities', () => {
+  test('can clamp a value to min max', () => {
+    expect(clamp(0, 0, 1)).toBe(0);
+    expect(clamp(1, 0, 1)).toBe(1);
+
+    expect(clamp(1.1, 0, 1)).toBe(1);
+    expect(clamp(-0.1, 0, 1)).toBe(0);
+
+    expect(clamp(0.1, 0, 1)).toBe(0.1);
+    expect(clamp(0.8, 0, 1)).toBe(0.8);
+  });
+
+  test('identity', () => {
+    expect(identity('text')).toBe('text');
+    expect(identity(2)).toBe(2);
+    const a = {};
+    expect(identity(a)).toBe(a);
+    expect(identity(null)).toBe(null);
+    expect(identity(undefined)).toBe(undefined);
+    const fn = () => ({});
+    expect(identity(fn)).toBe(fn);
+  });
+
+  test('compareByValueAsc', () => {
+    expect(compareByValueAsc(10, 20)).toBeLessThan(0);
+    expect(compareByValueAsc(20, 10)).toBeGreaterThan(0);
+    expect(compareByValueAsc(10, 10)).toBe(0);
+  });
+});

--- a/src/lib/utils/commons.ts
+++ b/src/lib/utils/commons.ts
@@ -5,3 +5,7 @@ export function identity<T>(value: T): T {
 export function compareByValueAsc(firstEl: number, secondEl: number): number {
   return firstEl - secondEl;
 }
+
+export function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/lib/utils/commons.ts
+++ b/src/lib/utils/commons.ts
@@ -6,6 +6,6 @@ export function compareByValueAsc(firstEl: number, secondEl: number): number {
   return firstEl - secondEl;
 }
 
-export function clamp(value: number, min: number, max: number) {
+export function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }

--- a/src/lib/utils/scales/scale_band.test.ts
+++ b/src/lib/utils/scales/scale_band.test.ts
@@ -60,7 +60,7 @@ describe.only('Scale Band', () => {
     expect(scale.scale(null)).toBeUndefined();
   });
   it('shall scale a numeric domain with padding', () => {
-    const scale = new ScaleBand([0, 1, 2], [0, 100], [0, 1]);
+    const scale = new ScaleBand([0, 1, 2], [0, 100], undefined, [0, 1]);
     expect(scale.bandwidth).toBe(20);
     expect(scale.step).toBe(20);
     // an empty 1 step place at the beginning
@@ -69,7 +69,7 @@ describe.only('Scale Band', () => {
     expect(scale.scale(2)).toBe(60);
     // an empty 1 step place at the end
 
-    const scale2 = new ScaleBand([0, 1, 2, 3], [0, 100], [0, 0.5]);
+    const scale2 = new ScaleBand([0, 1, 2, 3], [0, 100], undefined, [0, 0.5]);
     expect(scale2.bandwidth).toBe(20);
     expect(scale2.step).toBe(20);
     // an empty 1/2 step place at the beginning
@@ -80,7 +80,7 @@ describe.only('Scale Band', () => {
     // an empty 1/2 step place at the end
   });
   it('shall scale a numeric domain with rounding', () => {
-    const scale = new ScaleBand([0, 1, 2, 3], [0, 100], [0, 1], true);
+    const scale = new ScaleBand([0, 1, 2, 3], [0, 100], undefined, [0, 1], true);
     expect(scale.bandwidth).toBe(16);
     expect(scale.step).toBe(16);
     // an empty 1 step place at the beginning

--- a/src/lib/utils/scales/scale_band.test.ts
+++ b/src/lib/utils/scales/scale_band.test.ts
@@ -60,34 +60,24 @@ describe.only('Scale Band', () => {
     expect(scale.scale(null)).toBeUndefined();
   });
   it('shall scale a numeric domain with padding', () => {
-    const scale = new ScaleBand([0, 1, 2], [0, 100], undefined, [0, 1]);
+    const scale = new ScaleBand([0, 1, 2], [0, 120], undefined, 0.5);
     expect(scale.bandwidth).toBe(20);
-    expect(scale.step).toBe(20);
+    expect(scale.step).toBe(40);
     // an empty 1 step place at the beginning
-    expect(scale.scale(0)).toBe(20);
-    expect(scale.scale(1)).toBe(40);
-    expect(scale.scale(2)).toBe(60);
+    expect(scale.scale(0)).toBe(10); // padding
+    expect(scale.scale(1)).toBe(50); // padding + step
+    expect(scale.scale(2)).toBe(90);
     // an empty 1 step place at the end
 
-    const scale2 = new ScaleBand([0, 1, 2, 3], [0, 100], undefined, [0, 0.5]);
-    expect(scale2.bandwidth).toBe(20);
-    expect(scale2.step).toBe(20);
+    const scale2 = new ScaleBand([0, 1, 2, 3], [0, 100], undefined, 0.5);
+    expect(scale2.bandwidth).toBe(12.5);
+    expect(scale2.step).toBe(25);
     // an empty 1/2 step place at the beginning
-    expect(scale2.scale(0)).toBe(10);
-    expect(scale2.scale(1)).toBe(30);
-    expect(scale2.scale(2)).toBe(50);
-    expect(scale2.scale(3)).toBe(70);
+    expect(scale2.scale(0)).toBe(6.25);
+    expect(scale2.scale(1)).toBe(31.25);
+    expect(scale2.scale(2)).toBe(56.25);
+    expect(scale2.scale(3)).toBe(81.25);
     // an empty 1/2 step place at the end
-  });
-  it('shall scale a numeric domain with rounding', () => {
-    const scale = new ScaleBand([0, 1, 2, 3], [0, 100], undefined, [0, 1], true);
-    expect(scale.bandwidth).toBe(16);
-    expect(scale.step).toBe(16);
-    // an empty 1 step place at the beginning
-    expect(scale.scale(0)).toBe(18);
-    expect(scale.scale(1)).toBe(34);
-    expect(scale.scale(2)).toBe(50);
-    // an empty 1 step place at the end
   });
   test('shall invert all values in range', () => {
     const domain = ['a', 'b', 'c', 'd'];

--- a/src/lib/utils/scales/scale_band.ts
+++ b/src/lib/utils/scales/scale_band.ts
@@ -1,4 +1,5 @@
 import { scaleBand, scaleQuantize, ScaleQuantize } from 'd3-scale';
+import { clamp } from '../commons';
 import { StepType } from './scale_continuous';
 import { ScaleType } from './scales';
 import { Scale } from './scales';
@@ -12,32 +13,35 @@ export class ScaleBand implements Scale {
   readonly isInverted: boolean;
   readonly invertedScale: ScaleQuantize<number>;
   readonly minInterval: number;
+  readonly barsPadding: number;
   private readonly d3Scale: any;
 
   constructor(
     domain: any[],
     range: [number, number],
     overrideBandwidth?: number,
-    padding?: [number, number],
-    round?: boolean,
+    /**
+     * The proportion of the range that is reserved for blank space between bands
+     * A number between 0 and 1.
+     * @default 0
+     */
+    barsPadding: number = 0,
   ) {
     this.type = ScaleType.Ordinal;
     this.d3Scale = scaleBand();
     this.d3Scale.domain(domain);
     this.d3Scale.range(range);
-    if (padding) {
-      this.d3Scale.paddingInner(padding[0]);
-      this.d3Scale.paddingOuter(padding[1]);
-    }
-    if (round) {
-      this.d3Scale.round(round);
-    }
+    const safeBarPadding = clamp(barsPadding, 0, 1);
+    this.barsPadding = safeBarPadding;
+    this.d3Scale.paddingInner(safeBarPadding);
+    this.d3Scale.paddingOuter(safeBarPadding / 2);
     this.bandwidth = this.d3Scale.bandwidth() || 0;
+
     this.step = this.d3Scale.step();
     this.domain = this.d3Scale.domain();
     this.range = range.slice();
     if (overrideBandwidth) {
-      this.bandwidth = overrideBandwidth;
+      this.bandwidth = overrideBandwidth * (1 - safeBarPadding);
     }
     // TO FIX: we are assiming that it's ordered
     this.isInverted = this.domain[0] > this.domain[1];

--- a/src/lib/utils/scales/scale_band.ts
+++ b/src/lib/utils/scales/scale_band.ts
@@ -17,9 +17,9 @@ export class ScaleBand implements Scale {
   constructor(
     domain: any[],
     range: [number, number],
+    overrideBandwidth?: number,
     padding?: [number, number],
     round?: boolean,
-    overrideBandwidth?: number,
   ) {
     this.type = ScaleType.Ordinal;
     this.d3Scale = scaleBand();

--- a/src/lib/utils/scales/scale_continuous.test.ts
+++ b/src/lib/utils/scales/scale_continuous.test.ts
@@ -8,7 +8,7 @@ describe('Scale Continuous', () => {
     const domain = [0, 2];
     const minRange = 0;
     const maxRange = 100;
-    const scale = new ScaleContinuous(domain, [minRange, maxRange], ScaleType.Linear);
+    const scale = new ScaleContinuous(ScaleType.Linear, domain, [minRange, maxRange]);
     expect(scale.invert(0)).toBe(0);
     expect(scale.invert(50)).toBe(1);
     expect(scale.invert(100)).toBe(2);
@@ -20,7 +20,7 @@ describe('Scale Continuous', () => {
     const domain = [startTime.toMillis(), endTime.toMillis()];
     const minRange = 0;
     const maxRange = 100;
-    const scale = new ScaleContinuous(domain, [minRange, maxRange], ScaleType.Time);
+    const scale = new ScaleContinuous(ScaleType.Time, domain, [minRange, maxRange]);
     expect(scale.invert(0)).toBe(startTime.toMillis());
     expect(scale.invert(50)).toBe(midTime.toMillis());
     expect(scale.invert(100)).toBe(endTime.toMillis());
@@ -28,10 +28,10 @@ describe('Scale Continuous', () => {
   test('check if a scale is log scale', () => {
     const domain = [0, 2];
     const range: [number, number] = [0, 100];
-    const scaleLinear = new ScaleContinuous(domain, range, ScaleType.Linear);
-    const scaleLog = new ScaleContinuous(domain, range, ScaleType.Log);
-    const scaleTime = new ScaleContinuous(domain, range, ScaleType.Time);
-    const scaleSqrt = new ScaleContinuous(domain, range, ScaleType.Sqrt);
+    const scaleLinear = new ScaleContinuous(ScaleType.Linear, domain, range);
+    const scaleLog = new ScaleContinuous(ScaleType.Log, domain, range);
+    const scaleTime = new ScaleContinuous(ScaleType.Time, domain, range);
+    const scaleSqrt = new ScaleContinuous(ScaleType.Sqrt, domain, range);
     const scaleBand = new ScaleBand(domain, range);
     expect(isLogarithmicScale(scaleLinear)).toBe(false);
     expect(isLogarithmicScale(scaleLog)).toBe(true);

--- a/src/lib/utils/scales/scale_continuous.ts
+++ b/src/lib/utils/scales/scale_continuous.ts
@@ -78,10 +78,9 @@ export class ScaleContinuous implements Scale {
   private readonly d3Scale: any;
 
   constructor(
+    type: ScaleContinuousType,
     domain: any[],
     range: [number, number],
-    type: ScaleContinuousType,
-    clamp: boolean = false,
     bandwidth: number = 0,
     /** the min interval computed on the XDomain, not available for yDomains */
     minInterval: number = 0,
@@ -90,6 +89,7 @@ export class ScaleContinuous implements Scale {
      * or a fixed-offset name of the form 'utc+3', or the strings 'local' or 'utc'.
      */
     timeZone: string = 'utc',
+    clamp: boolean = false,
   ) {
     this.d3Scale = SCALES[type]();
     if (type === ScaleType.Log) {
@@ -99,10 +99,9 @@ export class ScaleContinuous implements Scale {
       this.domain = domain;
       this.d3Scale.domain(domain);
     }
+    this.bandwidth = bandwidth;
     this.d3Scale.range(range);
     this.d3Scale.clamp(clamp);
-    // this.d3Scale.nice();
-    this.bandwidth = bandwidth;
     this.step = 0;
     this.type = type;
     this.range = range;

--- a/src/lib/utils/scales/scale_continuous.ts
+++ b/src/lib/utils/scales/scale_continuous.ts
@@ -86,7 +86,7 @@ export class ScaleContinuous implements Scale {
     domain: any[],
     range: [number, number],
     /**
-     * The desidered bandwidth for a linea band scale.
+     * The desidered bandwidth for a linear band scale.
      * @default 0
      */
     bandwidth: number = 0,
@@ -98,7 +98,7 @@ export class ScaleContinuous implements Scale {
     /**
      * A time zone identifier. Can be any IANA zone supported by he host environment,
      * or a fixed-offset name of the form 'utc+3', or the strings 'local' or 'utc'.
-     * @default utc
+     * @default 'utc'
      */
     timeZone: string = 'utc',
     /**

--- a/src/lib/utils/scales/scale_continuous.ts
+++ b/src/lib/utils/scales/scale_continuous.ts
@@ -1,5 +1,6 @@
 import { scaleLinear, scaleLog, scaleSqrt, scaleUtc } from 'd3-scale';
 import { DateTime } from 'luxon';
+import { clamp } from '../commons';
 import { ScaleContinuousType, ScaleType } from './scales';
 import { Scale } from './scales';
 
@@ -67,6 +68,8 @@ export enum StepType {
 
 export class ScaleContinuous implements Scale {
   readonly bandwidth: number;
+  readonly totalBarsInCluster: number;
+  readonly bandwidthPadding: number;
   readonly minInterval: number;
   readonly step: number;
   readonly type: ScaleType;
@@ -75,21 +78,41 @@ export class ScaleContinuous implements Scale {
   readonly isInverted: boolean;
   readonly tickValues: number[];
   readonly timeZone: string;
+  readonly barsPadding: number;
   private readonly d3Scale: any;
 
   constructor(
     type: ScaleContinuousType,
     domain: any[],
     range: [number, number],
+    /**
+     * The desidered bandwidth for a linea band scale.
+     * @default 0
+     */
     bandwidth: number = 0,
-    /** the min interval computed on the XDomain, not available for yDomains */
+    /**
+     * The min interval computed on the XDomain. Not available for yDomains.
+     * @default 0
+     */
     minInterval: number = 0,
     /**
      * A time zone identifier. Can be any IANA zone supported by he host environment,
      * or a fixed-offset name of the form 'utc+3', or the strings 'local' or 'utc'.
+     * @default utc
      */
     timeZone: string = 'utc',
-    clamp: boolean = false,
+    /**
+     * The number of bars in the cluster. Used to correctly compute scales when
+     * using padding between bars.
+     * @default 1
+     */
+    totalBarsInCluster: number = 1,
+    /**
+     * The proportion of the range that is reserved for blank space between bands
+     * A number between 0 and 1.
+     * @default 0
+     */
+    barsPadding: number = 0,
   ) {
     this.d3Scale = SCALES[type]();
     if (type === ScaleType.Log) {
@@ -99,15 +122,18 @@ export class ScaleContinuous implements Scale {
       this.domain = domain;
       this.d3Scale.domain(domain);
     }
-    this.bandwidth = bandwidth;
+    const safeBarPadding = clamp(barsPadding, 0, 1);
+    this.barsPadding = safeBarPadding;
+    this.bandwidth = bandwidth * (1 - safeBarPadding);
+    this.bandwidthPadding = bandwidth * safeBarPadding;
     this.d3Scale.range(range);
-    this.d3Scale.clamp(clamp);
     this.step = 0;
     this.type = type;
     this.range = range;
     this.minInterval = minInterval;
     this.isInverted = this.domain[0] > this.domain[1];
     this.timeZone = timeZone;
+    this.totalBarsInCluster = totalBarsInCluster;
     if (type === ScaleType.Time) {
       const startDomain = DateTime.fromMillis(this.domain[0], { zone: this.timeZone });
       const endDomain = DateTime.fromMillis(this.domain[1], { zone: this.timeZone });
@@ -134,7 +160,7 @@ export class ScaleContinuous implements Scale {
   }
 
   scale(value: any) {
-    return this.d3Scale(value);
+    return this.d3Scale(value) + (this.bandwidthPadding / 2) * this.totalBarsInCluster;
   }
 
   ticks() {

--- a/src/lib/utils/scales/scale_time.test.ts
+++ b/src/lib/utils/scales/scale_time.test.ts
@@ -76,10 +76,9 @@ describe('[Scale Time] - timezones', () => {
       const maxRange = 100;
       const minInterval = (endTime - startTime) / 2;
       const scale = new ScaleContinuous(
+        ScaleType.Time,
         domain,
         [minRange, maxRange],
-        ScaleType.Time,
-        undefined,
         undefined,
         minInterval,
         'local',
@@ -108,10 +107,9 @@ describe('[Scale Time] - timezones', () => {
       const maxRange = 100;
       const minInterval = (endTime - startTime) / 2;
       const scale = new ScaleContinuous(
+        ScaleType.Time,
         domain,
         [minRange, maxRange],
-        ScaleType.Time,
-        undefined,
         undefined,
         minInterval,
         'utc',
@@ -140,10 +138,9 @@ describe('[Scale Time] - timezones', () => {
       const maxRange = 100;
       const minInterval = (endTime - startTime) / 2;
       const scale = new ScaleContinuous(
+        ScaleType.Time,
         domain,
         [minRange, maxRange],
-        ScaleType.Time,
-        undefined,
         undefined,
         minInterval,
         'utc+8',
@@ -172,10 +169,9 @@ describe('[Scale Time] - timezones', () => {
       const maxRange = 100;
       const minInterval = (endTime - startTime) / 2;
       const scale = new ScaleContinuous(
+        ScaleType.Time,
         domain,
         [minRange, maxRange],
-        ScaleType.Time,
-        undefined,
         undefined,
         minInterval,
         'utc-8',
@@ -208,10 +204,9 @@ describe('[Scale Time] - timezones', () => {
         const maxRange = 100;
         const minInterval = (endTime - startTime) / 2;
         const scale = new ScaleContinuous(
+          ScaleType.Time,
           domain,
           [minRange, maxRange],
-          ScaleType.Time,
-          undefined,
           undefined,
           minInterval,
           timezone,

--- a/src/lib/utils/scales/scales.test.ts
+++ b/src/lib/utils/scales/scales.test.ts
@@ -1,13 +1,14 @@
 import { DateTime } from 'luxon';
-import { limitLogScaleDomain } from './scale_continuous';
-import { createContinuousScale, createOrdinalScale, ScaleType } from './scales';
+import { ScaleBand } from './scale_band';
+import { limitLogScaleDomain, ScaleContinuous } from './scale_continuous';
+import { ScaleType } from './scales';
 
 describe('Scale Test', () => {
   test('Create an ordinal scale', () => {
     const data = ['a', 'b', 'c', 'd', 'a', 'b', 'c'];
     const minRange = 0;
     const maxRange = 100;
-    const ordinalScale = createOrdinalScale(data, minRange, maxRange);
+    const ordinalScale = new ScaleBand(data, [minRange, maxRange]);
     const { domain, range, bandwidth } = ordinalScale;
     expect(domain).toEqual(['a', 'b', 'c', 'd']);
     expect(range).toEqual([minRange, maxRange]);
@@ -25,7 +26,7 @@ describe('Scale Test', () => {
     const data = [0, 10];
     const minRange = 0;
     const maxRange = 100;
-    const linearScale = createContinuousScale(ScaleType.Linear, data, minRange, maxRange);
+    const linearScale = new ScaleContinuous(ScaleType.Linear, data, [minRange, maxRange]);
     const { domain, range } = linearScale;
     expect(domain).toEqual([0, 10]);
     expect(range).toEqual([minRange, maxRange]);
@@ -49,7 +50,7 @@ describe('Scale Test', () => {
     const data = [date1, date3];
     const minRange = 0;
     const maxRange = 100;
-    const timeScale = createContinuousScale(ScaleType.Time, data, minRange, maxRange);
+    const timeScale = new ScaleContinuous(ScaleType.Time, data, [minRange, maxRange]);
     const { domain, range } = timeScale;
     expect(domain).toEqual([date1, date3]);
     expect(range).toEqual([minRange, maxRange]);
@@ -64,7 +65,7 @@ describe('Scale Test', () => {
     const data = [1, 10];
     const minRange = 0;
     const maxRange = 100;
-    const logScale = createContinuousScale(ScaleType.Log, data, minRange, maxRange);
+    const logScale = new ScaleContinuous(ScaleType.Log, data, [minRange, maxRange]);
     const { domain, range } = logScale;
     expect(domain).toEqual([1, 10]);
     expect(range).toEqual([minRange, maxRange]);
@@ -77,7 +78,7 @@ describe('Scale Test', () => {
     const data = [0, 10];
     const minRange = 0;
     const maxRange = 100;
-    const logScale = createContinuousScale(ScaleType.Log, data, minRange, maxRange);
+    const logScale = new ScaleContinuous(ScaleType.Log, data, [minRange, maxRange]);
     const { domain, range } = logScale;
     expect(domain).toEqual([1, 10]);
     expect(range).toEqual([minRange, maxRange]);
@@ -90,7 +91,7 @@ describe('Scale Test', () => {
     const data = [0, 10];
     const minRange = 0;
     const maxRange = 100;
-    const sqrtScale = createContinuousScale(ScaleType.Sqrt, data, minRange, maxRange);
+    const sqrtScale = new ScaleContinuous(ScaleType.Sqrt, data, [minRange, maxRange]);
     const { domain, range } = sqrtScale;
     expect(domain).toEqual([0, 10]);
     expect(range).toEqual([minRange, maxRange]);
@@ -146,16 +147,14 @@ describe('Scale Test', () => {
     const minRange = 0;
     const maxRange = 120;
     const bandwidth = maxRange / 3;
-    const linearScale = createContinuousScale(
+    const linearScale = new ScaleContinuous(
       ScaleType.Linear,
       dataLinear,
-      minRange,
-      maxRange - bandwidth, // we currently limit the range like that a band linear scale
+      [minRange, maxRange - bandwidth], // we currently limit the range like that a band linear scale
       bandwidth,
-      false,
       1,
     );
-    const ordinalScale = createOrdinalScale(dataOrdinal, minRange, maxRange);
+    const ordinalScale = new ScaleBand(dataOrdinal, [minRange, maxRange]);
     expect(ordinalScale.invertWithStep(0)).toBe(0);
     expect(ordinalScale.invertWithStep(40)).toBe(1);
     expect(ordinalScale.invertWithStep(80)).toBe(2);
@@ -169,16 +168,14 @@ describe('Scale Test', () => {
     const minRange = 0;
     const maxRange = 100;
     const bandwidth = maxRange / 2;
-    const linearScale = createContinuousScale(
+    const linearScale = new ScaleContinuous(
       ScaleType.Linear,
       dataLinear,
-      minRange,
-      maxRange - bandwidth, // we currently limit the range like that a band linear scale
+      [minRange, maxRange - bandwidth], // we currently limit the range like that a band linear scale
       bandwidth,
-      false,
       1,
     );
-    const ordinalScale = createOrdinalScale(dataOrdinal, minRange, maxRange);
+    const ordinalScale = new ScaleBand(dataOrdinal, [minRange, maxRange]);
 
     expect(ordinalScale.scale(0)).toBe(0);
     expect(ordinalScale.scale(1)).toBe(50);
@@ -202,16 +199,14 @@ describe('Scale Test', () => {
     const minRange = 0;
     const maxRange = 100;
     const bandwidth = maxRange / 2;
-    const linearScale = createContinuousScale(
+    const linearScale = new ScaleContinuous(
       ScaleType.Linear,
       dataLinear,
-      minRange,
-      maxRange - bandwidth, // we currently limit the range like that a band linear scale
+      [minRange, maxRange - bandwidth], // we currently limit the range like that a band linear scale
       bandwidth,
-      false,
       1,
     );
-    const ordinalScale = createOrdinalScale(dataOrdinal, minRange, maxRange);
+    const ordinalScale = new ScaleBand(dataOrdinal, [minRange, maxRange]);
     expect(ordinalScale.invertWithStep(100)).toBe(1);
     expect(linearScale.invertWithStep(100)).toBe(1);
   });

--- a/src/lib/utils/scales/scales.ts
+++ b/src/lib/utils/scales/scales.ts
@@ -11,6 +11,7 @@ export interface Scale {
   minInterval: number;
   type: ScaleType;
   isInverted: boolean;
+  barsPadding: number;
 }
 export type ScaleFunction = (value: any) => number;
 

--- a/src/lib/utils/scales/scales.ts
+++ b/src/lib/utils/scales/scales.ts
@@ -1,5 +1,4 @@
-import { ScaleBand } from './scale_band';
-import { ScaleContinuous, StepType } from './scale_continuous';
+import { StepType } from './scale_continuous';
 
 export interface Scale {
   domain: any[];
@@ -40,49 +39,3 @@ export type ScaleContinuousType =
   | ScaleType.Time;
 export type ScaleOrdinalType = ScaleType.Ordinal;
 export type ScaleTypes = ScaleContinuousType | ScaleOrdinalType;
-
-/**
- * Return a continuous scale
- * @param type The type of scale (linear, log, sqrt)
- * @param domain The domain of the ordinal scale
- * @param minRange The max range of the scale
- * @param maxRange The min range of the scale
- * @param clamp if true, create a clamped scale
- */
-export function createContinuousScale(
-  type: ScaleContinuousType,
-  domain: number[],
-  minRange: number,
-  maxRange: number,
-  bandwidth?: number,
-  clamp?: boolean,
-  minInterval?: number,
-  timeZone?: string,
-): Scale {
-  return new ScaleContinuous(
-    domain,
-    [minRange, maxRange],
-    type,
-    clamp,
-    bandwidth,
-    minInterval,
-    timeZone,
-  );
-}
-
-/**
- * Return a ScaleOrdinal
- * @param domain The domain of the ordinal scale
- * @param minRange The max range of the scale
- * @param maxRange The min range of the scale
- */
-export function createOrdinalScale(
-  domain: any[],
-  minRange: number,
-  maxRange: number,
-  padding?: number,
-  overrideBandwidth?: number,
-): Scale {
-  const paddingOption = padding ? ([padding, padding] as [number, number]) : undefined;
-  return new ScaleBand(domain, [minRange, maxRange], paddingOption, false, overrideBandwidth);
-}

--- a/src/state/annotation_marker.test.tsx
+++ b/src/state/annotation_marker.test.tsx
@@ -11,7 +11,8 @@ import {
 import { DEFAULT_ANNOTATION_LINE_STYLE } from '../lib/themes/theme';
 import { Dimensions } from '../lib/utils/dimensions';
 import { getAnnotationId, getGroupId, GroupId } from '../lib/utils/ids';
-import { createContinuousScale, Scale, ScaleType } from '../lib/utils/scales/scales';
+import { ScaleContinuous } from '../lib/utils/scales/scale_continuous';
+import { Scale, ScaleType } from '../lib/utils/scales/scales';
 import {
   AnnotationLinePosition,
   computeLineAnnotationDimensions,
@@ -27,12 +28,10 @@ describe('annotation marker', () => {
   const maxRange = 100;
 
   const continuousData = [0, 10];
-  const continuousScale = createContinuousScale(
-    ScaleType.Linear,
-    continuousData,
+  const continuousScale = new ScaleContinuous(ScaleType.Linear, continuousData, [
     minRange,
     maxRange,
-  );
+  ]);
 
   const chartDimensions: Dimensions = {
     width: 10,

--- a/src/state/annotation_utils.test.ts
+++ b/src/state/annotation_utils.test.ts
@@ -9,8 +9,17 @@ import {
 } from '../lib/series/specs';
 import { DEFAULT_ANNOTATION_LINE_STYLE } from '../lib/themes/theme';
 import { Dimensions } from '../lib/utils/dimensions';
-import { AnnotationId, AxisId, getAnnotationId, getAxisId, getGroupId, GroupId } from '../lib/utils/ids';
-import { createContinuousScale, createOrdinalScale, Scale, ScaleType } from '../lib/utils/scales/scales';
+import {
+  AnnotationId,
+  AxisId,
+  getAnnotationId,
+  getAxisId,
+  getGroupId,
+  GroupId,
+} from '../lib/utils/ids';
+import { ScaleBand } from '../lib/utils/scales/scale_band';
+import { ScaleContinuous } from '../lib/utils/scales/scale_continuous';
+import { Scale, ScaleType } from '../lib/utils/scales/scales';
 import {
   AnnotationLinePosition,
   AnnotationLineProps,
@@ -35,10 +44,13 @@ describe('annotation utils', () => {
   const maxRange = 100;
 
   const continuousData = [0, 10];
-  const continuousScale = createContinuousScale(ScaleType.Linear, continuousData, minRange, maxRange);
+  const continuousScale = new ScaleContinuous(ScaleType.Linear, continuousData, [
+    minRange,
+    maxRange,
+  ]);
 
   const ordinalData = ['a', 'b', 'c', 'd', 'a', 'b', 'c'];
-  const ordinalScale = createOrdinalScale(ordinalData, minRange, maxRange);
+  const ordinalScale = new ScaleBand(ordinalData, [minRange, maxRange]);
 
   const chartDimensions: Dimensions = {
     width: 10,
@@ -106,11 +118,13 @@ describe('annotation utils', () => {
       axesSpecs,
     );
     const expectedDimensions = new Map();
-    expectedDimensions.set(annotationId, [{
-      position: [DEFAULT_LINE_OVERFLOW, 20, 10, 20],
-      details: { detailsText: 'foo', headerText: '2' },
-      tooltipLinePosition: [0, 20, 10, 20],
-    }]);
+    expectedDimensions.set(annotationId, [
+      {
+        position: [DEFAULT_LINE_OVERFLOW, 20, 10, 20],
+        details: { detailsText: 'foo', headerText: '2' },
+        tooltipLinePosition: [0, 20, 10, 20],
+      },
+    ]);
     expect(dimensions).toEqual(expectedDimensions);
   });
 
@@ -171,11 +185,13 @@ describe('annotation utils', () => {
       xScale,
       Position.Left,
     );
-    const expectedDimensions = [{
-      position: [DEFAULT_LINE_OVERFLOW, 20, 10, 20],
-      details: { detailsText: 'foo', headerText: '2' },
-      tooltipLinePosition: [0, 20, 10, 20],
-    }];
+    const expectedDimensions = [
+      {
+        position: [DEFAULT_LINE_OVERFLOW, 20, 10, 20],
+        details: { detailsText: 'foo', headerText: '2' },
+        tooltipLinePosition: [0, 20, 10, 20],
+      },
+    ];
     expect(dimensions).toEqual(expectedDimensions);
   });
 
@@ -204,11 +220,13 @@ describe('annotation utils', () => {
       xScale,
       Position.Right,
     );
-    const expectedDimensions = [{
-      position: [0, 20, 10, 20],
-      details: { detailsText: 'foo', headerText: '2' },
-      tooltipLinePosition: [0, 20, 10, 20],
-    }];
+    const expectedDimensions = [
+      {
+        position: [0, 20, 10, 20],
+        details: { detailsText: 'foo', headerText: '2' },
+        tooltipLinePosition: [0, 20, 10, 20],
+      },
+    ];
     expect(dimensions).toEqual(expectedDimensions);
   });
 
@@ -237,11 +255,13 @@ describe('annotation utils', () => {
       xScale,
       Position.Left,
     );
-    const expectedDimensions = [{
-      position: [20, 0, 20, 20 + DEFAULT_LINE_OVERFLOW],
-      details: { detailsText: 'foo', headerText: '2' },
-      tooltipLinePosition: [20, 0, 20, 20],
-    }];
+    const expectedDimensions = [
+      {
+        position: [20, 0, 20, 20 + DEFAULT_LINE_OVERFLOW],
+        details: { detailsText: 'foo', headerText: '2' },
+        tooltipLinePosition: [20, 0, 20, 20],
+      },
+    ];
     expect(dimensions).toEqual(expectedDimensions);
   });
 
@@ -294,11 +314,13 @@ describe('annotation utils', () => {
       xScale,
       Position.Left,
     );
-    const expectedDimensions = [{
-      position: [12.5, -DEFAULT_LINE_OVERFLOW, 12.5, 20],
-      details: { detailsText: 'foo', headerText: 'a' },
-      tooltipLinePosition: [12.5, 0, 12.5, 20],
-    }];
+    const expectedDimensions = [
+      {
+        position: [12.5, -DEFAULT_LINE_OVERFLOW, 12.5, 20],
+        details: { detailsText: 'foo', headerText: 'a' },
+        tooltipLinePosition: [12.5, 0, 12.5, 20],
+      },
+    ];
     expect(dimensions).toEqual(expectedDimensions);
   });
 
@@ -325,11 +347,13 @@ describe('annotation utils', () => {
       xScale,
       Position.Top,
     );
-    const expectedDimensions = [{
-      position: [20, -DEFAULT_LINE_OVERFLOW, 20, 20],
-      details: { detailsText: 'foo', headerText: '2' },
-      tooltipLinePosition: [20, 0, 20, 20],
-    }];
+    const expectedDimensions = [
+      {
+        position: [20, -DEFAULT_LINE_OVERFLOW, 20, 20],
+        details: { detailsText: 'foo', headerText: '2' },
+        tooltipLinePosition: [20, 0, 20, 20],
+      },
+    ];
     expect(dimensions).toEqual(expectedDimensions);
   });
 
@@ -356,11 +380,13 @@ describe('annotation utils', () => {
       xScale,
       Position.Bottom,
     );
-    const expectedDimensions = [{
-      position: [20, DEFAULT_LINE_OVERFLOW, 20, 20],
-      details: { detailsText: 'foo', headerText: '2' },
-      tooltipLinePosition: [20, 0, 20, 20],
-    }];
+    const expectedDimensions = [
+      {
+        position: [20, DEFAULT_LINE_OVERFLOW, 20, 20],
+        details: { detailsText: 'foo', headerText: '2' },
+        tooltipLinePosition: [20, 0, 20, 20],
+      },
+    ];
     expect(dimensions).toEqual(expectedDimensions);
   });
 
@@ -388,11 +414,13 @@ describe('annotation utils', () => {
       xScale,
       Position.Left,
     );
-    const expectedDimensions = [{
-      position: [-DEFAULT_LINE_OVERFLOW, 12.5, 10, 12.5],
-      details: { detailsText: 'foo', headerText: 'a' },
-      tooltipLinePosition: [0, 12.5, 10, 12.5],
-    }];
+    const expectedDimensions = [
+      {
+        position: [-DEFAULT_LINE_OVERFLOW, 12.5, 10, 12.5],
+        details: { detailsText: 'foo', headerText: 'a' },
+        tooltipLinePosition: [0, 12.5, 10, 12.5],
+      },
+    ];
     expect(dimensions).toEqual(expectedDimensions);
   });
 
@@ -420,46 +448,49 @@ describe('annotation utils', () => {
       xScale,
       Position.Left,
     );
-    const expectedDimensions = [{
-      position: [-DEFAULT_LINE_OVERFLOW, 20, 10, 20],
-      details: { detailsText: 'foo', headerText: '2' },
-      tooltipLinePosition: [0, 20, 10, 20],
-    }];
+    const expectedDimensions = [
+      {
+        position: [-DEFAULT_LINE_OVERFLOW, 20, 10, 20],
+        details: { detailsText: 'foo', headerText: '2' },
+        tooltipLinePosition: [0, 20, 10, 20],
+      },
+    ];
     expect(dimensions).toEqual(expectedDimensions);
   });
 
-  test('should compute line annotation dimensions for xDomain on a xScale (chartRotation -90, continuous scale)',
-    () => {
-      const chartRotation: Rotation = -90;
-      const yScales: Map<GroupId, Scale> = new Map();
+  test('should compute line annotation dimensions for xDomain on a xScale (chartRotation -90, continuous scale)', () => {
+    const chartRotation: Rotation = -90;
+    const yScales: Map<GroupId, Scale> = new Map();
 
-      const xScale: Scale = continuousScale;
+    const xScale: Scale = continuousScale;
 
-      const annotationId = getAnnotationId('foo-line');
-      const lineAnnotation: AnnotationSpec = {
-        annotationType: AnnotationTypes.Line,
-        annotationId,
-        domainType: AnnotationDomainTypes.XDomain,
-        dataValues: [{ dataValue: 2, details: 'foo' }],
-        groupId,
-        style: DEFAULT_ANNOTATION_LINE_STYLE,
-      };
+    const annotationId = getAnnotationId('foo-line');
+    const lineAnnotation: AnnotationSpec = {
+      annotationType: AnnotationTypes.Line,
+      annotationId,
+      domainType: AnnotationDomainTypes.XDomain,
+      dataValues: [{ dataValue: 2, details: 'foo' }],
+      groupId,
+      style: DEFAULT_ANNOTATION_LINE_STYLE,
+    };
 
-      const dimensions = computeLineAnnotationDimensions(
-        lineAnnotation,
-        chartDimensions,
-        chartRotation,
-        yScales,
-        xScale,
-        Position.Left,
-      );
-      const expectedDimensions = [{
+    const dimensions = computeLineAnnotationDimensions(
+      lineAnnotation,
+      chartDimensions,
+      chartRotation,
+      yScales,
+      xScale,
+      Position.Left,
+    );
+    const expectedDimensions = [
+      {
         position: [-DEFAULT_LINE_OVERFLOW, 0, 10, 0],
         details: { detailsText: 'foo', headerText: '2' },
         tooltipLinePosition: [0, 0, 10, 0],
-      }];
-      expect(dimensions).toEqual(expectedDimensions);
-    });
+      },
+    ];
+    expect(dimensions).toEqual(expectedDimensions);
+  });
 
   test('should compute line annotation dimensions for xDomain (chartRotation 180, continuous scale, top axis)', () => {
     const chartRotation: Rotation = 180;
@@ -485,45 +516,48 @@ describe('annotation utils', () => {
       xScale,
       Position.Top,
     );
-    const expectedDimensions = [{
-      position: [-10, -DEFAULT_LINE_OVERFLOW, -10, 20],
-      details: { detailsText: 'foo', headerText: '2' },
-      tooltipLinePosition: [-10, 0, -10, 20],
-    }];
+    const expectedDimensions = [
+      {
+        position: [-10, -DEFAULT_LINE_OVERFLOW, -10, 20],
+        details: { detailsText: 'foo', headerText: '2' },
+        tooltipLinePosition: [-10, 0, -10, 20],
+      },
+    ];
     expect(dimensions).toEqual(expectedDimensions);
   });
 
-  test('should compute line annotation dimensions for xDomain (chartRotation 180, continuous scale, bottom axis)',
-    () => {
-      const chartRotation: Rotation = 180;
-      const yScales: Map<GroupId, Scale> = new Map();
-      const xScale: Scale = continuousScale;
+  test('should compute line annotation dimensions for xDomain (chartRotation 180, continuous scale, bottom axis)', () => {
+    const chartRotation: Rotation = 180;
+    const yScales: Map<GroupId, Scale> = new Map();
+    const xScale: Scale = continuousScale;
 
-      const annotationId = getAnnotationId('foo-line');
-      const lineAnnotation: AnnotationSpec = {
-        annotationType: AnnotationTypes.Line,
-        annotationId,
-        domainType: AnnotationDomainTypes.XDomain,
-        dataValues: [{ dataValue: 2, details: 'foo' }],
-        groupId,
-        style: DEFAULT_ANNOTATION_LINE_STYLE,
-      };
+    const annotationId = getAnnotationId('foo-line');
+    const lineAnnotation: AnnotationSpec = {
+      annotationType: AnnotationTypes.Line,
+      annotationId,
+      domainType: AnnotationDomainTypes.XDomain,
+      dataValues: [{ dataValue: 2, details: 'foo' }],
+      groupId,
+      style: DEFAULT_ANNOTATION_LINE_STYLE,
+    };
 
-      const dimensions = computeLineAnnotationDimensions(
-        lineAnnotation,
-        chartDimensions,
-        chartRotation,
-        yScales,
-        xScale,
-        Position.Bottom,
-      );
-      const expectedDimensions = [{
+    const dimensions = computeLineAnnotationDimensions(
+      lineAnnotation,
+      chartDimensions,
+      chartRotation,
+      yScales,
+      xScale,
+      Position.Bottom,
+    );
+    const expectedDimensions = [
+      {
         position: [-10, DEFAULT_LINE_OVERFLOW, -10, 20],
         details: { detailsText: 'foo', headerText: '2' },
         tooltipLinePosition: [-10, DEFAULT_LINE_OVERFLOW, -10, 20],
-      }];
-      expect(dimensions).toEqual(expectedDimensions);
-    });
+      },
+    ];
+    expect(dimensions).toEqual(expectedDimensions);
+  });
 
   test('should not compute annotation line values for values outside of domain or AnnotationSpec.hideLines', () => {
     const chartRotation: Rotation = 0;
@@ -855,7 +889,12 @@ describe('annotation utils', () => {
       linePosition,
       Position.Bottom,
     );
-    expect(bottomLineTooltipPosition).toEqual({ xPosition: 1, yPosition: 4, xOffset: 50, yOffset: 100 });
+    expect(bottomLineTooltipPosition).toEqual({
+      xPosition: 1,
+      yPosition: 4,
+      xOffset: 50,
+      yOffset: 100,
+    });
 
     const topLineTooltipPosition = getAnnotationLineTooltipPosition(
       chartRotation,
@@ -869,17 +908,32 @@ describe('annotation utils', () => {
       linePosition,
       Position.Left,
     );
-    expect(leftLineTooltipPosition).toEqual({ xPosition: 1, yPosition: 4, xOffset: 0, yOffset: 50 });
+    expect(leftLineTooltipPosition).toEqual({
+      xPosition: 1,
+      yPosition: 4,
+      xOffset: 0,
+      yOffset: 50,
+    });
 
     const rightLineTooltipPosition = getAnnotationLineTooltipPosition(
       chartRotation,
       linePosition,
       Position.Right,
     );
-    expect(rightLineTooltipPosition).toEqual({ xPosition: 3, yPosition: 4, xOffset: 100, yOffset: 50 });
+    expect(rightLineTooltipPosition).toEqual({
+      xPosition: 3,
+      yPosition: 4,
+      xOffset: 100,
+      yOffset: 50,
+    });
   });
   test('should form the string for the position transform given a TransformPoint', () => {
-    const transformString = toTransformString({ xPosition: 1, yPosition: 4, xOffset: 50, yOffset: 100 });
+    const transformString = toTransformString({
+      xPosition: 1,
+      yPosition: 4,
+      xOffset: 50,
+      yOffset: 100,
+    });
     expect(transformString).toBe('translate(calc(1px - 50%),calc(4px - 100%))');
   });
   test('should get the transform for an annotation line tooltip', () => {
@@ -896,11 +950,13 @@ describe('annotation utils', () => {
   test('should compute the tooltip state for an annotation line', () => {
     const cursorPosition: Point = { x: 1, y: 2 };
 
-    const annotationLines: AnnotationLineProps[] = [{
-      position: [1, 2, 3, 4],
-      details: {},
-      tooltipLinePosition: [1, 2, 3, 4],
-    }];
+    const annotationLines: AnnotationLineProps[] = [
+      {
+        position: [1, 2, 3, 4],
+        details: {},
+        tooltipLinePosition: [1, 2, 3, 4],
+      },
+    ];
     const lineStyle = DEFAULT_ANNOTATION_LINE_STYLE;
     const chartRotation: Rotation = 0;
     const localAxesSpecs = new Map();
@@ -976,11 +1032,13 @@ describe('annotation utils', () => {
 
     const cursorPosition: Point = { x: 1, y: 2 };
 
-    const annotationLines: AnnotationLineProps[] = [{
-      position: [1, 2, 3, 4],
-      details: {},
-      tooltipLinePosition: [1, 2, 3, 4],
-    }];
+    const annotationLines: AnnotationLineProps[] = [
+      {
+        position: [1, 2, 3, 4],
+        details: {},
+        tooltipLinePosition: [1, 2, 3, 4],
+      },
+    ];
     const chartRotation: Rotation = 0;
     const localAxesSpecs: Map<AxisId, AxisSpec> = new Map();
 
@@ -1052,11 +1110,7 @@ describe('annotation utils', () => {
   test('should get associated axis for an annotation', () => {
     const localAxesSpecs = new Map();
 
-    const noAxis = getAnnotationAxis(
-      localAxesSpecs,
-      groupId,
-      AnnotationDomainTypes.XDomain,
-    );
+    const noAxis = getAnnotationAxis(localAxesSpecs, groupId, AnnotationDomainTypes.XDomain);
     expect(noAxis).toBe(null);
 
     localAxesSpecs.set(horizontalAxisSpec.id, horizontalAxisSpec);

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -624,7 +624,7 @@ describe('Chart Store', () => {
   test('can disable brush based on scale and listener', () => {
     store.xScale = undefined;
     expect(store.isBrushEnabled()).toBe(false);
-    store.xScale = new ScaleContinuous([0, 100], [0, 100], ScaleType.Linear);
+    store.xScale = new ScaleContinuous(ScaleType.Linear, [0, 100], [0, 100]);
     store.onBrushEndListener = undefined;
     expect(store.isBrushEnabled()).toBe(false);
     store.setOnBrushEndListener(() => ({}));
@@ -644,7 +644,7 @@ describe('Chart Store', () => {
       isXValue: false,
       seriesKey: 'a',
     };
-    store.xScale = new ScaleContinuous([0, 100], [0, 100], ScaleType.Linear);
+    store.xScale = new ScaleContinuous(ScaleType.Linear, [0, 100], [0, 100]);
     store.cursorPosition.x = 1;
     store.cursorPosition.y = 1;
     store.tooltipType.set(TooltipType.Crosshairs);
@@ -716,7 +716,7 @@ describe('Chart Store', () => {
     expect(clickListener.mock.calls[1][0]).toEqual([geom1.value, geom2.value]);
   });
   test('can compute annotation tooltip state', () => {
-    const scale = new ScaleContinuous([0, 100], [0, 100], ScaleType.Linear);
+    const scale = new ScaleContinuous(ScaleType.Linear, [0, 100], [0, 100]);
 
     store.cursorPosition.x = -1;
     store.cursorPosition.y = 0;

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -798,6 +798,7 @@ export class ChartStore {
         bboxCalculator,
         this.chartRotation,
         this.chartTheme.axes,
+        this.chartTheme.scales.barsPadding,
       );
       if (dimensions) {
         this.axesTicksDimensions.set(id, dimensions);
@@ -831,6 +832,7 @@ export class ChartStore {
       this.chartTheme.colors,
       this.chartDimensions,
       this.chartRotation,
+      this.chartTheme.scales.barsPadding,
     );
 
     // tslint:disable-next-line:no-console
@@ -852,6 +854,7 @@ export class ChartStore {
       seriesDomains.yDomain,
       totalBarsInCluster,
       this.legendPosition,
+      this.chartTheme.scales.barsPadding,
     );
     // tslint:disable-next-line:no-console
     // console.log({axisTicksPositions});

--- a/src/state/crosshair_utils.linear_snap.test.ts
+++ b/src/state/crosshair_utils.linear_snap.test.ts
@@ -109,33 +109,33 @@ describe('Crosshair utils linear scale', () => {
    */
   test('can snap position on linear scale (line/area)', () => {
     let snappedPosition = getSnapPosition(0, lineSeriesScale);
-    expect(snappedPosition.band).toEqual(1);
-    expect(snappedPosition.position).toEqual(0);
+    expect(snappedPosition!.band).toEqual(1);
+    expect(snappedPosition!.position).toEqual(0);
 
     snappedPosition = getSnapPosition(1, lineSeriesScale);
-    expect(snappedPosition.band).toEqual(1);
-    expect(snappedPosition.position).toEqual(60);
+    expect(snappedPosition!.band).toEqual(1);
+    expect(snappedPosition!.position).toEqual(60);
 
     snappedPosition = getSnapPosition(2, lineSeriesScale);
-    expect(snappedPosition.band).toEqual(1);
-    expect(snappedPosition.position).toEqual(120);
+    expect(snappedPosition!.band).toEqual(1);
+    expect(snappedPosition!.position).toEqual(120);
 
     // TODO uncomment this when we will limit the scale function to domain values.
     // snappedPosition = getSnapPosition(3, singleScale);
-    // expect(snappedPosition.band).toEqual(1);
-    // expect(snappedPosition.position).toBeUndefined();
+    // expect(snappedPosition!.band).toEqual(1);
+    // expect(snappedPosition!.position).toBeUndefined();
 
     snappedPosition = getSnapPosition(0, multiLineSeriesScale, 2);
-    expect(snappedPosition.band).toEqual(1);
-    expect(snappedPosition.position).toEqual(0);
+    expect(snappedPosition!.band).toEqual(1);
+    expect(snappedPosition!.position).toEqual(0);
 
     snappedPosition = getSnapPosition(1, multiLineSeriesScale, 2);
-    expect(snappedPosition.band).toEqual(1);
-    expect(snappedPosition.position).toEqual(60);
+    expect(snappedPosition!.band).toEqual(1);
+    expect(snappedPosition!.position).toEqual(60);
 
     snappedPosition = getSnapPosition(2, multiLineSeriesScale, 2);
-    expect(snappedPosition.band).toEqual(1);
-    expect(snappedPosition.position).toEqual(120);
+    expect(snappedPosition!.band).toEqual(1);
+    expect(snappedPosition!.position).toEqual(120);
   });
 
   /**
@@ -144,34 +144,34 @@ describe('Crosshair utils linear scale', () => {
    */
   test('can snap position on linear scale (bar)', () => {
     let snappedPosition = getSnapPosition(0, barSeriesScale);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(0);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(0);
 
     snappedPosition = getSnapPosition(1, barSeriesScale);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(40);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(40);
 
     snappedPosition = getSnapPosition(2, barSeriesScale);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(80);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(80);
 
     // TODO uncomment this when we will limit the scale function to domain values.
     // snappedPosition = getSnapPosition(3, singleScale);
-    // expect(snappedPosition.band).toEqual(40);
-    // expect(snappedPosition.position).toBeUndefined();
+    // expect(snappedPosition!.band).toEqual(40);
+    // expect(snappedPosition!.position).toBeUndefined();
 
     // test a scale with a value of totalBarsInCluster > 1
     snappedPosition = getSnapPosition(0, multiBarSeriesScale, 2);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(0);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(0);
 
     snappedPosition = getSnapPosition(1, multiBarSeriesScale, 2);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(40);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(40);
 
     snappedPosition = getSnapPosition(2, multiBarSeriesScale, 2);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(80);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(80);
   });
 
   /**
@@ -180,16 +180,16 @@ describe('Crosshair utils linear scale', () => {
    */
   test('can snap position on linear scale (mixed bars and lines)', () => {
     let snappedPosition = getSnapPosition(0, mixedLinesBarsSeriesScale, 4);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(0);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(0);
 
     snappedPosition = getSnapPosition(1, mixedLinesBarsSeriesScale, 4);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(40);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(40);
 
     snappedPosition = getSnapPosition(2, mixedLinesBarsSeriesScale, 4);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(80);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(80);
   });
   test('safeguard cursor band position', () => {
     const chartDimensions: Dimensions = { top: 0, left: 0, width: 120, height: 100 };

--- a/src/state/crosshair_utils.ordinal_snap.test.ts
+++ b/src/state/crosshair_utils.ordinal_snap.test.ts
@@ -104,78 +104,75 @@ describe('Crosshair utils ordinal scales', () => {
 
   test('can snap position on scale ordinal bar', () => {
     let snappedPosition = getSnapPosition('a', barSeriesScale);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(0);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(0);
 
     snappedPosition = getSnapPosition('b', barSeriesScale);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(40);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(40);
 
     snappedPosition = getSnapPosition('c', barSeriesScale);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(80);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(80);
 
     snappedPosition = getSnapPosition('x', barSeriesScale);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toBeUndefined();
+    expect(snappedPosition).toBeUndefined();
 
     snappedPosition = getSnapPosition('a', multiBarSeriesScale, 2);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(0);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(0);
 
     snappedPosition = getSnapPosition('b', multiBarSeriesScale, 2);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(40);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(40);
 
     snappedPosition = getSnapPosition('c', multiBarSeriesScale, 2);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(80);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(80);
   });
   test('can snap position on scale ordinal lines', () => {
     let snappedPosition = getSnapPosition('a', lineSeriesScale);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(0);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(0);
 
     snappedPosition = getSnapPosition('b', lineSeriesScale);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(40);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(40);
 
     snappedPosition = getSnapPosition('c', lineSeriesScale);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(80);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(80);
 
     snappedPosition = getSnapPosition('x', lineSeriesScale);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toBeUndefined();
+    expect(snappedPosition).toBeUndefined();
 
     snappedPosition = getSnapPosition('a', multiLineSeriesScale, 2);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(0);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(0);
 
     snappedPosition = getSnapPosition('b', multiLineSeriesScale, 2);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(40);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(40);
 
     snappedPosition = getSnapPosition('c', multiLineSeriesScale, 2);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(80);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(80);
   });
 
   test('can snap position on scale ordinal mixed lines/bars', () => {
     let snappedPosition = getSnapPosition('a', mixedLinesBarsSeriesScale, 4);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(0);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(0);
 
     snappedPosition = getSnapPosition('b', mixedLinesBarsSeriesScale, 4);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(40);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(40);
 
     snappedPosition = getSnapPosition('c', mixedLinesBarsSeriesScale, 4);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toEqual(80);
+    expect(snappedPosition!.band).toEqual(40);
+    expect(snappedPosition!.position).toEqual(80);
 
     snappedPosition = getSnapPosition('x', mixedLinesBarsSeriesScale, 4);
-    expect(snappedPosition.band).toEqual(40);
-    expect(snappedPosition.position).toBeUndefined();
+    expect(snappedPosition).toBeUndefined();
   });
 });

--- a/src/state/crosshair_utils.ts
+++ b/src/state/crosshair_utils.ts
@@ -14,12 +14,17 @@ export function getSnapPosition(
   value: string | number,
   scale: Scale,
   totalBarsInCluster: number = 1,
-): { band: number; position: number } {
+): { band: number; position: number } | undefined {
   const position = scale.scale(value);
+  if (position === undefined) {
+    return;
+  }
   if (scale.bandwidth > 0) {
+    const band = scale.bandwidth / (1 - scale.barsPadding);
+    const halfPadding = (band - scale.bandwidth) / 2;
     return {
-      position,
-      band: scale.bandwidth * totalBarsInCluster,
+      position: position - halfPadding * totalBarsInCluster,
+      band: band * totalBarsInCluster,
     };
   } else {
     return {
@@ -70,11 +75,15 @@ export function getCursorBandPosition(
     return;
   }
   const isHorizontalRotated = isHorizontalRotation(chartRotation);
-  const { position, band } = getSnapPosition(
+  const snappedPosition = getSnapPosition(
     xScale.invertWithStep(isHorizontalRotated ? x : y),
     xScale,
     totalBarsInCluster,
   );
+  if (!snappedPosition) {
+    return;
+  }
+  const { position, band } = snappedPosition;
   if (isHorizontalRotated) {
     return {
       top,

--- a/src/state/test/interactions.test.ts
+++ b/src/state/test/interactions.test.ts
@@ -169,7 +169,7 @@ describe('Chart state pointer interactions', () => {
     expect(store.highlightedGeometries.length).toBe(1);
   });
 
-  describe('mouse over with ordinal scale', () => {
+  describe('mouse over with Ordinal scale', () => {
     mouseOverTestSuite(ScaleType.Ordinal);
   });
   describe('mouse over with Linear scale', () => {

--- a/src/state/test/interactions.test.ts
+++ b/src/state/test/interactions.test.ts
@@ -153,9 +153,9 @@ describe('Chart state pointer interactions', () => {
   });
 
   test('can respond to tooltip types changes', () => {
-    store.xScale = new ScaleContinuous([0, 1], [0, 100], ScaleType.Linear, false, 50, 0.5);
+    store.xScale = new ScaleContinuous(ScaleType.Linear, [0, 1], [0, 100], 50, 0.5);
     store.yScales = new Map();
-    store.yScales.set(GROUP_ID, new ScaleContinuous([0, 1], [0, 100], ScaleType.Linear));
+    store.yScales.set(GROUP_ID, new ScaleContinuous(ScaleType.Linear, [0, 1], [0, 100]));
     store.geometriesIndex.set(0, [indexedGeom1Red]);
 
     store.tooltipType.set(TooltipType.None);

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -158,6 +158,7 @@ export function computeSeriesGeometries(
   chartColors: ColorConfig,
   chartDims: Dimensions,
   chartRotation: Rotation,
+  barsPadding?: number,
 ): {
   scales: {
     xScale: Scale;
@@ -181,7 +182,7 @@ export function computeSeriesGeometries(
   const { stackedBarsInCluster, totalBarsInCluster } = countBarsInCluster(stacked, nonStacked);
 
   // compute scales
-  const xScale = computeXScale(xDomain, totalBarsInCluster, 0, width);
+  const xScale = computeXScale(xDomain, totalBarsInCluster, 0, width, barsPadding);
   const yScales = computeYScales(yDomain, height, 0);
 
   // compute colors

--- a/stories/area_chart.tsx
+++ b/stories/area_chart.tsx
@@ -491,4 +491,49 @@ storiesOf('Area Chart', module)
         />
       </Chart>
     );
+  })
+  .add('stacked only grouped areas', () => {
+    const data1 = [[1, 2], [2, 2], [3, 3], [4, 5], [5, 5], [6, 3], [7, 8], [8, 2], [9, 1]];
+    const data2 = [[1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 4], [7, 3], [8, 2], [9, 4]];
+    const data3 = [[1, 6], [2, 6], [3, 3], [4, 2], [5, 1], [6, 1], [7, 5], [8, 6], [9, 7]];
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Axis id={getAxisId('bottom')} title={'index'} position={Position.Bottom} />
+        <Axis
+          id={getAxisId('left')}
+          title={KIBANA_METRICS.metrics.kibana_os_load[0].metric.title}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+        <AreaSeries
+          id={getSpecId('stacked area 1')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor={0}
+          yAccessors={[1]}
+          stackAccessors={[0]}
+          data={data1}
+          yScaleToDataExtent={false}
+        />
+        <AreaSeries
+          id={getSpecId('stacked area 2')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor={0}
+          yAccessors={[1]}
+          stackAccessors={[0]}
+          data={data2}
+          yScaleToDataExtent={false}
+        />
+        <AreaSeries
+          id={getSpecId('non stacked area')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor={0}
+          yAccessors={[1]}
+          data={data3}
+          yScaleToDataExtent={false}
+        />
+      </Chart>
+    );
   });

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -9,6 +9,7 @@ import {
   DARK_THEME,
   DataGenerator,
   getAxisId,
+  getGroupId,
   getSpecId,
   LIGHT_THEME,
   LineSeries,
@@ -579,7 +580,7 @@ storiesOf('Bar Chart', module)
 
         <BarSeries
           id={getSpecId('bars1')}
-          xScaleType={ScaleType.Ordinal}
+          xScaleType={ScaleType.Linear}
           yScaleType={ScaleType.Linear}
           xAccessor="x"
           yAccessors={['y']}
@@ -1162,6 +1163,120 @@ storiesOf('Bar Chart', module)
           splitSeriesAccessors={[3]}
           stackAccessors={[0]}
           data={data}
+        />
+      </Chart>
+    );
+  })
+  .add('[test] switch ordinal/linear x axis', () => {
+    return (
+      <Chart className={'story-chart'}>
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={select(
+            'scaleType',
+            {
+              linear: ScaleType.Linear,
+              ordinal: ScaleType.Ordinal,
+            },
+            ScaleType.Linear,
+          )}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+        />
+      </Chart>
+    );
+  })
+  .add('stacked only grouped areas', () => {
+    const data1 = [[1, 2], [2, 2], [3, 3], [4, 5], [5, 5], [6, 3], [7, 8], [8, 2], [9, 1]];
+    const data2 = [[1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 4], [7, 3], [8, 2], [9, 4]];
+    const data3 = [[1, 6], [2, 6], [3, 3], [4, 2], [5, 1], [6, 1], [7, 5], [8, 6], [9, 7]];
+    const data4 = [[1, 2], [2, 6], [3, 2], [4, 9], [5, 2], [6, 3], [7, 1], [8, 2], [9, 7]];
+    const data5 = [[1, 1], [2, 7], [3, 5], [4, 6], [5, 5], [6, 4], [7, 2], [8, 4], [9, 8]];
+    return (
+      <Chart renderer="canvas" className={'story-chart'}>
+        <Axis id={getAxisId('bottom')} title={'index'} position={Position.Bottom} />
+        <Axis
+          id={getAxisId('left')}
+          title={KIBANA_METRICS.metrics.kibana_os_load[0].metric.title}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+          domain={{ min: 0, max: 15 }}
+        />
+        <Axis
+          id={getAxisId('left group b')}
+          groupId={getGroupId('gb')}
+          title={KIBANA_METRICS.metrics.kibana_os_load[0].metric.title}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+          hide={true}
+          domain={{ min: 0, max: 15 }}
+        />
+        <BarSeries
+          id={getSpecId('stacked bar 1')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor={0}
+          yAccessors={[1]}
+          stackAccessors={[0]}
+          data={data1}
+          yScaleToDataExtent={false}
+        />
+        <BarSeries
+          id={getSpecId('stacked bar 2')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor={0}
+          yAccessors={[1]}
+          stackAccessors={[0]}
+          data={data2}
+          yScaleToDataExtent={false}
+        />
+
+        <BarSeries
+          id={getSpecId('stacked bar A')}
+          groupId={getGroupId('gb')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor={0}
+          yAccessors={[1]}
+          stackAccessors={[0]}
+          data={data4}
+          yScaleToDataExtent={false}
+        />
+        <BarSeries
+          id={getSpecId('stacked bar B')}
+          groupId={getGroupId('gb')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor={0}
+          yAccessors={[1]}
+          stackAccessors={[0]}
+          data={data5}
+          yScaleToDataExtent={false}
+        />
+        <BarSeries
+          id={getSpecId('non stacked bar')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor={0}
+          yAccessors={[1]}
+          data={data3}
+          yScaleToDataExtent={false}
         />
       </Chart>
     );

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -101,6 +101,9 @@ storiesOf('Stylings', module)
         top: range('padding top', 0, 50, 10),
         bottom: range('padding bottom', 0, 50, 10),
       },
+      scales: {
+        barsPadding: range('bar padding', 0, 1, 0.1, undefined, 0.01),
+      },
     };
     const customTheme = mergeWithDefaultTheme(theme, LIGHT_THEME);
     return (
@@ -437,25 +440,33 @@ storiesOf('Stylings', module)
     );
   })
   .add('custom series styles: bars', () => {
-    const useOnlyChartTheme = boolean('ignore series style (use only chart theme)', false, 'chartTheme');
+    const useOnlyChartTheme = boolean(
+      'ignore series style (use only chart theme)',
+      false,
+      'chartTheme',
+    );
 
-    const barSeriesStyle1 = useOnlyChartTheme ? undefined : {
-      border: {
-        stroke: color('borderStroke 1', 'white', 'group1'),
-        strokeWidth: range('strokeWidth 1', 0, 10, 1, 'group1'),
-        visible: boolean('borderVisible 1', true, 'group1'),
-      },
-      opacity: range('opacity 1', 0, 1, 1, 'group1', 0.1),
-    };
+    const barSeriesStyle1 = useOnlyChartTheme
+      ? undefined
+      : {
+          border: {
+            stroke: color('borderStroke 1', 'white', 'group1'),
+            strokeWidth: range('strokeWidth 1', 0, 10, 1, 'group1'),
+            visible: boolean('borderVisible 1', true, 'group1'),
+          },
+          opacity: range('opacity 1', 0, 1, 1, 'group1', 0.1),
+        };
 
-    const barSeriesStyle2 = useOnlyChartTheme ? undefined : {
-      border: {
-        stroke: color('borderStroke 2', 'white', 'group2'),
-        strokeWidth: range('strokeWidth 2', 0, 10, 1, 'group2'),
-        visible: boolean('borderVisible 2', true, 'group2'),
-      },
-      opacity: range('opacity 2', 0, 1, 1, 'group2', 0.1),
-    };
+    const barSeriesStyle2 = useOnlyChartTheme
+      ? undefined
+      : {
+          border: {
+            stroke: color('borderStroke 2', 'white', 'group2'),
+            strokeWidth: range('strokeWidth 2', 0, 10, 1, 'group2'),
+            visible: boolean('borderVisible 2', true, 'group2'),
+          },
+          opacity: range('opacity 2', 0, 1, 1, 'group2', 0.1),
+        };
 
     const chartTheme = {
       ...LIGHT_THEME,
@@ -475,11 +486,7 @@ storiesOf('Stylings', module)
     return (
       <Chart renderer="canvas" className={'story-chart'}>
         <Settings showLegend={true} legendPosition={Position.Right} theme={chartTheme} />
-        <Axis
-          id={getAxisId('bottom')}
-          position={Position.Bottom}
-          showOverlappingTicks={true}
-        />
+        <Axis id={getAxisId('bottom')} position={Position.Bottom} showOverlappingTicks={true} />
         <Axis
           id={getAxisId('left2')}
           title={'Left axis'}
@@ -525,7 +532,11 @@ storiesOf('Stylings', module)
     );
   })
   .add('custom series styles: lines', () => {
-    const useOnlyChartTheme = boolean('ignore series style (use only chart theme)', false, 'chartTheme');
+    const useOnlyChartTheme = boolean(
+      'ignore series style (use only chart theme)',
+      false,
+      'chartTheme',
+    );
     const lineSeriesStyle1 = useOnlyChartTheme ? undefined : generateLineSeriesStyleKnobs('lines1');
     const lineSeriesStyle2 = useOnlyChartTheme ? undefined : generateLineSeriesStyleKnobs('lines2');
 
@@ -591,7 +602,11 @@ storiesOf('Stylings', module)
       areaSeriesStyle: generateAreaSeriesStyleKnobs('chartTheme'),
     };
 
-    const useOnlyChartTheme = boolean('ignore series style (use only chart theme)', false, 'chartTheme');
+    const useOnlyChartTheme = boolean(
+      'ignore series style (use only chart theme)',
+      false,
+      'chartTheme',
+    );
 
     const dataset1 = [{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }];
     const dataset2 = dataset1.map((datum) => ({ ...datum, y: datum.y - 1 }));


### PR DESCRIPTION
## Summary

This PR will add paddings between bars clusters as shown in the screenshot 

<img width="802" alt="Screenshot 2019-04-24 at 20 22 37" src="https://user-images.githubusercontent.com/1421091/56684349-dc316980-66cf-11e9-8b01-df1559fcc242.png">


The background highlighter width will cover the full band without padding, to be aligned with the sensible areas used for mouse interactions.

The `Theme` as a slight change on API on the `ScalesConfig` property. From:
```tsx
export interface ScalesConfig {
  ordinal: {
    padding: number;
  };
}
```

to:

```tsx
export interface ScalesConfig {
  barsPadding: number;
}
```
This to reflect the fact that: the padding is used on every scale used on X axis (linear, time or ordinal) and it's applied in the same way for bars:
```
|half padding size | bar/bars bandwidth | half padding size|
```

The padding is expressed as the proportion of the range that is reserved for blank space between bands. A value of 0 means no blank space between bands, and a value of 1 means a bandwidth of zero. (see https://github.com/d3/d3-scale#band_paddingInner). The value is clamped between 0 and 1.

**NOTE**: this should be marked as **BRAKING CHANGE** as the theme API is changed

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
- [ ] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
