### PR TITLE
feat(style): allow fill and stroke overrides

### DIFF
--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -10,23 +10,38 @@ import {
   Position,
   ScaleType,
   Settings,
+  mergeWithDefaultTheme,
 } from '../src';
 import { KIBANA_METRICS } from '../src/lib/series/utils/test_dataset_kibana';
 
 export class Playground extends React.Component {
   render() {
-    return (
-      <>
-        {this.renderChart(Position.Right)}
-        {this.renderChart(Position.Bottom)}
-      </>
-    );
+    return <>{this.renderChart(Position.Right)}</>;
   }
   renderChart(legendPosition: Position) {
+    const theme = mergeWithDefaultTheme({
+      lineSeriesStyle: {
+        // area: {
+        //   fill: 'green',
+        //   opacity:0.2
+        // },
+        line: {
+          stroke: 'violet',
+          strokeWidth: 4,
+        },
+        point: {
+          fill: 'yellow',
+          stroke: 'black',
+          strokeWidth: 2,
+          radius: 6,
+        },
+      },
+    });
+    console.log(theme.areaSeriesStyle);
     return (
       <div className="chart">
         <Chart>
-          <Settings debug={true} showLegend={true} legendPosition={legendPosition} rotation={0} />
+          <Settings debug={false} showLegend={true} legendPosition={legendPosition} rotation={0} theme={theme} />
           <Axis
             id={getAxisId('timestamp')}
             title="timestamp"
@@ -40,6 +55,12 @@ export class Playground extends React.Component {
             yScaleType={ScaleType.Linear}
             data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 15)}
             xAccessor={0}
+            lineSeriesStyle={{
+              line: {
+                stroke: 'red',
+                opacity: 1,
+              },
+            }}
             yAccessors={[1]}
           />
           <LineSeries
@@ -49,30 +70,7 @@ export class Playground extends React.Component {
             data={KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15)}
             xAccessor={0}
             yAccessors={[1]}
-          />
-          <LineSeries
-            id={getSpecId('dataset C')}
-            xScaleType={ScaleType.Time}
-            yScaleType={ScaleType.Linear}
-            data={KIBANA_METRICS.metrics.kibana_os_load[2].data.slice(0, 15)}
-            xAccessor={0}
-            yAccessors={[1]}
-          />
-          <LineSeries
-            id={getSpecId('dataset D')}
-            xScaleType={ScaleType.Time}
-            yScaleType={ScaleType.Linear}
-            data={KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15)}
-            xAccessor={0}
-            yAccessors={[1]}
-          />
-          <LineSeries
-            id={getSpecId('dataset E')}
-            xScaleType={ScaleType.Time}
-            yScaleType={ScaleType.Linear}
-            data={KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15)}
-            xAccessor={0}
-            yAccessors={[1]}
+            stackAccessors={[0]}
           />
         </Chart>
       </div>

--- a/src/components/react_canvas/area_geometries.tsx
+++ b/src/components/react_canvas/area_geometries.tsx
@@ -4,18 +4,18 @@ import { Circle, Group, Path } from 'react-konva';
 import { animated, Spring } from 'react-spring/renderprops-konva.cjs';
 import { LegendItem } from '../../lib/series/legend';
 import { AreaGeometry, getGeometryStyle, PointGeometry } from '../../lib/series/rendering';
-import { AreaSeriesStyle, SharedGeometryStyle } from '../../lib/themes/theme';
+import { SharedGeometryStyle } from '../../lib/themes/theme';
 import {
-  buildAreaLineProps,
-  buildAreaPointProps,
-  buildAreaProps,
+  buildAreaRenderProps,
   buildPointStyleProps,
+  buildPointRenderProps,
+  PointStyleProps,
+  buildLineRenderProps,
 } from './utils/rendering_props_utils';
 
 interface AreaGeometriesDataProps {
   animated?: boolean;
   areas: AreaGeometry[];
-  style: AreaSeriesStyle;
   sharedStyle: SharedGeometryStyle;
   highlightedLegendItem: LegendItem | null;
 }
@@ -35,171 +35,113 @@ export class AreaGeometries extends React.PureComponent<AreaGeometriesDataProps,
     };
   }
   render() {
-    const { point, area, line } = this.props.style;
-
     return (
       <Group ref={this.barSeriesRef} key={'bar_series'}>
-        {this.renderAreaGeoms(area.visible)}
-        {this.renderAreaLines(line.visible)}
-        {this.renderAreaPoints(point.visible)}
+        {this.renderAreaGeoms()}
+        {this.renderAreaLines()}
+        {this.renderAreaPoints()}
       </Group>
     );
   }
-  private renderAreaPoints = (themeIsVisible: boolean): JSX.Element[] => {
+  private renderAreaPoints = (): JSX.Element[] => {
     const { areas } = this.props;
     return areas.reduce(
       (acc, glyph, i) => {
-        const { points, seriesPointStyle } = glyph;
+        const { points, seriesPointStyle, color } = glyph;
 
-        const isVisible = seriesPointStyle ? seriesPointStyle.visible : themeIsVisible;
-        if (!isVisible) {
+        if (!seriesPointStyle.visible) {
           return acc;
         }
 
-        const { radius, strokeWidth, opacity } = this.props.style.point;
-        const pointStyleProps = buildPointStyleProps({
-          radius,
-          strokeWidth,
-          opacity,
-          seriesPointStyle,
-        });
+        const pointStyleProps = buildPointStyleProps(color, seriesPointStyle);
 
         return [...acc, ...this.renderPoints(points, i, pointStyleProps)];
       },
       [] as JSX.Element[],
     );
   };
-  private renderPoints = (areaPoints: PointGeometry[], areaIndex: number, pointStyleProps: any): JSX.Element[] => {
+  private renderPoints = (
+    areaPoints: PointGeometry[],
+    areaIndex: number,
+    pointStyleProps: PointStyleProps,
+  ): JSX.Element[] => {
     const areaPointElements: JSX.Element[] = [];
+
     areaPoints.forEach((areaPoint, pointIndex) => {
-      const { x, y, color, transform } = areaPoint;
+      const { x, y, transform } = areaPoint;
+      const key = `area-point-${areaIndex}-${pointIndex}`;
 
       if (this.props.animated) {
         areaPointElements.push(
           <Group key={`area-point-group-${areaIndex}-${pointIndex}`} x={transform.x}>
             <Spring native from={{ y }} to={{ y }}>
               {() => {
-                const pointProps = buildAreaPointProps({
-                  areaIndex,
-                  pointIndex,
-                  x,
-                  y,
-                  color,
-                  pointStyleProps,
-                });
-                return <animated.Circle {...pointProps} />;
+                const pointProps = buildPointRenderProps(x, y, pointStyleProps);
+                return <animated.Circle key={key} {...pointProps} />;
               }}
             </Spring>
           </Group>,
         );
       } else {
-        const pointProps = buildAreaPointProps({
-          areaIndex,
-          pointIndex,
-          x: transform.x + x,
-          y,
-          color,
-          pointStyleProps,
-        });
-        areaPointElements.push(<Circle {...pointProps} />);
+        const pointProps = buildPointRenderProps(transform.x + x, y, pointStyleProps);
+        areaPointElements.push(<Circle key={key} {...pointProps} />);
       }
     });
     return areaPointElements;
   };
 
-  private renderAreaGeoms = (themeIsVisible: boolean): JSX.Element[] => {
-    const { areas } = this.props;
-    const { opacity } = this.props.style.area;
+  private renderAreaGeoms = (): JSX.Element[] => {
+    const { areas, sharedStyle } = this.props;
     const areasToRender: JSX.Element[] = [];
 
     areas.forEach((glyph, i) => {
-      const { area, color, transform, seriesAreaStyle } = glyph;
-      const isVisible = seriesAreaStyle ? seriesAreaStyle.visible : themeIsVisible;
-      if (!isVisible) {
+      const { area, color, transform, geometryId, seriesAreaStyle } = glyph;
+      if (!seriesAreaStyle.visible) {
         return;
       }
-
+      const customOpacity = seriesAreaStyle ? seriesAreaStyle.opacity : undefined;
+      const geometryStyle = getGeometryStyle(geometryId, this.props.highlightedLegendItem, sharedStyle, customOpacity);
+      const key = `area-${i}`;
       if (this.props.animated) {
         areasToRender.push(
           <Group key={`area-group-${i}`} x={transform.x}>
             <Spring native from={{ area }} to={{ area }}>
               {(props: { area: string }) => {
-                const areaProps = buildAreaProps({
-                  index: i,
-                  areaPath: props.area,
-                  xTransform: 0,
-                  color,
-                  opacity,
-                  seriesAreaStyle,
-                });
-                return <animated.Path {...areaProps} />;
+                const areaProps = buildAreaRenderProps(0, props.area, color, seriesAreaStyle, geometryStyle);
+                return <animated.Path key={key} {...areaProps} />;
               }}
             </Spring>
           </Group>,
         );
       } else {
-        const areaProps = buildAreaProps({
-          index: i,
-          areaPath: area,
-          xTransform: transform.x,
-          color,
-          opacity,
-          seriesAreaStyle,
-        });
-        areasToRender.push(<Path {...areaProps} />);
+        const areaProps = buildAreaRenderProps(transform.x, area, color, seriesAreaStyle, geometryStyle);
+        areasToRender.push(<Path key={key} {...areaProps} />);
       }
     });
     return areasToRender;
   };
-  private renderAreaLines = (themeIsVisible: boolean): JSX.Element[] => {
+  private renderAreaLines = (): JSX.Element[] => {
     const { areas, sharedStyle } = this.props;
-    const { strokeWidth } = this.props.style.line;
     const linesToRender: JSX.Element[] = [];
     areas.forEach((glyph, areaIndex) => {
       const { lines, color, geometryId, transform, seriesAreaLineStyle } = glyph;
-      const isVisible = seriesAreaLineStyle ? seriesAreaLineStyle.visible : themeIsVisible;
-      if (!isVisible) {
+      if (!seriesAreaLineStyle.visible) {
         return;
       }
 
-      const customOpacity = seriesAreaLineStyle ? seriesAreaLineStyle.opacity : undefined;
-
-      const geometryStyle = getGeometryStyle(geometryId, this.props.highlightedLegendItem, sharedStyle, customOpacity);
+      const geometryStyle = getGeometryStyle(
+        geometryId,
+        this.props.highlightedLegendItem,
+        sharedStyle,
+        seriesAreaLineStyle.opacity,
+      );
 
       lines.forEach((linePath, lineIndex) => {
-        const lineProps = buildAreaLineProps({
-          areaIndex,
-          lineIndex,
-          xTransform: transform.x,
-          linePath,
-          color,
-          strokeWidth,
-          geometryStyle,
-          seriesAreaLineStyle,
-        });
-        linesToRender.push(<Path {...lineProps} />);
+        const key = `area-${areaIndex}-line-${lineIndex}`;
+        const lineProps = buildLineRenderProps(transform.x, linePath, color, seriesAreaLineStyle, geometryStyle);
+        linesToRender.push(<Path key={key} {...lineProps} />);
       });
     });
     return linesToRender;
-    // if (this.props.animated) {
-    //   return (
-    //     <Group key={`area-line-group-${i}`} x={transform.x}>
-    //       <Spring native from={{ line }} to={{ line }}>
-    //         {(props: { line: string }) => {
-    //           const lineProps = buildAreaLineProps({
-    //             index: i,
-    //             linePath: props.line,
-    //             color,
-    //             strokeWidth,
-    //             geometryStyle,
-    //           });
-    //           return <animated.Path {...lineProps} />;
-    //         }}
-    //       </Spring>
-    //     </Group>
-    //   );
-    // } else {
-
-    // }
   };
 }

--- a/src/components/react_canvas/area_geometries.tsx
+++ b/src/components/react_canvas/area_geometries.tsx
@@ -77,14 +77,14 @@ export class AreaGeometries extends React.PureComponent<AreaGeometriesDataProps,
             <Spring native from={{ y }} to={{ y }}>
               {() => {
                 const pointProps = buildPointRenderProps(x, y, pointStyleProps);
-                return <animated.Circle key={key} {...pointProps} />;
+                return <animated.Circle {...pointProps} key={key} />;
               }}
             </Spring>
           </Group>,
         );
       } else {
         const pointProps = buildPointRenderProps(transform.x + x, y, pointStyleProps);
-        areaPointElements.push(<Circle key={key} {...pointProps} />);
+        areaPointElements.push(<Circle {...pointProps} key={key} />);
       }
     });
     return areaPointElements;
@@ -108,14 +108,14 @@ export class AreaGeometries extends React.PureComponent<AreaGeometriesDataProps,
             <Spring native from={{ area }} to={{ area }}>
               {(props: { area: string }) => {
                 const areaProps = buildAreaRenderProps(0, props.area, color, seriesAreaStyle, geometryStyle);
-                return <animated.Path key={key} {...areaProps} />;
+                return <animated.Path {...areaProps} key={key} />;
               }}
             </Spring>
           </Group>,
         );
       } else {
         const areaProps = buildAreaRenderProps(transform.x, area, color, seriesAreaStyle, geometryStyle);
-        areasToRender.push(<Path key={key} {...areaProps} />);
+        areasToRender.push(<Path {...areaProps} key={key} />);
       }
     });
     return areasToRender;
@@ -139,7 +139,7 @@ export class AreaGeometries extends React.PureComponent<AreaGeometriesDataProps,
       lines.forEach((linePath, lineIndex) => {
         const key = `area-${areaIndex}-line-${lineIndex}`;
         const lineProps = buildLineRenderProps(transform.x, linePath, color, seriesAreaLineStyle, geometryStyle);
-        linesToRender.push(<Path key={key} {...lineProps} />);
+        linesToRender.push(<Path {...lineProps} key={key} />);
       });
     });
     return linesToRender;

--- a/src/components/react_canvas/axis.tsx
+++ b/src/components/react_canvas/axis.tsx
@@ -82,7 +82,7 @@ export class Axis extends React.PureComponent<AxisProps> {
       ? getVerticalAxisTickLineProps(position, tickPadding, tickSize, tick.position)
       : getHorizontalAxisTickLineProps(position, tickPadding, tickSize, tick.position, maxLabelBboxHeight);
 
-    return <Line key={`tick-${i}`} points={lineProps} {...tickLineStyle} />;
+    return <Line {...tickLineStyle} key={`tick-${i}`} points={lineProps} />;
   };
   private renderAxis = () => {
     const { ticks, axisPosition, debug } = this.props;

--- a/src/components/react_canvas/bar_geometries.tsx
+++ b/src/components/react_canvas/bar_geometries.tsx
@@ -76,7 +76,7 @@ export class BarGeometries extends React.PureComponent<BarGeometriesDataProps, B
                   geometryStyle,
                 );
 
-                return <animated.Rect key={key} {...barProps} />;
+                return <animated.Rect {...barProps} key={key} />;
               }}
             </Spring>
           </Group>
