### PR TITLE
fix(specs):add custom style inside each specific series style

### DIFF
--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -122,6 +122,7 @@ export type BasicSeriesSpec = SeriesSpec & SeriesAccessors & SeriesScales & {
 export type BarSeriesSpec = BasicSeriesSpec & {
   /** @default bar */
   seriesType: 'bar';
+  barSeriesStyle?: CustomBarSeriesStyle;
 };
 
 /**
@@ -131,6 +132,7 @@ export type LineSeriesSpec = BasicSeriesSpec & {
   /** @default line */
   seriesType: 'line';
   curve?: CurveType;
+  lineSeriesStyle?: LineSeriesStyle;
 };
 
 /**
@@ -141,6 +143,7 @@ export type AreaSeriesSpec = BasicSeriesSpec & {
   seriesType: 'area';
   /** The type of interpolator to be used to interpolate values between points */
   curve?: CurveType;
+  areaSeriesStyle?: AreaSeriesStyle;
 };
 
 /**

--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -110,11 +110,7 @@ export interface SeriesScales {
   yScaleToDataExtent: boolean;
 }
 
-export type BasicSeriesSpec = SeriesSpec & SeriesAccessors & SeriesScales & {
-  barSeriesStyle?: CustomBarSeriesStyle;
-  lineSeriesStyle?: LineSeriesStyle;
-  areaSeriesStyle?: AreaSeriesStyle;
-};
+export type BasicSeriesSpec = SeriesSpec & SeriesAccessors & SeriesScales;
 
 /**
  * This spec describe the dataset configuration used to display a bar series.
@@ -298,4 +294,16 @@ export function isLineAnnotation(spec: AnnotationSpec): spec is LineAnnotationSp
 
 export function isRectAnnotation(spec: AnnotationSpec): spec is RectAnnotationSpec {
   return spec.annotationType === AnnotationTypes.Rectangle;
+}
+
+export function isBarSeriesSpec(spec: BasicSeriesSpec): spec is BarSeriesSpec {
+  return spec.seriesType === 'bar';
+}
+
+export function isLineSeriesSpec(spec: BasicSeriesSpec): spec is LineSeriesSpec {
+  return spec.seriesType === 'line';
+}
+
+export function isAreaSeriesSpec(spec: BasicSeriesSpec): spec is AreaSeriesSpec {
+  return spec.seriesType === 'area';
 }

--- a/src/state/annotation_utils.test.ts
+++ b/src/state/annotation_utils.test.ts
@@ -987,7 +987,7 @@ describe('annotation utils', () => {
         position: [0, 10, 20, 10],
         details: {},
         tooltipLinePosition: [0, 10, 20, 10],
-      }
+      },
     ];
     const lineStyle = DEFAULT_ANNOTATION_LINE_STYLE;
     const chartRotation: Rotation = 0;

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -27,6 +27,9 @@ import {
   AxisSpec,
   BasicSeriesSpec,
   DomainRange,
+  isAreaSeriesSpec,
+  isBarSeriesSpec,
+  isLineSeriesSpec,
   LineSeriesSpec,
   Rotation,
 } from '../lib/series/specs';
@@ -343,8 +346,8 @@ export function renderGeometries(
       continue;
     }
     const color = seriesColorsMap.get(ds.seriesColorKey) || defaultColor;
-    switch (spec.seriesType) {
-      case 'bar':
+
+    if (isBarSeriesSpec(spec)) {
         const shift = isStacked ? indexOffset : indexOffset + i;
 
         // TODO: we can handle style merging here and not pass that off to the component
@@ -373,8 +376,7 @@ export function renderGeometries(
         );
         bars.push(...renderedBars.barGeometries);
         geometriesCounts.bars += renderedBars.barGeometries.length;
-        break;
-      case 'line':
+    } else if (isLineSeriesSpec(spec)) {
         const lineShift = clusteredCount > 0 ? clusteredCount : 1;
         const lineSeriesStyle = spec.lineSeriesStyle;
         const renderedLines = renderLine(
@@ -397,8 +399,7 @@ export function renderGeometries(
         lines.push(renderedLines.lineGeometry);
         geometriesCounts.linePoints += renderedLines.lineGeometry.points.length;
         geometriesCounts.lines += 1;
-        break;
-      case 'area':
+    } else if (isAreaSeriesSpec(spec)) {
         const areaShift = clusteredCount > 0 ? clusteredCount : 1;
         const areaSeriesStyle = spec.areaSeriesStyle;
         const renderedAreas = renderArea(
@@ -421,7 +422,6 @@ export function renderGeometries(
         areas.push(renderedAreas.areaGeometry);
         geometriesCounts.areasPoints += renderedAreas.areaGeometry.points.length;
         geometriesCounts.areas += 1;
-        break;
     }
   }
   const geometriesIndex = mergeGeometriesIndexes(


### PR DESCRIPTION
## Summary

Fixes #188 
In specs.ts, BasicSeriesSpec included the styles for LineSeriesSpec, AreaSeriesSpec, and BarSeriesSpec. This PR removes barSeriesStyle, lineSeriesStyle, and areaSeriesStyle from BasicSeries style and includes the SeriesStyle per each chart type. 

Included in specs.ts are the type guards for utils.ts 

```
export function isBarSeriesSpec(spec: BasicSeriesSpec): spec is BarSeriesSpec {
  return spec.seriesType === 'bar';
}

export function isLineSeriesSpec(spec: BasicSeriesSpec): spec is LineSeriesSpec {
  return spec.seriesType === 'line';
}

export function isAreaSeriesSpec(spec: BasicSeriesSpec): spec is AreaSeriesSpec {
  return spec.seriesType === 'area';
}
```

### Checklist

~~-  Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~~
~~-  Proper documentation or storybook story was added for features that require explanation or tutorials~~

~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~

~~- [ ] Unit tests were updated or added to match the most common scenarios~~
- [X] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
