### PR TITLE
fix(legend): avoid expanding label on click

### DIFF
--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -17,7 +17,7 @@ export class Playground extends React.Component {
   render() {
     return (
       <Chart>
-        <Settings showLegend={true} legendPosition={Position.Bottom} rotation={0} />
+        <Settings showLegend={true} legendPosition={Position.Right} rotation={0} />
         <Axis
           id={getAxisId('timestamp')}
           title="timestamp"
@@ -39,7 +39,7 @@ export class Playground extends React.Component {
           yAccessors={[1]}
         />
         <LineSeries
-          id={getSpecId('dataset B')}
+          id={getSpecId('bar series 1')}
           xScaleType={ScaleType.Time}
           yScaleType={ScaleType.Linear}
           data={KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15)}
@@ -47,7 +47,7 @@ export class Playground extends React.Component {
           yAccessors={[1]}
         />
         <LineSeries
-          id={getSpecId('dataset C')}
+          id={getSpecId('bar series 2')}
           xScaleType={ScaleType.Time}
           yScaleType={ScaleType.Linear}
           data={KIBANA_METRICS.metrics.kibana_os_load[2].data.slice(0, 15)}

--- a/src/components/legend_element.tsx
+++ b/src/components/legend_element.tsx
@@ -123,7 +123,7 @@ class LegendElementComponent extends React.Component<LegendElementProps, LegendE
         <EuiFlexItem grow={false}>
           {this.renderVisibilityButton(legendItemKey, isSeriesVisible)}
         </EuiFlexItem>
-        <EuiFlexItem onClick={onTitleClick} grow={false}>
+        <EuiFlexItem onClick={onTitleClick} grow={true}>
           <EuiPopover
             id="contentPanel"
             button={


### PR DESCRIPTION
## Summary

The version `4.2.2` has introduced a bug on the rendering of the legend when the eye button is clicked as displayed in the gif.

![May-20-2019 23-43-01](https://user-images.githubusercontent.com/1421091/58053898-2be14480-7b59-11e9-86ba-15261cc1b3bf.gif)

This PR fix that issue specifying the grow parameter into the title element.

![May-20-2019 23-45-16](https://user-images.githubusercontent.com/1421091/58053957-5cc17980-7b59-11e9-95a1-19bb5b3a8d87.gif)


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~[ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~~
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- ~[ ] Unit tests were updated or added to match the most common scenarios~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