@@ -94,7 +94,7 @@ export class BarGeometries extends React.PureComponent<BarGeometriesDataProps, B
         );
         return (
           <React.Fragment key={index}>
-            <Rect key={key} {...barProps} />
+            <Rect {...barProps} key={key} />
           </React.Fragment>
         );
       }

--- a/src/components/react_canvas/bar_geometries.tsx
+++ b/src/components/react_canvas/bar_geometries.tsx
@@ -4,13 +4,12 @@ import { Group, Rect } from 'react-konva';
 import { animated, Spring } from 'react-spring/renderprops-konva.cjs';
 import { LegendItem } from '../../lib/series/legend';
 import { BarGeometry, getGeometryStyle } from '../../lib/series/rendering';
-import { BarSeriesStyle, SharedGeometryStyle } from '../../lib/themes/theme';
-import { buildBarProps } from './utils/rendering_props_utils';
+import { SharedGeometryStyle } from '../../lib/themes/theme';
+import { buildBarRenderProps } from './utils/rendering_props_utils';
 
 interface BarGeometriesDataProps {
   animated?: boolean;
   bars: BarGeometry[];
-  style: BarSeriesStyle;
   sharedStyle: SharedGeometryStyle;
   highlightedLegendItem: LegendItem | null;
 }
@@ -40,11 +39,9 @@ export class BarGeometries extends React.PureComponent<BarGeometriesDataProps, B
 
   private renderBarGeoms = (bars: BarGeometry[]): JSX.Element[] => {
     const { overBar } = this.state;
-    const { style, sharedStyle } = this.props;
+    const { sharedStyle } = this.props;
     return bars.map((bar, index) => {
       const { x, y, width, height, color, seriesStyle } = bar;
-      const border = seriesStyle ? seriesStyle.border : style.border;
-      const customOpacity = seriesStyle ? seriesStyle.opacity : undefined;
 
       // Properties to determine if we need to highlight individual bars depending on hover state
       const hasGeometryHover = overBar != null;
@@ -58,49 +55,46 @@ export class BarGeometries extends React.PureComponent<BarGeometriesDataProps, B
         bar.geometryId,
         this.props.highlightedLegendItem,
         sharedStyle,
-        customOpacity,
+        seriesStyle.rect.opacity,
         individualHighlight,
       );
+      const key = `bar-${index}`;
 
       if (this.props.animated) {
         return (
           <Group key={index}>
             <Spring native from={{ y: y + height, height: 0 }} to={{ y, height }}>
               {(props: { y: number; height: number }) => {
-                const barProps = buildBarProps({
-                  index,
+                const barProps = buildBarRenderProps(
                   x,
-                  y: props.y,
+                  props.y,
                   width,
-                  height: props.height,
-                  fill: color,
-                  stroke: border.stroke,
-                  strokeWidth: border.strokeWidth,
-                  borderEnabled: border.visible,
+                  props.height,
+                  color,
+                  seriesStyle.rect,
+                  seriesStyle.rectBorder,
                   geometryStyle,
-                });
+                );
 
-                return <animated.Rect {...barProps} />;
+                return <animated.Rect key={key} {...barProps} />;
               }}
             </Spring>
           </Group>
         );
       } else {
-        const barProps = buildBarProps({
-          index,
+        const barProps = buildBarRenderProps(
           x,
           y,
           width,
           height,
-          fill: color,
-          stroke: border.stroke,
-          strokeWidth: border.strokeWidth,
-          borderEnabled: border.visible,
+          color,
+          seriesStyle.rect,
+          seriesStyle.rectBorder,
           geometryStyle,
-        });
+        );
         return (
           <React.Fragment key={index}>
-            <Rect {...barProps} />
+            <Rect key={key} {...barProps} />
           </React.Fragment>
         );
       }

--- a/src/components/react_canvas/grid.tsx
+++ b/src/components/react_canvas/grid.tsx
@@ -20,7 +20,7 @@ export class Grid extends React.PureComponent<GridProps> {
 
     const config = gridLineStyle ? mergeWithDefaultGridLineConfig(gridLineStyle) : DEFAULT_GRID_LINE_CONFIG;
 
-    return <Line key={`tick-${i}`} points={linePosition} {...config} />;
+    return <Line {...config} key={`tick-${i}`} points={linePosition} />;
   };
 
   private renderGrid = () => {

--- a/src/components/react_canvas/line_annotation.tsx
+++ b/src/components/react_canvas/line_annotation.tsx
@@ -24,7 +24,7 @@ export class LineAnnotation extends React.PureComponent<LineAnnotationProps> {
       ...line,
     };
 
-    return <Line key={`tick-${i}`} {...lineProps} />;
+    return <Line {...lineProps} key={`tick-${i}`} />;
   };
 
   private renderAnnotation = () => {

--- a/src/components/react_canvas/line_geometries.tsx
+++ b/src/components/react_canvas/line_geometries.tsx
@@ -74,14 +74,14 @@ export class LineGeometries extends React.PureComponent<LineGeometriesDataProps,
             <Spring native from={{ y }} to={{ y }}>
               {() => {
                 const pointProps = buildPointRenderProps(x, y, pointStyleProps);
-                return <animated.Circle key={key} {...pointProps} />;
+                return <animated.Circle {...pointProps} key={key} />;
               }}
             </Spring>
           </Group>,
         );
       } else {
         const pointProps = buildPointRenderProps(transform.x + x, y, pointStyleProps);
-        linePointsElements.push(<Circle key={key} {...pointProps} />);
+        linePointsElements.push(<Circle {...pointProps} key={key} />);
       }
     });
     return linePointsElements;
@@ -108,14 +108,14 @@ export class LineGeometries extends React.PureComponent<LineGeometriesDataProps,
             <Spring native reset from={{ opacity: 0 }} to={{ opacity: 1 }}>
               {() => {
                 const lineProps = buildLineRenderProps(0, line, color, seriesLineStyle, geometryStyle);
-                return <animated.Path key={key} {...lineProps} />;
+                return <animated.Path {...lineProps} key={key} />;
               }}
             </Spring>
           </Group>,
         );
       } else {
         const lineProps = buildLineRenderProps(transform.x, line, color, seriesLineStyle, geometryStyle);
-        lineElements.push(<Path key={key} {...lineProps} />);
+        lineElements.push(<Path {...lineProps} key={key} />);
       }
     });
 

--- a/src/components/react_canvas/line_geometries.tsx
+++ b/src/components/react_canvas/line_geometries.tsx
@@ -4,18 +4,17 @@ import { Circle, Group, Path } from 'react-konva';
 import { animated, Spring } from 'react-spring/renderprops-konva.cjs';
 import { LegendItem } from '../../lib/series/legend';
 import { getGeometryStyle, LineGeometry, PointGeometry } from '../../lib/series/rendering';
-import { LineSeriesStyle, SharedGeometryStyle } from '../../lib/themes/theme';
+import { SharedGeometryStyle } from '../../lib/themes/theme';
 import {
-  buildLinePointProps,
-  buildLineProps,
+  buildLineRenderProps,
   buildPointStyleProps,
   PointStyleProps,
+  buildPointRenderProps,
 } from './utils/rendering_props_utils';
 
 interface LineGeometriesDataProps {
   animated?: boolean;
   lines: LineGeometry[];
-  style: LineSeriesStyle;
   sharedStyle: SharedGeometryStyle;
   highlightedLegendItem: LegendItem | null;
 }
@@ -36,35 +35,24 @@ export class LineGeometries extends React.PureComponent<LineGeometriesDataProps,
   }
 
   render() {
-    const { point, line } = this.props.style;
-
     return (
       <Group ref={this.barSeriesRef} key={'bar_series'}>
-        {this.renderLineGeoms(line.visible)}
-        {this.renderLinePoints(point.visible)}
+        {this.renderLineGeoms()}
+        {this.renderLinePoints()}
       </Group>
     );
   }
 
