### PR TITLE
feat(series): stack series in percentage mode

### DIFF
--- a/src/lib/series/domains/y_domain.test.ts
+++ b/src/lib/series/domains/y_domain.test.ts
@@ -691,4 +691,109 @@ describe('Y Domain', () => {
     const errorMessage = 'custom yDomain for a is invalid, computed min is greater than custom max';
     expect(attemptToMerge).toThrowError(errorMessage);
   });
+  test('Should merge Y domain with stacked as percentage', () => {
+    const dataSeries1: RawDataSeries[] = [
+      {
+        specId: getSpecId('a'),
+        key: [''],
+        seriesColorKey: '',
+        data: [{ x: 1, y1: 2 }, { x: 2, y1: 2 }, { x: 3, y1: 2 }, { x: 4, y1: 5 }],
+      },
+      {
+        specId: getSpecId('a'),
+        key: [''],
+        seriesColorKey: '',
+        data: [{ x: 1, y1: 2 }, { x: 4, y1: 7 }],
+      },
+    ];
+    const dataSeries2: RawDataSeries[] = [
+      {
+        specId: getSpecId('a'),
+        key: [''],
+        seriesColorKey: '',
+        data: [{ x: 1, y1: 10 }, { x: 2, y1: 10 }, { x: 3, y1: 2 }, { x: 4, y1: 5 }],
+      },
+    ];
+    const specDataSeries = new Map();
+    specDataSeries.set(getSpecId('a'), dataSeries1);
+    specDataSeries.set(getSpecId('b'), dataSeries2);
+    const mergedDomain = mergeYDomain(
+      specDataSeries,
+      [
+        {
+          seriesType: 'area',
+          yScaleType: ScaleType.Linear,
+          groupId: getGroupId('a'),
+          id: getSpecId('a'),
+          stackAccessors: ['a'],
+          yScaleToDataExtent: true,
+          stackAsPercentage: true,
+        },
+        {
+          seriesType: 'area',
+          yScaleType: ScaleType.Log,
+          groupId: getGroupId('a'),
+          id: getSpecId('b'),
+          yScaleToDataExtent: true,
+        },
+      ],
+      new Map(),
+    );
+    expect(mergedDomain).toEqual([
+      {
+        groupId: 'a',
+        domain: [0, 1],
+        scaleType: ScaleType.Linear,
+        isBandScale: false,
+        type: 'yDomain',
+      },
+    ]);
+  });
+  test('Should merge Y domain with as percentage regadless of custom domains', () => {
+    const groupId = getGroupId('a');
+
+    const dataSeries: RawDataSeries[] = [
+      {
+        specId: getSpecId('a'),
+        key: [''],
+        seriesColorKey: '',
+        data: [{ x: 1, y1: 2 }, { x: 2, y1: 2 }, { x: 3, y1: 2 }, { x: 4, y1: 5 }],
+      },
+      {
+        specId: getSpecId('a'),
+        key: [''],
+        seriesColorKey: '',
+        data: [{ x: 1, y1: 2 }, { x: 4, y1: 7 }],
+      },
+    ];
+    const specDataSeries = new Map();
+    specDataSeries.set(getSpecId('a'), dataSeries);
+    const domainsByGroupId = new Map<GroupId, DomainRange>();
+    domainsByGroupId.set(groupId, { min: 2, max: 20 });
+
+    const mergedDomain = mergeYDomain(
+      specDataSeries,
+      [
+        {
+          seriesType: 'area',
+          yScaleType: ScaleType.Linear,
+          groupId,
+          id: getSpecId('a'),
+          stackAccessors: ['a'],
+          yScaleToDataExtent: true,
+          stackAsPercentage: true,
+        },
+      ],
+      domainsByGroupId,
+    );
+    expect(mergedDomain).toEqual([
+      {
+        type: 'yDomain',
+        groupId,
+        domain: [0, 1],
+        scaleType: ScaleType.Linear,
+        isBandScale: false,
+      },
+    ]);
+  });
 });

