### PR TITLE
feat(annotation): position custom rect_annotation tooltip by elastic-charts styles

### DIFF
--- a/src/components/annotation_tooltips.tsx
+++ b/src/components/annotation_tooltips.tsx
@@ -40,12 +40,7 @@ class AnnotationTooltipComponent extends React.Component<AnnotationTooltipProps>
         return <LineAnnotationTooltip {...props} />;
       }
       case 'rectangle': {
-        const props = { details, position };
-
-        if (tooltipState.renderTooltip) {
-          return tooltipState.renderTooltip(position, details);
-        }
-
+        const props = { details, position, customTooltip: tooltipState.renderTooltip };
         return <RectAnnotationTooltip {...props} />;
       }
       default:
@@ -119,12 +114,14 @@ export const AnnotationTooltip = inject('chartStore')(observer(AnnotationTooltip
 function RectAnnotationTooltip(props: {
   details?: string;
   position: { transform: string; top: number; left: number };
+  customTooltip?: (details?: string) => JSX.Element;
 }) {
-  const { details, position } = props;
+  const { details, position, customTooltip } = props;
+  const tooltipContent = customTooltip ? customTooltip(details) : details;
   return (
     <div className="echAnnotation__tooltip" style={{ ...position }}>
       <div className="echAnnotation__details">
-        <div className="echAnnotation__detailsText">{details}</div>
+        <div className="echAnnotation__detailsText">{tooltipContent}</div>
       </div>
     </div>
   );

--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -292,7 +292,7 @@ export interface RectAnnotationDatum {
 export type RectAnnotationSpec = BaseAnnotationSpec & {
   annotationType: 'rectangle';
   /** Custom rendering function for tooltip */
-  renderTooltip?: (position: { transform: string; top: number; left: number }, details?: string) => JSX.Element;
+  renderTooltip?: (details?: string) => JSX.Element;
   /** Data values defined with coordinates and details */
   dataValues: RectAnnotationDatum[];
   /** Custom annotation style */

--- a/src/state/annotation_utils.ts
+++ b/src/state/annotation_utils.ts
@@ -31,7 +31,7 @@ export interface AnnotationTooltipState {
   transform: string;
   top?: number;
   left?: number;
-  renderTooltip?: (position: { transform: string; top: number; left: number }, details?: string) => JSX.Element;
+  renderTooltip?: (details?: string) => JSX.Element;
 }
 export interface AnnotationDetails {
   headerText?: string;
@@ -925,7 +925,7 @@ export function computeRectAnnotationTooltipState(
   annotationRects: AnnotationRectProps[],
   chartRotation: Rotation,
   chartDimensions: Dimensions,
-  renderTooltip?: (position: { transform: string; top: number; left: number }, details?: string) => JSX.Element,
+  renderTooltip?: (details?: string) => JSX.Element,
 ): AnnotationTooltipState {
   const cursorPosition = getRotatedCursor(rawCursorPosition, chartDimensions, chartRotation);
 

--- a/stories/annotations.tsx
+++ b/stories/annotations.tsx
@@ -1,6 +1,6 @@
 import { array, boolean, color, number, select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
-import React, { CSSProperties } from 'react';
+import React from 'react';
 import {
   AnnotationDomainTypes,
   Axis,
@@ -508,16 +508,9 @@ storiesOf('Annotations', module)
     };
 
     const hasCustomTooltip = boolean('has custom tooltip render', false);
-    const tooltipStyle: CSSProperties = {
-      position: 'absolute',
-      backgroundColor: '#e76f6f',
-      color: '#e6e6e6',
-      overflow: 'hidden',
-      overflowWrap: 'break-word',
-      width: '120px',
-    };
-    const customTooltip = (position: { transform: string; top: number; left: number }, details?: string) => (
-      <div style={{ ...tooltipStyle, ...position }}>
+
+    const customTooltip = (details?: string) => (
+      <div>
         <Icon type="alert" />
         {details}
       </div>


### PR DESCRIPTION
BREAKING CHANGE: this changes the type signature of `RectAnnotation.renderTooltip?` from `(position, details) => JSX.Element` to `(details) => JSX.Element`.  This allows the user to pass in a custom element without having to do the heavy lifting of writing the container positioning styles themselves.

## Summary

Previously, the `renderTooltip?` property of a `RectAnnotationSpec` was used in such a way that if defined, the returned component would be used instead of the default tooltip component to render the tooltip details.  However, it was implemented in a way that required the user to also use the position information and write their own styles to position the tooltip correctly.  This lends to a not great developer user experience when the user just wants to pass a custom component (as in the Storybook case where we just need to include an icon) because then the developer needs to write their own CSS styles to handle the position of the tooltip container itself.

Instead, now we embed the custom component within the tooltip container so that the user does not need to worry about positioning.  This also helps with making it so that the user still has customization capabilities while remaining some consistence with respect to the rest of the elastic-chart internal style.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