-  private renderLinePoints = (themeIsVisible: boolean): JSX.Element[] => {
+  private renderLinePoints = (): JSX.Element[] => {
     const { lines } = this.props;
     return lines.reduce(
       (acc, glyph, i) => {
-        const { points, seriesPointStyle } = glyph;
+        const { points, seriesPointStyle, color } = glyph;
 
-        const isVisible = seriesPointStyle ? seriesPointStyle.visible : themeIsVisible;
-        if (!isVisible) {
+        if (!seriesPointStyle.visible) {
           return acc;
         }
-
-        const { radius, strokeWidth, opacity } = this.props.style.point;
-        const pointStyleProps = buildPointStyleProps({
-          radius,
-          strokeWidth,
-          opacity,
-          seriesPointStyle,
-        });
-
+        const pointStyleProps = buildPointStyleProps(color, seriesPointStyle);
         return [...acc, ...this.renderPoints(points, i, pointStyleProps)];
       },
       [] as JSX.Element[],
@@ -78,57 +66,40 @@ export class LineGeometries extends React.PureComponent<LineGeometriesDataProps,
   ): JSX.Element[] => {
     const linePointsElements: JSX.Element[] = [];
     linePoints.forEach((linePoint, pointIndex) => {
-      const { x, y, color, transform } = linePoint;
-
+      const { x, y, transform } = linePoint;
+      const key = `line-point-${lineIndex}-${pointIndex}`;
       if (this.props.animated) {
         linePointsElements.push(
           <Group key={`line-point-group-${lineIndex}-${pointIndex}`} x={transform.x}>
             <Spring native from={{ y }} to={{ y }}>
               {() => {
-                const pointProps = buildLinePointProps({
-                  lineIndex,
-                  pointIndex,
-                  x,
-                  y,
-                  color,
-                  pointStyleProps,
-                });
-                return <animated.Circle {...pointProps} />;
+                const pointProps = buildPointRenderProps(x, y, pointStyleProps);
+                return <animated.Circle key={key} {...pointProps} />;
               }}
             </Spring>
           </Group>,
         );
       } else {
-        const pointProps = buildLinePointProps({
-          lineIndex,
-          pointIndex,
-          x: transform.x + x,
-          y,
-          color,
-          pointStyleProps,
-        });
-        linePointsElements.push(<Circle {...pointProps} />);
+        const pointProps = buildPointRenderProps(transform.x + x, y, pointStyleProps);
+        linePointsElements.push(<Circle key={key} {...pointProps} />);
       }
     });
     return linePointsElements;
   };
 
-  private renderLineGeoms = (themeIsVisible: boolean): JSX.Element[] => {
-    const { style, lines, sharedStyle } = this.props;
-    const { strokeWidth } = style.line;
+  private renderLineGeoms = (): JSX.Element[] => {
+    const { lines, sharedStyle } = this.props;
 
     const lineElements: JSX.Element[] = [];
 
     lines.forEach((glyph, index) => {
       const { line, color, transform, geometryId, seriesLineStyle } = glyph;
-      const isVisible = seriesLineStyle ? seriesLineStyle.visible : themeIsVisible;
 
-      if (!isVisible) {
+      if (!seriesLineStyle.visible) {
         return;
       }
-
+      const key = `line-${index}`;
       const customOpacity = seriesLineStyle ? seriesLineStyle.opacity : undefined;
-
       const geometryStyle = getGeometryStyle(geometryId, this.props.highlightedLegendItem, sharedStyle, customOpacity);
 
       if (this.props.animated) {
@@ -136,31 +107,15 @@ export class LineGeometries extends React.PureComponent<LineGeometriesDataProps,
           <Group key={index} x={transform.x}>
             <Spring native reset from={{ opacity: 0 }} to={{ opacity: 1 }}>
               {() => {
-                const lineProps = buildLineProps({
-                  index,
-                  xTransform: 0,
-                  linePath: line,
-                  color,
-                  strokeWidth,
-                  geometryStyle,
-                  seriesLineStyle,
-                });
-                return <animated.Path {...lineProps} />;
+                const lineProps = buildLineRenderProps(0, line, color, seriesLineStyle, geometryStyle);
+                return <animated.Path key={key} {...lineProps} />;
               }}
             </Spring>
           </Group>,
         );
       } else {
-        const lineProps = buildLineProps({
-          index,
-          xTransform: transform.x,
-          linePath: line,
-          color,
-          strokeWidth,
-          geometryStyle,
-          seriesLineStyle,
-        });
-        lineElements.push(<Path {...lineProps} />);
+        const lineProps = buildLineRenderProps(transform.x, line, color, seriesLineStyle, geometryStyle);
+        lineElements.push(<Path key={key} {...lineProps} />);
       }
     });
 

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -82,7 +82,6 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         key={'bar-geometries'}
         animated={canDataBeAnimated}
         bars={geometries.bars}
-        style={chartTheme.barSeriesStyle}
         sharedStyle={chartTheme.sharedStyle}
         highlightedLegendItem={highlightedLegendItem}
       />
@@ -108,7 +107,6 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         key={'line-geometries'}
         animated={canDataBeAnimated}
         lines={geometries.lines}
-        style={chartTheme.lineSeriesStyle}
         sharedStyle={chartTheme.sharedStyle}
         highlightedLegendItem={highlightedLegendItem}
       />
@@ -134,7 +132,6 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         key={'area-geometries'}
         animated={canDataBeAnimated}
         areas={geometries.areas}
-        style={chartTheme.areaSeriesStyle}
         sharedStyle={chartTheme.sharedStyle}
         highlightedLegendItem={highlightedLegendItem}
       />

--- a/src/components/react_canvas/rect_annotation.tsx
+++ b/src/components/react_canvas/rect_annotation.tsx
@@ -26,7 +26,7 @@ export class RectAnnotation extends React.PureComponent<RectAnnotationProps> {
       height,
     };
 
-    return <Rect key={`rect-${i}`} {...rectProps} />;
+    return <Rect {...rectProps} key={`rect-${i}`} />;
   };
 
   private renderAnnotation = () => {

--- a/src/components/react_canvas/utils/rendering_props_utils.test.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.test.ts
@@ -1,107 +1,79 @@
 import { Rotation } from '../../../lib/series/specs';
 import {
-  buildAreaLineProps,
-  buildAreaPointProps,
-  buildAreaProps,
-  buildBarProps,
+  buildAreaRenderProps,
+  buildBarRenderProps,
   buildBarValueProps,
-  buildLinePointProps,
-  buildLineProps,
-  buildPointStyleProps,
+  buildLineRenderProps,
+  buildPointRenderProps,
   getBarValueClipDimensions,
   isBarValueOverflow,
   rotateBarValueProps,
+  buildPointStyleProps,
 } from './rendering_props_utils';
 
 describe('[canvas] Area Geometries props', () => {
   test('can build area point props', () => {
-    const pointStyleProps = buildPointStyleProps({
+    const pointStyleProps = buildPointStyleProps('red', {
+      visible: true,
       radius: 30,
       strokeWidth: 2,
       opacity: 0.5,
     });
 
-    const props = buildAreaPointProps({
-      areaIndex: 1,
-      pointIndex: 2,
-      x: 10,
-      y: 20,
-      color: 'red',
-      pointStyleProps,
-    });
+    const props = buildPointRenderProps(10, 20, pointStyleProps);
     expect(props).toEqual({
-      key: 'area-point-1-2',
       x: 10,
       y: 20,
       radius: 30,
       strokeWidth: 2,
       strokeEnabled: true,
       stroke: 'red',
-      fill: 'white',
+      fill: 'red',
       opacity: 0.5,
       strokeHitEnabled: false,
       perfectDrawEnabled: false,
       listening: false,
     });
 
-    const noStrokePointStyleProps = buildPointStyleProps({
+    const noStrokePointStyleProps = buildPointStyleProps('blue', {
+      visible: true,
       radius: 30,
+      stroke: 'red',
       strokeWidth: 0,
       opacity: 0.5,
     });
 
-    const propsNoStroke = buildAreaPointProps({
-      areaIndex: 1,
-      pointIndex: 2,
-      x: 10,
-      y: 20,
-      color: 'red',
-      pointStyleProps: noStrokePointStyleProps,
-    });
+    const propsNoStroke = buildPointRenderProps(10, 20, noStrokePointStyleProps);
     expect(propsNoStroke).toEqual({
-      key: 'area-point-1-2',
       x: 10,
       y: 20,
       radius: 30,
       strokeWidth: 0,
       strokeEnabled: false,
       stroke: 'red',
-      fill: 'white',
+      fill: 'blue',
       opacity: 0.5,
       strokeHitEnabled: false,
       perfectDrawEnabled: false,
       listening: false,
     });
 
-    const seriesPointStyleProps = buildPointStyleProps({
-      radius: 30,
-      strokeWidth: 2,
-      opacity: 0.5,
-      seriesPointStyle: {
-        radius: 123,
-        stroke: 'series-stroke',
-        strokeWidth: 456,
-        opacity: 789,
-        visible: true,
-      },
+    const seriesPointStyleProps = buildPointStyleProps('violet', {
+      visible: true,
+      fill: 'pink',
+      radius: 123,
+      strokeWidth: 456,
+      opacity: 789,
     });
-    const seriesPointStyle = buildAreaPointProps({
-      areaIndex: 1,
-      pointIndex: 2,
-      x: 10,
-      y: 20,
-      color: 'red',
-      pointStyleProps: seriesPointStyleProps,
-    });
+    const seriesPointStyle = buildPointRenderProps(10, 20, seriesPointStyleProps);
     expect(seriesPointStyle).toEqual({
-      key: 'area-point-1-2',
       x: 10,
       y: 20,
       radius: 123,
       strokeWidth: 456,
       strokeEnabled: true,
-      stroke: 'red',
-      fill: 'white',
+      stroke: 'violet',
+      fill: 'pink',
       opacity: 789,
       strokeHitEnabled: false,
       perfectDrawEnabled: false,
@@ -109,65 +81,73 @@ describe('[canvas] Area Geometries props', () => {
     });
   });
   test('can build area path props', () => {
-    const props = buildAreaProps({
-      index: 1,
-      areaPath: 'M0,0L10,10Z',
-      xTransform: 40,
-      color: 'red',
-      opacity: 0.5,
-    });
+    const props = buildAreaRenderProps(
+      40,
+      'M0,0L10,10Z',
+
+      'red',
+      {
+        opacity: 0.5,
+        visible: true,
+      },
+      {
+        opacity: 0.8,
+      },
+    );
     expect(props).toEqual({
-      key: 'area-1',
       data: 'M0,0L10,10Z',
       x: 40,
       fill: 'red',
       lineCap: 'round',
       lineJoin: 'round',
-      opacity: 0.5,
+      opacity: 0.8,
       strokeHitEnabled: false,
       perfectDrawEnabled: false,
       listening: false,
     });
 
-    const seriesAreaStyle = buildAreaProps({
-      index: 1,
-      areaPath: 'M0,0L10,10Z',
-      xTransform: 0,
-      color: 'red',
-      opacity: 0.5,
-      seriesAreaStyle: {
+    const seriesAreaStyle = buildAreaRenderProps(
+      0,
+      'M0,0L10,10Z',
+      'red',
+
+      {
         opacity: 123,
-        fill: '',
+        fill: 'blue',
         visible: true,
       },
-    });
+      {
+        opacity: 1,
+      },
+    );
     expect(seriesAreaStyle).toEqual({
-      key: 'area-1',
       data: 'M0,0L10,10Z',
       x: 0,
-      fill: 'red',
+      fill: 'blue',
       lineCap: 'round',
       lineJoin: 'round',
-      opacity: 123,
+      opacity: 1,
       strokeHitEnabled: false,
       perfectDrawEnabled: false,
       listening: false,
     });
   });
   test('can build area line path props', () => {
-    const props = buildAreaLineProps({
-      areaIndex: 1,
-      lineIndex: 2,
-      xTransform: 40,
-      linePath: 'M0,0L10,10Z',
-      color: 'red',
-      strokeWidth: 1,
-      geometryStyle: {
+    const props = buildLineRenderProps(
+      40,
+      'M0,0L10,10Z',
+      'red',
+
+      {
+        visible: true,
+        opacity: 1,
+        strokeWidth: 1,
+      },
+      {
         opacity: 0.5,
       },
-    });
+    );
     expect(props).toEqual({
-      key: `area-1-line-2`,
       data: 'M0,0L10,10Z',
       x: 40,
       stroke: 'red',
@@ -181,28 +161,26 @@ describe('[canvas] Area Geometries props', () => {
     });
     expect(props.fill).toBeFalsy();
 
-    const seriesLineStyle = buildAreaLineProps({
-      areaIndex: 1,
-      xTransform: 0,
-      lineIndex: 2,
-      linePath: 'M0,0L10,10Z',
-      color: 'red',
-      strokeWidth: 1,
-      geometryStyle: {
-        opacity: 0.5,
-      },
-      seriesAreaLineStyle: {
+    const seriesLineStyle = buildLineRenderProps(
+      0,
+
+      'M0,0L10,10Z',
+      'red',
+
+      {
         opacity: 0.5,
         stroke: 'series-stroke',
         strokeWidth: 66,
         visible: true,
       },
-    });
+      {
+        opacity: 0.5,
+      },
+    );
     expect(seriesLineStyle).toEqual({
-      key: `area-1-line-2`,
       data: 'M0,0L10,10Z',
       x: 0,
-      stroke: 'red',
+      stroke: 'series-stroke',
       strokeWidth: 66,
       lineCap: 'round',
       lineJoin: 'round',
@@ -216,92 +194,65 @@ describe('[canvas] Area Geometries props', () => {
 
 describe('[canvas] Line Geometries', () => {
   test('can build line point props', () => {
-    const pointStyleProps = buildPointStyleProps({
+    const pointStyleProps = buildPointStyleProps('pink', {
+      visible: true,
       radius: 30,
       strokeWidth: 2,
       opacity: 0.5,
     });
 
-    const props = buildLinePointProps({
-      lineIndex: 1,
-      pointIndex: 2,
-      x: 10,
-      y: 20,
-      color: 'red',
-      pointStyleProps,
-    });
+    const props = buildPointRenderProps(10, 20, pointStyleProps);
     expect(props).toEqual({
-      key: 'line-point-1-2',
       x: 10,
       y: 20,
       radius: 30,
       strokeWidth: 2,
       strokeEnabled: true,
-      stroke: 'red',
-      fill: 'white',
+      stroke: 'pink',
+      fill: 'pink',
       opacity: 0.5,
       strokeHitEnabled: false,
       perfectDrawEnabled: false,
       listening: false,
     });
 
-    const noStrokeStyleProps = buildPointStyleProps({
+    const noStrokeStyleProps = buildPointStyleProps('pink', {
+      visible: true,
       radius: 30,
       strokeWidth: 0,
       opacity: 0.5,
     });
-    const propsNoStroke = buildLinePointProps({
-      lineIndex: 1,
-      pointIndex: 2,
-      x: 10,
-      y: 20,
-      color: 'red',
-      pointStyleProps: noStrokeStyleProps,
-    });
+    const propsNoStroke = buildPointRenderProps(10, 20, noStrokeStyleProps);
     expect(propsNoStroke).toEqual({
-      key: 'line-point-1-2',
       x: 10,
       y: 20,
       radius: 30,
       strokeWidth: 0,
       strokeEnabled: false,
-      stroke: 'red',
-      fill: 'white',
+      stroke: 'pink',
+      fill: 'pink',
       opacity: 0.5,
       strokeHitEnabled: false,
       perfectDrawEnabled: false,
       listening: false,
     });
 
-    const seriesPointStyleProps = buildPointStyleProps({
-      radius: 30,
-      strokeWidth: 2,
-      opacity: 0.5,
-      seriesPointStyle: {
-        stroke: 'series-stroke',
-        strokeWidth: 6,
-        visible: true,
-        radius: 12,
-        opacity: 18,
-      },
+    const seriesPointStyleProps = buildPointStyleProps('pink', {
+      stroke: 'series-stroke',
+      strokeWidth: 6,
+      visible: true,
+      radius: 12,
+      opacity: 18,
     });
-    const seriesPointStyle = buildLinePointProps({
-      lineIndex: 1,
-      pointIndex: 2,
-      x: 10,
-      y: 20,
-      color: 'red',
-      pointStyleProps: seriesPointStyleProps,
-    });
+    const seriesPointStyle = buildPointRenderProps(10, 20, seriesPointStyleProps);
     expect(seriesPointStyle).toEqual({
-      key: 'line-point-1-2',
       x: 10,
       y: 20,
       radius: 12,
       strokeWidth: 6,
       strokeEnabled: true,
-      stroke: 'red',
-      fill: 'white',
+      stroke: 'series-stroke',
+      fill: 'pink',
       opacity: 18,
       strokeHitEnabled: false,
       perfectDrawEnabled: false,
@@ -309,18 +260,22 @@ describe('[canvas] Line Geometries', () => {
     });
   });
   test('can build line path props', () => {
-    const props = buildLineProps({
-      index: 1,
-      linePath: 'M0,0L10,10Z',
-      xTransform: 40,
-      color: 'red',
-      strokeWidth: 1,
-      geometryStyle: {
+    const props = buildLineRenderProps(
+      40,
+      'M0,0L10,10Z',
+
+      'red',
+
+      {
+        visible: true,
+        opacity: 1,
+        strokeWidth: 1,
+      },
+      {
         opacity: 0.5,
       },
-    });
+    );
     expect(props).toEqual({
-      key: `line-1`,
       data: 'M0,0L10,10Z',
       x: 40,
       stroke: 'red',
@@ -334,23 +289,22 @@ describe('[canvas] Line Geometries', () => {
     });
     expect(props.fill).toBeFalsy();
 
-    const seriesLineStyleProps = buildLineProps({
-      index: 1,
-      linePath: 'M0,0L10,10Z',
-      xTransform: 0,
-      color: 'red',
-      strokeWidth: 1,
-      geometryStyle: {
-        opacity: 0.5,
-      },
-      seriesLineStyle: {
-        stroke: 'series-stroke',
+    const seriesLineStyleProps = buildLineRenderProps(
+      0,
+      'M0,0L10,10Z',
+
+      'red',
+
+      {
+        opacity: 1,
         strokeWidth: 66,
         visible: true,
       },
-    });
+      {
+        opacity: 0.5,
+      },
+    );
     expect(seriesLineStyleProps).toEqual({
-      key: `line-1`,
       data: 'M0,0L10,10Z',
       x: 0,
       stroke: 'red',
@@ -367,22 +321,25 @@ describe('[canvas] Line Geometries', () => {
 
 describe('[canvas] Bar Geometries', () => {
   test('can build bar props', () => {
-    const props = buildBarProps({
-      index: 1,
-      x: 10,
-      y: 20,
-      width: 30,
-      height: 40,
-      fill: 'red',
-      stroke: 'blue',
-      strokeWidth: 1,
-      borderEnabled: true,
-      geometryStyle: {
+    const props = buildBarRenderProps(
+      10,
+      20,
+      30,
+      40,
+      'red',
+      {
+        opacity: 1,
+      },
+      {
+        stroke: 'blue',
+        strokeWidth: 1,
+        visible: true,
+      },
+      {
         opacity: 0.5,
       },
-    });
+    );
     expect(props).toEqual({
-      key: `bar-1`,
       x: 10,
       y: 20,
       width: 30,

--- a/src/components/react_canvas/utils/rendering_props_utils.test.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.test.ts
@@ -353,6 +353,38 @@ describe('[canvas] Bar Geometries', () => {
       listening: false,
       opacity: 0.5,
     });
+
+    const barWithNoBorder = buildBarRenderProps(
+      10,
+      20,
+      30,
+      40,
+      'red',
+      {
+        opacity: 1,
+      },
+      {
+        strokeWidth: 0,
+        visible: true,
+      },
+      {
+        opacity: 0.5,
+      },
+    );
+    expect(barWithNoBorder).toEqual({
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 40,
+      fill: 'red',
+      stroke: 'transparent',
+      strokeWidth: 0,
+      strokeEnabled: false,
+      strokeHitEnabled: false,
+      perfectDrawEnabled: false,
+      listening: false,
+      opacity: 0.5,
+    });
   });
 
   test('can build bar value props', () => {

--- a/src/components/react_canvas/utils/rendering_props_utils.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.ts
@@ -1,158 +1,23 @@
 import { GeometryStyle } from '../../../lib/series/rendering';
 import { Rotation } from '../../../lib/series/specs';
-import { AreaStyle, DisplayValueStyle, LineStyle, PointStyle } from '../../../lib/themes/theme';
+import {
+  AreaStyle,
+  DisplayValueStyle,
+  LineStyle,
+  PointStyle,
+  RectStyle,
+  RectBorderStyle,
+} from '../../../lib/themes/theme';
 import { Dimensions } from '../../../lib/utils/dimensions';
 import { GlobalKonvaElementProps } from '../globals';
 
 export interface PointStyleProps {
   radius: number;
+  stroke: string;
   strokeWidth: number;
   strokeEnabled: boolean;
   fill: string;
   opacity: number;
-}
-
-export function buildAreaPointProps({
-  areaIndex,
-  pointIndex,
-  x,
-  y,
-  color,
-  pointStyleProps,
-}: {
-  areaIndex: number;
-  pointIndex: number;
-  x: number;
-  y: number;
-  color: string;
-  pointStyleProps: PointStyleProps;
-}) {
-  return {
-    key: `area-point-${areaIndex}-${pointIndex}`,
-    x,
-    y,
-    stroke: color,
-    ...pointStyleProps,
-    ...GlobalKonvaElementProps,
-  };
-}
-
-export function buildPointStyleProps({
-  radius,
-  strokeWidth,
-  opacity,
-  seriesPointStyle,
-}: {
-  radius: number;
-  strokeWidth: number;
-  opacity: number;
-  seriesPointStyle?: PointStyle;
-}): PointStyleProps {
-  const pointStrokeWidth = seriesPointStyle ? seriesPointStyle.strokeWidth : strokeWidth;
-  return {
-    radius: seriesPointStyle ? seriesPointStyle.radius : radius,
-    strokeWidth: pointStrokeWidth,
-    strokeEnabled: pointStrokeWidth !== 0,
-    fill: 'white',
-    opacity: seriesPointStyle ? seriesPointStyle.opacity : opacity,
-  };
-}
-
-export function buildAreaProps({
-  index,
-  areaPath,
-  xTransform,
-  color,
-  opacity,
-  seriesAreaStyle,
-}: {
-  index: number;
-  areaPath: string;
-  xTransform: number;
-  color: string;
-  opacity: number;
-  seriesAreaStyle?: AreaStyle;
-}) {
-  return {
-    key: `area-${index}`,
-    data: areaPath,
-    x: xTransform,
-    fill: color,
-    lineCap: 'round',
-    lineJoin: 'round',
-    opacity: seriesAreaStyle ? seriesAreaStyle.opacity : opacity,
-    ...GlobalKonvaElementProps,
-  };
-}
-
-export function buildAreaLineProps({
-  areaIndex,
-  lineIndex,
-  xTransform,
-  linePath,
-  color,
-  strokeWidth,
-  geometryStyle,
-  seriesAreaLineStyle,
-}: {
-  areaIndex: number;
-  lineIndex: number;
-  xTransform: number;
-  linePath: string;
-  color: string;
-  strokeWidth: number;
-  geometryStyle: GeometryStyle;
-  seriesAreaLineStyle?: LineStyle;
-}) {
-  return {
-    key: `area-${areaIndex}-line-${lineIndex}`,
-    data: linePath,
-    x: xTransform,
-    stroke: color,
-    strokeWidth: seriesAreaLineStyle ? seriesAreaLineStyle.strokeWidth : strokeWidth,
-    lineCap: 'round',
-    lineJoin: 'round',
-    ...geometryStyle,
-    ...GlobalKonvaElementProps,
-  };
-}
-
-export function buildBarProps({
-  index,
-  x,
-  y,
-  width,
-  height,
-  fill,
-  stroke,
-  strokeWidth,
-  borderEnabled,
-  geometryStyle,
-}: {
-  index: number;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  fill: string;
-  stroke: string;
-  strokeWidth: number;
-  borderEnabled: boolean;
-  geometryStyle: GeometryStyle;
-}) {
-  return {
-    key: `bar-${index}`,
-    x,
-    y,
-    width,
-    height,
-    fill,
-    strokeWidth,
-    stroke,
-    strokeEnabled: borderEnabled,
-    ...GlobalKonvaElementProps,
-    ...geometryStyle,
-  };
 }
 
 export function rotateBarValueProps(
@@ -369,56 +234,127 @@ export function buildBarValueProps({
   return props;
 }
 
-export function buildLinePointProps({
-  lineIndex,
-  pointIndex,
-  x,
-  y,
-  color,
-  pointStyleProps,
-}: {
-  lineIndex: number;
-  pointIndex: number;
-  x: number;
-  y: number;
-  color: string;
-  pointStyleProps: PointStyleProps;
-}) {
+/**
+ * Return the style of a point.
+ * The color value is used for stroke or fill if they are undefind in the PointStyle
+ * @param color the series color
+ * @param pointStyle the merged point style
+ */
+export function buildPointStyleProps(color: string, pointStyle: PointStyle): PointStyleProps {
+  const { strokeWidth, opacity } = pointStyle;
+  const stroke = pointStyle.stroke || color;
+  const fill = pointStyle.fill || color;
   return {
-    key: `line-point-${lineIndex}-${pointIndex}`,
+    radius: pointStyle.radius,
+    stroke,
+    strokeWidth,
+    strokeEnabled: strokeWidth !== 0,
+    fill: fill,
+    opacity,
+  };
+}
+
+/**
+ * Return the rendering props for a point
+ * @param x the x position of the point
+ * @param y the y position of the point
+ * @param pointStyleProps the style props of the point
+ */
+export function buildPointRenderProps(x: number, y: number, pointStyleProps: PointStyleProps) {
+  return {
     x,
     y,
-    stroke: color,
     ...pointStyleProps,
     ...GlobalKonvaElementProps,
   };
 }
 
-export function buildLineProps({
-  index,
-  xTransform,
-  linePath,
-  color,
-  strokeWidth,
-  geometryStyle,
-  seriesLineStyle,
-}: {
-  index: number;
-  xTransform: number;
-  linePath: string;
-  color: string;
-  strokeWidth: number;
-  geometryStyle: GeometryStyle;
-  seriesLineStyle?: LineStyle;
-}) {
+/**
+ * Return the rendering props for a line. The color of the line will be overwritten
+ * by the stroke color of the lineStyle parameter if present
+ * @param x the horizontal offset to place the line
+ * @param linePath the SVG line path
+ * @param color the computed color of the line for this series
+ * @param lineStyle the line style
+ * @param geometryStyle the highlight geometry style
+ */
+export function buildLineRenderProps(
+  x: number,
+  linePath: string,
+  color: string,
+  lineStyle: LineStyle,
+  geometryStyle: GeometryStyle,
+) {
   return {
-    key: `line-${index}`,
-    x: xTransform,
+    x,
     data: linePath,
-    stroke: color,
-    strokeWidth: seriesLineStyle ? seriesLineStyle.strokeWidth : strokeWidth,
+    stroke: lineStyle.stroke || color,
+    strokeWidth: lineStyle.strokeWidth,
     lineCap: 'round',
     lineJoin: 'round',
+    ...geometryStyle,
+    ...GlobalKonvaElementProps,
+  };
+}
+
+/**
+ * Return the rendering props for an area. The color of the area will be overwritten
+ * by the fill color of the areaStyle parameter if present
+ * @param areaPath the SVG area path
+ * @param x the horizontal offset to place the area
+ * @param color the computed color of the line for this series
+ * @param areaStyle the area style
+ * @param geometryStyle the highlight geometry style
+ */
+export function buildAreaRenderProps(
+  xTransform: number,
+  areaPath: string,
+  color: string,
+  areaStyle: AreaStyle,
+  geometryStyle: GeometryStyle,
+) {
+  return {
+    x: xTransform,
+    data: areaPath,
+    fill: areaStyle.fill || color,
+    lineCap: 'round',
+    lineJoin: 'round',
+    ...geometryStyle,
+    ...GlobalKonvaElementProps,
+  };
+}
+
+/**
+ * Return the rendering props for a bar. The color of the bar will be overwritten
+ * by the fill color of the rectStyle parameter if present
+ * @param x the x position of the rect
+ * @param y the y position of the rect
+ * @param width the width of the rect
+ * @param height the height of the rect
+ * @param color the computed color of the rect for this series
+ * @param rectStyle the rect style
+ * @param borderStyle the border rect style
+ * @param geometryStyle the highlight geometry style
+ */
+export function buildBarRenderProps(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  color: string,
+  rectStyle: RectStyle,
+  borderStyle: RectBorderStyle,
+  geometryStyle: GeometryStyle,
+) {
+  return {
+    x,
+    y,
+    width,
+    height,
+    fill: rectStyle.fill || color,
+    strokeWidth: borderStyle.strokeWidth || 0,
+    stroke: borderStyle.stroke || 'transparent',
+    strokeEnabled: borderStyle.visible && borderStyle.strokeWidth > 0,
     ...geometryStyle,
     ...GlobalKonvaElementProps,
   };

--- a/src/components/react_canvas/utils/rendering_props_utils.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.ts
@@ -352,7 +352,7 @@ export function buildBarRenderProps(
     width,
     height,
     fill: rectStyle.fill || color,
-    strokeWidth: borderStyle.strokeWidth || 0,
+    strokeWidth: borderStyle.strokeWidth,
     stroke: borderStyle.stroke || 'transparent',
     strokeEnabled: borderStyle.visible && borderStyle.strokeWidth > 0,
     ...geometryStyle,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from './lib/themes/theme';
 export { LIGHT_THEME } from './lib/themes/light_theme';
 export { DARK_THEME } from './lib/themes/dark_theme';
 export * from './lib/themes/theme_commons';
+export { RecursivePartial } from './lib/utils/commons';
 export { CurveType } from './lib/series/curves';
 export { timeFormatter, niceTimeFormatter, niceTimeFormatByDay } from './utils/data/formatters';
 export { DataGenerator } from './utils/data_generators/data_generator';

--- a/src/lib/series/rendering.areas.test.ts
+++ b/src/lib/series/rendering.areas.test.ts
@@ -11,6 +11,55 @@ const SPEC_ID = getSpecId('spec_1');
 const GROUP_ID = getGroupId('group_1');
 
 describe('Rendering points - areas', () => {
+  describe('Empty line for missing data', () => {
+    const pointSeriesSpec: AreaSeriesSpec = {
+      id: SPEC_ID,
+      groupId: GROUP_ID,
+      seriesType: 'area',
+      yScaleToDataExtent: false,
+      data: [[0, 10], [1, 5]],
+      xAccessor: 0,
+      yAccessors: [1],
+      xScaleType: ScaleType.Ordinal,
+      yScaleType: ScaleType.Linear,
+    };
+    const pointSeriesMap = new Map<SpecId, AreaSeriesSpec>();
+    pointSeriesMap.set(SPEC_ID, pointSeriesSpec);
+    const pointSeriesDomains = computeSeriesDomains(pointSeriesMap, new Map());
+    const xScale = computeXScale(pointSeriesDomains.xDomain, pointSeriesMap.size, 0, 100);
+    const yScales = computeYScales(pointSeriesDomains.yDomain, 100, 0);
+    let renderedArea: {
+      areaGeometry: AreaGeometry;
+      indexedGeometries: Map<any, IndexedGeometry[]>;
+    };
+
+    beforeEach(() => {
+      renderedArea = renderArea(
+        25, // adding a ideal 25px shift, generally applied by renderGeometries
+        [],
+        xScale,
+        yScales.get(GROUP_ID)!,
+        'red',
+        CurveType.LINEAR,
+        SPEC_ID,
+        false,
+        [],
+        0,
+        LIGHT_THEME.areaSeriesStyle,
+      );
+    });
+    test('Render geometry but empty upper and lower lines and area paths', () => {
+      const {
+        areaGeometry: { lines, area, color, geometryId, transform },
+      } = renderedArea;
+      expect(lines.length).toBe(0);
+      expect(area).toBe('');
+      expect(color).toBe('red');
+      expect(geometryId.seriesKey).toEqual([]);
+      expect(geometryId.specId).toEqual(SPEC_ID);
+      expect(transform).toEqual({ x: 25, y: 0 });
+    });
+  });
   describe('Single series area chart - ordinal', () => {
     const pointSeriesSpec: AreaSeriesSpec = {
       id: SPEC_ID,

--- a/src/lib/series/rendering.areas.test.ts
+++ b/src/lib/series/rendering.areas.test.ts
@@ -6,6 +6,7 @@ import { CurveType } from './curves';
 import { AreaGeometry, IndexedGeometry, PointGeometry, renderArea } from './rendering';
 import { computeXScale, computeYScales } from './scales';
 import { AreaSeriesSpec } from './specs';
+import { LIGHT_THEME } from '../themes/light_theme';
 const SPEC_ID = getSpecId('spec_1');
 const GROUP_ID = getGroupId('group_1');
 
@@ -44,6 +45,7 @@ describe('Rendering points - areas', () => {
         false,
         [],
         0,
+        LIGHT_THEME.areaSeriesStyle,
       );
     });
     test('Can render an line and area paths', () => {
@@ -159,6 +161,7 @@ describe('Rendering points - areas', () => {
         false,
         [],
         0,
+        LIGHT_THEME.areaSeriesStyle,
       );
       secondLine = renderArea(
         25, // adding a ideal 25px shift, generally applied by renderGeometries
@@ -171,6 +174,7 @@ describe('Rendering points - areas', () => {
         false,
         [],
         0,
+        LIGHT_THEME.areaSeriesStyle,
       );
     });
 
@@ -317,6 +321,7 @@ describe('Rendering points - areas', () => {
         false,
         [],
         0,
+        LIGHT_THEME.areaSeriesStyle,
       );
     });
     test('Can render a linear area', () => {
@@ -426,6 +431,7 @@ describe('Rendering points - areas', () => {
         false,
         [],
         0,
+        LIGHT_THEME.areaSeriesStyle,
       );
       secondLine = renderArea(
         0, // not applied any shift, renderGeometries applies it only with mixed charts
@@ -438,6 +444,7 @@ describe('Rendering points - areas', () => {
         false,
         [],
         0,
+        LIGHT_THEME.areaSeriesStyle,
       );
     });
     test('can render two linear areas', () => {
@@ -583,6 +590,7 @@ describe('Rendering points - areas', () => {
         false,
         [],
         0,
+        LIGHT_THEME.areaSeriesStyle,
       );
     });
     test('Can render a time area', () => {
@@ -692,6 +700,7 @@ describe('Rendering points - areas', () => {
         false,
         [],
         0,
+        LIGHT_THEME.areaSeriesStyle,
       );
       secondLine = renderArea(
         0, // not applied any shift, renderGeometries applies it only with mixed charts
@@ -704,6 +713,7 @@ describe('Rendering points - areas', () => {
         false,
         [],
         0,
+        LIGHT_THEME.areaSeriesStyle,
       );
     });
     test('can render first spec points', () => {
@@ -834,6 +844,7 @@ describe('Rendering points - areas', () => {
         false,
         [],
         0,
+        LIGHT_THEME.areaSeriesStyle,
       );
     });
     test('Can render a splitted area and line', () => {

--- a/src/lib/series/rendering.bands.test.ts
+++ b/src/lib/series/rendering.bands.test.ts
@@ -6,6 +6,7 @@ import { CurveType } from './curves';
 import { AreaGeometry, IndexedGeometry, PointGeometry, renderArea, renderBars } from './rendering';
 import { computeXScale, computeYScales } from './scales';
 import { AreaSeriesSpec, BarSeriesSpec } from './specs';
+import { LIGHT_THEME } from '../themes/light_theme';
 const SPEC_ID = getSpecId('spec_1');
 const GROUP_ID = getGroupId('group_1');
 
@@ -45,6 +46,7 @@ describe('Rendering bands - areas', () => {
         true,
         [],
         0,
+        LIGHT_THEME.areaSeriesStyle,
       );
     });
     test('Can render upper and lower lines and area paths', () => {
@@ -182,6 +184,7 @@ describe('Rendering bands - areas', () => {
         true,
         [],
         0,
+        LIGHT_THEME.areaSeriesStyle,
       );
     });
     test('Can render upper and lower lines and area paths', () => {
@@ -351,6 +354,7 @@ describe('Rendering bands - areas', () => {
         'red',
         SPEC_ID,
         [],
+        LIGHT_THEME.barSeriesStyle,
       );
       expect(barGeometries.length).toBe(3);
       expect(barGeometries[0]).toEqual({
@@ -368,6 +372,25 @@ describe('Rendering bands - areas', () => {
           specId: SPEC_ID,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
       expect(barGeometries[1]).toEqual({
         x: 50,
@@ -384,6 +407,25 @@ describe('Rendering bands - areas', () => {
           specId: SPEC_ID,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
       expect(barGeometries[2]).toEqual({
         x: 75,
@@ -399,6 +441,25 @@ describe('Rendering bands - areas', () => {
         geometryId: {
           specId: SPEC_ID,
           seriesKey: [],
+        },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
         },
       });
     });

--- a/src/lib/series/rendering.bands.test.ts
+++ b/src/lib/series/rendering.bands.test.ts
@@ -11,6 +11,56 @@ const SPEC_ID = getSpecId('spec_1');
 const GROUP_ID = getGroupId('group_1');
 
 describe('Rendering bands - areas', () => {
+  describe('Empty line for missing data', () => {
+    const pointSeriesSpec: AreaSeriesSpec = {
+      id: SPEC_ID,
+      groupId: GROUP_ID,
+      seriesType: 'area',
+      yScaleToDataExtent: false,
+      data: [[0, 2, 10], [1, 3, 5]],
+      xAccessor: 0,
+      y0Accessors: [1],
+      yAccessors: [2],
+      xScaleType: ScaleType.Ordinal,
+      yScaleType: ScaleType.Linear,
+    };
+    const pointSeriesMap = new Map<SpecId, AreaSeriesSpec>();
+    pointSeriesMap.set(SPEC_ID, pointSeriesSpec);
+    const pointSeriesDomains = computeSeriesDomains(pointSeriesMap, new Map());
+    const xScale = computeXScale(pointSeriesDomains.xDomain, pointSeriesMap.size, 0, 100);
+    const yScales = computeYScales(pointSeriesDomains.yDomain, 100, 0);
+    let renderedArea: {
+      areaGeometry: AreaGeometry;
+      indexedGeometries: Map<any, IndexedGeometry[]>;
+    };
+
+    beforeEach(() => {
+      renderedArea = renderArea(
+        25, // adding a ideal 25px shift, generally applied by renderGeometries
+        [],
+        xScale,
+        yScales.get(GROUP_ID)!,
+        'red',
+        CurveType.LINEAR,
+        SPEC_ID,
+        true,
+        [],
+        0,
+        LIGHT_THEME.areaSeriesStyle,
+      );
+    });
+    test('Render geometry but empty upper and lower lines and area paths', () => {
+      const {
+        areaGeometry: { lines, area, color, geometryId, transform },
+      } = renderedArea;
+      expect(lines.length).toBe(0);
+      expect(area).toBe('');
+      expect(color).toBe('red');
+      expect(geometryId.seriesKey).toEqual([]);
+      expect(geometryId.specId).toEqual(SPEC_ID);
+      expect(transform).toEqual({ x: 25, y: 0 });
+    });
+  });
   describe('Single band area chart', () => {
     const pointSeriesSpec: AreaSeriesSpec = {
       id: SPEC_ID,

--- a/src/lib/series/rendering.bars.test.ts
+++ b/src/lib/series/rendering.bars.test.ts
@@ -5,6 +5,7 @@ import { ScaleType } from '../utils/scales/scales';
 import { renderBars } from './rendering';
 import { computeXScale, computeYScales } from './scales';
 import { BarSeriesSpec } from './specs';
+import { LIGHT_THEME } from '../themes/light_theme';
 
 const SPEC_ID = getSpecId('spec_1');
 const GROUP_ID = getGroupId('group_1');
@@ -38,6 +39,7 @@ describe('Rendering bars', () => {
         'red',
         SPEC_ID,
         [],
+        LIGHT_THEME.barSeriesStyle,
       );
 
       expect(barGeometries[0]).toEqual({
@@ -55,6 +57,25 @@ describe('Rendering bars', () => {
           specId: SPEC_ID,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
       expect(barGeometries[1]).toEqual({
         x: 50,
@@ -71,6 +92,25 @@ describe('Rendering bars', () => {
           specId: SPEC_ID,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
       expect(barGeometries.length).toBe(2);
     });
@@ -84,6 +124,7 @@ describe('Rendering bars', () => {
         'red',
         SPEC_ID,
         [],
+        LIGHT_THEME.barSeriesStyle,
         { valueFormatter, showValueLabel: true, isAlternatingValueLabel: true },
       );
       expect(barGeometries[0].displayValue).toBeDefined();
@@ -98,6 +139,7 @@ describe('Rendering bars', () => {
         'red',
         SPEC_ID,
         [],
+        LIGHT_THEME.barSeriesStyle,
         {},
       );
       expect(barGeometries[0].displayValue).toBeUndefined();
@@ -113,6 +155,7 @@ describe('Rendering bars', () => {
         'red',
         SPEC_ID,
         [],
+        LIGHT_THEME.barSeriesStyle,
         { valueFormatter, showValueLabel: true, isAlternatingValueLabel: true },
       );
       expect(barGeometries[0].displayValue!.text).toBeDefined();
@@ -129,6 +172,7 @@ describe('Rendering bars', () => {
         'red',
         SPEC_ID,
         [],
+        LIGHT_THEME.barSeriesStyle,
         { valueFormatter, showValueLabel: true, isValueContainedInElement: true },
       );
       expect(barGeometries[0].displayValue!.width).toBe(50);
@@ -175,6 +219,7 @@ describe('Rendering bars', () => {
         'red',
         spec1Id,
         [],
+        LIGHT_THEME.barSeriesStyle,
       );
       expect(barGeometries.length).toEqual(2);
       expect(barGeometries[0]).toEqual({
@@ -192,6 +237,25 @@ describe('Rendering bars', () => {
           specId: spec1Id,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
       expect(barGeometries[1]).toEqual({
         x: 50,
@@ -208,6 +272,25 @@ describe('Rendering bars', () => {
           specId: spec1Id,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
     });
     test('can render second spec bars', () => {
@@ -219,6 +302,7 @@ describe('Rendering bars', () => {
         'blue',
         spec2Id,
         [],
+        LIGHT_THEME.barSeriesStyle,
       );
       expect(barGeometries.length).toEqual(2);
       expect(barGeometries[0]).toEqual({
@@ -236,6 +320,25 @@ describe('Rendering bars', () => {
           specId: spec2Id,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
       expect(barGeometries[1]).toEqual({
         x: 75,
@@ -251,6 +354,25 @@ describe('Rendering bars', () => {
         geometryId: {
           specId: spec2Id,
           seriesKey: [],
+        },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
         },
       });
     });
@@ -282,6 +404,7 @@ describe('Rendering bars', () => {
         'red',
         SPEC_ID,
         [],
+        LIGHT_THEME.barSeriesStyle,
       );
       expect(barGeometries[0]).toEqual({
         x: 0,
@@ -298,6 +421,25 @@ describe('Rendering bars', () => {
           specId: SPEC_ID,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
       expect(barGeometries[1]).toEqual({
         x: 50,
@@ -313,6 +455,25 @@ describe('Rendering bars', () => {
         geometryId: {
           specId: SPEC_ID,
           seriesKey: [],
+        },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
         },
       });
     });
@@ -358,6 +519,7 @@ describe('Rendering bars', () => {
         'red',
         spec1Id,
         [],
+        LIGHT_THEME.barSeriesStyle,
       );
       expect(barGeometries.length).toEqual(2);
       expect(barGeometries[0]).toEqual({
@@ -375,6 +537,25 @@ describe('Rendering bars', () => {
           specId: spec1Id,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
       expect(barGeometries[1]).toEqual({
         x: 50,
@@ -391,6 +572,25 @@ describe('Rendering bars', () => {
           specId: spec1Id,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
     });
     test('can render second spec bars', () => {
@@ -402,6 +602,7 @@ describe('Rendering bars', () => {
         'blue',
         spec2Id,
         [],
+        LIGHT_THEME.barSeriesStyle,
       );
       expect(barGeometries.length).toEqual(2);
       expect(barGeometries[0]).toEqual({
@@ -419,6 +620,25 @@ describe('Rendering bars', () => {
           specId: spec2Id,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
       expect(barGeometries[1]).toEqual({
         x: 75,
@@ -434,6 +654,25 @@ describe('Rendering bars', () => {
         geometryId: {
           specId: spec2Id,
           seriesKey: [],
+        },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
         },
       });
     });
@@ -479,6 +718,7 @@ describe('Rendering bars', () => {
         'red',
         spec1Id,
         [],
+        LIGHT_THEME.barSeriesStyle,
       );
       expect(barGeometries.length).toEqual(2);
       expect(barGeometries[0]).toEqual({
@@ -496,6 +736,25 @@ describe('Rendering bars', () => {
           specId: spec1Id,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
       expect(barGeometries[1]).toEqual({
         x: 50,
@@ -512,6 +771,25 @@ describe('Rendering bars', () => {
           specId: spec1Id,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
     });
     test('can render second spec bars', () => {
@@ -523,6 +801,7 @@ describe('Rendering bars', () => {
         'blue',
         spec2Id,
         [],
+        LIGHT_THEME.barSeriesStyle,
       );
       expect(barGeometries.length).toEqual(2);
       expect(barGeometries[0]).toEqual({
@@ -540,6 +819,25 @@ describe('Rendering bars', () => {
           specId: spec2Id,
           seriesKey: [],
         },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
+        },
       });
       expect(barGeometries[1]).toEqual({
         x: 75,
@@ -555,6 +853,25 @@ describe('Rendering bars', () => {
         geometryId: {
           specId: spec2Id,
           seriesKey: [],
+        },
+        displayValue: undefined,
+        seriesStyle: {
+          displayValue: {
+            fill: 'gray',
+            fontFamily: 'sans-serif',
+            fontSize: 10,
+            fontStyle: 'normal',
+            offsetX: 0,
+            offsetY: 0,
+            padding: 0,
+          },
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            strokeWidth: 0,
+            visible: false,
+          },
         },
       });
     });

--- a/src/lib/series/rendering.lines.test.ts
+++ b/src/lib/series/rendering.lines.test.ts
@@ -12,6 +12,52 @@ const SPEC_ID = getSpecId('spec_1');
 const GROUP_ID = getGroupId('group_1');
 
 describe('Rendering points - line', () => {
+  describe('Empty line for missing data', () => {
+    const pointSeriesSpec: LineSeriesSpec = {
+      id: SPEC_ID,
+      groupId: GROUP_ID,
+      seriesType: 'line',
+      yScaleToDataExtent: false,
+      data: [[0, 10], [1, 5]],
+      xAccessor: 0,
+      yAccessors: [1],
+      xScaleType: ScaleType.Ordinal,
+      yScaleType: ScaleType.Linear,
+    };
+    const pointSeriesMap = new Map<SpecId, LineSeriesSpec>();
+    pointSeriesMap.set(SPEC_ID, pointSeriesSpec);
+    const pointSeriesDomains = computeSeriesDomains(pointSeriesMap, new Map());
+    const xScale = computeXScale(pointSeriesDomains.xDomain, pointSeriesMap.size, 0, 100);
+    const yScales = computeYScales(pointSeriesDomains.yDomain, 100, 0);
+    let renderedLine: {
+      lineGeometry: LineGeometry;
+      indexedGeometries: Map<any, IndexedGeometry[]>;
+    };
+
+    beforeEach(() => {
+      renderedLine = renderLine(
+        25, // adding a ideal 25px shift, generally applied by renderGeometries
+        [],
+        xScale,
+        yScales.get(GROUP_ID)!,
+        'red',
+        CurveType.LINEAR,
+        SPEC_ID,
+        false,
+        [],
+        0,
+        LIGHT_THEME.lineSeriesStyle,
+      );
+    });
+    test('Can render the geometry without a line', () => {
+      const { lineGeometry } = renderedLine;
+      expect(lineGeometry.line).toBe('');
+      expect(lineGeometry.color).toBe('red');
+      expect(lineGeometry.geometryId.seriesKey).toEqual([]);
+      expect(lineGeometry.geometryId.specId).toEqual(SPEC_ID);
+      expect(lineGeometry.transform).toEqual({ x: 25, y: 0 });
+    });
+  });
   describe('Single series line chart - ordinal', () => {
     const pointSeriesSpec: LineSeriesSpec = {
       id: SPEC_ID,

--- a/src/lib/series/rendering.lines.test.ts
+++ b/src/lib/series/rendering.lines.test.ts
@@ -7,6 +7,7 @@ import { CurveType } from './curves';
 import { IndexedGeometry, LineGeometry, PointGeometry, renderLine } from './rendering';
 import { computeXScale, computeYScales } from './scales';
 import { LineSeriesSpec } from './specs';
+import { LIGHT_THEME } from '../themes/light_theme';
 const SPEC_ID = getSpecId('spec_1');
 const GROUP_ID = getGroupId('group_1');
 
@@ -45,6 +46,7 @@ describe('Rendering points - line', () => {
         false,
         [],
         0,
+        LIGHT_THEME.lineSeriesStyle,
       );
     });
     test('Can render a line', () => {
@@ -155,6 +157,7 @@ describe('Rendering points - line', () => {
         false,
         [],
         0,
+        LIGHT_THEME.lineSeriesStyle,
       );
       secondLine = renderLine(
         25, // adding a ideal 25px shift, generally applied by renderGeometries
@@ -167,6 +170,7 @@ describe('Rendering points - line', () => {
         false,
         [],
         0,
+        LIGHT_THEME.lineSeriesStyle,
       );
     });
 
@@ -311,6 +315,7 @@ describe('Rendering points - line', () => {
         false,
         [],
         0,
+        LIGHT_THEME.lineSeriesStyle,
       );
     });
     test('Can render a linear line', () => {
@@ -419,6 +424,7 @@ describe('Rendering points - line', () => {
         false,
         [],
         0,
+        LIGHT_THEME.lineSeriesStyle,
       );
       secondLine = renderLine(
         0, // not applied any shift, renderGeometries applies it only with mixed charts
@@ -431,6 +437,7 @@ describe('Rendering points - line', () => {
         false,
         [],
         0,
+        LIGHT_THEME.lineSeriesStyle,
       );
     });
     test('can render two linear lines', () => {
@@ -574,6 +581,7 @@ describe('Rendering points - line', () => {
         false,
         [],
         0,
+        LIGHT_THEME.lineSeriesStyle,
       );
     });
     test('Can render a time line', () => {
@@ -682,6 +690,7 @@ describe('Rendering points - line', () => {
         false,
         [],
         0,
+        LIGHT_THEME.lineSeriesStyle,
       );
       secondLine = renderLine(
         0, // not applied any shift, renderGeometries applies it only with mixed charts
@@ -694,6 +703,7 @@ describe('Rendering points - line', () => {
         false,
         [],
         0,
+        LIGHT_THEME.lineSeriesStyle,
       );
     });
     test('can render first spec points', () => {
@@ -824,6 +834,7 @@ describe('Rendering points - line', () => {
         false,
         [],
         0,
+        LIGHT_THEME.lineSeriesStyle,
       );
     });
     test('Can render a splitted line', () => {

--- a/src/lib/series/rendering.test.ts
+++ b/src/lib/series/rendering.test.ts
@@ -4,6 +4,24 @@ import { BarGeometry, getGeometryStyle, isPointOnGeometry, PointGeometry } from 
 
 describe('Rendering utils', () => {
   test('check if point is in geometry', () => {
+    const seriesStyle = {
+      rect: {
+        opacity: 1,
+      },
+      rectBorder: {
+        strokeWidth: 1,
+        visible: false,
+      },
+      displayValue: {
+        fill: 'black',
+        fontFamily: '',
+        fontSize: 2,
+        offsetX: 0,
+        offsetY: 0,
+        padding: 2,
+      },
+    };
+
     const geometry: BarGeometry = {
       color: 'red',
       geometryId: {
@@ -19,6 +37,7 @@ describe('Rendering utils', () => {
       y: 0,
       width: 10,
       height: 10,
+      seriesStyle,
     };
     expect(isPointOnGeometry(0, 0, geometry)).toBe(true);
     expect(isPointOnGeometry(10, 10, geometry)).toBe(true);

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -272,7 +272,7 @@ export function renderBars(
         ? {
             text: displayValueText,
             width: displayValueWidth,
-            height: fontSize || 0,
+            height: fontSize,
             hideClippedValue,
             isValueContainedInElement: displayValueSettings.isValueContainedInElement,
           }

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -3,11 +3,11 @@ import { CanvasTextBBoxCalculator } from '../axes/canvas_text_bbox_calculator';
 import {
   AreaSeriesStyle,
   AreaStyle,
-  CustomBarSeriesStyle,
   LineSeriesStyle,
   LineStyle,
   PointStyle,
   SharedGeometryStyle,
+  BarSeriesStyle,
 } from '../themes/theme';
 import { SpecId } from '../utils/ids';
 import { isLogarithmicScale } from '../utils/scales/scale_continuous';
@@ -63,7 +63,7 @@ export interface BarGeometry {
   };
   geometryId: GeometryId;
   value: GeometryValue;
-  seriesStyle?: CustomBarSeriesStyle;
+  seriesStyle: BarSeriesStyle;
 }
 export interface LineGeometry {
   line: string;
@@ -74,8 +74,8 @@ export interface LineGeometry {
     y: number;
   };
   geometryId: GeometryId;
-  seriesLineStyle?: LineStyle;
-  seriesPointStyle?: PointStyle;
+  seriesLineStyle: LineStyle;
+  seriesPointStyle: PointStyle;
 }
 export interface AreaGeometry {
   area: string;
@@ -87,9 +87,9 @@ export interface AreaGeometry {
     y: number;
   };
   geometryId: GeometryId;
-  seriesAreaStyle?: AreaStyle;
-  seriesAreaLineStyle?: LineStyle;
-  seriesPointStyle?: PointStyle;
+  seriesAreaStyle: AreaStyle;
+  seriesAreaLineStyle: LineStyle;
+  seriesPointStyle: PointStyle;
 }
 
 export function isPointGeometry(ig: IndexedGeometry): ig is PointGeometry {
@@ -195,8 +195,8 @@ export function renderBars(
   color: string,
   specId: SpecId,
   seriesKey: any[],
+  seriesStyle: BarSeriesStyle,
   displayValueSettings?: DisplayValueSpec,
-  seriesStyle?: CustomBarSeriesStyle,
 ): {
   barGeometries: BarGeometry[];
   indexedGeometries: Map<any, IndexedGeometry[]>;
@@ -207,8 +207,8 @@ export function renderBars(
   const barGeometries: BarGeometry[] = [];
 
   const bboxCalculator = new CanvasTextBBoxCalculator();
-  const fontSize = seriesStyle && seriesStyle.displayValue ? seriesStyle.displayValue.fontSize : undefined;
-  const fontFamily = seriesStyle && seriesStyle.displayValue ? seriesStyle.displayValue.fontFamily : undefined;
+  const fontSize = seriesStyle.displayValue.fontSize;
+  const fontFamily = seriesStyle.displayValue.fontFamily;
 
   dataset.forEach((datum) => {
     const { y0, y1, initialY1 } = datum;
@@ -314,7 +314,7 @@ export function renderLine(
   hasY0Accessors: boolean,
   seriesKey: any[],
   xScaleOffset: number,
-  seriesStyle?: LineSeriesStyle,
+  seriesStyle: LineSeriesStyle,
 ): {
   lineGeometry: LineGeometry;
   indexedGeometries: Map<any, IndexedGeometry[]>;
@@ -328,9 +328,6 @@ export function renderLine(
     .curve(getCurveFactory(curve));
   const y = 0;
   const x = shift;
-
-  const seriesPointStyle = seriesStyle ? seriesStyle.point : undefined;
-  const seriesLineStyle = seriesStyle ? seriesStyle.line : undefined;
 
   const { pointGeometries, indexedGeometries } = renderPoints(
     shift - xScaleOffset,
@@ -354,8 +351,8 @@ export function renderLine(
       specId,
       seriesKey,
     },
-    seriesLineStyle,
-    seriesPointStyle,
+    seriesLineStyle: seriesStyle.line,
+    seriesPointStyle: seriesStyle.point,
   };
   return {
     lineGeometry,
@@ -374,7 +371,7 @@ export function renderArea(
   hasY0Accessors: boolean,
   seriesKey: any[],
   xScaleOffset: number,
-  seriesStyle?: AreaSeriesStyle,
+  seriesStyle: AreaSeriesStyle,
 ): {
   areaGeometry: AreaGeometry;
   indexedGeometries: Map<any, IndexedGeometry[]>;
@@ -406,10 +403,6 @@ export function renderArea(
     }
   }
 
-  const seriesPointStyle = seriesStyle ? seriesStyle.point : undefined;
-  const seriesAreaStyle = seriesStyle ? seriesStyle.area : undefined;
-  const seriesAreaLineStyle = seriesStyle ? seriesStyle.line : undefined;
-
   const { pointGeometries, indexedGeometries } = renderPoints(
     shift - xScaleOffset,
     dataset,
@@ -434,9 +427,9 @@ export function renderArea(
       specId,
       seriesKey,
     },
-    seriesAreaStyle,
-    seriesAreaLineStyle,
-    seriesPointStyle,
+    seriesAreaStyle: seriesStyle.area,
+    seriesAreaLineStyle: seriesStyle.line,
+    seriesPointStyle: seriesStyle.point,
   };
   return {
     areaGeometry,

--- a/src/lib/series/specs.ts
+++ b/src/lib/series/specs.ts
@@ -1,13 +1,13 @@
 import {
   AreaSeriesStyle,
-  CustomBarSeriesStyle,
   GridLineConfig,
   LineAnnotationStyle,
   LineSeriesStyle,
   RectAnnotationStyle,
+  BarSeriesStyle,
 } from '../themes/theme';
 import { Accessor } from '../utils/accessor';
-import { Omit } from '../utils/commons';
+import { Omit, RecursivePartial } from '../utils/commons';
 import { AnnotationId, AxisId, GroupId, SpecId } from '../utils/ids';
 import { ScaleContinuousType, ScaleType } from '../utils/scales/scales';
 import { CurveType } from './curves';
@@ -135,7 +135,7 @@ export type BarSeriesSpec = BasicSeriesSpec & {
   seriesType: 'bar';
   /** If true, will stack all BarSeries and align bars to ticks (instead of centered on ticks) */
   enableHistogramMode?: boolean;
-  barSeriesStyle?: CustomBarSeriesStyle;
+  barSeriesStyle?: RecursivePartial<BarSeriesStyle>;
 };
 
 /**
@@ -154,7 +154,7 @@ export type LineSeriesSpec = BasicSeriesSpec &
     /** @default line */
     seriesType: 'line';
     curve?: CurveType;
-    lineSeriesStyle?: LineSeriesStyle;
+    lineSeriesStyle?: RecursivePartial<LineSeriesStyle>;
   };
 
 /**
@@ -166,7 +166,7 @@ export type AreaSeriesSpec = BasicSeriesSpec &
     seriesType: 'area';
     /** The type of interpolator to be used to interpolate values between points */
     curve?: CurveType;
-    areaSeriesStyle?: AreaSeriesStyle;
+    areaSeriesStyle?: RecursivePartial<AreaSeriesStyle>;
   };
 
 interface HistogramConfig {

--- a/src/lib/series/tooltip.test.ts
+++ b/src/lib/series/tooltip.test.ts
@@ -29,6 +29,23 @@ describe('Tooltip formatting', () => {
     tickSize: 0,
     tickFormat: (d) => `${d}`,
   };
+  const seriesStyle = {
+    rect: {
+      opacity: 1,
+    },
+    rectBorder: {
+      strokeWidth: 1,
+      visible: false,
+    },
+    displayValue: {
+      fill: 'black',
+      fontFamily: '',
+      fontSize: 2,
+      offsetX: 0,
+      offsetY: 0,
+      padding: 2,
+    },
+  };
   const indexedGeometry: BarGeometry = {
     x: 0,
     y: 0,
@@ -44,6 +61,7 @@ describe('Tooltip formatting', () => {
       y: 10,
       accessor: 'y1',
     },
+    seriesStyle,
   };
 
   test('format simple tooltip', () => {

--- a/src/lib/themes/dark_theme.ts
+++ b/src/lib/themes/dark_theme.ts
@@ -13,52 +13,41 @@ export const DARK_THEME: Theme = {
   chartMargins: DEFAULT_CHART_MARGINS,
   lineSeriesStyle: {
     line: {
-      stroke: DEFAULT_MISSING_COLOR,
-      strokeWidth: 1,
       visible: true,
-    },
-    border: {
-      stroke: 'white',
-      strokeWidth: 2,
-      visible: false,
+      strokeWidth: 1,
+      opacity: 1,
     },
     point: {
       visible: true,
+      strokeWidth: 0,
       radius: 1,
-      stroke: 'white',
-      strokeWidth: 0.5,
       opacity: 1,
     },
   },
   areaSeriesStyle: {
     area: {
-      fill: DEFAULT_MISSING_COLOR,
       visible: true,
       opacity: 1,
     },
     line: {
-      stroke: DEFAULT_MISSING_COLOR,
-      strokeWidth: 1,
       visible: true,
-    },
-    border: {
-      stroke: 'white',
-      strokeWidth: 2,
-      visible: false,
+      strokeWidth: 1,
+      opacity: 1,
     },
     point: {
       visible: true,
+      strokeWidth: 0,
       radius: 1,
-      stroke: 'white',
-      strokeWidth: 0.5,
       opacity: 1,
     },
   },
   barSeriesStyle: {
-    border: {
-      stroke: 'white',
-      strokeWidth: 2,
+    rect: {
+      opacity: 1,
+    },
+    rectBorder: {
       visible: false,
+      strokeWidth: 0,
     },
     displayValue: {
       fontSize: 10,

--- a/src/lib/themes/light_theme.ts
+++ b/src/lib/themes/light_theme.ts
@@ -13,52 +13,41 @@ export const LIGHT_THEME: Theme = {
   chartMargins: DEFAULT_CHART_MARGINS,
   lineSeriesStyle: {
     line: {
-      stroke: DEFAULT_MISSING_COLOR,
-      strokeWidth: 1,
       visible: true,
-    },
-    border: {
-      stroke: 'gray',
-      strokeWidth: 2,
-      visible: false,
+      strokeWidth: 1,
+      opacity: 1,
     },
     point: {
       visible: true,
-      radius: 1,
-      stroke: 'white',
-      strokeWidth: 0.5,
+      strokeWidth: 0,
+      radius: 4,
       opacity: 1,
     },
   },
   areaSeriesStyle: {
     area: {
-      fill: DEFAULT_MISSING_COLOR,
       visible: true,
-      opacity: 0.8,
+      opacity: 1,
     },
     line: {
-      stroke: DEFAULT_MISSING_COLOR,
-      strokeWidth: 1.5,
       visible: true,
-    },
-    border: {
-      stroke: 'gray',
-      strokeWidth: 2,
-      visible: false,
+      strokeWidth: 1,
+      opacity: 1,
     },
     point: {
       visible: true,
-      radius: 1,
-      stroke: 'white',
-      strokeWidth: 0.5,
+      strokeWidth: 0,
+      radius: 4,
       opacity: 1,
     },
   },
   barSeriesStyle: {
-    border: {
-      stroke: 'white',
-      strokeWidth: 1,
+    rect: {
+      opacity: 1,
+    },
+    rectBorder: {
       visible: false,
+      strokeWidth: 0,
     },
     displayValue: {
       fontSize: 10,

--- a/src/lib/themes/theme.test.ts
+++ b/src/lib/themes/theme.test.ts
@@ -152,11 +152,7 @@ describe('Theme', () => {
           stroke: 'elastic_charts',
           strokeWidth: 314571,
           visible: true,
-        },
-        border: {
-          stroke: 'elastic_charts',
-          strokeWidth: 314571,
-          visible: true,
+          opacity: 1,
         },
         point: {
           radius: 314571,
@@ -190,11 +186,7 @@ describe('Theme', () => {
           stroke: 'elastic_charts',
           strokeWidth: 314571,
           visible: true,
-        },
-        border: {
-          stroke: 'elastic_charts',
-          strokeWidth: 314571,
-          visible: true,
+          opacity: 1,
         },
         point: {
           visible: true,
@@ -220,7 +212,7 @@ describe('Theme', () => {
     it('should merge partial theme: barSeriesStyle', () => {
       const partialTheme: PartialTheme = {
         barSeriesStyle: {
-          border: {
+          rectBorder: {
             stroke: 'elastic_charts',
           },
           displayValue: {
@@ -233,9 +225,12 @@ describe('Theme', () => {
       expect(mergedTheme).toEqual({
         ...DARK_THEME,
         barSeriesStyle: {
-          border: {
-            ...DARK_THEME.barSeriesStyle.border,
-            ...partialTheme!.barSeriesStyle!.border,
+          rect: {
+            opacity: 1,
+          },
+          rectBorder: {
+            ...DARK_THEME.barSeriesStyle.rectBorder,
+            ...partialTheme!.barSeriesStyle!.rectBorder,
           },
           displayValue: {
             ...DARK_THEME.barSeriesStyle.displayValue,

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -32,8 +32,10 @@ export interface StrokeStyle {
   stroke: string;
   /** The stroke width in pixel */
   strokeWidth: number;
+}
+export interface StrokeDashArray {
   /** The dash array for dashed strokes */
-  dash?: number[];
+  dash: number[];
 }
 export interface FillStyle {
   /** The fill color in hex, rgba, hsl */
@@ -107,36 +109,80 @@ export const BaseThemeTypes: Readonly<{ [key: string]: BaseThemeType }> = Object
 });
 
 export type DisplayValueStyle = TextStyle & {
-  offsetX?: number;
-  offsetY?: number;
+  offsetX: number;
+  offsetY: number;
 };
 
-export interface BarSeriesStyle {
-  border: StrokeStyle & Visible;
-  displayValue?: DisplayValueStyle;
+export interface PointStyle {
+  /** is the point visible or hidden */
+  visible: boolean;
+  /** a static stroke color if defined, if not it will use the color of the series */
+  stroke?: string;
+  /** the stroke width of the point */
+  strokeWidth: number;
+  /**  a static fill color if defined, if not it will use the color of the series */
+  fill?: string;
+  /** the opacity of each point on the theme/series */
+  opacity: number;
+  /** the radius of each point of the theme/series */
+  radius: number;
 }
 
-export type CustomBarSeriesStyle = BarSeriesStyle & Partial<Opacity>;
+export interface LineStyle {
+  /** is the line visible or hidden ? */
+  visible: boolean;
+  /** a static stroke color if defined, if not it will use the color of the series */
+  stroke?: string;
+  /** the stroke width of the line */
+  strokeWidth: number;
+  /** the opacity of each line on the theme/series */
+  opacity: number;
+}
+
+export interface AreaStyle {
+  /** is the area is visible or hidden ? */
+  visible: boolean;
+  /** a static fill color if defined, if not it will use the color of the series */
+  fill?: string;
+  /** the opacity of each area on the theme/series */
+  opacity: number;
+}
+
+export interface RectStyle {
+  /** a static fill color if defined, if not it will use the color of the series */
+  fill?: string;
+  /** the opacity of each rect on the theme/series */
+  opacity: number;
+}
+
+export interface RectBorderStyle {
+  /** is the rect border visible or hidden ? */
+  visible: boolean;
+  /** a static stroke color if defined, if not it will use the color of the series */
+  stroke?: string;
+  /** the stroke width of the rect border */
+  strokeWidth: number;
+}
+export interface BarSeriesStyle {
+  rect: RectStyle;
+  rectBorder: RectBorderStyle;
+  displayValue: DisplayValueStyle;
+}
 
 export interface LineSeriesStyle {
   line: LineStyle;
-  border: StrokeStyle & Visible;
   point: PointStyle;
 }
-
-export type PointStyle = StrokeStyle & Opacity & Visible & Radius;
-export type LineStyle = StrokeStyle & Visible & Partial<Opacity>;
-export type AreaStyle = FillStyle & Opacity & Visible;
 
 export interface AreaSeriesStyle {
   area: AreaStyle;
   line: LineStyle;
-  border: StrokeStyle & Visible;
   point: PointStyle;
 }
+
 export interface CrosshairStyle {
   band: FillStyle & Visible;
-  line: StrokeStyle & Visible;
+  line: StrokeStyle & Visible & Partial<StrokeDashArray>;
 }
 
 export interface LineAnnotationStyle {

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -6,9 +6,7 @@ import { LIGHT_THEME } from './light_theme';
 interface Visible {
   visible: boolean;
 }
-interface Radius {
-  radius: number;
-}
+
 export interface TextStyle {
   fontSize: number;
   fontFamily: string;

--- a/src/lib/utils/interactions.test.ts
+++ b/src/lib/utils/interactions.test.ts
@@ -10,6 +10,25 @@ import {
   isFollowTooltipType,
   TooltipType,
 } from './interactions';
+
+const seriesStyle = {
+  rect: {
+    opacity: 1,
+  },
+  rectBorder: {
+    strokeWidth: 1,
+    visible: false,
+  },
+  displayValue: {
+    fill: 'black',
+    fontFamily: '',
+    fontSize: 2,
+    offsetX: 0,
+    offsetY: 0,
+    padding: 2,
+  },
+};
+
 const ig1: IndexedGeometry = {
   color: 'red',
   geometryId: {
@@ -25,6 +44,7 @@ const ig1: IndexedGeometry = {
   y: 0,
   width: 50,
   height: 50,
+  seriesStyle,
 };
 const ig2: IndexedGeometry = {
   geometryId: {
@@ -41,6 +61,7 @@ const ig2: IndexedGeometry = {
   y: 0,
   width: 10,
   height: 10,
+  seriesStyle,
 };
 const ig3: IndexedGeometry = {
   geometryId: {
@@ -58,6 +79,7 @@ const ig3: IndexedGeometry = {
   y: 0,
   width: 50,
   height: 50,
+  seriesStyle,
 };
 const ig4: IndexedGeometry = {
   geometryId: {
@@ -74,6 +96,7 @@ const ig4: IndexedGeometry = {
   y: 0,
   width: 50,
   height: 50,
+  seriesStyle,
 };
 const ig5: IndexedGeometry = {
   geometryId: {
@@ -90,6 +113,7 @@ const ig5: IndexedGeometry = {
   y: 0,
   width: 50,
   height: 50,
+  seriesStyle,
 };
 const ig6: PointGeometry = {
   geometryId: {

--- a/src/state/chart_state.test.ts
+++ b/src/state/chart_state.test.ts
@@ -684,6 +684,23 @@ describe('Chart Store', () => {
     expect(store.isTooltipVisible.get()).toBe(true);
   });
   test('handle click on chart', () => {
+    const barStyle = {
+      rect: {
+        opacity: 1,
+      },
+      rectBorder: {
+        strokeWidth: 1,
+        visible: false,
+      },
+      displayValue: {
+        fill: 'black',
+        fontFamily: '',
+        fontSize: 2,
+        offsetX: 0,
+        offsetY: 0,
+        padding: 2,
+      },
+    };
     const geom1: IndexedGeometry = {
       color: 'red',
       geometryId: {
@@ -699,6 +716,7 @@ describe('Chart Store', () => {
       y: 0,
       width: 0,
       height: 0,
+      seriesStyle: barStyle,
     };
     const geom2: IndexedGeometry = {
       color: 'blue',
@@ -715,6 +733,7 @@ describe('Chart Store', () => {
       y: 0,
       width: 0,
       height: 0,
+      seriesStyle: barStyle,
     };
     const clickListener = jest.fn<void, [GeometryValue[]]>(
       (): void => {

--- a/src/state/test/interactions.test.ts
+++ b/src/state/test/interactions.test.ts
@@ -74,6 +74,24 @@ function initStore(spec: BasicSeriesSpec) {
   store.seriesSpecs.set(spec.id, spec);
   return store;
 }
+
+const barStyle = {
+  rect: {
+    opacity: 1,
+  },
+  rectBorder: {
+    strokeWidth: 1,
+    visible: false,
+  },
+  displayValue: {
+    fill: 'black',
+    fontFamily: '',
+    fontSize: 2,
+    offsetX: 0,
+    offsetY: 0,
+    padding: 2,
+  },
+};
 const indexedGeom1Red: BarGeometry = {
   color: 'red',
   x: 0,
@@ -89,6 +107,7 @@ const indexedGeom1Red: BarGeometry = {
     specId: SPEC_ID,
     seriesKey: [],
   },
+  seriesStyle: barStyle,
 };
 const indexedGeom2Blue: BarGeometry = {
   color: 'blue',
@@ -105,6 +124,7 @@ const indexedGeom2Blue: BarGeometry = {
     specId: SPEC_ID,
     seriesKey: [],
   },
+  seriesStyle: barStyle,
 };
 
 describe('Chart state pointer interactions', () => {

--- a/src/state/utils.test.ts
+++ b/src/state/utils.test.ts
@@ -698,6 +698,181 @@ describe('Chart State utils', () => {
       expect(geometries.geometriesCounts.lines).toBe(0);
       expect(geometries.geometriesCounts.areas).toBe(6);
     });
+    test('can compute line geometries with custom style', () => {
+      const line1: LineSeriesSpec = {
+        id: getSpecId('line1'),
+        groupId: getGroupId('group2'),
+        seriesType: 'line',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        lineSeriesStyle: {
+          line: {
+            strokeWidth: 100,
+          },
+          point: {
+            fill: 'green',
+          },
+        },
+        data: BARCHART_1Y1G,
+      };
+      const line2: LineSeriesSpec = {
+        id: getSpecId('line2'),
+        groupId: getGroupId('group2'),
+        seriesType: 'line',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const line3: LineSeriesSpec = {
+        id: getSpecId('line3'),
+        groupId: getGroupId('group2'),
+        seriesType: 'line',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const seriesSpecs = new Map<SpecId, BasicSeriesSpec>([[line1.id, line1], [line2.id, line2], [line3.id, line3]]);
+      const axesSpecs = new Map<AxisId, AxisSpec>();
+      const chartRotation = 0;
+      const chartDimensions = { width: 100, height: 100, top: 0, left: 0 };
+      const chartColors = {
+        vizColors: ['violet', 'green', 'blue'],
+        defaultVizColor: 'red',
+      };
+      const chartTheme = { ...LIGHT_THEME, colors: chartColors };
+      const domainsByGroupId = mergeDomainsByGroupId(axesSpecs, chartRotation);
+      const seriesDomains = computeSeriesDomains(seriesSpecs, domainsByGroupId);
+      const seriesColorMap = getSeriesColorMap(seriesDomains.seriesColors, chartColors, new Map());
+      const geometries = computeSeriesGeometries(
+        seriesSpecs,
+        seriesDomains.xDomain,
+        seriesDomains.yDomain,
+        seriesDomains.formattedDataSeries,
+        seriesColorMap,
+        chartTheme,
+        chartDimensions,
+        chartRotation,
+        axesSpecs,
+        false,
+      );
+      expect(geometries.geometries.lines[0].color).toBe('violet');
+      expect(geometries.geometries.lines[0].seriesLineStyle).toEqual({
+        visible: true,
+        strokeWidth: 100, // the override strokeWidth
+        opacity: 1,
+      });
+      expect(geometries.geometries.lines[0].seriesPointStyle).toEqual({
+        visible: true,
+        fill: 'green', // the override strokeWidth
+        opacity: 1,
+        radius: 4,
+        strokeWidth: 0,
+      });
+    });
+    test('can compute area geometries with custom style', () => {
+      const area1: AreaSeriesSpec = {
+        id: getSpecId('area1'),
+        groupId: getGroupId('group2'),
+        seriesType: 'area',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+        areaSeriesStyle: {
+          line: {
+            strokeWidth: 100,
+          },
+          point: {
+            fill: 'point-fill-custom-color',
+          },
+          area: {
+            fill: 'area-fill-custom-color',
+            opacity: 0.2,
+          },
+        },
+      };
+      const area2: AreaSeriesSpec = {
+        id: getSpecId('area2'),
+        groupId: getGroupId('group2'),
+        seriesType: 'area',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const area3: AreaSeriesSpec = {
+        id: getSpecId('area3'),
+        groupId: getGroupId('group2'),
+        seriesType: 'area',
+        yScaleType: ScaleType.Log,
+        xScaleType: ScaleType.Linear,
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        yScaleToDataExtent: false,
+        data: BARCHART_1Y1G,
+      };
+      const seriesSpecs = new Map<SpecId, BasicSeriesSpec>([[area1.id, area1], [area2.id, area2], [area3.id, area3]]);
+      const axesSpecs = new Map<AxisId, AxisSpec>();
+      const chartRotation = 0;
+      const chartDimensions = { width: 100, height: 100, top: 0, left: 0 };
+      const chartColors = {
+        vizColors: ['violet', 'green', 'blue'],
+        defaultVizColor: 'red',
+      };
+      const chartTheme = { ...LIGHT_THEME, colors: chartColors };
+      const domainsByGroupId = mergeDomainsByGroupId(axesSpecs, chartRotation);
+      const seriesDomains = computeSeriesDomains(seriesSpecs, domainsByGroupId);
+      const seriesColorMap = getSeriesColorMap(seriesDomains.seriesColors, chartColors, new Map());
+      const geometries = computeSeriesGeometries(
+        seriesSpecs,
+        seriesDomains.xDomain,
+        seriesDomains.yDomain,
+        seriesDomains.formattedDataSeries,
+        seriesColorMap,
+        chartTheme,
+        chartDimensions,
+        chartRotation,
+        axesSpecs,
+        false,
+      );
+      expect(geometries.geometries.areas[0].color).toBe('violet');
+      expect(geometries.geometries.areas[0].seriesAreaStyle).toEqual({
+        visible: true,
+        fill: 'area-fill-custom-color',
+        opacity: 0.2,
+      });
+      expect(geometries.geometries.areas[0].seriesAreaLineStyle).toEqual({
+        visible: true,
+        strokeWidth: 100,
+        opacity: 1,
+      });
+      expect(geometries.geometries.areas[0].seriesPointStyle).toEqual({
+        visible: true,
+        fill: 'point-fill-custom-color', // the override strokeWidth
+        opacity: 1,
+        radius: 4,
+        strokeWidth: 0,
+      });
+    });
     test('can compute bars geometries counts', () => {
       const bars1: BarSeriesSpec = {
         id: getSpecId('bars1'),

--- a/src/state/utils.test.ts
+++ b/src/state/utils.test.ts
@@ -521,12 +521,14 @@ describe('Chart State utils', () => {
         yScaleToDataExtent: false,
         data: BARCHART_1Y1G,
         barSeriesStyle: {
-          border: {
+          rectBorder: {
             stroke: 'stroke',
             strokeWidth: 123,
             visible: true,
           },
-          opacity: 0.2,
+          rect: {
+            opacity: 0.2,
+          },
         },
         displayValueSettings: {
           showValueLabel: true,

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -37,7 +37,7 @@ import {
   Rotation,
 } from '../lib/series/specs';
 import { ColorConfig, Theme } from '../lib/themes/theme';
-import { identity } from '../lib/utils/commons';
+import { identity, mergePartial } from '../lib/utils/commons';
 import { Dimensions } from '../lib/utils/dimensions';
 import { Domain } from '../lib/utils/domain';
 import { AxisId, GroupId, SpecId } from '../lib/utils/ids';
@@ -385,15 +385,9 @@ export function renderGeometries(
     if (isBarSeriesSpec(spec)) {
       const shift = isStacked ? indexOffset : indexOffset + i;
 
-      // TODO: we can handle style merging here and not pass that off to the component
-      // then barSeriesStyle should not be an optional parameter and we can simplify
-      // the props building in the geometries component
-      const barSeriesStyle = spec.barSeriesStyle
-        ? {
-            ...chartTheme.barSeriesStyle,
-            ...spec.barSeriesStyle,
-          }
-        : chartTheme.barSeriesStyle;
+      const barSeriesStyle = mergePartial(chartTheme.barSeriesStyle, spec.barSeriesStyle, {
+        mergeOptionalPartialValues: true,
+      });
 
       const { yAxis } = getAxesSpecForSpecId(axesSpecs, spec.groupId);
       const valueFormatter = yAxis && yAxis.tickFormat ? yAxis.tickFormat : identity;
@@ -413,15 +407,17 @@ export function renderGeometries(
         color,
         ds.specId,
         ds.key,
-        displayValueSettings,
         barSeriesStyle,
+        displayValueSettings,
       );
       barGeometriesIndex = mergeGeometriesIndexes(barGeometriesIndex, renderedBars.indexedGeometries);
       bars.push(...renderedBars.barGeometries);
       geometriesCounts.bars += renderedBars.barGeometries.length;
     } else if (isLineSeriesSpec(spec)) {
       const lineShift = clusteredCount > 0 ? clusteredCount : 1;
-      const lineSeriesStyle = spec.lineSeriesStyle;
+      const lineSeriesStyle = spec.lineSeriesStyle
+        ? mergePartial(chartTheme.lineSeriesStyle, spec.lineSeriesStyle, { mergeOptionalPartialValues: true })
+        : chartTheme.lineSeriesStyle;
 
       const xScaleOffset = computeXScaleOffset(xScale, enableHistogramMode, spec.histogramModeAlignment);
 
@@ -445,8 +441,9 @@ export function renderGeometries(
       geometriesCounts.lines += 1;
     } else if (isAreaSeriesSpec(spec)) {
       const areaShift = clusteredCount > 0 ? clusteredCount : 1;
-      const areaSeriesStyle = spec.areaSeriesStyle;
-
+      const areaSeriesStyle = spec.areaSeriesStyle
+        ? mergePartial(chartTheme.areaSeriesStyle, spec.areaSeriesStyle, { mergeOptionalPartialValues: true })
+        : chartTheme.areaSeriesStyle;
       const xScaleOffset = computeXScaleOffset(xScale, enableHistogramMode, spec.histogramModeAlignment);
 
       const renderedAreas = renderArea(

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -28,12 +28,14 @@ import {
   Settings,
   timeFormatter,
   TooltipType,
+  BarSeriesStyle,
 } from '../src/';
 import * as TestDatasets from '../src/lib/series/utils/test_dataset';
 
 import { KIBANA_METRICS } from '../src/lib/series/utils/test_dataset_kibana';
 
 import { TEST_DATASET_DISCOVER } from '../src/lib/series/utils/test_dataset_discover_per_30s';
+import { RecursivePartial } from '../src/lib/utils/commons';
 
 const dateFormatter = timeFormatter('HH:mm:ss');
 
@@ -100,11 +102,8 @@ storiesOf('Bar Chart', module)
       },
     };
 
-    const barStyle = {
-      barSeriesStyle: {
-        ...LIGHT_THEME.barSeriesStyle,
-        ...displayValueStyle,
-      },
+    const barStyle: RecursivePartial<BarSeriesStyle> = {
+      ...displayValueStyle,
     };
 
     const debug = boolean('debug', true);
@@ -119,7 +118,12 @@ storiesOf('Bar Chart', module)
       0,
     );
 
-    const theme = mergeWithDefaultTheme(barStyle, LIGHT_THEME);
+    const theme = mergeWithDefaultTheme(
+      {
+        barSeriesStyle: barStyle,
+      },
+      LIGHT_THEME,
+    );
     const dataSize = select(
       'data volume size',
       {

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -19,7 +19,6 @@ import {
   LIGHT_THEME,
   LineAnnotation,
   LineSeries,
-  mergeWithDefaultTheme,
   niceTimeFormatByDay,
   Position,
   RectAnnotation,
@@ -100,22 +99,19 @@ storiesOf('Bar Chart', module)
       0,
     );
 
-    const theme = mergeWithDefaultTheme(
-      {
-        barSeriesStyle: {
-          displayValue: {
-            fontSize: number('value font size', 10),
-            fontFamily: `'Open Sans', Helvetica, Arial, sans-serif`,
-            fontStyle: 'normal',
-            padding: 0,
-            fill: color('value color', '#000'),
-            offsetX: number('offsetX', 0),
-            offsetY: number('offsetY', 0),
-          },
+    const theme = {
+      barSeriesStyle: {
+        displayValue: {
+          fontSize: number('value font size', 10),
+          fontFamily: `'Open Sans', Helvetica, Arial, sans-serif`,
+          fontStyle: 'normal',
+          padding: 0,
+          fill: color('value color', '#000'),
+          offsetX: number('offsetX', 0),
+          offsetY: number('offsetY', 0),
         },
       },
-      LIGHT_THEME,
-    );
+    };
 
     const dataSize = select(
       'data volume size',
@@ -1377,25 +1373,22 @@ storiesOf('Bar Chart', module)
       0,
     );
 
-    const theme = mergeWithDefaultTheme(
-      {
-        scales: {
-          barsPadding: number('bars padding', 0.25, {
-            range: true,
-            min: 0,
-            max: 1,
-            step: 0.1,
-          }),
-          histogramPadding: number('histogram padding', 0.05, {
-            range: true,
-            min: 0,
-            max: 1,
-            step: 0.1,
-          }),
-        },
+    const theme = {
+      scales: {
+        barsPadding: number('bars padding', 0.25, {
+          range: true,
+          min: 0,
+          max: 1,
+          step: 0.1,
+        }),
+        histogramPadding: number('histogram padding', 0.05, {
+          range: true,
+          min: 0,
+          max: 1,
+          step: 0.1,
+        }),
       },
-      LIGHT_THEME,
-    );
+    };
 
     const otherSeriesSelection = select(
       'other series',
@@ -1512,19 +1505,16 @@ storiesOf('Bar Chart', module)
       0,
     );
 
-    const theme = mergeWithDefaultTheme(
-      {
-        scales: {
-          barsPadding: number('bars padding', 0.25, {
-            range: true,
-            min: 0,
-            max: 1,
-            step: 0.1,
-          }),
-        },
+    const theme = {
+      scales: {
+        barsPadding: number('bars padding', 0.25, {
+          range: true,
+          min: 0,
+          max: 1,
+          step: 0.1,
+        }),
       },
-      LIGHT_THEME,
-    );
+    };
 
     const hasHistogramBarSeries = boolean('hasHistogramBarSeries', false);
 

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -28,14 +28,12 @@ import {
   Settings,
   timeFormatter,
   TooltipType,
-  BarSeriesStyle,
 } from '../src/';
 import * as TestDatasets from '../src/lib/series/utils/test_dataset';
 
 import { KIBANA_METRICS } from '../src/lib/series/utils/test_dataset_kibana';
 
 import { TEST_DATASET_DISCOVER } from '../src/lib/series/utils/test_dataset_discover_per_30s';
-import { RecursivePartial } from '../src/lib/utils/commons';
 
 const dateFormatter = timeFormatter('HH:mm:ss');
 
@@ -90,22 +88,6 @@ storiesOf('Bar Chart', module)
       hideClippedValue,
     };
 
-    const displayValueStyle = {
-      displayValue: {
-        fontSize: number('value font size', 10),
-        fontFamily: `'Open Sans', Helvetica, Arial, sans-serif`,
-        fontStyle: 'normal',
-        padding: 0,
-        fill: color('value color', '#000'),
-        offsetX: number('offsetX', 0),
-        offsetY: number('offsetY', 0),
-      },
-    };
-
-    const barStyle: RecursivePartial<BarSeriesStyle> = {
-      ...displayValueStyle,
-    };
-
     const debug = boolean('debug', true);
     const chartRotation = select<Rotation>(
       'chartRotation',
@@ -120,10 +102,21 @@ storiesOf('Bar Chart', module)
 
     const theme = mergeWithDefaultTheme(
       {
-        barSeriesStyle: barStyle,
+        barSeriesStyle: {
+          displayValue: {
+            fontSize: number('value font size', 10),
+            fontFamily: `'Open Sans', Helvetica, Arial, sans-serif`,
+            fontStyle: 'normal',
+            padding: 0,
+            fill: color('value color', '#000'),
+            offsetX: number('offsetX', 0),
+            offsetY: number('offsetY', 0),
+          },
+        },
       },
       LIGHT_THEME,
     );
+
     const dataSize = select(
       'data volume size',
       {

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -9,15 +9,12 @@ import {
   Chart,
   CurveType,
   CustomSeriesColorsMap,
-  DARK_THEME,
   DataGenerator,
   DataSeriesColorsValues,
   DEFAULT_MISSING_COLOR,
   getAxisId,
   getSpecId,
-  LIGHT_THEME,
   LineSeries,
-  mergeWithDefaultTheme,
   PartialTheme,
   Position,
   ScaleType,
@@ -128,15 +125,9 @@ storiesOf('Stylings', module)
     const withBottomTitle = boolean('bottom axis with title', true);
     const withRightTitle = boolean('right axis with title', true);
     const withTopTitle = boolean('top axis with title', true);
-    const customTheme = mergeWithDefaultTheme(theme, LIGHT_THEME);
     return (
       <Chart className={'story-chart'}>
-        <Settings
-          theme={customTheme}
-          debug={boolean('debug', true)}
-          showLegend={true}
-          legendPosition={Position.Right}
-        />
+        <Settings theme={theme} debug={boolean('debug', true)} showLegend={true} legendPosition={Position.Right} />
         <Axis
           id={getAxisId('bottom')}
           position={Position.Bottom}
@@ -203,11 +194,10 @@ storiesOf('Stylings', module)
         },
       },
     };
-    const customTheme = mergeWithDefaultTheme(theme, LIGHT_THEME);
     return (
       <Chart className={'story-chart'}>
         <Settings
-          theme={customTheme}
+          theme={theme}
           debug={boolean('debug', true)}
           rotation={select('rotation', { '0': 0, '90': 90, '-90': -90, '180': 180 }, 0)}
         />
@@ -319,14 +309,13 @@ storiesOf('Stylings', module)
 
     const darkmode = boolean('darkmode', false, 'Colors');
     const className = darkmode ? 'story-chart-dark' : 'story-chart';
-    const defaultTheme = darkmode ? DARK_THEME : LIGHT_THEME;
-    const customTheme = mergeWithDefaultTheme(theme, defaultTheme);
     switchTheme(darkmode ? 'dark' : 'light');
 
     return (
       <Chart className={className}>
         <Settings
-          theme={customTheme}
+          theme={theme}
+          baseThemeType={darkmode ? 'dark' : 'light'}
           debug={boolean('debug', false)}
           showLegend={true}
           legendPosition={Position.Right}
@@ -492,7 +481,7 @@ storiesOf('Stylings', module)
       },
     };
 
-    const theme = mergeWithDefaultTheme({
+    const theme = {
       barSeriesStyle: {
         rectBorder: {
           stroke: color('theme border stroke', 'red', 'Chart Global Theme'),
@@ -503,7 +492,7 @@ storiesOf('Stylings', module)
           opacity: range('theme opacity ', 0, 1, 0.9, 'Chart Global Theme', 0.1),
         },
       },
-    });
+    };
 
     return (
       <Chart renderer="canvas" className={'story-chart'}>
@@ -545,9 +534,9 @@ storiesOf('Stylings', module)
     const lineSeriesStyle1 = generateLineSeriesStyleKnobs('Line 1 style', 'line1', 'lime', 'green', 4, 10, 6);
     const lineSeriesStyle2 = generateLineSeriesStyleKnobs('Line 2 style', 'line2', 'blue', 'violet', 2, 5, 4);
 
-    const chartTheme = mergeWithDefaultTheme({
+    const chartTheme = {
       lineSeriesStyle: generateLineSeriesStyleKnobs('Chart Global Theme', 'chartTheme'),
-    });
+    };
 
     const dataset1 = [{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }];
     const dataset2 = dataset1.map((datum) => ({ ...datum, y: datum.y - 1 }));
@@ -598,9 +587,9 @@ storiesOf('Stylings', module)
   .add('custom series styles: area', () => {
     const applyLineStyles = boolean('apply line series style', true, 'Chart Global Theme');
 
-    const chartTheme = mergeWithDefaultTheme({
+    const chartTheme = {
       areaSeriesStyle: generateAreaSeriesStyleKnobs('Chart Global Theme', 'chartTheme'),
-    });
+    };
 
     const dataset1 = [{ x: 0, y: 3 }, { x: 1, y: 6 }, { x: 2, y: 4 }, { x: 3, y: 10 }];
     const dataset2 = dataset1.map((datum) => ({ ...datum, y: datum.y - 1 }));
@@ -673,13 +662,12 @@ storiesOf('Stylings', module)
         },
       },
     };
-    const customTheme = mergeWithDefaultTheme(theme, LIGHT_THEME);
     const customStyle = {
       tickLabelPadding: number('Tick Label Padding Axis Spec', 0),
     };
     return (
       <Chart className={'story-chart'}>
-        <Settings theme={customTheme} debug={boolean('debug', true)} />
+        <Settings theme={theme} debug={boolean('debug', true)} />
         <Axis
           id={getAxisId('bottom')}
           position={Position.Bottom}


### PR DESCRIPTION
## Summary

This PR allows the computed series color to be overridden by the theme or the series specific style.

**BREAKING CHANGE**: `LineStyle`, `AreaStyle` and `BarSeriesStyle` types differs on the optional values.
`stroke` and `fill` on the theme or specific series style now override the computed series color.

The a style overrides with the following flows:
- if a style is declared at the Spec level (on a Bar/Area/Line component) it will take precedence over all the other style (any `stroke` or `fill` prop will override the computed series color for that specific style element). If not go to next
- if a `stroke` or `fill` is present on the chart `theme` prop for a Bar/Area/Line than it will use that color for the point (stroke or fill) line (stroke) bar(stroke, fill, borderStroke)
- if no `stroke` or `fill` is configured on theme or series specific style than we will use the one computed or assigned with `customSeriesColors` prop

<img width="928" alt="Screenshot 2019-07-03 at 15 24 09" src="https://user-images.githubusercontent.com/1421091/60595122-ae8b2f80-9da6-11e9-92bb-5bade1240f51.png">
<img width="923" alt="Screenshot 2019-07-03 at 15 24 17" src="https://user-images.githubusercontent.com/1421091/60595126-afbc5c80-9da6-11e9-90f7-6011cb66ba93.png">
<img width="928" alt="Screenshot 2019-07-03 at 15 24 23" src="https://user-images.githubusercontent.com/1421091/60595132-b1862000-9da6-11e9-92b5-ee6906d640ab.png">

**notes**
- I've refactored the `build...props` used to compute the props for rendering lines/areas/bars/points, cleaning a but the function semantics.
- The payload of each individual `bar` rendered geometry is currently increased, but I will find a better way to specify that for bars in the future.
- I've cleaned the defaults of the two themes
- I've cleaned the stories for custom styles to align it with that new feature

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
