### PR TITLE
fix: adjust domain & range for single value histogram

### DIFF
--- a/src/lib/axes/axis_utils.ts
+++ b/src/lib/axes/axis_utils.ts
@@ -61,12 +61,23 @@ export function computeAxisTicksDimensions(
   chartRotation: Rotation,
   axisConfig: AxisConfig,
   barsPadding?: number,
+  enableHistogramMode?: boolean,
 ): AxisTicksDimensions | null {
   if (axisSpec.hide) {
     return null;
   }
 
-  const scale = getScaleForAxisSpec(axisSpec, xDomain, yDomain, totalBarsInCluster, chartRotation, 0, 1, barsPadding);
+  const scale = getScaleForAxisSpec(
+    axisSpec,
+    xDomain,
+    yDomain,
+    totalBarsInCluster,
+    chartRotation,
+    0,
+    1,
+    barsPadding,
+    enableHistogramMode,
+  );
   if (!scale) {
     throw new Error(`Cannot compute scale for axis spec ${axisSpec.id}`);
   }
@@ -112,6 +123,7 @@ export function getScaleForAxisSpec(
   minRange: number,
   maxRange: number,
   barsPadding?: number,
+  enableHistogramMode?: boolean,
 ): Scale | null {
   const axisIsYDomain = isYDomain(axisSpec.position, chartRotation);
 
@@ -122,7 +134,7 @@ export function getScaleForAxisSpec(
     }
     return null;
   } else {
-    return computeXScale(xDomain, totalBarsInCluster, minRange, maxRange, barsPadding);
+    return computeXScale(xDomain, totalBarsInCluster, minRange, maxRange, barsPadding, enableHistogramMode);
   }
 }
 
