### PR TITLE
fix: handle splitted series with group value to 0

### DIFF
--- a/src/chart_types/xy_chart/legend/legend.test.ts
+++ b/src/chart_types/xy_chart/legend/legend.test.ts
@@ -216,5 +216,41 @@ describe('Legends', () => {
     expect(label).toBe('a - b');
     label = getSeriesColorLabel(['a', 'b'], false, spec2);
     expect(label).toBe('a - b');
+
+    label = getSeriesColorLabel([null], true);
+    expect(label).toBeUndefined();
+    label = getSeriesColorLabel([null], true, spec1);
+    expect(label).toBe('Spec 1 title');
+    label = getSeriesColorLabel([null], true, spec2);
+    expect(label).toBe('spec2');
+    label = getSeriesColorLabel([undefined], true);
+    expect(label).toBeUndefined();
+    label = getSeriesColorLabel([undefined], true, spec1);
+    expect(label).toBe('Spec 1 title');
+    label = getSeriesColorLabel([undefined], true, spec2);
+    expect(label).toBe('spec2');
+
+    label = getSeriesColorLabel([0], true);
+    expect(label).toBeUndefined();
+    label = getSeriesColorLabel([0], true, spec1);
+    expect(label).toBe('Spec 1 title');
+
+    label = getSeriesColorLabel([null], false);
+    expect(label).toBeUndefined();
+    label = getSeriesColorLabel([null], false, spec1);
+    expect(label).toBe('Spec 1 title');
+    label = getSeriesColorLabel([null], false, spec2);
+    expect(label).toBe('spec2');
+    label = getSeriesColorLabel([undefined], false);
+    expect(label).toBeUndefined();
+    label = getSeriesColorLabel([undefined], false, spec1);
+    expect(label).toBe('Spec 1 title');
+    label = getSeriesColorLabel([undefined], false, spec2);
+    expect(label).toBe('spec2');
+
+    label = getSeriesColorLabel([0], false);
+    expect(label).toBe('0');
+    label = getSeriesColorLabel([0], false, spec1);
+    expect(label).toBe('0');
   });
 });

--- a/src/chart_types/xy_chart/legend/legend.ts
+++ b/src/chart_types/xy_chart/legend/legend.ts
@@ -71,8 +71,7 @@ export function getSeriesColorLabel(
   spec?: BasicSeriesSpec,
 ): string | undefined {
   let label = '';
-
-  if (hasSingleSeries || colorValues.length === 0 || !colorValues[0]) {
+  if (hasSingleSeries || colorValues.length === 0 || colorValues[0] == null) {
     if (!spec) {
       return;
     }


### PR DESCRIPTION
## Summary
The current implementation wrongly interpret a zero value in the colorValues list of a legend item
as a single series. This cause that series to be named with the spec name or the spec id. Instead a splitted series with a group value of zero, should be threated in the same way as anyother splitted series, using the group value as the series name

fix #288

**from**
<img width="206" alt="Screenshot 2019-08-06 at 11 26 48" src="https://user-images.githubusercontent.com/1421091/62528431-24b70200-b83d-11e9-8cc9-2449d0971409.png">

**to**
<img width="194" alt="Screenshot 2019-08-06 at 11 26 33" src="https://user-images.githubusercontent.com/1421091/62528445-2aace300-b83d-11e9-91b2-092d783429f4.png">


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
