### PR TITLE
feat(theme): allow recursive partial theme

### DIFF
--- a/.playground/tsconfig.json
+++ b/.playground/tsconfig.json
@@ -3,5 +3,8 @@
   "compilerOptions": {
     "downlevelIteration": true,
     "target": "es5"
-  }
+  },
+  "exclude": [
+    "../**/*.test.*"
+  ]
 }

--- a/.playground/webpack.config.js
+++ b/.playground/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
         loader: 'ts-loader',
         exclude: /node_modules/,
         options: {
-          configFile: './tsconfig.json',
+          configFile: 'tsconfig.json',
         },
       },
       {

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig",
+  "exclude": ["../**/*.test.*"]
+}

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -8,15 +8,17 @@ module.exports = (baseConfig, env, config) => {
     config.devtool = 'source-map';
   }
   config.module.rules.push({
-    test: /\.(ts|tsx)$/,
-    use: [
-      {
-        loader: require.resolve('ts-loader'),
-      },
-      {
-        loader: require.resolve('react-docgen-typescript-loader'),
-      },
-    ],
+    test: /\.tsx?$/,
+    loader: require.resolve('ts-loader'),
+    exclude: /node_modules/,
+    options: {
+      configFile: 'tsconfig.json',
+    },
+  });
+  config.module.rules.push({
+    test: /\.tsx?$/,
+    loader: require.resolve('react-docgen-typescript-loader'),
+    exclude: /node_modules/,
   });
   config.module.rules.push({
     test: /\.tsx?$/,

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,6 +1,15 @@
 {
-  "roots": ["<rootDir>/src"],
+  "roots": [
+    "<rootDir>/src"
+  ],
   "preset": "ts-jest",
   "testEnvironment": "jest-environment-jsdom-fourteen",
-  "setupFilesAfterEnv": ["<rootDir>/scripts/setup_enzyme.ts"]
+  "setupFilesAfterEnv": [
+    "<rootDir>/scripts/setup_enzyme.ts"
+  ],
+  "globals": {
+    "ts-jest": {
+      "tsConfig": "tsconfig.jest.json"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "cz": "git-cz",
     "build:clean": "rm -rf ./dist",
-    "build:ts": "tsc -p ./tsconfig.json",
+    "build:ts": "tsc -p ./tsconfig.lib.json",
     "build:sass": "node-sass src/theme_light.scss dist/theme_light.css --output-style compressed && node-sass src/theme_dark.scss dist/theme_dark.css --output-style compressed && node-sass src/theme_only_light.scss dist/theme_only_light.css --output-style compressed && node-sass src/theme_only_dark.scss dist/theme_only_dark.css --output-style compressed",
     "concat:sass": "node scripts/concat_sass.js",
     "build": "yarn build:clean && yarn build:ts && yarn build:sass && yarn concat:sass",
@@ -27,7 +27,7 @@
     "watch": "yarn test --watch",
     "semantic-release": "semantic-release",
     "typecheck:src": "yarn build:ts --noEmit",
-    "typecheck:all": "tsc -p ./tsconfig.all.json --noEmit",
+    "typecheck:all": "tsc -p ./tsconfig.json --noEmit",
     "playground": "cd .playground && webpack-dev-server"
   },
   "files": [

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -1,7 +1,0 @@
-declare type RecursivePartial<T> = {
-  [P in keyof T]?: T[P] extends (infer U)[]
-    ? RecursivePartial<U>[]
-    : T[P] extends readonly (infer U)[] // eslint-disable-line prettier/prettier
-    ? readonly RecursivePartial<U>[]
-    : RecursivePartial<T[P]>
-};

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -1,0 +1,7 @@
+declare type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? RecursivePartial<U>[]
+    : T[P] extends readonly (infer U)[] // eslint-disable-line prettier/prettier
+    ? readonly RecursivePartial<U>[]
+    : RecursivePartial<T[P]>
+};

--- a/src/lib/themes/theme.test.ts
+++ b/src/lib/themes/theme.test.ts
@@ -3,25 +3,19 @@ import { DARK_THEME } from './dark_theme';
 import { LIGHT_THEME } from './light_theme';
 import {
   AreaSeriesStyle,
-  AxisConfig,
-  BarSeriesStyle,
-  ColorConfig,
-  CrosshairStyle,
   DEFAULT_ANNOTATION_LINE_STYLE,
   DEFAULT_ANNOTATION_RECT_STYLE,
   DEFAULT_GRID_LINE_CONFIG,
-  LegendStyle,
   LineSeriesStyle,
   mergeWithDefaultAnnotationLine,
   mergeWithDefaultAnnotationRect,
   mergeWithDefaultGridLineConfig,
   mergeWithDefaultTheme,
-  ScalesConfig,
-  SharedGeometryStyle,
+  PartialTheme,
   Theme,
 } from './theme';
 
-describe('Themes', () => {
+describe('Theme', () => {
   let CLONED_LIGHT_THEME: Theme;
   let CLONED_DARK_THEME: Theme;
 
@@ -36,367 +30,355 @@ describe('Themes', () => {
     expect(DARK_THEME).toEqual(CLONED_DARK_THEME);
   });
 
-  it('should merge partial theme: margins', () => {
-    const customTheme = mergeWithDefaultTheme({
-      chartMargins: {
+  describe('mergeWithDefaultGridLineConfig', () => {
+    it('should merge partial grid line configs', () => {
+      const fullConfig = {
+        stroke: 'foo',
+        strokeWidth: 1,
+        opacity: 0,
+        dash: [0, 0],
+      };
+      expect(mergeWithDefaultGridLineConfig(fullConfig)).toEqual(fullConfig);
+      expect(mergeWithDefaultGridLineConfig({})).toEqual(DEFAULT_GRID_LINE_CONFIG);
+    });
+  });
+
+  describe('mergeWithDefaultAnnotationLine', () => {
+    it('should merge custom and default annotation line configs', () => {
+      expect(mergeWithDefaultAnnotationLine()).toEqual(DEFAULT_ANNOTATION_LINE_STYLE);
+
+      const customLineConfig = {
+        stroke: 'foo',
+        strokeWidth: 50,
+        opacity: 1,
+      };
+
+      const defaultLineConfig = {
+        stroke: '#000',
+        strokeWidth: 3,
+        opacity: 1,
+      };
+
+      const customDetailsConfig = {
+        fontSize: 50,
+        fontFamily: 'custom-font-family',
+        fontStyle: 'custom-font-style',
+        fill: 'custom-fill',
+        padding: 20,
+      };
+
+      const defaultDetailsConfig = {
+        fontSize: 10,
+        fontFamily: `'Open Sans', Helvetica, Arial, sans-serif`,
+        fontStyle: 'normal',
+        fill: 'gray',
+        padding: 0,
+      };
+
+      const expectedMergedCustomLineConfig = { line: customLineConfig, details: defaultDetailsConfig };
+      const mergedCustomLineConfig = mergeWithDefaultAnnotationLine({ line: customLineConfig });
+      expect(mergedCustomLineConfig).toEqual(expectedMergedCustomLineConfig);
+
+      const expectedMergedCustomDetailsConfig = { line: defaultLineConfig, details: customDetailsConfig };
+      const mergedCustomDetailsConfig = mergeWithDefaultAnnotationLine({ details: customDetailsConfig });
+      expect(mergedCustomDetailsConfig).toEqual(expectedMergedCustomDetailsConfig);
+    });
+  });
+
+  describe('mergeWithDefaultAnnotationRect', () => {
+    it('should merge custom and default rect annotation style', () => {
+      expect(mergeWithDefaultAnnotationRect()).toEqual(DEFAULT_ANNOTATION_RECT_STYLE);
+
+      const customConfig = {
+        stroke: 'customStroke',
+        fill: 'customFill',
+      };
+
+      const expectedMergedConfig = {
+        stroke: 'customStroke',
+        fill: 'customFill',
+        opacity: 0.5,
+        strokeWidth: 1,
+      };
+
+      expect(mergeWithDefaultAnnotationRect(customConfig)).toEqual(expectedMergedConfig);
+    });
+  });
+
+  describe('mergeWithDefaultTheme', () => {
+    it('should merge partial theme: margins', () => {
+      const customTheme = mergeWithDefaultTheme({
+        chartMargins: {
+          bottom: 314571,
+          top: 314571,
+          left: 314571,
+          right: 314571,
+        },
+      });
+      expect(customTheme.chartMargins).toBeDefined();
+      expect(customTheme.chartMargins.bottom).toBe(314571);
+      expect(customTheme.chartMargins.left).toBe(314571);
+      expect(customTheme.chartMargins.right).toBe(314571);
+      expect(customTheme.chartMargins.top).toBe(314571);
+    });
+
+    it('should merge partial theme: paddings', () => {
+      const chartPaddings: Margins = {
         bottom: 314571,
         top: 314571,
         left: 314571,
         right: 314571,
-      },
-    });
-    expect(customTheme.chartMargins).toBeDefined();
-    expect(customTheme.chartMargins.bottom).toBe(314571);
-    expect(customTheme.chartMargins.left).toBe(314571);
-    expect(customTheme.chartMargins.right).toBe(314571);
-    expect(customTheme.chartMargins.top).toBe(314571);
-  });
-
-  it('should merge partial theme: paddings', () => {
-    const chartPaddings: Margins = {
-      bottom: 314571,
-      top: 314571,
-      left: 314571,
-      right: 314571,
-    };
-    const customTheme = mergeWithDefaultTheme({
-      chartPaddings,
-    });
-    expect(customTheme.chartPaddings).toBeDefined();
-    expect(customTheme.chartPaddings.bottom).toBe(314571);
-    expect(customTheme.chartPaddings.left).toBe(314571);
-    expect(customTheme.chartPaddings.right).toBe(314571);
-    expect(customTheme.chartPaddings.top).toBe(314571);
-    const customDarkTheme = mergeWithDefaultTheme(
-      {
+      };
+      const customTheme = mergeWithDefaultTheme({
         chartPaddings,
-      },
-      DARK_THEME,
-    );
-    expect(customDarkTheme.chartPaddings).toEqual(chartPaddings);
-  });
-
-  it('should merge partial theme: lineSeriesStyle', () => {
-    const lineSeriesStyle: LineSeriesStyle = {
-      line: {
-        stroke: 'elastic_charts',
-        strokeWidth: 314571,
-        visible: true,
-      },
-      border: {
-        stroke: 'elastic_charts',
-        strokeWidth: 314571,
-        visible: true,
-      },
-      point: {
-        radius: 314571,
-        stroke: 'elastic_charts',
-        strokeWidth: 314571,
-        visible: true,
-        opacity: 314571,
-      },
-    };
-    const customTheme = mergeWithDefaultTheme({
-      lineSeriesStyle,
+      });
+      expect(customTheme.chartPaddings).toBeDefined();
+      expect(customTheme.chartPaddings.bottom).toBe(314571);
+      expect(customTheme.chartPaddings.left).toBe(314571);
+      expect(customTheme.chartPaddings.right).toBe(314571);
+      expect(customTheme.chartPaddings.top).toBe(314571);
+      const customDarkTheme = mergeWithDefaultTheme(
+        {
+          chartPaddings,
+        },
+        DARK_THEME,
+      );
+      expect(customDarkTheme.chartPaddings).toEqual(chartPaddings);
     });
-    expect(customTheme.lineSeriesStyle).toEqual(lineSeriesStyle);
-    const customDarkTheme = mergeWithDefaultTheme(
-      {
+
+    it('should merge partial theme: lineSeriesStyle', () => {
+      const lineSeriesStyle: LineSeriesStyle = {
+        line: {
+          stroke: 'elastic_charts',
+          strokeWidth: 314571,
+          visible: true,
+        },
+        border: {
+          stroke: 'elastic_charts',
+          strokeWidth: 314571,
+          visible: true,
+        },
+        point: {
+          radius: 314571,
+          stroke: 'elastic_charts',
+          strokeWidth: 314571,
+          visible: true,
+          opacity: 314571,
+        },
+      };
+      const customTheme = mergeWithDefaultTheme({
         lineSeriesStyle,
-      },
-      DARK_THEME,
-    );
-    expect(customDarkTheme.lineSeriesStyle).toEqual(lineSeriesStyle);
-  });
-
-  it('should merge partial theme: areaSeriesStyle', () => {
-    const areaSeriesStyle: AreaSeriesStyle = {
-      area: {
-        fill: 'elastic_charts',
-        visible: true,
-        opacity: 314571,
-      },
-      line: {
-        stroke: 'elastic_charts',
-        strokeWidth: 314571,
-        visible: true,
-      },
-      border: {
-        stroke: 'elastic_charts',
-        strokeWidth: 314571,
-        visible: true,
-      },
-      point: {
-        visible: true,
-        radius: 314571,
-        stroke: 'elastic_charts',
-        strokeWidth: 314571,
-        opacity: 314571,
-      },
-    };
-    const customTheme = mergeWithDefaultTheme({
-      areaSeriesStyle,
+      });
+      expect(customTheme.lineSeriesStyle).toEqual(lineSeriesStyle);
+      const customDarkTheme = mergeWithDefaultTheme(
+        {
+          lineSeriesStyle,
+        },
+        DARK_THEME,
+      );
+      expect(customDarkTheme.lineSeriesStyle).toEqual(lineSeriesStyle);
     });
-    expect(customTheme.areaSeriesStyle).toEqual(areaSeriesStyle);
-    const customDarkTheme = mergeWithDefaultTheme(
-      {
+
+    it('should merge partial theme: areaSeriesStyle', () => {
+      const areaSeriesStyle: AreaSeriesStyle = {
+        area: {
+          fill: 'elastic_charts',
+          visible: true,
+          opacity: 314571,
+        },
+        line: {
+          stroke: 'elastic_charts',
+          strokeWidth: 314571,
+          visible: true,
+        },
+        border: {
+          stroke: 'elastic_charts',
+          strokeWidth: 314571,
+          visible: true,
+        },
+        point: {
+          visible: true,
+          radius: 314571,
+          stroke: 'elastic_charts',
+          strokeWidth: 314571,
+          opacity: 314571,
+        },
+      };
+      const customTheme = mergeWithDefaultTheme({
         areaSeriesStyle,
-      },
-      DARK_THEME,
-    );
-    expect(customDarkTheme.areaSeriesStyle).toEqual(areaSeriesStyle);
-  });
-
-  it('should merge partial theme: barSeriesStyle', () => {
-    const barSeriesStyle: BarSeriesStyle = {
-      border: {
-        stroke: 'elastic_charts',
-        strokeWidth: 314571,
-        visible: true,
-      },
-      displayValue: {
-        fontSize: 10,
-        fontStyle: 'custom-font-style',
-        fontFamily: 'custom-font',
-        padding: 5,
-        fill: 'custom-fill',
-      },
-    };
-    const customTheme = mergeWithDefaultTheme({
-      barSeriesStyle,
+      });
+      expect(customTheme.areaSeriesStyle).toEqual(areaSeriesStyle);
+      const customDarkTheme = mergeWithDefaultTheme(
+        {
+          areaSeriesStyle,
+        },
+        DARK_THEME,
+      );
+      expect(customDarkTheme.areaSeriesStyle).toEqual(areaSeriesStyle);
     });
-    expect(customTheme.barSeriesStyle).toEqual(barSeriesStyle);
-    const customDarkTheme = mergeWithDefaultTheme(
-      {
-        barSeriesStyle,
-      },
-      DARK_THEME,
-    );
-    expect(customDarkTheme.barSeriesStyle).toEqual(barSeriesStyle);
-  });
 
-  it('should merge partial theme: sharedStyle', () => {
-    const sharedStyle: SharedGeometryStyle = {
-      default: {
-        opacity: 314571,
-      },
-      highlighted: {
-        opacity: 314571,
-      },
-      unhighlighted: {
-        opacity: 314571,
-      },
-    };
-    const customTheme = mergeWithDefaultTheme({
-      sharedStyle,
+    it('should merge partial theme: barSeriesStyle', () => {
+      const partialTheme: PartialTheme = {
+        barSeriesStyle: {
+          border: {
+            stroke: 'elastic_charts',
+          },
+          displayValue: {
+            fontSize: 10,
+            fontStyle: 'custom-font-style',
+          },
+        },
+      };
+      const mergedTheme = mergeWithDefaultTheme(partialTheme, DARK_THEME);
+      expect(mergedTheme).toEqual({
+        ...DARK_THEME,
+        barSeriesStyle: {
+          border: {
+            ...DARK_THEME.barSeriesStyle.border,
+            ...partialTheme!.barSeriesStyle!.border,
+          },
+          displayValue: {
+            ...DARK_THEME.barSeriesStyle.displayValue,
+            ...partialTheme!.barSeriesStyle!.displayValue,
+          },
+        },
+      });
     });
-    expect(customTheme.sharedStyle).toEqual(sharedStyle);
-    const customDarkTheme = mergeWithDefaultTheme(
-      {
-        sharedStyle,
-      },
-      DARK_THEME,
-    );
-    expect(customDarkTheme.sharedStyle).toEqual(sharedStyle);
-  });
 
-  it('should merge partial theme: scales', () => {
-    const scales: ScalesConfig = {
-      barsPadding: 314571,
-      histogramPadding: 0.05,
-    };
-    const customTheme = mergeWithDefaultTheme({
-      scales,
+    it('should merge partial theme: sharedStyle', () => {
+      const partialTheme: PartialTheme = {
+        sharedStyle: {
+          highlighted: {
+            opacity: 100,
+          },
+        },
+      };
+      const mergedTheme = mergeWithDefaultTheme(partialTheme, DARK_THEME);
+      expect(mergedTheme).toEqual({
+        ...DARK_THEME,
+        sharedStyle: {
+          ...DARK_THEME.sharedStyle,
+          highlighted: {
+            ...DARK_THEME.sharedStyle.highlighted,
+            ...partialTheme!.sharedStyle!.highlighted,
+          },
+        },
+      });
     });
-    expect(customTheme.scales).toEqual(scales);
-    const customDarkTheme = mergeWithDefaultTheme(
-      {
-        scales,
-      },
-      DARK_THEME,
-    );
-    expect(customDarkTheme.scales).toEqual(scales);
-  });
 
-  it('should merge partial theme: axes', () => {
-    const axes: AxisConfig = {
-      axisTitleStyle: {
-        fontSize: 314571,
-        fontStyle: 'elastic_charts',
-        fontFamily: 'elastic_charts',
-        padding: 314571,
-        fill: 'elastic_charts',
-      },
-      axisLineStyle: {
-        stroke: 'elastic_charts',
-        strokeWidth: 314571,
-      },
-      tickLabelStyle: {
-        fontSize: 314571,
-        fontFamily: 'elastic_charts',
-        fontStyle: 'elastic_charts',
-        fill: 'elastic_charts',
-        padding: 314571,
-      },
-      tickLineStyle: {
-        stroke: 'elastic_charts',
-        strokeWidth: 314571,
-      },
-    };
-    const customTheme = mergeWithDefaultTheme({
-      axes,
+    it('should merge partial theme: scales', () => {
+      const partialTheme: PartialTheme = {
+        scales: {
+          barsPadding: 314571,
+        },
+      };
+      const mergedTheme = mergeWithDefaultTheme(partialTheme, DARK_THEME);
+      expect(mergedTheme).toEqual({
+        ...DARK_THEME,
+        scales: {
+          ...DARK_THEME.scales,
+          ...partialTheme!.scales,
+        },
+      });
     });
-    expect(customTheme.axes).toEqual(axes);
-    const customDarkTheme = mergeWithDefaultTheme(
-      {
-        axes,
-      },
-      DARK_THEME,
-    );
-    expect(customDarkTheme.axes).toEqual(axes);
-  });
 
-  it('should merge partial theme: colors', () => {
-    const colors: ColorConfig = {
-      vizColors: ['elastic_charts_c1', 'elastic_charts_c2'],
-      defaultVizColor: 'elastic_charts',
-    };
-    const customTheme = mergeWithDefaultTheme({
-      colors,
+    it('should merge partial theme: axes', () => {
+      const partialTheme: PartialTheme = {
+        axes: {
+          axisTitleStyle: {
+            fontStyle: 'elastic_charts',
+          },
+          axisLineStyle: {
+            stroke: 'elastic_charts',
+          },
+        },
+      };
+      const mergedTheme = mergeWithDefaultTheme(partialTheme, DARK_THEME);
+      expect(mergedTheme).toEqual({
+        ...DARK_THEME,
+        axes: {
+          ...DARK_THEME.axes,
+          axisTitleStyle: {
+            ...DARK_THEME.axes.axisTitleStyle,
+            ...partialTheme!.axes!.axisTitleStyle,
+          },
+          axisLineStyle: {
+            ...DARK_THEME.axes.axisLineStyle,
+            ...partialTheme!.axes!.axisLineStyle,
+          },
+        },
+      });
     });
-    expect(customTheme.colors).toEqual(colors);
-    const customDarkTheme = mergeWithDefaultTheme(
-      {
-        colors,
-      },
-      DARK_THEME,
-    );
-    expect(customDarkTheme.colors).toEqual(colors);
 
-    const vizColors: Partial<ColorConfig> = {
-      vizColors: ['elastic_charts_c1', 'elastic_charts_c2'],
-    };
-    const partialUpdatedCustomTheme = mergeWithDefaultTheme({
-      colors: vizColors,
+    it('should merge partial theme: colors', () => {
+      const partialTheme: PartialTheme = {
+        colors: {
+          vizColors: ['elastic_charts_c1', 'elastic_charts_c2'],
+        },
+      };
+      const mergedTheme = mergeWithDefaultTheme(partialTheme, DARK_THEME);
+      expect(mergedTheme).toEqual({
+        ...DARK_THEME,
+        colors: {
+          ...DARK_THEME.colors,
+          ...partialTheme!.colors,
+        },
+      });
     });
-    expect(partialUpdatedCustomTheme.colors.vizColors).toEqual(vizColors.vizColors);
 
-    const defaultVizColor: Partial<ColorConfig> = {
-      defaultVizColor: 'elastic_charts',
-    };
-    const partialUpdated2CustomTheme = mergeWithDefaultTheme({
-      colors: defaultVizColor,
+    it('should merge partial theme: legend', () => {
+      const partialTheme: PartialTheme = {
+        legend: {
+          horizontalHeight: 314571,
+        },
+      };
+      const mergedTheme = mergeWithDefaultTheme(partialTheme, DARK_THEME);
+      expect(mergedTheme).toEqual({
+        ...DARK_THEME,
+        legend: {
+          ...DARK_THEME.legend,
+          ...partialTheme!.legend,
+        },
+      });
     });
-    expect(partialUpdated2CustomTheme.colors.defaultVizColor).toEqual(defaultVizColor.defaultVizColor);
-  });
 
-  it('should merge partial theme: legends', () => {
-    const legend: LegendStyle = {
-      verticalWidth: 314571,
-      horizontalHeight: 314571,
-    };
-    const customTheme = mergeWithDefaultTheme({
-      legend,
+    it('should merge partial theme: crosshair', () => {
+      const partialTheme: PartialTheme = {
+        crosshair: {
+          band: {
+            fill: 'elastic_charts_c1',
+          },
+          line: {
+            strokeWidth: 314571,
+          },
+        },
+      };
+      const mergedTheme = mergeWithDefaultTheme(partialTheme, DARK_THEME);
+      expect(mergedTheme).toEqual({
+        ...DARK_THEME,
+        crosshair: {
+          ...DARK_THEME.crosshair,
+          band: {
+            ...DARK_THEME.crosshair.band,
+            ...partialTheme!.crosshair!.band,
+          },
+          line: {
+            ...DARK_THEME.crosshair.line,
+            ...partialTheme!.crosshair!.line,
+          },
+        },
+      });
     });
-    expect(customTheme.legend).toEqual(legend);
-    const customDarkTheme = mergeWithDefaultTheme(
-      {
-        legend,
-      },
-      DARK_THEME,
-    );
-    expect(customDarkTheme.legend).toEqual(legend);
-  });
-  it('should merge partial theme: crosshair', () => {
-    const crosshair: CrosshairStyle = {
-      band: {
-        visible: false,
-        fill: 'elastic_charts_c1',
-      },
-      line: {
-        visible: false,
-        stroke: 'elastic_charts_c1',
-        strokeWidth: 314571,
-      },
-    };
-    const customTheme = mergeWithDefaultTheme({
-      crosshair,
+
+    it('should override all values if provided', () => {
+      const mergedTheme = mergeWithDefaultTheme(LIGHT_THEME, DARK_THEME);
+      expect(mergedTheme).toEqual(LIGHT_THEME);
     });
-    expect(customTheme.crosshair).toEqual(crosshair);
-    const customDarkTheme = mergeWithDefaultTheme(
-      {
-        crosshair,
-      },
-      DARK_THEME,
-    );
-    expect(customDarkTheme.crosshair).toEqual(crosshair);
-  });
 
-  it('should merge partial grid line configs', () => {
-    const fullConfig = {
-      stroke: 'foo',
-      strokeWidth: 1,
-      opacity: 0,
-      dash: [0, 0],
-    };
-    expect(mergeWithDefaultGridLineConfig(fullConfig)).toEqual(fullConfig);
-    expect(mergeWithDefaultGridLineConfig({})).toEqual(DEFAULT_GRID_LINE_CONFIG);
-  });
-
-  it('should merge custom and default annotation line configs', () => {
-    expect(mergeWithDefaultAnnotationLine()).toEqual(DEFAULT_ANNOTATION_LINE_STYLE);
-
-    const customLineConfig = {
-      stroke: 'foo',
-      strokeWidth: 50,
-      opacity: 1,
-    };
-
-    const defaultLineConfig = {
-      stroke: '#000',
-      strokeWidth: 3,
-      opacity: 1,
-    };
-
-    const customDetailsConfig = {
-      fontSize: 50,
-      fontFamily: 'custom-font-family',
-      fontStyle: 'custom-font-style',
-      fill: 'custom-fill',
-      padding: 20,
-    };
-
-    const defaultDetailsConfig = {
-      fontSize: 10,
-      fontFamily: `'Open Sans', Helvetica, Arial, sans-serif`,
-      fontStyle: 'normal',
-      fill: 'gray',
-      padding: 0,
-    };
-
-    const expectedMergedCustomLineConfig = { line: customLineConfig, details: defaultDetailsConfig };
-    const mergedCustomLineConfig = mergeWithDefaultAnnotationLine({ line: customLineConfig });
-    expect(mergedCustomLineConfig).toEqual(expectedMergedCustomLineConfig);
-
-    const expectedMergedCustomDetailsConfig = { line: defaultLineConfig, details: customDetailsConfig };
-    const mergedCustomDetailsConfig = mergeWithDefaultAnnotationLine({ details: customDetailsConfig });
-    expect(mergedCustomDetailsConfig).toEqual(expectedMergedCustomDetailsConfig);
-  });
-  it('should merge custom and default rect annotation style', () => {
-    expect(mergeWithDefaultAnnotationRect()).toEqual(DEFAULT_ANNOTATION_RECT_STYLE);
-
-    const customConfig = {
-      stroke: 'customStroke',
-      fill: 'customFill',
-    };
-
-    const expectedMergedConfig = {
-      stroke: 'customStroke',
-      fill: 'customFill',
-      opacity: 0.5,
-      strokeWidth: 1,
-    };
-
-    expect(mergeWithDefaultAnnotationRect(customConfig)).toEqual(expectedMergedConfig);
+    it('should default to LIGHT_THEME', () => {
+      const partialTheme: PartialTheme = {};
+      const mergedTheme = mergeWithDefaultTheme(partialTheme);
+      expect(mergedTheme).toEqual(LIGHT_THEME);
+    });
   });
 });

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -1,5 +1,5 @@
 import { GeometryStyle } from '../series/rendering';
-import { mergePartial } from '../utils/commons';
+import { mergePartial, RecursivePartial } from '../utils/commons';
 import { Margins } from '../utils/dimensions';
 import { LIGHT_THEME } from './light_theme';
 

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -100,10 +100,11 @@ export interface Theme {
 
 export type PartialTheme = RecursivePartial<Theme>;
 
-export enum BaseThemeType {
-  Light,
-  Dark,
-}
+export type BaseThemeType = 'light' | 'dark';
+export const BaseThemeTypes: Readonly<{ [key: string]: BaseThemeType }> = Object.freeze({
+  Light: 'light',
+  Dark: 'dark',
+});
 
 export type DisplayValueStyle = TextStyle & {
   offsetX?: number;

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -1,4 +1,5 @@
 import { GeometryStyle } from '../series/rendering';
+import { mergePartial } from '../utils/commons';
 import { Margins } from '../utils/dimensions';
 import { LIGHT_THEME } from './light_theme';
 
@@ -97,6 +98,13 @@ export interface Theme {
   crosshair: CrosshairStyle;
 }
 
+export type PartialTheme = RecursivePartial<Theme>;
+
+export enum BaseThemeType {
+  Light,
+  Dark,
+}
+
 export type DisplayValueStyle = TextStyle & {
   offsetX?: number;
   offsetY?: number;
@@ -136,20 +144,6 @@ export interface LineAnnotationStyle {
 }
 
 export type RectAnnotationStyle = StrokeStyle & FillStyle & Opacity;
-
-export interface PartialTheme {
-  chartMargins?: Margins;
-  chartPaddings?: Margins;
-  lineSeriesStyle?: LineSeriesStyle;
-  areaSeriesStyle?: AreaSeriesStyle;
-  barSeriesStyle?: BarSeriesStyle;
-  sharedStyle?: SharedGeometryStyle;
-  axes?: Partial<AxisConfig>;
-  scales?: Partial<ScalesConfig>;
-  colors?: Partial<ColorConfig>;
-  legend?: Partial<LegendStyle>;
-  crosshair?: Partial<CrosshairStyle>;
-}
 
 export const DEFAULT_GRID_LINE_CONFIG: GridLineConfig = {
   stroke: 'red',
@@ -229,74 +223,5 @@ export function mergeWithDefaultAnnotationRect(config?: Partial<RectAnnotationSt
 }
 
 export function mergeWithDefaultTheme(theme: PartialTheme, defaultTheme: Theme = LIGHT_THEME): Theme {
-  const customTheme: Theme = {
-    ...defaultTheme,
-  };
-  if (theme.chartMargins) {
-    customTheme.chartMargins = {
-      ...defaultTheme.chartMargins,
-      ...theme.chartMargins,
-    };
-  }
-  if (theme.chartPaddings) {
-    customTheme.chartPaddings = {
-      ...defaultTheme.chartPaddings,
-      ...theme.chartPaddings,
-    };
-  }
-  if (theme.areaSeriesStyle) {
-    customTheme.areaSeriesStyle = {
-      ...defaultTheme.areaSeriesStyle,
-      ...theme.areaSeriesStyle,
-    };
-  }
-  if (theme.lineSeriesStyle) {
-    customTheme.lineSeriesStyle = {
-      ...defaultTheme.lineSeriesStyle,
-      ...theme.lineSeriesStyle,
-    };
-  }
-  if (theme.barSeriesStyle) {
-    customTheme.barSeriesStyle = {
-      ...defaultTheme.barSeriesStyle,
-      ...theme.barSeriesStyle,
-    };
-  }
-  if (theme.sharedStyle) {
-    customTheme.sharedStyle = {
-      ...defaultTheme.sharedStyle,
-      ...theme.sharedStyle,
-    };
-  }
-  if (theme.scales) {
-    customTheme.scales = {
-      ...defaultTheme.scales,
-      ...theme.scales,
-    };
-  }
-  if (theme.axes) {
-    customTheme.axes = {
-      ...defaultTheme.axes,
-      ...theme.axes,
-    };
-  }
-  if (theme.colors) {
-    customTheme.colors = {
-      ...defaultTheme.colors,
-      ...theme.colors,
-    };
-  }
-  if (theme.legend) {
-    customTheme.legend = {
-      ...defaultTheme.legend,
-      ...theme.legend,
-    };
-  }
-  if (theme.crosshair) {
-    customTheme.crosshair = {
-      ...defaultTheme.crosshair,
-      ...theme.crosshair,
-    };
-  }
-  return customTheme;
+  return mergePartial(defaultTheme, theme);
 }

--- a/src/lib/utils/commons.test.ts
+++ b/src/lib/utils/commons.test.ts
@@ -1,4 +1,4 @@
-import { clamp, compareByValueAsc, identity } from './commons';
+import { clamp, compareByValueAsc, identity, mergePartial } from './commons';
 
 describe('commons utilities', () => {
   test('can clamp a value to min max', () => {
@@ -27,5 +27,111 @@ describe('commons utilities', () => {
     expect(compareByValueAsc(10, 20)).toBeLessThan(0);
     expect(compareByValueAsc(20, 10)).toBeGreaterThan(0);
     expect(compareByValueAsc(10, 10)).toBe(0);
+  });
+
+  describe('mergePartial', () => {
+    let baseClone: TestType;
+    interface TestType {
+      string: string;
+      number: number;
+      boolean: boolean;
+      array1: Partial<TestType>[];
+      array2: number[];
+      nested: Partial<TestType>;
+    }
+    type PartialTestType = RecursivePartial<TestType>;
+    const base: TestType = {
+      string: 'string1',
+      boolean: false,
+      number: 1,
+      array1: [
+        {
+          string: 'string2',
+        },
+      ],
+      array2: [1, 2, 3],
+      nested: {
+        string: 'string2',
+        number: 2,
+      },
+    };
+
+    beforeAll(() => {
+      baseClone = JSON.parse(JSON.stringify(base)) as TestType;
+    });
+
+    test('should allow partial to be undefined', () => {
+      expect(mergePartial('test')).toBe('test');
+    });
+    test('should override base value with partial', () => {
+      expect(mergePartial(1 as number, 2)).toBe(2);
+    });
+
+    test('should NOT return original base structure', () => {
+      expect(mergePartial(base)).not.toBe(base);
+    });
+
+    test('should override string value in base', () => {
+      const partial: PartialTestType = { string: 'test' };
+      const newBase = mergePartial(base, partial);
+      expect(newBase).toEqual({
+        ...newBase,
+        string: partial.string,
+      });
+    });
+
+    test('should override boolean value in base', () => {
+      const partial: PartialTestType = { boolean: true };
+      const newBase = mergePartial(base, partial);
+      expect(newBase).toEqual({
+        ...newBase,
+        boolean: partial.boolean,
+      });
+    });
+
+    test('should override number value in base', () => {
+      const partial: PartialTestType = { number: 3 };
+      const newBase = mergePartial(base, partial);
+      expect(newBase).toEqual({
+        ...newBase,
+        number: partial.number,
+      });
+    });
+
+    test('should override complex array value in base', () => {
+      const partial: PartialTestType = { array1: [{ string: 'test' }] };
+      const newBase = mergePartial(base, partial);
+      expect(newBase).toEqual({
+        ...newBase,
+        array1: partial!.array1,
+      });
+    });
+
+    test('should override simple array value in base', () => {
+      const partial: PartialTestType = { array2: [4, 5, 6] };
+      const newBase = mergePartial(base, partial);
+      expect(newBase).toEqual({
+        ...newBase,
+        array2: partial!.array2,
+      });
+    });
+
+    test('should override nested values in base', () => {
+      const partial: PartialTestType = { nested: { number: 5 } };
+      const newBase = mergePartial(base, partial);
+      expect(newBase).toEqual({
+        ...newBase,
+        nested: {
+          ...newBase.nested,
+          number: partial!.nested!.number,
+        },
+      });
+    });
+
+    test('should not mutate base structure', () => {
+      const partial: PartialTestType = { number: 3 };
+      mergePartial(base, partial);
+      expect(base).toEqual(baseClone);
+    });
   });
 });

--- a/src/lib/utils/commons.test.ts
+++ b/src/lib/utils/commons.test.ts
@@ -1,4 +1,4 @@
-import { clamp, compareByValueAsc, identity, mergePartial } from './commons';
+import { clamp, compareByValueAsc, identity, mergePartial, RecursivePartial } from './commons';
 
 describe('commons utilities', () => {
   test('can clamp a value to min max', () => {
@@ -63,6 +63,7 @@ describe('commons utilities', () => {
     test('should allow partial to be undefined', () => {
       expect(mergePartial('test')).toBe('test');
     });
+
     test('should override base value with partial', () => {
       expect(mergePartial(1 as number, 2)).toBe(2);
     });

--- a/src/lib/utils/commons.ts
+++ b/src/lib/utils/commons.ts
@@ -12,3 +12,28 @@ export function clamp(value: number, min: number, max: number): number {
 
 // Can remove once we upgrade to TypesScript >= 3.5
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+/**
+ * Merges values of a partial structure with a base structure.
+ *
+ * @param base structure to be duplicated, must have all props of `partial`
+ * @param partial structure to override values from base
+ *
+ * @returns new base structure with updated partial values
+ */
+export function mergePartial<T>(base: T, partial?: RecursivePartial<T>): T {
+  if (Array.isArray(base)) {
+    return partial ? (partial as T) : base; // No nested array merging
+  } else if (typeof base === 'object') {
+    return Object.keys(base).reduce(
+      (newBase, key) => {
+        // @ts-ignore
+        newBase[key] = mergePartial(base[key], partial && partial[key]);
+        return newBase;
+      },
+      { ...base },
+    );
+  }
+
+  return partial !== undefined ? (partial as T) : base;
+}

--- a/src/lib/utils/commons.ts
+++ b/src/lib/utils/commons.ts
@@ -13,6 +13,36 @@ export function clamp(value: number, min: number, max: number): number {
 // Can remove once we upgrade to TypesScript >= 3.5
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
+
+/**
+ * Replaces all properties on any type as optional, includes nested types
+ *
+ * example:
+ * ```ts
+ * interface Person {
+ *  name: string;
+ *  age?: number;
+ *  spouse: Person;
+ *  children: Person[];
+ * }
+ * type PartialPerson = RecursivePartial<Person>;
+ * // results in
+ * interface PartialPerson {
+ *  name?: string;
+ *  age?: number;
+ *  spouse?: RecursivePartial<Person>;
+ *  children?: RecursivePartial<Person>[]
+ * }
+ * ```
+ */
+export type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? RecursivePartial<U>[]
+    : T[P] extends readonly (infer U)[] // eslint-disable-line prettier/prettier
+    ? readonly RecursivePartial<U>[]
+    : RecursivePartial<T[P]>
+};
+
 /**
  * Merges values of a partial structure with a base structure.
  *

--- a/src/specs/settings.test.tsx
+++ b/src/specs/settings.test.tsx
@@ -6,7 +6,7 @@ import { LIGHT_THEME } from '../lib/themes/light_theme';
 import { TooltipType } from '../lib/utils/interactions';
 import { ChartStore } from '../state/chart_state';
 import { DEFAULT_TOOLTIP_SNAP, DEFAULT_TOOLTIP_TYPE, SettingsComponent, SettingSpecProps } from './settings';
-import { PartialTheme, BaseThemeType } from '../lib/themes/theme';
+import { PartialTheme, BaseThemeTypes } from '../lib/themes/theme';
 
 describe('Settings spec component', () => {
   test('should update store on mount if spec has a chart store', () => {
@@ -162,7 +162,7 @@ describe('Settings spec component', () => {
 
     const updatedProps: SettingSpecProps = {
       theme: partialTheme,
-      baseThemeType: BaseThemeType.Dark,
+      baseThemeType: BaseThemeTypes.Dark,
       rotation: 90 as Rotation,
       rendering: 'svg' as Rendering,
       animateData: true,

--- a/src/specs/settings.test.tsx
+++ b/src/specs/settings.test.tsx
@@ -5,7 +5,8 @@ import { DARK_THEME } from '../lib/themes/dark_theme';
 import { LIGHT_THEME } from '../lib/themes/light_theme';
 import { TooltipType } from '../lib/utils/interactions';
 import { ChartStore } from '../state/chart_state';
-import { DEFAULT_TOOLTIP_SNAP, DEFAULT_TOOLTIP_TYPE, SettingsComponent } from './settings';
+import { DEFAULT_TOOLTIP_SNAP, DEFAULT_TOOLTIP_TYPE, SettingsComponent, SettingSpecProps } from './settings';
+import { PartialTheme, BaseThemeType } from '../lib/themes/theme';
 
 describe('Settings spec component', () => {
   test('should update store on mount if spec has a chart store', () => {
@@ -67,7 +68,7 @@ describe('Settings spec component', () => {
     expect(chartStore.debug).toBe(false);
     expect(chartStore.xDomain).toBeUndefined();
 
-    const updatedProps = {
+    const updatedProps: SettingSpecProps = {
       theme: DARK_THEME,
       rotation: 90 as Rotation,
       rendering: 'svg' as Rendering,
@@ -147,5 +148,43 @@ describe('Settings spec component', () => {
     expect(chartStore.onLegendItemClickListener).toEqual(onLegendEvent);
     expect(chartStore.onLegendItemPlusClickListener).toEqual(onLegendEvent);
     expect(chartStore.onLegendItemMinusClickListener).toEqual(onLegendEvent);
+  });
+
+  test('should allow partial theme', () => {
+    const chartStore = new ChartStore();
+    const partialTheme: PartialTheme = {
+      colors: {
+        defaultVizColor: 'aquamarine',
+      },
+    };
+
+    expect(chartStore.chartTheme).toEqual(LIGHT_THEME);
+
+    const updatedProps: SettingSpecProps = {
+      theme: partialTheme,
+      baseThemeType: BaseThemeType.Dark,
+      rotation: 90 as Rotation,
+      rendering: 'svg' as Rendering,
+      animateData: true,
+      showLegend: true,
+      tooltip: {
+        type: TooltipType.None,
+        snap: false,
+      },
+      legendPosition: Position.Bottom,
+      showLegendDisplayValue: false,
+      debug: true,
+      xDomain: { min: 0, max: 10 },
+    };
+
+    mount(<SettingsComponent chartStore={chartStore} {...updatedProps} />);
+
+    expect(chartStore.chartTheme).toEqual({
+      ...DARK_THEME,
+      colors: {
+        ...DARK_THEME.colors,
+        ...partialTheme.colors,
+      },
+    });
   });
 });

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -32,7 +32,7 @@ function isTooltipType(config: TooltipType | TooltipProps): config is TooltipTyp
   return typeof config === 'string';
 }
 
-interface SettingSpecProps {
+export interface SettingSpecProps {
   chartStore?: ChartStore;
   theme?: Theme | PartialTheme;
   baseThemeType?: BaseThemeType;

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -1,8 +1,10 @@
 import { inject } from 'mobx-react';
 import { PureComponent } from 'react';
+
 import { DomainRange, Position, Rendering, Rotation } from '../lib/series/specs';
+import { DARK_THEME } from '../lib/themes/dark_theme';
 import { LIGHT_THEME } from '../lib/themes/light_theme';
-import { Theme } from '../lib/themes/theme';
+import { BaseThemeType, mergeWithDefaultTheme, PartialTheme, Theme } from '../lib/themes/theme';
 import { Domain } from '../lib/utils/domain';
 import { TooltipType, TooltipValueFormatter } from '../lib/utils/interactions';
 import {
@@ -32,7 +34,8 @@ function isTooltipType(config: TooltipType | TooltipProps): config is TooltipTyp
 
 interface SettingSpecProps {
   chartStore?: ChartStore;
-  theme?: Theme;
+  theme?: Theme | PartialTheme;
+  baseThemeType?: BaseThemeType;
   rendering: Rendering;
   rotation: Rotation;
   animateData: boolean;
@@ -54,10 +57,20 @@ interface SettingSpecProps {
   xDomain?: Domain | DomainRange;
 }
 
+function getTheme(theme?: Theme | PartialTheme, baseThemeType: BaseThemeType = BaseThemeType.Light): Theme {
+  if (theme) {
+    const baseTheme = baseThemeType === BaseThemeType.Light ? LIGHT_THEME : DARK_THEME;
+    return mergeWithDefaultTheme(theme, baseTheme);
+  }
+
+  return LIGHT_THEME;
+}
+
 function updateChartStore(props: SettingSpecProps) {
   const {
     chartStore,
     theme,
+    baseThemeType,
     rotation,
     rendering,
     animateData,
@@ -80,7 +93,8 @@ function updateChartStore(props: SettingSpecProps) {
   if (!chartStore) {
     return;
   }
-  chartStore.chartTheme = theme || LIGHT_THEME;
+
+  chartStore.chartTheme = getTheme(theme, baseThemeType);
   chartStore.chartRotation = rotation;
   chartStore.chartRendering = rendering;
   chartStore.animateData = animateData;
@@ -136,6 +150,7 @@ export class SettingsComponent extends PureComponent<SettingSpecProps> {
     animateData: true,
     showLegend: false,
     debug: false,
+    baseThemeType: BaseThemeType.Light,
     tooltip: {
       type: DEFAULT_TOOLTIP_TYPE,
       snap: DEFAULT_TOOLTIP_SNAP,

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -4,7 +4,7 @@ import { PureComponent } from 'react';
 import { DomainRange, Position, Rendering, Rotation } from '../lib/series/specs';
 import { DARK_THEME } from '../lib/themes/dark_theme';
 import { LIGHT_THEME } from '../lib/themes/light_theme';
-import { BaseThemeType, mergeWithDefaultTheme, PartialTheme, Theme } from '../lib/themes/theme';
+import { BaseThemeType, mergeWithDefaultTheme, PartialTheme, Theme, BaseThemeTypes } from '../lib/themes/theme';
 import { Domain } from '../lib/utils/domain';
 import { TooltipType, TooltipValueFormatter } from '../lib/utils/interactions';
 import {
@@ -57,9 +57,9 @@ export interface SettingSpecProps {
   xDomain?: Domain | DomainRange;
 }
 
-function getTheme(theme?: Theme | PartialTheme, baseThemeType: BaseThemeType = BaseThemeType.Light): Theme {
+function getTheme(theme?: Theme | PartialTheme, baseThemeType: BaseThemeType = BaseThemeTypes.Light): Theme {
   if (theme) {
-    const baseTheme = baseThemeType === BaseThemeType.Light ? LIGHT_THEME : DARK_THEME;
+    const baseTheme = baseThemeType === BaseThemeTypes.Light ? LIGHT_THEME : DARK_THEME;
     return mergeWithDefaultTheme(theme, baseTheme);
   }
 
@@ -150,7 +150,7 @@ export class SettingsComponent extends PureComponent<SettingSpecProps> {
     animateData: true,
     showLegend: false,
     debug: false,
-    baseThemeType: BaseThemeType.Light,
+    baseThemeType: BaseThemeTypes.Light,
     tooltip: {
       type: DEFAULT_TOOLTIP_TYPE,
       snap: DEFAULT_TOOLTIP_SNAP,

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -6,6 +6,7 @@ import {
   AreaSeries,
   Axis,
   BarSeries,
+  BaseThemeType,
   Chart,
   CurveType,
   CustomSeriesColorsMap,
@@ -361,6 +362,51 @@ storiesOf('Stylings', module)
           yAccessors={['y']}
           curve={CurveType.CURVE_MONOTONE_X}
           data={data3}
+        />
+      </Chart>
+    );
+  })
+  .add('partial custom theme', () => {
+    const customPartialTheme: PartialTheme = {
+      barSeriesStyle: {
+        border: {
+          stroke: color('BarBorderStroke', 'white'),
+          visible: true,
+        },
+      },
+    };
+
+    return (
+      <Chart className="story-chart">
+        <Settings
+          showLegend
+          theme={customPartialTheme}
+          baseThemeType={BaseThemeType.Light}
+          legendPosition={Position.Right}
+        />
+        <Axis id={getAxisId('bottom')} position={Position.Bottom} title="Bottom axis" showOverlappingTicks={true} />
+        <Axis
+          id={getAxisId('left2')}
+          title="Left axis"
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+        <Axis id={getAxisId('top')} position={Position.Top} title="Top axis" showOverlappingTicks={true} />
+        <Axis
+          id={getAxisId('right')}
+          title="Right axis"
+          position={Position.Right}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          splitSeriesAccessors={['g']}
+          stackAccessors={['x']}
+          data={data1}
         />
       </Chart>
     );

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -6,7 +6,6 @@ import {
   AreaSeries,
   Axis,
   BarSeries,
-  BaseThemeType,
   Chart,
   CurveType,
   CustomSeriesColorsMap,
@@ -23,6 +22,7 @@ import {
   Position,
   ScaleType,
   Settings,
+  BaseThemeTypes,
 } from '../src/';
 import * as TestDatasets from '../src/lib/series/utils/test_dataset';
 import { palettes } from '../src/lib/themes/colors';
@@ -381,7 +381,7 @@ storiesOf('Stylings', module)
         <Settings
           showLegend
           theme={customPartialTheme}
-          baseThemeType={BaseThemeType.Light}
+          baseThemeType={BaseThemeTypes.Light}
           legendPosition={Position.Right}
         />
         <Axis id={getAxisId('bottom')} position={Position.Bottom} title="Bottom axis" showOverlappingTicks={true} />

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig",
-  "include": ["stories/**/*"]
-}

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,23 +10,12 @@
     "esModuleInterop": true,
     "module": "CommonJS",
     "target": "es5",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
+    "lib": ["esnext", "dom"],
     "moduleResolution": "node",
     "jsx": "react",
     "allowJs": false,
     "skipLibCheck": true,
-    "downlevelIteration": true,
-    "typeRoots": [
-      "node_modules/**/@types",
-      "node_modules/@types",
-      "src/@types"
-    ]
+    "downlevelIteration": true
   },
-  "include": [
-    "src/**/*",
-    "stories/**/*"
-  ]
+  "include": ["src/**/*", "stories/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "outDir": "./dist/",
     "noImplicitAny": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "sourceMap": true,
     "preserveConstEnums": true,
     "strict": true,
@@ -18,12 +18,15 @@
     "jsx": "react",
     "allowJs": false,
     "skipLibCheck": true,
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "typeRoots": [
+      "node_modules/**/@types",
+      "node_modules/@types",
+      "src/@types"
+    ]
   },
   "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "**/*.test.*"
+    "src/**/*",
+    "stories/**/*"
   ]
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,9 +1,8 @@
 {
+  "compilerOptions": {
+    "noUnusedLocals": true
+  },
   "extends": "./tsconfig",
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "**/*.test.*"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.*"]
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "**/*.test.*"
+  ]
+}


### PR DESCRIPTION
## Summary
Issue #201

Allow partial theme object for chart `Settings`

You can now specify a `PartialTheme` to pass to the `Settings` component where every field in the full `Theme` type is *recursively* optional.

### Before
If you wanted to change one property in a nested type lets say `left` margin we want to set to `0`. You would need to include the default/base values of `right`, `top` and `bottom` margins for those to carry over, otherwise, they will be removed!

```ts
const theme: PartialTheme = {
  chartMargins: {
    left: 0,
    right: 10,
    top: 10,
    bottom: 10,
  },
};
```

### After
You *ONLY* need to include the values you want, then pass that to the `Settings` component.
```ts
const theme: PartialTheme = {
  chartMargins: {
    left: 0,
  },
};
```

There is also no need to merge this `PartialTheme` theme using the `mergeWithDefaultTheme` function, although you can if you really want to 😏. This will happen automatically within the `Settings`. By default, it will **deep-merge** your `PartialTheme` with the `LIGHT_THEME` as a base. However, if you would like to set the base to be something else you can pass that as a prop.

```tsx
<Chart className="story-chart-dark">
  <Settings
    theme={customPartialTheme}
    baseThemeType={BaseThemeTypes.Dark}
  />
  ...
/>

```

### Checklist

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
