### PR TITLE
fix(chart_resizer): debounce resize set to leading

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     "react-dom": "^16.8.3",
     "react-konva": "16.8.3",
     "react-spring": "^8.0.8",
-    "resize-observer-polyfill": "^1.5.1"
+    "resize-observer-polyfill": "^1.5.1",
+    "ts-debounce": "^1.0.0"
   },
   "peerDependencies": {
     "@elastic/datemath": "^5.0.2",

--- a/src/components/chart_resizer.tsx
+++ b/src/components/chart_resizer.tsx
@@ -14,7 +14,7 @@ class Resizer extends React.Component<ResizerProps> {
   constructor(props: ResizerProps) {
     super(props);
     this.containerRef = React.createRef();
-    this.ro = new ResizeObserver(debounce(this.onResize, 200));
+    this.ro = new ResizeObserver(debounce(this.onResize, 200, { leading: true }));
   }
 
   componentDidMount() {

--- a/src/components/chart_resizer.tsx
+++ b/src/components/chart_resizer.tsx
@@ -7,14 +7,8 @@ import { ChartStore } from '../state/chart_state';
 interface ResizerProps {
   chartStore?: ChartStore;
 }
-interface ResizerState {
-  initialResizeComplete: boolean;
-}
-class Resizer extends React.Component<ResizerProps, ResizerState> {
-  state = {
-    initialResizeComplete: false,
-  };
-
+class Resizer extends React.Component<ResizerProps> {
+  private initialResizeComplete = false;
   private containerRef: RefObject<HTMLDivElement>;
   private ro: ResizeObserver;
   private onResizeDebounced: (entries: ResizeObserverEntry[]) => void;
@@ -58,12 +52,10 @@ class Resizer extends React.Component<ResizerProps, ResizerState> {
   }
 
   private handleResize = (entries: ResizeObserverEntry[]) => {
-    if (this.state.initialResizeComplete) {
+    if (this.initialResizeComplete) {
       this.onResizeDebounced(entries);
     } else {
-      this.setState({
-        initialResizeComplete: true,
-      });
+      this.initialResizeComplete = true;
       this.onResize(entries);
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13217,6 +13217,11 @@ trough@^1.0.0:
   dependencies:
     glob "^7.1.2"
 
+ts-debounce@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ts-debounce/-/ts-debounce-1.0.0.tgz#e433301744ba75fe25466f7f23e1382c646aae6a"
+  integrity sha512-V+IzWj418IoqqxVJD6I0zjPtgIyvAJ8VyViqzcxZ0JRiJXsi5mCmy1yUKkWd2gUygT28a8JsVFCgqdrf2pLUHQ==
+
 ts-jest@^24.0.0:
   version "24.0.2"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.2.tgz#8dde6cece97c31c03e80e474c749753ffd27194d"


### PR DESCRIPTION
## Summary

Fix for `ChartResizer` initial render delay. A 200ms delay was applied to all initial renders.

Set debounce to `leading` to prevent initial load delay of 200ms.

Issue #109

### Before
![Screen Recording 2019-06-05 at 05 14 PM](https://user-images.githubusercontent.com/19007109/58994234-6aac0700-87b5-11e9-8229-8ed07463ae74.gif)

### After
![Screen Recording 2019-06-05 at 05 17 PM](https://user-images.githubusercontent.com/19007109/58994347-cf676180-87b5-11e9-877f-ee90fee99435.gif)


### Checklist

- [ ] ~~Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~~
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] ~~Proper documentation or storybook story was added for features that require explanation or tutorials~~
- [ ] ~~Unit tests were updated or added to match the most common scenarios~~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
