### PR TITLE
chore: configure release slack message as markdown

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,7 +11,8 @@
       "semantic-release-slack-bot",
       {
         "notifyOnSuccess": true,
-        "notifyOnFail": true
+        "notifyOnFail": true,
+        "markdownReleaseNotes": true
       }
     ]
   ]


### PR DESCRIPTION
## Summary

Fix the semantic-release slack-bot configuration to threat the releasenote as markdown

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- ~[ ] Unit tests were updated or added to match the most common scenarios~
- ~[ ] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)~
