### PR TITLE
refactor(legend): remove visibility button

### DIFF
--- a/src/components/legend/_legend_item.scss
+++ b/src/components/legend/_legend_item.scss
@@ -32,6 +32,9 @@
   @include euiTextTruncate;
   margin-right: $euiSizeXS;
   flex: 1;
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .echLegendItem__title--selected {

--- a/src/components/legend/_legend_item.scss
+++ b/src/components/legend/_legend_item.scss
@@ -56,3 +56,7 @@
     display: none;
   }
 }
+
+.echLegendItem-isHidden {
+  color: $euiColorDarkShade;
+}

--- a/src/components/legend/legend_item.tsx
+++ b/src/components/legend/legend_item.tsx
@@ -52,8 +52,11 @@ class LegendItemComponent extends React.Component<LegendItemProps, LegendItemSta
     const isSelected = legendItemKey === this.props.chartStore!.selectedLegendItemKey.get();
     const hasDisplayValue = this.props.chartStore!.showLegendDisplayValue.get();
     const hasTitleClickListener = Boolean(this.props.chartStore!.onLegendItemClickListener);
+    const itemClasses = classNames('echLegendItem', {
+      'echLegendItem-isHidden': !isSeriesVisible,
+    });
     return (
-      <div className="echLegendItem" onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      <div className={itemClasses} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         {this.renderColor(this.toggleColorPicker, color, isSeriesVisible)}
         {this.renderTitle(label, onTitleClick, hasTitleClickListener, isSelected, hasDisplayValue)}
         {this.renderDisplayValue(displayValue, showLegendDisplayValue, isSeriesVisible)}

--- a/src/components/legend/legend_item.tsx
+++ b/src/components/legend/legend_item.tsx
@@ -54,20 +54,24 @@ class LegendItemComponent extends React.Component<LegendItemProps, LegendItemSta
     const hasTitleClickListener = Boolean(this.props.chartStore!.onLegendItemClickListener);
     return (
       <div className="echLegendItem" onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-        {this.renderColor(this.toggleColorPicker, color)}
+        {this.renderColor(this.toggleColorPicker, color, isSeriesVisible)}
         {this.renderTitle(label, onTitleClick, hasTitleClickListener, isSelected, hasDisplayValue)}
         {this.renderDisplayValue(displayValue, showLegendDisplayValue, isSeriesVisible)}
       </div>
     );
   }
-  renderColor(colorClickAction: () => void, color: string | undefined) {
+  renderColor(colorClickAction: () => void, color?: string, isSeriesVisible: boolean = true) {
     if (!color) {
       return null;
     }
-    // TODO add color picler
+    // TODO add color picker
+    const iconType = isSeriesVisible ? 'dot' : 'eyeClosed';
+    const iconColor = isSeriesVisible ? color : undefined;
+    const ariaLabel = isSeriesVisible ? 'series color' : 'series hidden';
+    const viewBox = isSeriesVisible ? undefined : '-3 -3 22 22';
     return (
       <div className="echLegendItem__color">
-        <Icon type="dot" aria-label="series color" color={color} onClick={colorClickAction} />
+        <Icon type={iconType} aria-label={ariaLabel} color={iconColor} onClick={colorClickAction} viewBox={viewBox} />
       </div>
     );
   }

--- a/src/components/legend/legend_item.tsx
+++ b/src/components/legend/legend_item.tsx
@@ -46,7 +46,7 @@ class LegendItemComponent extends React.Component<LegendItemProps, LegendItemSta
     const { legendItemKey } = this.props;
     const { color, label, isSeriesVisible, displayValue, onMouseEnter, onMouseLeave } = this.props;
 
-    const onTitleClick = this.onLegendTitleClick(legendItemKey);
+    const onTitleClick = this.onVisibilityClick(legendItemKey);
 
     const showLegendDisplayValue = this.props.chartStore!.showLegendDisplayValue.get();
     const isSelected = legendItemKey === this.props.chartStore!.selectedLegendItemKey.get();
@@ -55,7 +55,6 @@ class LegendItemComponent extends React.Component<LegendItemProps, LegendItemSta
     return (
       <div className="echLegendItem" onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         {this.renderColor(this.toggleColorPicker, color)}
-        {this.renderVisibilityButton(legendItemKey, isSeriesVisible)}
         {this.renderTitle(label, onTitleClick, hasTitleClickListener, isSelected, hasDisplayValue)}
         {this.renderDisplayValue(displayValue, showLegendDisplayValue, isSeriesVisible)}
       </div>
@@ -84,7 +83,7 @@ class LegendItemComponent extends React.Component<LegendItemProps, LegendItemSta
 
   renderTitle(
     title: string | undefined,
-    onTitleClick: () => void,
+    onTitleClick: (event: React.MouseEvent<Element, MouseEvent>) => void,
     hasTitleClickListener: boolean,
     isSelected: boolean,
     hasDisplayValue: boolean,
@@ -153,7 +152,7 @@ class LegendItemComponent extends React.Component<LegendItemProps, LegendItemSta
   //   );
   // }
 
-  private onVisibilityClick = (legendItemKey: string) => (event: React.MouseEvent<SVGElement>) => {
+  private onVisibilityClick = (legendItemKey: string) => (event: React.MouseEvent) => {
     if (event.shiftKey) {
       this.props.chartStore!.toggleSingleSeries(legendItemKey);
     } else {

--- a/src/components/legend/legend_item.tsx
+++ b/src/components/legend/legend_item.tsx
@@ -70,11 +70,11 @@ class LegendItemComponent extends React.Component<LegendItemProps, LegendItemSta
     // TODO add color picker
     const iconType = isSeriesVisible ? 'dot' : 'eyeClosed';
     const iconColor = isSeriesVisible ? color : undefined;
-    const ariaLabel = isSeriesVisible ? 'series color' : 'series hidden';
+    const title = isSeriesVisible ? 'series color' : 'series hidden';
     const viewBox = isSeriesVisible ? undefined : '-3 -3 22 22';
     return (
-      <div className="echLegendItem__color">
-        <Icon type={iconType} aria-label={ariaLabel} color={iconColor} onClick={colorClickAction} viewBox={viewBox} />
+      <div className="echLegendItem__color" aria-label={title} title={title}>
+        <Icon type={iconType} color={iconColor} onClick={colorClickAction} viewBox={viewBox} />
       </div>
     );
   }


### PR DESCRIPTION
## Summary

This PR removes the visibility button. The visibility change handling is applied on the legend item title.

**BREAKING CHANGE**: the `onLegendItemClick` click handler is no longer applied when clicking on the title. Instead a simple visibility change is applied.

Before:
<img width="589" alt="Screenshot 2019-07-02 at 10 13 31" src="https://user-images.githubusercontent.com/1421091/60495968-2592cc00-9cb2-11e9-868b-c8177c3600a5.png">

After:
<img width="603" alt="Screenshot 2019-07-02 at 10 12 48" src="https://user-images.githubusercontent.com/1421091/60496123-74406600-9cb2-11e9-9139-29c8cdf11e0d.png">

cc @cchaos 
I've some doubts on this because removes two important features right now:
- without the eye/eyeclosed icons we don't have a graphic representation that specify that a series is hidden. Is a ~~strikethrough~~ enough or is much more difficult to read?
- There are few legend item interaction that we need to support:
    - Hide/show series (currently the only interaction on TSVB, but not an interaction on vizlib)
    - click to filter (on vizlib clicking on the legend item is used to create and apply a global filter)

Before merging I'd like to check with you @cchaos these things.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