@@ -580,6 +592,7 @@ export function getAxisTicksPositions(
       minMaxRanges.minRange,
       minMaxRanges.maxRange,
       barsPadding,
+      enableHistogramMode,
     );
 
     if (!scale) {

--- a/src/lib/series/scales.test.ts
+++ b/src/lib/series/scales.test.ts
@@ -41,6 +41,44 @@ describe('Series scales', () => {
     expect(scale.scale(3)).toBe(expectedBandwidth * 0);
   });
 
+  describe('computeXScale with single value domain', () => {
+    const maxRange = 120;
+    const singleDomainValue = 3;
+    const minInterval = 1;
+
+    test('should return extended domain & range when in histogram mode', () => {
+      const xDomainSingleValue: XDomain = {
+        type: 'xDomain',
+        isBandScale: true,
+        domain: [singleDomainValue, singleDomainValue],
+        minInterval: minInterval,
+        scaleType: ScaleType.Linear,
+      };
+      const enableHistogramMode = true;
+
+      const scale = computeXScale(xDomainSingleValue, 1, 0, maxRange, 0, enableHistogramMode);
+      expect(scale.bandwidth).toBe(maxRange);
+      expect(scale.domain).toEqual([singleDomainValue, singleDomainValue + minInterval]);
+      expect(scale.range).toEqual([0, maxRange]);
+    });
+
+    test('should return unextended domain & range when not in histogram mode', () => {
+      const xDomainSingleValue: XDomain = {
+        type: 'xDomain',
+        isBandScale: true,
+        domain: [singleDomainValue, singleDomainValue],
+        minInterval: minInterval,
+        scaleType: ScaleType.Linear,
+      };
+      const enableHistogramMode = false;
+
+      const scale = computeXScale(xDomainSingleValue, 1, 0, maxRange, 0, enableHistogramMode);
+      expect(scale.bandwidth).toBe(maxRange);
+      expect(scale.domain).toEqual([singleDomainValue, singleDomainValue]);
+      expect(scale.range).toEqual([0, 0]);
+    });
+  });
+
   test('should compute X Scale ordinal', () => {
     const nonZeroGroupScale = computeXScale(xDomainOrdinal, 1, 120, 0);
     const expectedBandwidth = 60;

--- a/src/lib/series/scales.ts
+++ b/src/lib/series/scales.ts
@@ -61,22 +61,24 @@ export function computeXScale(
     return new ScaleBand(domain, [minRange, maxRange], bandwidth, barsPadding);
   } else {
     if (isBandScale) {
-      const isSingleValueHistogram = enableHistogramMode && domain[1] - domain[0] === 0;
-      const domainMin = domain[0];
-      const domainMax = isSingleValueHistogram ? domain[0] + minInterval : domain[1];
-      const domainForScale = [domainMin, domainMax];
+      const [domainMin, domainMax] = domain;
+      const isSingleValueHistogram = enableHistogramMode && domainMax - domainMin === 0;
 
-      const intervalCount = (domainForScale[1] - domainForScale[0]) / minInterval;
+      const adjustedDomainMax = isSingleValueHistogram ? domainMin + minInterval : domainMax;
+      const adjustedDomain = [domainMin, adjustedDomainMax];
+
+      const intervalCount = (adjustedDomain[1] - adjustedDomain[0]) / minInterval;
       const intervalCountOffest = isSingleValueHistogram ? 0 : 1;
       const bandwidth = rangeDiff / (intervalCount + intervalCountOffest);
-      const start = isInverse ? minRange - bandwidth : minRange;
-      const end = isInverse ? maxRange : maxRange - bandwidth;
-      const rangeEnd = isSingleValueHistogram ? end + bandwidth : end;
+
+      const rangeEndOffset = isSingleValueHistogram ? 0 : bandwidth;
+      const start = isInverse ? minRange - rangeEndOffset : minRange;
+      const end = isInverse ? maxRange : maxRange - rangeEndOffset;
 
       const scale = new ScaleContinuous(
         scaleType,
-        domainForScale,
-        [start, rangeEnd],
+        adjustedDomain,
+        [start, end],
         bandwidth / totalBarsInCluster,
         minInterval,
         timeZone,

--- a/src/lib/series/scales.ts
+++ b/src/lib/series/scales.ts
@@ -38,6 +38,23 @@ export function countBarsInCluster(
   };
 }
 
+function getBandScaleRange(
+  isInverse: boolean,
+  isSingleValueHistogram: boolean,
+  minRange: number,
+  maxRange: number,
+  bandwidth: number,
+): {
+  start: number;
+  end: number;
+} {
+  const rangeEndOffset = isSingleValueHistogram ? 0 : bandwidth;
+  const start = isInverse ? minRange - rangeEndOffset : minRange;
+  const end = isInverse ? maxRange : maxRange - rangeEndOffset;
+
+  return { start, end };
+}
+
 /**
  * Compute the x scale used to align geometries to the x axis.
  * @param xDomain the x domain
@@ -62,7 +79,7 @@ export function computeXScale(
   } else {
     if (isBandScale) {
       const [domainMin, domainMax] = domain;
-      const isSingleValueHistogram = enableHistogramMode && domainMax - domainMin === 0;
+      const isSingleValueHistogram = !!enableHistogramMode && domainMax - domainMin === 0;
 
       const adjustedDomainMax = isSingleValueHistogram ? domainMin + minInterval : domainMax;
       const adjustedDomain = [domainMin, adjustedDomainMax];
@@ -71,9 +88,7 @@ export function computeXScale(
       const intervalCountOffest = isSingleValueHistogram ? 0 : 1;
       const bandwidth = rangeDiff / (intervalCount + intervalCountOffest);
 
-      const rangeEndOffset = isSingleValueHistogram ? 0 : bandwidth;
-      const start = isInverse ? minRange - rangeEndOffset : minRange;
-      const end = isInverse ? maxRange : maxRange - rangeEndOffset;
+      const { start, end } = getBandScaleRange(isInverse, isSingleValueHistogram, minRange, maxRange, bandwidth);
 
       const scale = new ScaleContinuous(
         scaleType,

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -836,6 +836,7 @@ export class ChartStore {
         this.chartRotation,
         this.chartTheme.axes,
         barsPadding,
+        this.enableHistogramMode.get(),
       );
       if (dimensions) {
         this.axesTicksDimensions.set(id, dimensions);

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -193,7 +193,7 @@ export function computeSeriesGeometries(
   const { stackedBarsInCluster, totalBarsInCluster } = countBarsInCluster(stacked, nonStacked);
 
   // compute scales
-  const xScale = computeXScale(xDomain, totalBarsInCluster, 0, width, barsPadding);
+  const xScale = computeXScale(xDomain, totalBarsInCluster, 0, width, barsPadding, enableHistogramMode);
   const yScales = computeYScales(yDomain, height, 0);
 
   // compute colors

--- a/stories/annotations.tsx
+++ b/stories/annotations.tsx
@@ -547,4 +547,68 @@ storiesOf('Annotations', module)
         />
       </Chart>
     );
+  })
+  .add('[test] line annotation single value histogram', () => {
+    const dataValues = [
+      {
+        dataValue: 3.5,
+      },
+    ];
+
+    const style = {
+      line: {
+        strokeWidth: 3,
+        stroke: '#f00',
+        opacity: 1,
+      },
+      details: {
+        fontSize: 12,
+        fontFamily: 'Arial',
+        fontStyle: 'bold',
+        fill: 'gray',
+        padding: 0,
+      },
+    };
+
+    const chartRotation = select<Rotation>(
+      'chartRotation',
+      {
+        '0 deg': 0,
+        '90 deg': 90,
+        '-90 deg': -90,
+        '180 deg': 180,
+      },
+      0,
+    );
+
+    const isBottom = boolean('x domain axis is bottom', true);
+    const axisPosition = isBottom ? Position.Bottom : Position.Top;
+
+    const xDomain = {
+      minInterval: 1,
+      // max: 4,
+    };
+
+    return (
+      <Chart className={'story-chart'}>
+        <Settings debug={boolean('debug', false)} rotation={chartRotation} xDomain={xDomain} />
+        <LineAnnotation
+          annotationId={getAnnotationId('anno_1')}
+          domainType={AnnotationDomainTypes.XDomain}
+          dataValues={dataValues}
+          style={style}
+        />
+        <Axis id={getAxisId('horizontal')} position={axisPosition} title={'x-domain axis'} />
+        {/* <Axis id={getAxisId('vertical')} title={'y-domain axis'} position={Position.Left} /> */}
+        <BarSeries
+          enableHistogramMode={true}
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={[{ x: 3, y: 2 }]}
+        />
+      </Chart>
+    );
   });

--- a/stories/annotations.tsx
+++ b/stories/annotations.tsx
@@ -581,12 +581,8 @@ storiesOf('Annotations', module)
       0,
     );
 
