### PR TITLE
fix(crosshair): adjust band position for rotation

### DIFF
--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -292,7 +292,7 @@ export class ChartStore {
     const updatedCursorBand = getCursorBandPosition(
       this.chartRotation,
       this.chartDimensions,
-      this.cursorPosition,
+      { x: xAxisCursorPosition, y: yAxisCursorPosition},
       this.isTooltipSnapEnabled.get(),
       this.xScale,
       this.geometriesIndexKeys,

--- a/src/state/crosshair_utils.linear_snap.test.ts
+++ b/src/state/crosshair_utils.linear_snap.test.ts
@@ -454,7 +454,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 119,
+          left: -1,
           top: 0,
           height: 100,
           width: 1,
@@ -472,7 +472,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 119,
+          left: -1,
           top: 0,
           height: 100,
           width: 1,
@@ -490,7 +490,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 79,
+          left: 39,
           top: 0,
           height: 100,
           width: 1,
@@ -508,7 +508,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 29,
+          left: 89,
           top: 0,
           height: 100,
           width: 1,
@@ -851,7 +851,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 99,
+          top: -1,
           height: 1,
           width: 120,
         });
@@ -869,7 +869,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 99,
+          top: -1,
           height: 1,
           width: 120,
         });
@@ -887,7 +887,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 59,
+          top: 39,
           height: 1,
           width: 120,
         });
@@ -905,7 +905,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 9,
+          top: 89,
           height: 1,
           width: 120,
         });

--- a/src/state/crosshair_utils.linear_snap.test.ts
+++ b/src/state/crosshair_utils.linear_snap.test.ts
@@ -454,7 +454,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 0,
+          left: 119,
           top: 0,
           height: 100,
           width: 1,
@@ -472,7 +472,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 0,
+          left: 119,
           top: 0,
           height: 100,
           width: 1,
@@ -490,7 +490,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 40,
+          left: 79,
           top: 0,
           height: 100,
           width: 1,
@@ -508,7 +508,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 90,
+          left: 29,
           top: 0,
           height: 100,
           width: 1,
@@ -544,7 +544,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 0,
+          left: -1,
           top: 0,
           height: 100,
           width: 1,
@@ -562,7 +562,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 0,
+          left: -1,
           top: 0,
           height: 100,
           width: 1,
@@ -580,7 +580,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 0,
+          left: -1,
           top: 0,
           height: 100,
           width: 1,
@@ -598,7 +598,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 60,
+          left: 59,
           top: 0,
           height: 100,
           width: 1,
@@ -616,7 +616,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 120,
+          left: 119,
           top: 0,
           height: 100,
           width: 1,
@@ -851,7 +851,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 0,
+          top: 99,
           height: 1,
           width: 120,
         });
@@ -869,7 +869,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 0,
+          top: 99,
           height: 1,
           width: 120,
         });
@@ -887,7 +887,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 40,
+          top: 59,
           height: 1,
           width: 120,
         });
@@ -905,7 +905,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 90,
+          top: 9,
           height: 1,
           width: 120,
         });
@@ -941,7 +941,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 0,
+          top: -21,
           height: 1,
           width: 120,
         });
@@ -959,7 +959,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 0,
+          top: -21,
           height: 1,
           width: 120,
         });
@@ -977,7 +977,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 0,
+          top: 39,
           height: 1,
           width: 120,
         });
@@ -995,7 +995,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 60,
+          top: 39,
           height: 1,
           width: 120,
         });
@@ -1013,7 +1013,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 120,
+          top: 99,
           height: 1,
           width: 120,
         });
@@ -1192,7 +1192,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 40,
+          left: 0,
           top: 0,
           height: 100,
           width: 40,
@@ -1337,7 +1337,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 0,
+          top: -20,
           height: 40,
           width: 120,
         });
@@ -1355,7 +1355,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 0,
+          top: -20,
           height: 40,
           width: 120,
         });
@@ -1373,7 +1373,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 40,
+          top: 20,
           height: 40,
           width: 120,
         });
@@ -1391,7 +1391,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 80,
+          top: 60,
           height: 40,
           width: 120,
         });