--- a/src/lib/series/domains/y_domain.ts
+++ b/src/lib/series/domains/y_domain.ts
@@ -39,9 +39,7 @@ export function mergeYDomain(
   const yDomains = specsByGroupIdsEntries.map(
     ([groupId, groupSpecs]): YDomain => {
       const groupYScaleType = coerceYScaleTypes([...groupSpecs.stacked, ...groupSpecs.nonStacked]);
-      const isPercentageStack = groupSpecs.stacked.some((spec) => {
-        return Boolean(spec.stackAsPercentage);
-      });
+      const { isPercentageStack } = groupSpecs;
 
       let domain: number[];
       if (isPercentageStack) {
@@ -152,10 +150,14 @@ function computeYNonStackedDomain(dataseries: RawDataSeries[], scaleToExtent: bo
   return computeContinuousDataDomain([...yValues.values()], identity, scaleToExtent);
 }
 export function splitSpecsByGroupId(specs: YBasicSeriesSpec[]) {
-  const specsByGroupIds = new Map<GroupId, { stacked: YBasicSeriesSpec[]; nonStacked: YBasicSeriesSpec[] }>();
+  const specsByGroupIds = new Map<
+    GroupId,
+    { isPercentageStack: boolean; stacked: YBasicSeriesSpec[]; nonStacked: YBasicSeriesSpec[] }
+  >();
   // split each specs by groupId and by stacked or not
   specs.forEach((spec) => {
     const group = specsByGroupIds.get(spec.groupId) || {
+      isPercentageStack: false,
       stacked: [],
       nonStacked: [],
     };
@@ -163,6 +165,9 @@ export function splitSpecsByGroupId(specs: YBasicSeriesSpec[]) {
       group.stacked.push(spec);
     } else {
       group.nonStacked.push(spec);
+    }
+    if (spec.stackAsPercentage === true) {
+      group.isPercentageStack = true;
     }
     specsByGroupIds.set(spec.groupId, group);
   });

--- a/src/lib/series/domains/y_domain.ts
+++ b/src/lib/series/domains/y_domain.ts
@@ -16,15 +16,8 @@ export type YDomain = BaseDomain & {
 };
 export type YBasicSeriesSpec = Pick<
   BasicSeriesSpec,
-  | 'id'
-  | 'seriesType'
-  | 'yScaleType'
-  | 'groupId'
-  | 'stackAccessors'
-  | 'yScaleToDataExtent'
-  | 'colorAccessors'
-  | 'stackAsPercentage'
->;
+  'id' | 'seriesType' | 'yScaleType' | 'groupId' | 'stackAccessors' | 'yScaleToDataExtent' | 'colorAccessors'
+> & { stackAsPercentage?: boolean };
 
 export function mergeYDomain(
   dataSeries: Map<SpecId, RawDataSeries[]>,

--- a/src/lib/series/domains/y_domain.ts
+++ b/src/lib/series/domains/y_domain.ts
@@ -43,9 +43,9 @@ export function mergeYDomain(
         return Boolean(spec.stackAsPercentage);
       });
 
-      let groupDomain: number[];
+      let domain: number[];
       if (isPercentageStack) {
-        groupDomain = computeContinuousDataDomain([0, 1], identity);
+        domain = computeContinuousDataDomain([0, 1], identity);
       } else {
         // compute stacked domain
         const isStackedScaleToExtent = groupSpecs.stacked.some((spec) => {
@@ -62,35 +62,33 @@ export function mergeYDomain(
         const nonStackedDomain = computeYNonStackedDomain(nonStackedDataSeries, isNonStackedScaleToExtent);
 
         // merge stacked and non stacked domain together
-        groupDomain = computeContinuousDataDomain(
+        domain = computeContinuousDataDomain(
           [...stackedDomain, ...nonStackedDomain],
           identity,
           isStackedScaleToExtent || isNonStackedScaleToExtent,
         );
-      }
 
-      const [computedDomainMin, computedDomainMax] = groupDomain;
-      let domain = groupDomain;
+        const [computedDomainMin, computedDomainMax] = domain;
 
-      const customDomain = domainsByGroupId.get(groupId);
+        const customDomain = domainsByGroupId.get(groupId);
 
-      if (customDomain && isCompleteBound(customDomain)) {
-        // Don't need to check min > max because this has been validated on axis domain merge
-        domain = [customDomain.min, customDomain.max];
-      } else if (customDomain && isLowerBound(customDomain)) {
-        if (customDomain.min > computedDomainMax) {
-          throw new Error(`custom yDomain for ${groupId} is invalid, custom min is greater than computed max`);
+        if (customDomain && isCompleteBound(customDomain)) {
+          // Don't need to check min > max because this has been validated on axis domain merge
+          domain = [customDomain.min, customDomain.max];
+        } else if (customDomain && isLowerBound(customDomain)) {
+          if (customDomain.min > computedDomainMax) {
+            throw new Error(`custom yDomain for ${groupId} is invalid, custom min is greater than computed max`);
+          }
+
+          domain = [customDomain.min, computedDomainMax];
+        } else if (customDomain && isUpperBound(customDomain)) {
+          if (computedDomainMin > customDomain.max) {
+            throw new Error(`custom yDomain for ${groupId} is invalid, computed min is greater than custom max`);
+          }
+
+          domain = [computedDomainMin, customDomain.max];
         }
-
-        domain = [customDomain.min, computedDomainMax];
-      } else if (customDomain && isUpperBound(customDomain)) {
-        if (computedDomainMin > customDomain.max) {
-          throw new Error(`custom yDomain for ${groupId} is invalid, computed min is greater than custom max`);
-        }
-
-        domain = [computedDomainMin, customDomain.max];
       }
-
       return {
         type: 'yDomain',
         isBandScale: false,

--- a/src/lib/series/legend.ts
+++ b/src/lib/series/legend.ts
@@ -56,7 +56,7 @@ export function computeLegend(
       isLegendItemVisible: !hideInLegend,
       displayValue: {
         raw: series.lastValue,
-        formatted: formatter(series.lastValue),
+        formatted: isSeriesVisible ? formatter(series.lastValue) : undefined,
       },
     });
   });

--- a/src/lib/series/series.ts
+++ b/src/lib/series/series.ts
@@ -219,12 +219,20 @@ export function getFormattedDataseries(
   }[] = [];
 
   specsByGroupIdsEntries.forEach(([groupId, groupSpecs]) => {
+    const isPercentageStack = groupSpecs.stacked.some((spec) => {
+      return Boolean(spec.stackAsPercentage);
+    });
     // format stacked data series
     const stackedDataSeries = getRawDataSeries(groupSpecs.stacked, dataSeries);
+    const stackedDataSeriesValues = formatStackedDataSeriesValues(
+      stackedDataSeries.rawDataSeries,
+      false,
+      isPercentageStack,
+    );
     stackedFormattedDataSeries.push({
       groupId,
       counts: stackedDataSeries.counts,
-      dataSeries: formatStackedDataSeriesValues(stackedDataSeries.rawDataSeries, false),
+      dataSeries: stackedDataSeriesValues,
     });
 
     // format non stacked data series

--- a/src/lib/series/series.ts
+++ b/src/lib/series/series.ts
@@ -219,9 +219,7 @@ export function getFormattedDataseries(
   }[] = [];
 
   specsByGroupIdsEntries.forEach(([groupId, groupSpecs]) => {
-    const isPercentageStack = groupSpecs.stacked.some((spec) => {
-      return Boolean(spec.stackAsPercentage);
-    });
+    const { isPercentageStack } = groupSpecs;
     // format stacked data series
     const stackedDataSeries = getRawDataSeries(groupSpecs.stacked, dataSeries);
     const stackedDataSeriesValues = formatStackedDataSeriesValues(

--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -96,6 +96,10 @@ export interface SeriesAccessors {
   splitSeriesAccessors?: Accessor[];
   /** An array of fields thats indicates the stack membership */
   stackAccessors?: Accessor[];
+  /**
+   * Stack each series in percentage for each point.
+   */
+  stackAsPercentage?: boolean;
   /** An optional array of field name thats indicates the stack membership */
   colorAccessors?: Accessor[];
 }

--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -96,10 +96,6 @@ export interface SeriesAccessors {
   splitSeriesAccessors?: Accessor[];
   /** An array of fields thats indicates the stack membership */
   stackAccessors?: Accessor[];
-  /**
-   * Stack each series in percentage for each point.
-   */
-  stackAsPercentage?: boolean;
   /** An optional array of field name thats indicates the stack membership */
   colorAccessors?: Accessor[];
 }
@@ -140,6 +136,10 @@ export type BarSeriesSpec = BasicSeriesSpec & {
   /** If true, will stack all BarSeries and align bars to ticks (instead of centered on ticks) */
   enableHistogramMode?: boolean;
   barSeriesStyle?: CustomBarSeriesStyle;
+  /**
+   * Stack each series in percentage for each point.
+   */
+  stackAsPercentage?: boolean;
 };
 
 /**
@@ -171,6 +171,10 @@ export type AreaSeriesSpec = BasicSeriesSpec &
     /** The type of interpolator to be used to interpolate values between points */
     curve?: CurveType;
     areaSeriesStyle?: AreaSeriesStyle;
+    /**
+     * Stack each series in percentage for each point.
+     */
+    stackAsPercentage?: boolean;
   };
 
 interface HistogramConfig {

--- a/src/lib/series/stacked_percent_series_utils.test.ts
+++ b/src/lib/series/stacked_percent_series_utils.test.ts
@@ -1,0 +1,293 @@
+import { getSpecId } from '../utils/ids';
+import { RawDataSeries } from './series';
+import { formatStackedDataSeriesValues } from './stacked_series_utils';
+
+describe('Stacked Series Utils', () => {
+  const STANDARD_DATA_SET: RawDataSeries[] = [
+    {
+      data: [
+        {
+          x: 0,
+          y1: 10,
+        },
+      ],
+      key: [],
+      seriesColorKey: 'color-key',
+      specId: getSpecId('spec1'),
+    },
+    {
+      data: [
+        {
+          x: 0,
+          y1: 20,
+        },
+      ],
+      key: [],
+      seriesColorKey: 'color-key',
+      specId: getSpecId('spec2'),
+    },
+    {
+      data: [
+        {
+          x: 0,
+          y1: 70,
+        },
+      ],
+      key: [],
+      seriesColorKey: 'color-key',
+      specId: getSpecId('spec3'),
+    },
+  ];
+  const WITH_NULL_DATASET: RawDataSeries[] = [
+    {
+      data: [
+        {
+          x: 0,
+          y1: 10,
+        },
+      ],
+      key: [],
+      seriesColorKey: 'color-key',
+      specId: getSpecId('spec1'),
+    },
+    {
+      data: [
+        {
+          x: 0,
+          y1: null,
+        },
+      ],
+      key: [],
+      seriesColorKey: 'color-key',
+      specId: getSpecId('spec2'),
+    },
+    {
+      data: [
+        {
+          x: 0,
+          y1: 30,
+        },
+      ],
+      key: [],
+      seriesColorKey: 'color-key',
+      specId: getSpecId('spec3'),
+    },
+  ];
+  const STANDARD_DATA_SET_WY0: RawDataSeries[] = [
+    {
+      data: [
+        {
+          x: 0,
+          y0: 2,
+          y1: 10,
+        },
+      ],
+      key: [],
+      seriesColorKey: 'color-key',
+      specId: getSpecId('spec1'),
+    },
+    {
+      data: [
+        {
+          x: 0,
+          y0: 4,
+          y1: 20,
+        },
+      ],
+      key: [],
+      seriesColorKey: 'color-key',
+      specId: getSpecId('spec2'),
+    },
+    {
+      data: [
+        {
+          x: 0,
+          y0: 6,
+          y1: 70,
+        },
+      ],
+      key: [],
+      seriesColorKey: 'color-key',
+      specId: getSpecId('spec3'),
+    },
+  ];
+  const WITH_NULL_DATASET_WY0: RawDataSeries[] = [
+    {
+      data: [
+        {
+          x: 0,
+          y0: 2,
+          y1: 10,
+        },
+      ],
+      key: [],
+      seriesColorKey: 'color-key',
+      specId: getSpecId('spec1'),
+    },
+    {
+      data: [
+        {
+          x: 0,
+          y1: null,
+        },
+      ],
+      key: [],
+      seriesColorKey: 'color-key',
+      specId: getSpecId('spec2'),
+    },
+    {
+      data: [
+        {
+          x: 0,
+          y0: 6,
+          y1: 90,
+        },
+      ],
+      key: [],
+      seriesColorKey: 'color-key',
+      specId: getSpecId('spec3'),
+    },
+  ];
+  const DATA_SET_WITH_NULL_2: RawDataSeries[] = [
+    {
+      specId: getSpecId('spec1'),
+      key: ['a'],
+      seriesColorKey: 'a',
+      data: [{ x: 1, y1: 10 }, { x: 2, y1: 20 }, { x: 4, y1: 40 }],
+    },
+    {
+      specId: getSpecId('spec1'),
+      key: ['b'],
+      seriesColorKey: 'b',
+      data: [{ x: 1, y1: 90 }, { x: 3, y1: 30 }],
+    },
+  ];
+
+  describe.only('Format stacked dataset', () => {
+    test('format data without nulls', () => {
+      const formattedData = formatStackedDataSeriesValues(STANDARD_DATA_SET, false, true);
+      const data0 = formattedData[0].data[0];
+      expect(data0.initialY1).toBe(0.1);
+      expect(data0.y0).toBe(0);
+      expect(data0.y1).toBe(0.1);
+
+      const data1 = formattedData[1].data[0];
+      expect(data1.initialY1).toBe(0.2);
+      expect(data1.y0).toBe(0.1);
+      expect(data1.y1).toBeCloseTo(0.3);
+
+      const data2 = formattedData[2].data[0];
+      expect(data2.initialY1).toBe(0.7);
+      expect(data2.y0).toBe(0.3);
+      expect(data2.y1).toBe(1);
+    });
+    test('format data with nulls', () => {
+      const formattedData = formatStackedDataSeriesValues(WITH_NULL_DATASET, false, true);
+      const data0 = formattedData[0].data[0];
+      expect(data0.initialY1).toBe(0.25);
+      expect(data0.y0).toBe(0);
+      expect(data0.y1).toBe(0.25);
+
+      expect(formattedData[1].data[0]).toEqual({
+        datum: undefined,
+        initialY0: null,
+        initialY1: null,
+        x: 0,
+        y1: null,
+        y0: 0.25,
+      });
+
+      const data2 = formattedData[2].data[0];
+      expect(data2.initialY1).toBe(0.75);
+      expect(data2.y0).toBe(0.25);
+      expect(data2.y1).toBe(1);
+    });
+    test('format data without nulls with y0 values', () => {
+      const formattedData = formatStackedDataSeriesValues(STANDARD_DATA_SET_WY0, false, true);
+      const data0 = formattedData[0].data[0];
+      expect(data0.initialY0).toBe(0.02);
+      expect(data0.initialY1).toBe(0.1);
+      expect(data0.y0).toBe(0.02);
+      expect(data0.y1).toBe(0.1);
+
+      const data1 = formattedData[1].data[0];
+      expect(data1.initialY0).toBe(0.04);
+      expect(data1.initialY1).toBe(0.2);
+      expect(data1.y0).toBe(0.14);
+      expect(data1.y1).toBeCloseTo(0.3, 5);
+
+      const data2 = formattedData[2].data[0];
+      expect(data2.initialY0).toBe(0.06);
+      expect(data2.initialY1).toBe(0.7);
+      expect(data2.y0).toBe(0.36);
+      expect(data2.y1).toBe(1);
+    });
+    test('format data with nulls', () => {
+      const formattedData = formatStackedDataSeriesValues(WITH_NULL_DATASET_WY0, false, true);
+      const data0 = formattedData[0].data[0];
+      expect(data0.initialY0).toBe(0.02);
+      expect(data0.initialY1).toBe(0.1);
+      expect(data0.y0).toBe(0.02);
+      expect(data0.y1).toBe(0.1);
+
+      const data1 = formattedData[1].data[0];
+      expect(data1.initialY0).toBe(null);
+      expect(data1.initialY1).toBe(null);
+      expect(data1.y0).toBe(0.1);
+      expect(data1.y1).toBe(null);
+
+      const data2 = formattedData[2].data[0];
+      expect(data2.initialY0).toBe(0.06);
+      expect(data2.initialY1).toBe(0.9);
+      expect(data2.y0).toBe(0.16);
+      expect(data2.y1).toBe(1);
+    });
+    test('format data without nulls on second series', () => {
+      const formattedData = formatStackedDataSeriesValues(DATA_SET_WITH_NULL_2, false, true);
+      expect(formattedData.length).toBe(2);
+      expect(formattedData[0].data.length).toBe(3);
+      expect(formattedData[1].data.length).toBe(2);
+
+      expect(formattedData[0].data[0]).toEqual({
+        datum: undefined,
+        initialY0: null,
+        initialY1: 0.1,
+        x: 1,
+        y0: 0,
+        y1: 0.1,
+      });
+      expect(formattedData[0].data[1]).toEqual({
+        datum: undefined,
+        initialY0: null,
+        initialY1: 1,
+        x: 2,
+        y0: 0,
+        y1: 1,
+      });
+      expect(formattedData[0].data[2]).toEqual({
+        datum: undefined,
+        initialY0: null,
+        initialY1: 1,
+        x: 4,
+        y0: 0,
+        y1: 1,
+      });
+      expect(formattedData[1].data[0]).toEqual({
+        datum: undefined,
+        initialY0: null,
+        initialY1: 0.9,
+        x: 1,
+        y0: 0.1,
+        y1: 1,
+      });
+      expect(formattedData[1].data[1]).toEqual({
+        datum: undefined,
+        initialY0: null,
+        initialY1: 1,
+        x: 3,
+        y0: 0,
+        y1: 1,
+      });
+    });
+  });
+});

--- a/src/lib/series/stacked_series_utils.test.ts
+++ b/src/lib/series/stacked_series_utils.test.ts
@@ -182,6 +182,7 @@ describe('Stacked Series Utils', () => {
       expect(x0StackArray).toBeDefined();
       expect(x0StackArray.length).toBe(3);
       expect(x0StackArray).toEqual([10, 20, 30]);
+      // expect(x0StackArray).toEqual([10, 20, 30]);
     });
     test('with values with nulls', () => {
       const stackedMap = getYValueStackMap(WITH_NULL_DATASET);
@@ -206,7 +207,9 @@ describe('Stacked Series Utils', () => {
       expect(computedStackedMap.size).toBe(1);
       const x0Array = computedStackedMap.get(0)!;
       expect(x0Array).toBeDefined();
-      expect(x0Array).toEqual([0, 10, 30, 60]);
+      expect(x0Array.values).toEqual([0, 10, 30, 60]);
+      expect(x0Array.percent).toEqual([0, 0.16666666666666666, 0.5, 1]);
+      expect(x0Array.total).toBe(60);
     });
     test('with null values', () => {
       const stackedMap = getYValueStackMap(WITH_NULL_DATASET);
@@ -214,7 +217,9 @@ describe('Stacked Series Utils', () => {
       expect(computedStackedMap.size).toBe(1);
       const x0Array = computedStackedMap.get(0)!;
       expect(x0Array).toBeDefined();
-      expect(x0Array).toEqual([0, 10, 10, 40]);
+      expect(x0Array.values).toEqual([0, 10, 10, 40]);
+      expect(x0Array.percent).toEqual([0, 0.25, 0.25, 1]);
+      expect(x0Array.total).toBe(40);
     });
   });
   describe('Format stacked dataset', () => {

--- a/src/lib/series/stacked_series_utils.ts
+++ b/src/lib/series/stacked_series_utils.ts
@@ -1,5 +1,11 @@
 import { DataSeries, DataSeriesDatum, RawDataSeries } from './series';
 
+interface StackedValues {
+  values: number[];
+  percent: number[];
+  total: number;
+}
+
 /**
  * Map each y value from a RawDataSeries on it's specific x value into,
  * ordering the stack based on the dataseries index.
@@ -26,22 +32,8 @@ export function getYValueStackMap(dataseries: RawDataSeries[]): Map<any, number[
 export function computeYStackedMapValues(
   yValueStackMap: Map<any, number[]>,
   scaleToExtent: boolean,
-): Map<
-  any,
-  {
-    values: number[];
-    percent: number[];
-    total: number;
-  }
-> {
-  const stackedValues = new Map<
-    any,
-    {
-      values: number[];
-      percent: number[];
-      total: number;
-    }
-  >();
+): Map<any, StackedValues> {
+  const stackedValues = new Map<any, StackedValues>();
 
   yValueStackMap.forEach((yStackArray, xValue) => {
     const stackArray = yStackArray.reduce(

--- a/src/lib/series/stacked_series_utils.ts
+++ b/src/lib/series/stacked_series_utils.ts
@@ -26,28 +26,65 @@ export function getYValueStackMap(dataseries: RawDataSeries[]): Map<any, number[
 export function computeYStackedMapValues(
   yValueStackMap: Map<any, number[]>,
   scaleToExtent: boolean,
-): Map<any, number[]> {
-  const stackedValues = new Map<any, number[]>();
+): Map<
+  any,
+  {
+    values: number[];
+    percent: number[];
+    total: number;
+  }
+> {
+  const stackedValues = new Map<
+    any,
+    {
+      values: number[];
+      percent: number[];
+      total: number;
+    }
+  >();
 
   yValueStackMap.forEach((yStackArray, xValue) => {
     const stackArray = yStackArray.reduce(
-      (stackedValue, currentValue, index) => {
-        if (stackedValue.length === 0) {
+      (acc, currentValue, index) => {
+        if (acc.values.length === 0) {
           if (scaleToExtent) {
-            return [currentValue, currentValue];
+            return {
+              values: [currentValue, currentValue],
+              total: currentValue,
+            };
           }
-          return [0, currentValue];
+          return {
+            values: [0, currentValue],
+            total: currentValue,
+          };
         }
-        return [...stackedValue, stackedValue[index] + currentValue];
+        return {
+          values: [...acc.values, acc.values[index] + currentValue],
+          total: acc.total + currentValue,
+        };
       },
-      [] as number[],
+      {
+        values: [] as number[],
+        total: 0,
+      },
     );
-    stackedValues.set(xValue, stackArray);
+    const percent = stackArray.values.map((value) => {
+      return value / stackArray.total;
+    });
+    stackedValues.set(xValue, {
+      values: stackArray.values,
+      percent,
+      total: stackArray.total,
+    });
   });
   return stackedValues;
 }
 
-export function formatStackedDataSeriesValues(dataseries: RawDataSeries[], scaleToExtent: boolean): DataSeries[] {
+export function formatStackedDataSeriesValues(
+  dataseries: RawDataSeries[],
+  scaleToExtent: boolean,
+  isPercentageMode: boolean = false,
+): DataSeries[] {
   const yValueStackMap = getYValueStackMap(dataseries);
 
   const stackedValues = computeYStackedMapValues(yValueStackMap, scaleToExtent);
@@ -55,17 +92,25 @@ export function formatStackedDataSeriesValues(dataseries: RawDataSeries[], scale
   const stackedDataSeries: DataSeries[] = dataseries.map((ds, seriesIndex) => {
     const newData: DataSeriesDatum[] = [];
     ds.data.forEach((data) => {
-      const { x, y1, datum } = data;
-      if (stackedValues.get(x) === undefined) {
+      const { x, datum } = data;
+      const stack = stackedValues.get(x);
+      if (!stack) {
         return;
       }
+      let y1: number | null = null;
+      if (isPercentageMode) {
+        y1 = data.y1 != null ? data.y1 / stack.total : null;
+      } else {
+        y1 = data.y1;
+      }
+      let y0 = isPercentageMode && data.y0 != null ? data.y0 / stack.total : data.y0;
       let computedY0: number | null;
       if (scaleToExtent) {
-        computedY0 = data.y0 ? data.y0 : y1;
+        computedY0 = y0 ? y0 : y1;
       } else {
-        computedY0 = data.y0 ? data.y0 : 0;
+        computedY0 = y0 ? y0 : 0;
       }
-      const initialY0 = data.y0 == null ? null : data.y0;
+      const initialY0 = y0 == null ? null : y0;
       if (seriesIndex === 0) {
         newData.push({
           x,
@@ -76,17 +121,20 @@ export function formatStackedDataSeriesValues(dataseries: RawDataSeries[], scale
           datum,
         });
       } else {
-        const stack = stackedValues.get(x);
-        if (!stack) {
-          return;
-        }
-        const stackY = stack[seriesIndex];
-        const stackedY1 = y1 !== null ? stackY + y1 : null;
-        let stackedY0: number | null = data.y0 == null ? stackY : stackY + data.y0;
-        // configure null y0 if y1 is null
-        // it's semantically right to say y0 is null if y1 is null
-        if (stackedY1 === null) {
-          stackedY0 = null;
+        const stackY = isPercentageMode ? stack.percent[seriesIndex] : stack.values[seriesIndex];
+        let stackedY1: number | null = null;
+        let stackedY0: number | null = null;
+        if (isPercentageMode) {
+          stackedY1 = y1 !== null ? stackY + y1 : null;
+          stackedY0 = y0 != null ? stackY + y0 : stackY;
+        } else {
+          stackedY1 = y1 !== null ? stackY + y1 : null;
+          stackedY0 = y0 != null ? stackY + y0 : stackY;
+          // configure null y0 if y1 is null
+          // it's semantically right to say y0 is null if y1 is null
+          if (stackedY1 === null) {
+            stackedY0 = null;
+          }
         }
         newData.push({
           x,
@@ -98,6 +146,7 @@ export function formatStackedDataSeriesValues(dataseries: RawDataSeries[], scale
         });
       }
     });
+
     return {
       specId: ds.specId,
       key: ds.key,

--- a/src/specs/bar_series.tsx
+++ b/src/specs/bar_series.tsx
@@ -18,6 +18,7 @@ export class BarSeriesSpecComponent extends PureComponent<BarSpecProps> {
     yScaleToDataExtent: false,
     hideInLegend: false,
     enableHistogramMode: false,
+    stackAsPercentage: false,
   };
   componentDidMount() {
     const { chartStore, children, ...config } = this.props;

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -135,21 +135,21 @@ export function computeSeriesDomains(
       }
     });
   });
-  const updatesSeriesColor = new Map<string, DataSeriesColorsValues>();
+  const updatedSeriesColors = new Map<string, DataSeriesColorsValues>();
   seriesColors.forEach((value, key) => {
     const lastValue = lastValues.get(key);
     const updatedColorSet = {
       ...value,
       lastValue,
     };
-    updatesSeriesColor.set(key, updatedColorSet);
+    updatedSeriesColors.set(key, updatedColorSet);
   });
   return {
     xDomain,
     yDomain,
     splittedDataSeries,
     formattedDataSeries,
-    seriesColors: updatesSeriesColor,
+    seriesColors: updatedSeriesColors,
   };
 }
 

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -122,14 +122,34 @@ export function computeSeriesDomains(
 
   const formattedDataSeries = getFormattedDataseries(specsArray, splittedSeries);
   // tslint:disable-next-line:no-console
-  // console.log({ formattedDataSeries, xDomain, yDomain });
+  // console.log({ formattedDataSeries, xDomain, yDomain });\
+  const lastValues = new Map<string, number>();
 
+  formattedDataSeries.stacked.forEach((ds) => {
+    ds.dataSeries.forEach((series) => {
+      if (series.data.length > 0) {
+        const last = series.data[series.data.length - 1];
+        if (last !== null && last.initialY1 !== null) {
+          lastValues.set(series.seriesColorKey, last.initialY1);
+        }
+      }
+    });
+  });
+  const updatesSeriesColor = new Map<string, DataSeriesColorsValues>();
+  seriesColors.forEach((value, key) => {
+    const lastValue = lastValues.get(key);
+    const updatedColorSet = {
+      ...value,
+      lastValue,
+    };
+    updatesSeriesColor.set(key, updatedColorSet);
+  });
   return {
     xDomain,
     yDomain,
     splittedDataSeries,
     formattedDataSeries,
-    seriesColors,
+    seriesColors: updatesSeriesColor,
   };
 }
 

--- a/stories/area_chart.tsx
+++ b/stories/area_chart.tsx
@@ -228,6 +228,42 @@ storiesOf('Area Chart', module)
       </Chart>
     );
   })
+  .add('stacked as percentage', () => {
+    const stackedAsPercentage = boolean('stacked as percentage', true);
+    return (
+      <Chart className={'story-chart'}>
+        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Axis id={getAxisId('bottom')} position={Position.Bottom} title={'Bottom axis'} showOverlappingTicks={true} />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => `${Number(d * 100).toFixed(0)} %`}
+        />
+
+        <AreaSeries
+          id={getSpecId('areas')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          stackAccessors={['x']}
+          stackAsPercentage={stackedAsPercentage}
+          splitSeriesAccessors={['g']}
+          data={[
+            { x: 0, y: 2, g: 'a' },
+            { x: 1, y: 7, g: 'a' },
+            { x: 2, y: 3, g: 'a' },
+            { x: 3, y: 6, g: 'a' },
+            { x: 0, y: 4, g: 'b' },
+            { x: 1, y: 5, g: 'b' },
+            { x: 2, y: 8, g: 'b' },
+            { x: 3, y: 2, g: 'b' },
+          ]}
+        />
+      </Chart>
+    );
+  })
   .add('stacked with separated specs', () => {
     return (
       <Chart className={'story-chart'}>

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -475,6 +475,43 @@ storiesOf('Bar Chart', module)
       </Chart>
     );
   })
+  .add('stacked as percentage', () => {
+    const stackedAsPercentage = boolean('stacked as percentage', true);
+    const clusterBars = boolean('cluster', true);
+    return (
+      <Chart className={'story-chart'}>
+        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Axis id={getAxisId('bottom')} position={Position.Bottom} title={'Bottom axis'} showOverlappingTicks={true} />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => (stackedAsPercentage && clusterBars ? `${Number(d * 100).toFixed(0)} %` : d)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          stackAccessors={clusterBars ? ['x'] : []}
+          stackAsPercentage={stackedAsPercentage}
+          splitSeriesAccessors={['g']}
+          data={[
+            { x: 0, y: 2, g: 'a' },
+            { x: 1, y: 7, g: 'a' },
+            { x: 2, y: 3, g: 'a' },
+            { x: 3, y: 6, g: 'a' },
+            { x: 0, y: 4, g: 'b' },
+            { x: 1, y: 5, g: 'b' },
+            { x: 2, y: 8, g: 'b' },
+            { x: 3, y: 2, g: 'b' },
+          ]}
+        />
+      </Chart>
+    );
+  })
   .add('clustered with axis and legend', () => {
     const chartRotation = select<Rotation>(
       'chartRotation',

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -495,7 +495,7 @@ storiesOf('Bar Chart', module)
           yScaleType={ScaleType.Linear}
           xAccessor="x"
           yAccessors={['y']}
-          stackAccessors={clusterBars ? ['x'] : []}
+          stackAccessors={clusterBars ? [] : ['x']}
           stackAsPercentage={stackedAsPercentage}
           splitSeriesAccessors={['g']}
           data={[


### PR DESCRIPTION
## Summary

This PR will add a new props that allows stacking bars, areas and lines using the percentage
mode. For each stacked x value, we scale their value to the percentage on that bucket.

That option mode is applied by groups of series (specified by `groupId`) so you need to specify only one prop on one of the group series the property: `stackAsPercentage={true}`

```tsx
<Axis 
  id={getAxisId('count')} 
  title="count" 
  position={Position.Left} 
  tickFormat={d => `${Number(d * 100).toFixed(1)}%`}/>
<AreaSeries
    id={getSpecId('dataset A')}
    xScaleType={ScaleType.Time}
    yScaleType={ScaleType.Linear}
    data={KIBANA_METRICS.metrics.kibana_os_load[1].data}
    xAccessor={0}
    yAccessors={[1]}
    stackAccessors={[0]}
    stackAsPercentage={true}
  />
<AreaSeries
    id={getSpecId('dataset B')}
    xScaleType={ScaleType.Time}
    yScaleType={ScaleType.Linear}
    data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
    xAccessor={0}
    yAccessors={[1]}
    stackAccessors={[0]}
    stackAsPercentage={true}
  />
```
100% stacked bars:

<img width="656" alt="Screenshot 2019-06-26 at 14 57 50" src="https://user-images.githubusercontent.com/1421091/60186094-6f4f6280-982b-11e9-91b0-d87f99eee001.png">

100% stacked areas:

<img width="576" alt="Screenshot 2019-06-26 at 14 43 35" src="https://user-images.githubusercontent.com/1421091/60186137-80986f00-982b-11e9-98c2-5de492155592.png">

100% stacked areas with `y0accessors` on a single area:
<img width="571" alt="Screenshot 2019-06-26 at 14 43 44" src="https://user-images.githubusercontent.com/1421091/60186172-8aba6d80-982b-11e9-9b1d-fea9a880b79d.png">

100% stacked areas with `y0accessors` on multiple areas:
<img width="569" alt="Screenshot 2019-06-26 at 14 43 52" src="https://user-images.githubusercontent.com/1421091/60186202-986ff300-982b-11e9-9752-3adb60395f99.png">



fix #222


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
