### PR TITLE
fix: export GeometryValue so onElementClick callbacks can be typed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,3 +24,4 @@ export {
   RectAnnotationDatum,
   RectAnnotationSpec,
 } from './lib/series/specs';
+export { GeometryValue } from './lib/series/rendering';


### PR DESCRIPTION
## Summary

This PR exports  `GeometryValue` so that library consumers can use the type in type annotations (for example, when defining a `onElementClick` callback).

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
~- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
~- [ ] Unit tests were updated or added to match the most common scenarios~
- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
