### PR TITLE
fix: handle chart click as mouseUp to prevent click while brushing

### DIFF
--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -293,7 +293,6 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
   };
   onStartBrusing = (event: { evt: MouseEvent }) => {
     window.addEventListener('mouseup', this.onEndBrushing);
-    this.props.chartStore!.onBrushStart();
     const { brushExtent } = this.props.chartStore!;
     const point = getPoint(event.evt, brushExtent);
     this.setState(() => ({
@@ -315,6 +314,9 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
   onBrushing = (event: { evt: MouseEvent }) => {
     if (!this.state.brushing) {
       return;
+    }
+    if (!this.props.chartStore!.isBrushing.get()) {
+      this.props.chartStore!.onBrushStart();
     }
     const { brushExtent } = this.props.chartStore!;
     const point = getPoint(event.evt, brushExtent);
@@ -394,7 +396,10 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         onMouseLeave={() => {
           setCursorPosition(-1, -1);
         }}
-        onClick={() => {
+        onMouseUp={() => {
+          if (this.props.chartStore!.isBrushing.get()) {
+            return;
+          }
           this.props.chartStore!.handleChartClick();
         }}
         className={className}

--- a/stories/interactions.tsx
+++ b/stories/interactions.tsx
@@ -442,7 +442,11 @@ storiesOf('Interactions', module)
     const oneDay = 1000 * 60 * 60 * 24;
     return (
       <Chart className={'story-chart'}>
-        <Settings debug={boolean('debug', false)} onBrushEnd={action('onBrushEnd')} />
+        <Settings
+          debug={boolean('debug', false)}
+          onBrushEnd={action('onBrushEnd')}
+          onElementClick={action('onElementClick')}
+        />
         <Axis
           id={getAxisId('bottom')}
           position={Position.Bottom}


### PR DESCRIPTION
## Summary

This PR implements a fix for the issue of the `onElementClick` handler being called `onBrushEnd`.

(In the Discover histogram, `onElementClick` and `onBrushEnd` are defined for the chart because a bar can be clickable to set the timefilter and the brush tool can also be used to set the timefilter.  This bug causes the `onElementClick` handler to take precendence as it will be called after the `onBrushEnd` handler is called, resulting in a brush event being overridden by a click on a bar.)

Before: (note how `onElementClick` is registered after `onBrushEnd`)
![interactions_broken](https://user-images.githubusercontent.com/452850/61750738-f7f1ed80-ad5a-11e9-9827-558c56c0122c.gif)

After: (no `onElementClick` after `onBrushEnd`)
![interactions_fixed](https://user-images.githubusercontent.com/452850/61750739-f7f1ed80-ad5a-11e9-8dcf-fe7996b413f2.gif)

The source of this issue was that in the previous implementation, the `onElementClick` callback was called `onClick`; when both `onBrushEnd` and `onElementClick` are defined for a chart, then, the `onClick` event would be captured on mouse up, including on mouse up after the user has been brushing.

Preventing this required changing the `onClick` to `onMouseUp` and within the `onMouseUp` handler, checking if the chartStore's `isBrushing` property is true; when true, we `return` so that the event can be handled as the end of a brush  event, and when false, we call the `onElementClick` callback.  The reason for changing from `onClick` to `onMouseUp` is because we need to be able to check the `isBrushing` property; with `onClick`, the brush end handler has already set `isBrushing` to false (as this happens `onMouseUp`) and with `onMouseDown`, the brush start handler has not yet set `isBrushing` to true.

The other change is that we set `isBrushing` to true not right after `onBrushStart` but rather `onBrushing`.  This was necessary because if we set `isBrushing` to true immediately `onBrushStart` (which is handled `onMouseDown` of the brush layer), then `isBrushing` would always be `true` after clicking–even when not brushing and just clicking.  So we set `isBrushing` to true only `onBrushing`, that is, only `onMouseMove` followed by `onMouseDown`.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~- [] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