--- a/src/state/crosshair_utils.linear_snap.test.ts
+++ b/src/state/crosshair_utils.linear_snap.test.ts
@@ -453,8 +453,9 @@ describe('Crosshair utils linear scale', () => {
           [0, 1, 2],
           1,
         );
+
         expect(bandPosition).toEqual({
-          left: -1,
+          left: 120,
           top: 0,
           height: 100,
           width: 1,
@@ -472,7 +473,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: -1,
+          left: 120,
           top: 0,
           height: 100,
           width: 1,
@@ -490,7 +491,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 39,
+          left: 80,
           top: 0,
           height: 100,
           width: 1,
@@ -508,7 +509,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 89,
+          left: 30,
           top: 0,
           height: 100,
           width: 1,
@@ -544,7 +545,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: -1,
+          left: 120,
           top: 0,
           height: 100,
           width: 1,
@@ -562,7 +563,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: -1,
+          left: 120,
           top: 0,
           height: 100,
           width: 1,
@@ -580,7 +581,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: -1,
+          left: 120,
           top: 0,
           height: 100,
           width: 1,
@@ -598,7 +599,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 59,
+          left: 60,
           top: 0,
           height: 100,
           width: 1,
@@ -616,7 +617,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 119,
+          left: 0,
           top: 0,
           height: 100,
           width: 1,
@@ -671,7 +672,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 0,
+          top: 45,
           height: 1,
           width: 120,
         });
@@ -689,7 +690,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 40,
+          top: 0,
           height: 1,
           width: 120,
         });
@@ -707,7 +708,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 90,
+          top: 0,
           height: 1,
           width: 120,
         });
@@ -761,7 +762,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 0,
+          top: 60,
           height: 1,
           width: 120,
         });
@@ -797,7 +798,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 60,
+          top: 0,
           height: 1,
           width: 120,
         });
@@ -815,7 +816,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 120,
+          top: 0,
           height: 1,
           width: 120,
         });
@@ -851,7 +852,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: -1,
+          top: 100,
           height: 1,
           width: 120,
         });
@@ -869,7 +870,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: -1,
+          top: 55,
           height: 1,
           width: 120,
         });
@@ -887,7 +888,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 39,
+          top: 100,
           height: 1,
           width: 120,
         });
@@ -905,7 +906,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 89,
+          top: 100,
           height: 1,
           width: 120,
         });
@@ -941,7 +942,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: -21,
+          top: 100,
           height: 1,
           width: 120,
         });
@@ -959,7 +960,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: -21,
+          top: 40,
           height: 1,
           width: 120,
         });
@@ -977,7 +978,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 39,
+          top: 100,
           height: 1,
           width: 120,
         });
@@ -995,7 +996,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 39,
+          top: 100,
           height: 1,
           width: 120,
         });
@@ -1013,7 +1014,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 99,
+          top: 100,
           height: 1,
           width: 120,
         });
@@ -1156,7 +1157,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 0,
+          left: 80,
           top: 0,
           height: 100,
           width: 40,
@@ -1174,7 +1175,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 0,
+          left: 80,
           top: 0,
           height: 100,
           width: 40,
@@ -1192,7 +1193,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 0,
+          left: 40,
           top: 0,
           height: 100,
           width: 40,
@@ -1210,7 +1211,7 @@ describe('Crosshair utils linear scale', () => {
           1,
         );
         expect(bandPosition).toEqual({
-          left: 80,
+          left: 0,
           top: 0,
           height: 100,
           width: 40,
@@ -1265,7 +1266,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 0,
+          top: 40,
           height: 40,
           width: 120,
         });
@@ -1283,7 +1284,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 40,
+          top: 0,
           height: 40,
           width: 120,
         });
@@ -1301,7 +1302,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 80,
+          top: 0,
           height: 40,
           width: 120,
         });
@@ -1337,7 +1338,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: -20,
+          top: 60,
           height: 40,
           width: 120,
         });
@@ -1355,7 +1356,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: -20,
+          top: 20,
           height: 40,
           width: 120,
         });
