### PR TITLE
fix(types): export missing types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 export * from './specs';
 export { Chart } from './components/chart';
 export { TooltipType, TooltipValue, TooltipValueFormatter } from './chart_types/xy_chart/utils/interactions';
-export { getAxisId, getGroupId, getSpecId, getAnnotationId } from './utils/ids';
+export { SpecId, GroupId, AxisId, AnnotationId, getAxisId, getGroupId, getSpecId, getAnnotationId } from './utils/ids';
 export { ScaleType } from './utils/scales/scales';
-export { Position, Rendering, Rotation } from './chart_types/xy_chart/utils/specs';
+export { Position, Rendering, Rotation, TickFormatter } from './chart_types/xy_chart/utils/specs';
 export * from './utils/themes/theme';
 export { LIGHT_THEME } from './utils/themes/light_theme';
 export { DARK_THEME } from './utils/themes/dark_theme';
@@ -26,3 +26,10 @@ export {
 } from './chart_types/xy_chart/utils/specs';
 export { GeometryValue } from './chart_types/xy_chart/rendering/rendering';
 export { AnnotationTooltipFormatter } from './chart_types/xy_chart/annotations/annotation_utils';
+export { SettingSpecProps } from './specs/settings';
+export {
+  BrushEndListener,
+  ElementClickListener,
+  ElementOverListener,
+  LegendItemListener,
+} from './chart_types/xy_chart/store/chart_state';


### PR DESCRIPTION
## Summary

Some consumers in Kibana needs this exported types. They are getting the types from the dist folder.
To avoid that I've exported those required types from the main index.ts file

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- ~[ ] Unit tests were updated or added to match the most common scenarios~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
