### PR TITLE
ci(codecov): fix codecov upload on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
   - export PATH="$HOME/.yarn/bin:$PATH"
 script:
-  - yarn build && yarn lint && yarn test
+  - yarn global add codecov -g
+  - yarn build && yarn lint && yarn test --coverage
 after_success:
+  - codecov
   - yarn semantic-release
 before_deploy: yarn storybook:build
 deploy:


### PR DESCRIPTION
## Summary

After switching to jenkins for PRs (https://github.com/elastic/elastic-charts/pull/174), I've also removed codecov upload from travisCI on master branch.
This commit will recover the codecov uploads from travis and enables a correct coverage check
between PRs and master

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- ~[ ] Unit tests were updated or added to match the most common scenarios~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
