### PR TITLE
chore: add check to PR template for exports

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@ If it involves visual changes include a screenshot or gif.
 
 Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.
 
+- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
 - [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
 - [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
 - [ ] Unit tests were updated or added to match the most common scenarios


### PR DESCRIPTION
## Summary

This adds a check to the PR template checklist to ensure that any exports we want exposed to the user are exported in `src/index.ts`.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
~- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
~- [ ] Unit tests were updated or added to match the most common scenarios~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