@@ -1373,7 +1374,7 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toEqual({
           left: 0,
-          top: 20,
+          top: 60,
           height: 40,
           width: 120,
         });

--- a/src/state/crosshair_utils.ts
+++ b/src/state/crosshair_utils.ts
@@ -1,5 +1,6 @@
 import { Rotation } from '../lib/series/specs';
 import { Dimensions } from '../lib/utils/dimensions';
+import { getValidXPosition } from '../lib/utils/interactions';
 import { Scale } from '../lib/utils/scales/scales';
 import { isHorizontalRotation } from './utils';
 
@@ -76,7 +77,22 @@ export function getCursorBandPosition(
     return;
   }
   const isHorizontalRotated = isHorizontalRotation(chartRotation);
-  const invertedValue = xScale.invertWithStep(isHorizontalRotated ? x : y, data);
+  const xAxisCursorPosition = getValidXPosition(
+    x,
+    y,
+    chartRotation,
+    chartDimensions,
+  );
+
+  const yAxisCursorPosition = getValidXPosition(
+      x,
+      y,
+      chartRotation,
+      chartDimensions,
+    );
+
+  const invertedValue = xScale.invertWithStep(isHorizontalRotated ? xAxisCursorPosition : yAxisCursorPosition, data);
+
   if (invertedValue == null) {
     return;
   }
