### PR TITLE
fix(tooltip): fix overflow for long series names

### DIFF
--- a/src/components/_tooltip.scss
+++ b/src/components/_tooltip.scss
@@ -10,13 +10,13 @@
   table {
     border-collapse: collapse;
     border-spacing: 0;
+    table-layout: fixed;
+    width: 100%;
+
     td,
     th {
       padding: 3px;
     }
-  }
-  table {
-    width: 100%;
   }
 }
 
@@ -25,10 +25,13 @@
   padding: $euiSizeXS ($euiSizeXS * 2);
 }
 
-.echTooltip__label {
-  @include euiTextTruncate;
-  // Border indicates series color
+.echTooltip__cell {
+  display: flex;
   border-left: $euiSizeXS solid transparent;
+}
+
+.echTooltip__label {
+  flex: 1;
 }
 
 .echTooltip__value {
@@ -38,7 +41,7 @@
 }
 
 .echTooltip__rowHighlighted {
-  background-color: transparentize($euiColorGhost, .9);
+  background-color: transparentize($euiColorGhost, 0.9);
   border-radius: $euiBorderRadius;
 }
 

--- a/src/components/_tooltip.scss
+++ b/src/components/_tooltip.scss
@@ -7,48 +7,40 @@
   pointer-events: none;
   user-select: none;
 
-  table {
-    border-collapse: collapse;
-    border-spacing: 0;
-    table-layout: fixed;
-    width: 100%;
-
-    td,
-    th {
-      padding: 3px;
-    }
+  &__list {
+    margin: $euiSizeXS;
   }
-}
 
-.echTooltip__header {
-  @include euiToolTipTitle;
-  padding: $euiSizeXS ($euiSizeXS * 2);
-}
+  &__header {
+    @include euiToolTipTitle;
+    padding: $euiSizeXS ($euiSizeXS * 2);
+  }
 
-.echTooltip__cell {
-  display: flex;
-  border-left: $euiSizeXS solid transparent;
-}
+  &__item {
+    display: flex;
+    padding: 3px;
+    box-sizing: border-box;
+    border-left: $euiSizeXS solid transparent;
+  }
 
-.echTooltip__label {
-  flex: 1;
-}
+  &__label {
+    @include euiTextOverflowWrap;
+    min-width: 1px;
+    flex: 1;
+  }
 
-.echTooltip__value {
-  font-weight: $euiFontWeightBold;
-  text-align: right;
-  font-feature-settings: 'tnum';
-}
+  &__value {
+    font-weight: $euiFontWeightBold;
+    text-align: right;
+    font-feature-settings: 'tnum';
+    margin-left: 8px;
+  }
 
-.echTooltip__rowHighlighted {
-  background-color: transparentize($euiColorGhost, 0.9);
-  border-radius: $euiBorderRadius;
-}
+  &__rowHighlighted {
+    background-color: transparentize($euiColorGhost, 0.9);
+  }
 
-.echTooltip--hidden {
-  opacity: 0;
-}
-
-.echTooltip__table {
-  margin: $euiSizeXS;
+  &--hidden {
+    opacity: 0;
+  }
 }

--- a/src/components/tooltips.tsx
+++ b/src/components/tooltips.tsx
@@ -29,30 +29,25 @@ class TooltipsComponent extends React.Component<TooltipProps> {
     return (
       <div className="echTooltip" style={{ transform: tooltipPosition.transform }}>
         <div className="echTooltip__header">{this.renderHeader(tooltipData[0], tooltipHeaderFormatter)}</div>
-        <div className="echTooltip__table">
-          <table>
-            <tbody>
-              {tooltipData.slice(1).map(({ name, value, color, isHighlighted }, index) => {
-                const classes = classNames({
-                  /* eslint @typescript-eslint/camelcase:0 */
-                  echTooltip__rowHighlighted: isHighlighted,
-                });
-                return (
-                  <tr key={`row-${index}`} className={classes}>
-                    <td
-                      className="echTooltip__cell"
-                      style={{
-                        borderLeftColor: color,
-                      }}
-                    >
-                      <span className="echTooltip__label">{name}</span>
-                      <span className="echTooltip__value">{value}</span>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+        <div className="echTooltip__list">
+          {tooltipData.slice(1).map(({ name, value, color, isHighlighted, seriesKey }) => {
+            const classes = classNames('echTooltip__item', {
+              /* eslint @typescript-eslint/camelcase:0 */
+              echTooltip__rowHighlighted: isHighlighted,
+            });
+            return (
+              <div
+                key={seriesKey}
+                className={classes}
+                style={{
+                  borderLeftColor: color,
+                }}
+              >
+                <span className="echTooltip__label">{name}</span>
+                <span className="echTooltip__value">{value}</span>
+              </div>
+            );
+          })}
         </div>
       </div>
     );

--- a/src/components/tooltips.tsx
+++ b/src/components/tooltips.tsx
@@ -21,9 +21,11 @@ class TooltipsComponent extends React.Component<TooltipProps> {
 
   render() {
     const { isTooltipVisible, tooltipData, tooltipPosition, tooltipHeaderFormatter } = this.props.chartStore!;
+
     if (!isTooltipVisible.get()) {
       return <div className="echTooltip echTooltip--hidden" />;
     }
+
     return (
       <div className="echTooltip" style={{ transform: tooltipPosition.transform }}>
         <div className="echTooltip__header">{this.renderHeader(tooltipData[0], tooltipHeaderFormatter)}</div>
@@ -38,14 +40,14 @@ class TooltipsComponent extends React.Component<TooltipProps> {
                 return (
                   <tr key={`row-${index}`} className={classes}>
                     <td
-                      className="echTooltip__label"
+                      className="echTooltip__cell"
                       style={{
                         borderLeftColor: color,
                       }}
                     >
-                      {name}
+                      <span className="echTooltip__label">{name}</span>
+                      <span className="echTooltip__value">{value}</span>
                     </td>
-                    <td className="echTooltip__value">{value}</td>
                   </tr>
                 );
               })}


### PR DESCRIPTION
## Summary

Allow long series names in tooltip to wrap to next line

fix #270

### Before
<img width="815" alt="Screen Shot 2019-07-30 at 12 51 08 PM" src="https://user-images.githubusercontent.com/19007109/62158714-ba024580-b2d5-11e9-8bbd-75245d88527e.png">

### After
<img width="813" alt="Screen Shot 2019-07-30 at 1 57 12 PM" src="https://user-images.githubusercontent.com/19007109/62158730-c5557100-b2d5-11e9-9a54-686f7b63d5fb.png">




### Checklist
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
