### PR TITLE
fix(bars): remove border visibility based on bar width

### DIFF
--- a/src/components/react_canvas/bar_geometries.tsx
+++ b/src/components/react_canvas/bar_geometries.tsx
@@ -20,7 +20,7 @@ interface BarGeometriesDataState {
 export class BarGeometries extends React.PureComponent<
   BarGeometriesDataProps,
   BarGeometriesDataState
-  > {
+> {
   static defaultProps: Partial<BarGeometriesDataProps> = {
     animated: false,
   };
@@ -43,10 +43,7 @@ export class BarGeometries extends React.PureComponent<
 
   private renderBarGeoms = (bars: BarGeometry[]): JSX.Element[] => {
     const { overBar } = this.state;
-    const {
-      style,
-      sharedStyle,
-    } = this.props;
+    const { style, sharedStyle } = this.props;
     return bars.map((bar, index) => {
       const { x, y, width, height, color, seriesStyle } = bar;
       const border = seriesStyle ? seriesStyle.border : style.border;
@@ -68,8 +65,6 @@ export class BarGeometries extends React.PureComponent<
         individualHighlight,
       );
 
-      // min border depending on bar width bars with white border
-      const borderEnabled = border.visible && width > border.strokeWidth * 7;
       if (this.props.animated) {
         return (
           <Group key={index}>
@@ -84,7 +79,7 @@ export class BarGeometries extends React.PureComponent<
                   fill: color,
                   stroke: border.stroke,
                   strokeWidth: border.strokeWidth,
-                  borderEnabled,
+                  borderEnabled: border.visible,
                   geometryStyle,
                 });
 
@@ -103,7 +98,7 @@ export class BarGeometries extends React.PureComponent<
           fill: color,
           stroke: border.stroke,
           strokeWidth: border.strokeWidth,
-          borderEnabled,
+          borderEnabled: border.visible,
           geometryStyle,
         });
         return <Rect {...barProps} />;


### PR DESCRIPTION
## Summary

This PR will disable the automatic removal of a border for narrow bars. We let the
user/developer decide the right size of the bar border width.

fix #189

<img width="967" alt="Screenshot 2019-04-24 at 23 02 32" src="https://user-images.githubusercontent.com/1421091/56693582-1822f980-66e5-11e9-8dbd-7946a8b17f48.png">


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