@@ -86,15 +102,21 @@ export function getCursorBandPosition(
   }
   const { position, band } = snappedPosition;
   if (isHorizontalRotated) {
+    const adjustedLeft = snapEnabled ? position : x;
+    const leftPosition = chartRotation === 0 ? left + adjustedLeft : left + width - adjustedLeft - band;
+
     return {
       top,
-      left: left + (snapEnabled ? position : x),
+      left: leftPosition,
       width: band,
       height,
     };
   } else {
+    const adjustedTop = snapEnabled ? position : y;
+    const topPosition = chartRotation === 90 ? top + adjustedTop : top + height - adjustedTop - band;
+
     return {
-      top: top + (snapEnabled ? position : y),
+      top: topPosition,
       left,
       width,
       height: band,

--- a/src/state/crosshair_utils.ts
+++ b/src/state/crosshair_utils.ts
@@ -84,14 +84,7 @@ export function getCursorBandPosition(
     chartDimensions,
   );
 
-  const yAxisCursorPosition = getValidXPosition(
-      x,
-      y,
-      chartRotation,
-      chartDimensions,
-    );
-
-  const invertedValue = xScale.invertWithStep(isHorizontalRotated ? xAxisCursorPosition : yAxisCursorPosition, data);
+  const invertedValue = xScale.invertWithStep(xAxisCursorPosition, data);
 
   if (invertedValue == null) {
     return;
@@ -112,7 +105,7 @@ export function getCursorBandPosition(
       height,
     };
   } else {
-    const adjustedTop = snapEnabled ? position : yAxisCursorPosition;
+    const adjustedTop = snapEnabled ? position : xAxisCursorPosition;
     const topPosition = chartRotation === 90 ? top + adjustedTop : top + height - adjustedTop - band;
 
     return {

--- a/src/state/crosshair_utils.ts
+++ b/src/state/crosshair_utils.ts
@@ -102,7 +102,7 @@ export function getCursorBandPosition(
   }
   const { position, band } = snappedPosition;
   if (isHorizontalRotated) {
-    const adjustedLeft = snapEnabled ? position : x;
+    const adjustedLeft = snapEnabled ? position : xAxisCursorPosition;
     const leftPosition = chartRotation === 0 ? left + adjustedLeft : left + width - adjustedLeft - band;
 
     return {
@@ -112,7 +112,7 @@ export function getCursorBandPosition(
       height,
     };
   } else {
-    const adjustedTop = snapEnabled ? position : y;
+    const adjustedTop = snapEnabled ? position : yAxisCursorPosition;
     const topPosition = chartRotation === 90 ? top + adjustedTop : top + height - adjustedTop - band;
 
     return {

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -519,9 +519,44 @@ storiesOf('Bar Chart', module)
     );
   })
   .add('clustered with axis and legend', () => {
+    const chartRotation = select<Rotation>(
+      'chartRotation',
+      {
+        '0 deg': 0,
+        '90 deg': 90,
+        '-90 deg': -90,
+        '180 deg': 180,
+      },
+      0,
+    );
+
+    const theme = {
+      ...LIGHT_THEME,
+      chartMargins: {
+        left: 30,
+        right: 0,
+        top: 30,
+        bottom: 0,
+      },
+      chartPaddings: {
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+      },
+      scales: {
+        barsPadding: number('bar padding', 0, {
+          range: true,
+          min: 0,
+          max: 1,
+          step: 0.01,
+        }),
+      },
+    };
+
     return (
       <Chart className={'story-chart'}>
-        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Settings showLegend={true} legendPosition={Position.Right} theme={theme} rotation={chartRotation}/>
         <Axis
           id={getAxisId('bottom')}
           position={Position.Bottom}

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -238,8 +238,43 @@ storiesOf('Bar Chart', module)
     );
   })
   .add('with linear x axis', () => {
+    const chartRotation = select<Rotation>(
+      'chartRotation',
+      {
+        '0 deg': 0,
+        '90 deg': 90,
+        '-90 deg': -90,
+        '180 deg': 180,
+      },
+      0,
+    );
+
+    const theme = {
+      ...LIGHT_THEME,
+      chartMargins: {
+        left: 30,
+        right: 0,
+        top: 30,
+        bottom: 0,
+      },
+      chartPaddings: {
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+      },
+      scales: {
+        barsPadding: number('bar padding', 0, {
+          range: true,
+          min: 0,
+          max: 1,
+          step: 0.01,
+        }),
+      },
+    };
     return (
       <Chart className={'story-chart'}>
+        <Settings rotation={chartRotation} theme={theme} />
         <Axis
           id={getAxisId('bottom')}
           position={Position.Bottom}

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -251,18 +251,6 @@ storiesOf('Bar Chart', module)
 
     const theme = {
       ...LIGHT_THEME,
-      chartMargins: {
-        left: 30,
-        right: 0,
-        top: 30,
-        bottom: 0,
-      },
-      chartPaddings: {
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-      },
       scales: {
         barsPadding: number('bar padding', 0, {
           range: true,
@@ -532,18 +520,6 @@ storiesOf('Bar Chart', module)
 
     const theme = {
       ...LIGHT_THEME,
-      chartMargins: {
-        left: 30,
-        right: 0,
-        top: 30,
-        bottom: 0,
-      },
-      chartPaddings: {
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-      },
       scales: {
         barsPadding: number('bar padding', 0, {
           range: true,

--- a/stories/line_chart.tsx
+++ b/stories/line_chart.tsx
@@ -1,4 +1,4 @@
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import {
@@ -10,6 +10,7 @@ import {
   LineSeries,
   niceTimeFormatByDay,
   Position,
+  Rotation,
   ScaleType,
   Settings,
   timeFormatter,
@@ -67,8 +68,20 @@ storiesOf('Line Chart', module)
     );
   })
   .add('ordinal w axis', () => {
+    const chartRotation = select<Rotation>(
+      'chartRotation',
+      {
+        '0 deg': 0,
+        '90 deg': 90,
+        '-90 deg': -90,
+        '180 deg': 180,
+      },
+      0,
+    );
+
     return (
       <Chart className={'story-chart'}>
+        <Settings rotation={chartRotation} />
         <Axis
           id={getAxisId('bottom')}
           position={Position.Bottom}


### PR DESCRIPTION
## Summary

This PR introduces a fix so that the band highlighter position appears correctly positioned when chartRotation of -90 or 180 is defined.  Previously, these flipped rotations were not being accounted for in computing the position, causing the bands to appear on the wrong side of the chart.  (This is most noticeable with series which have discontinuous data.)

Previous bug:
![band_rotation_bug](https://user-images.githubusercontent.com/452850/58587421-36af6f80-8212-11e9-996e-047982d77108.gif)

After implementing fix:
![band_fix](https://user-images.githubusercontent.com/452850/58584905-390ecb00-820c-11e9-8fe3-ba39bb53a2b4.gif)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