-    const isBottom = boolean('x domain axis is bottom', true);
-    const axisPosition = isBottom ? Position.Bottom : Position.Top;
-
     const xDomain = {
       minInterval: 1,
-      // max: 4,
     };
 
     return (
@@ -598,8 +594,8 @@ storiesOf('Annotations', module)
           dataValues={dataValues}
           style={style}
         />
-        <Axis id={getAxisId('horizontal')} position={axisPosition} title={'x-domain axis'} />
-        {/* <Axis id={getAxisId('vertical')} title={'y-domain axis'} position={Position.Left} /> */}
+        <Axis id={getAxisId('horizontal')} position={Position.Bottom} title={'x-domain axis'} />
+        <Axis id={getAxisId('vertical')} title={'y-domain axis'} position={Position.Left} />
         <BarSeries
           enableHistogramMode={true}
           id={getSpecId('bars')}


### PR DESCRIPTION
## Summary

fix #262 

Previously, a line annotation within a single value histogram's domain range would not appear correctly, rendering the line at the domain start position.  For example with a single value histogram with domain `3` to `4`, an annotation line at `3.5` would be rendered at `3`.  This PR adds handling for computing the x scale for a single value histogram such that the line now correctly renders in the right position:

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/452850/61316892-b7bcc900-a7b6-11e9-90f5-544ef59cacd0.png">

The issue was that the annotations rely on the xScale for the x-axis position but with a single value domain, calling `xScale.scale` would return `0` for all values because the domain and range passed into the scale constructor created a scale that could not compute the right values because the domain would be single value (`[3, 3]` for our example) and the range would also be single value (`[0, 0]` in the example here).  

To address this, we now do a check in `computeXScale` such that if the `enableHistogramMode` flag is true and the domain is a single value domain, we adjust the domain and range values passed into the constructor so that the returned scale's domain and range have been adjusted to account for histogram mode (the domain is extended by the `minInterval`, which will default to `1` unless the user passes in a custom `minInterval` for `xDomain`).

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
