### PR TITLE
feat: style individual bars in a series

### DIFF
--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -6,7 +6,7 @@ import {
   LineSeriesStyle,
   RectAnnotationStyle,
 } from '../themes/theme';
-import { Accessor } from '../utils/accessor';
+import { Accessor, AccessorFn } from '../utils/accessor';
 import { Omit } from '../utils/commons';
 import { AnnotationId, AxisId, GroupId, SpecId } from '../utils/ids';
 import { ScaleContinuousType, ScaleType } from '../utils/scales/scales';
@@ -83,7 +83,7 @@ export interface SeriesAccessors {
   /** An array of fields thats indicates the stack membership */
   stackAccessors?: Accessor[];
   /** An optional array of field name thats indicates the stack membership */
-  colorAccessors?: Accessor[];
+  colorAccessors?: Array<Accessor | AccessorFn>;
 }
 
 export interface SeriesScales {

--- a/src/lib/utils/accessor.ts
+++ b/src/lib/utils/accessor.ts
@@ -10,12 +10,18 @@ export type Accessor = AccessorString;
  */
 export function getAccessorFn(accessor: Accessor): AccessorFn {
   if (typeof accessor === 'string' || typeof accessor === 'number') {
-    return (datum: Datum) => {
-      return datum[accessor];
-    };
+    return (datum: Datum) => datum[accessor];
   }
-  if (typeof accessor === 'function') {
+  if (isAccessorFn(accessor)) {
     return accessor;
   }
   throw new Error('Accessor must be a string or a function');
+}
+
+/**
+ * Returns if the accessor is an AccessorFn
+ * @param accessor the spec accessor
+ */
+export function isAccessorFn(accessor: Accessor | AccessorFn): boolean {
+  return typeof accessor === 'function';
 }

--- a/src/lib/utils/domain.ts
+++ b/src/lib/utils/domain.ts
@@ -13,13 +13,6 @@ export interface SpecDomain {
   isStacked?: boolean;
 }
 
-export interface ColorDomain {
-  accessors: Accessor[];
-  yAccessors?: Accessor[];
-  domain: string[];
-  scaleType: ScaleType;
-}
-
 export interface SeriesScales {
   groupLevel: number;
   xDomain: Domain;

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -740,6 +740,35 @@ storiesOf('Bar Chart', module)
       </Chart>
     );
   })
+  .add('Style individual bars in a series', () => {
+    return (
+      <Chart className={'story-chart'}>
+        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Axis
+          id={getAxisId('bottom')}
+          position={Position.Bottom}
+          title={'Bottom axis'}
+          showOverlappingTicks={true}
+        />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars1')}
+          xScaleType={ScaleType.Ordinal}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y1', 'y2']}
+          colorAccessors={[(d) => d.y1 >= 2 ? 'nick' : null]}
+          data={TestDatasets.BARCHART_2Y0G}
+        />
+      </Chart>
+    );
+  })
   .add('1y0g', () => {
     return (
       <Chart className={'story-chart'}>


### PR DESCRIPTION
## Summary
Issue #216

Add ability to style(only color) individual bars in a series

Allow `colorAccessors` to be of type `AccessorFn`

https://github.com/elastic/elastic-charts/blob/79422c2d392e2912070b30d0efbbc36d58d3414e/src/lib/utils/accessor.ts#L3

### Checklist

- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
- [ ] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
