### PR TITLE
feat(brush): show crosshair cursor when brush enabled 

### DIFF
--- a/src/components/_container.scss
+++ b/src/components/_container.scss
@@ -13,3 +13,7 @@
     }
   }
 }
+
+.echChart--isBrushEnabled {
+  cursor: crosshair;
+}

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { inject, observer } from 'mobx-react';
 import React from 'react';
 import { Layer, Rect, Stage } from 'react-konva';
@@ -376,6 +377,10 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
       clipHeight: chartDimensions.height,
     };
 
+    const className = classNames({
+      'echChart--isBrushEnabled': this.props.chartStore!.isCrosshairCursorVisible.get(),
+    });
+
     return (
       <div
         style={{
@@ -395,6 +400,7 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         onClick={() => {
           this.props.chartStore!.handleChartClick();
         }}
+        className={className}
       >
         <Stage
           width={parentDimensions.width}

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -836,4 +836,34 @@ describe('Chart Store', () => {
     expectedTooltipValues.set('seriesKey', 123);
     expect(store.legendItemTooltipValues.get()).toEqual(expectedTooltipValues);
   });
+  describe('can determine if crosshair cursor is visible', () => {
+    const brushEndListener = (): void => {
+      return;
+    };
+
+    beforeEach(() => {
+      store.xScale = new ScaleContinuous(ScaleType.Linear, [0, 100], [0, 100]);
+    });
+
+    test('when cursor is outside of chart bounds', () => {
+      store.cursorPosition.x = -1;
+      store.cursorPosition.y = -1;
+      store.onBrushEndListener = brushEndListener;
+      expect(store.isCrosshairCursorVisible.get()).toBe(false);
+    });
+
+    test('when cursor is within chart bounds and brush enabled', () => {
+      store.cursorPosition.x = 10;
+      store.cursorPosition.y = 10;
+      store.onBrushEndListener = brushEndListener;
+      expect(store.isCrosshairCursorVisible.get()).toBe(true);
+    });
+
+    test('when cursor is within chart bounds and brush disabled', () => {
+      store.cursorPosition.x = 10;
+      store.cursorPosition.y = 10;
+      store.onBrushEndListener = undefined;
+      expect(store.isCrosshairCursorVisible.get()).toBe(false);
+    });
+  });
 });

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -228,7 +228,7 @@ export class ChartStore {
     const xPos = this.cursorPosition.x;
     const yPos = this.cursorPosition.y;
 
-    if (yPos === -1 || xPos === -1) {
+    if (yPos < 0 || xPos < 0) {
       return false;
     }
 

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -222,6 +222,20 @@ export class ChartStore {
   });
 
   /**
+   * determine if crosshair cursor should be visible based on cursor position and brush enablement
+   */
+  isCrosshairCursorVisible = computed(() => {
+    const xPos = this.cursorPosition.x;
+    const yPos = this.cursorPosition.y;
+
+    if (yPos === -1 || xPos === -1) {
+      return false;
+    }
+
+    return this.isBrushEnabled();
+  });
+
+  /**
    * x and y values are relative to the container.
    */
   setCursorPosition = action((x: number, y: number) => {


### PR DESCRIPTION
## Summary

This PR adds the functionality that when `onBrushEndListener` is defined and the cursor is within the chart bounds (excluding the axes), the cursor will appear as a crosshair instead of the pointer or default.

Notice below (from Kibana Discover) that the bottom version (the original implementation) has the crosshair cursor visible to indicate to the user that the brushing is possible, while in the top version (elastic-charts version), the cursor remains the default.

![discover_crosshair](https://user-images.githubusercontent.com/452850/59715932-bb662b80-91c9-11e9-8489-8e8b3f55504c.gif)

This PR adds a new computed method to the chart store that checks the cursor position and `isBrushEnabled` to determine if the crosshair cursor should be visible.

![crosshair_cursor](https://user-images.githubusercontent.com/452850/59716157-4a734380-91ca-11e9-87e8-edeb1580c489.gif)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
