### PR TITLE
feat: allow custom series naming

### DIFF
--- a/src/chart_types/xy_chart/legend/legend.ts
+++ b/src/chart_types/xy_chart/legend/legend.ts
@@ -24,6 +24,7 @@ export interface LegendItem {
 export function computeLegend(
   seriesColor: Map<string, DataSeriesColorsValues>,
   seriesColorMap: Map<string, string>,
+  seriesNameMap: Map<string, string>,
   specs: Map<SpecId, BasicSeriesSpec>,
   defaultColor: string,
   axesSpecs: Map<AxisId, AxisSpec>,
@@ -36,7 +37,7 @@ export function computeLegend(
     const spec = specs.get(series.specId);
     const color = seriesColorMap.get(key) || defaultColor;
     const hasSingleSeries = seriesColor.size === 1;
-    const label = getSeriesColorLabel(series.colorValues, hasSingleSeries, spec);
+    const label = getSeriesColorLabel(series.colorValues, hasSingleSeries, seriesNameMap, key, spec);
     const isSeriesVisible = deselectedDataSeries ? findDataSeriesByColorValues(deselectedDataSeries, series) < 0 : true;
 
     if (!label || !spec) {
@@ -68,8 +69,16 @@ export function computeLegend(
 export function getSeriesColorLabel(
   colorValues: any[],
   hasSingleSeries: boolean,
+  seriesNameMap: Map<string, string>,
+  seriesKey: string,
   spec?: BasicSeriesSpec,
 ): string | undefined {
+  const customLabel = seriesNameMap.get(seriesKey!);
+
+  if (customLabel) {
+    return customLabel;
+  }
+
   let label = '';
 
   if (hasSingleSeries || colorValues.length === 0 || !colorValues[0]) {

--- a/src/chart_types/xy_chart/store/chart_state.ts
+++ b/src/chart_types/xy_chart/store/chart_state.ts
@@ -27,6 +27,7 @@ import {
   FormattedDataSeries,
   getSeriesColorMap,
   RawDataSeries,
+  getSeriesNameMap,
 } from '../utils/series';
 import {
   AnnotationSpec,
@@ -167,6 +168,7 @@ export class ChartStore {
   deselectedDataSeries: DataSeriesColorsValues[] | null = null;
   customSeriesColors: Map<string, string> = new Map();
   seriesColorMap: Map<string, string> = new Map();
+  seriesNameMap: Map<string, string> = new Map();
   totalBarsInCluster?: number;
 
   tooltipData = observable.array<TooltipValue>([], { deep: false });
@@ -368,13 +370,20 @@ export class ChartStore {
 
         // format the tooltip values
         const yAxisFormatSpec = [0, 180].includes(this.chartRotation) ? yAxis : xAxis;
-        const formattedTooltip = formatTooltip(indexedGeometry, spec, false, isHighlighted, yAxisFormatSpec);
+        const formattedTooltip = formatTooltip(
+          indexedGeometry,
+          spec,
+          false,
+          isHighlighted,
+          this.seriesNameMap,
+          yAxisFormatSpec,
+        );
         // format only one time the x value
         if (!xValueInfo) {
           // if we have a tooltipHeaderFormatter, then don't pass in the xAxis as the user will define a formatter
           const xAxisFormatSpec = [0, 180].includes(this.chartRotation) ? xAxis : yAxis;
           const formatterAxis = this.tooltipHeaderFormatter ? undefined : xAxisFormatSpec;
-          xValueInfo = formatTooltip(indexedGeometry, spec, true, false, formatterAxis);
+          xValueInfo = formatTooltip(indexedGeometry, spec, true, false, this.seriesNameMap, formatterAxis);
           return [xValueInfo, ...acc, formattedTooltip];
         }
 
@@ -803,9 +812,12 @@ export class ChartStore {
       this.customSeriesColors,
     );
 
+    this.seriesNameMap = getSeriesNameMap(this.seriesSpecs);
+
     this.legendItems = computeLegend(
       this.seriesDomainsAndData.seriesColors,
       this.seriesColorMap,
+      this.seriesNameMap,
       this.seriesSpecs,
       this.chartTheme.colors.defaultVizColor,
       this.axesSpecs,

--- a/src/chart_types/xy_chart/tooltip/tooltip.test.ts
+++ b/src/chart_types/xy_chart/tooltip/tooltip.test.ts
@@ -3,6 +3,7 @@ import { ScaleType } from '../../../utils/scales/scales';
 import { BarGeometry } from '../rendering/rendering';
 import { AxisSpec, BarSeriesSpec, Position } from '../utils/specs';
 import { formatTooltip } from './tooltip';
+import { getColorValuesAsString } from '../utils/series';
 
 describe('Tooltip formatting', () => {
   const SPEC_ID_1 = getSpecId('bar_1');
@@ -65,7 +66,7 @@ describe('Tooltip formatting', () => {
   };
 
   test('format simple tooltip', () => {
-    const tooltipValue = formatTooltip(indexedGeometry, SPEC_1, false, false, YAXIS_SPEC);
+    const tooltipValue = formatTooltip(indexedGeometry, SPEC_1, false, false, new Map(), YAXIS_SPEC);
     expect(tooltipValue).toBeDefined();
     expect(tooltipValue.name).toBe('bar_1');
     expect(tooltipValue.isXValue).toBe(false);
@@ -81,13 +82,29 @@ describe('Tooltip formatting', () => {
         seriesKey: ['y1'],
       },
     };
-    const tooltipValue = formatTooltip(geometry, SPEC_1, false, false, YAXIS_SPEC);
+    const tooltipValue = formatTooltip(geometry, SPEC_1, false, false, new Map(), YAXIS_SPEC);
     expect(tooltipValue).toBeDefined();
     expect(tooltipValue.name).toBe('y1');
     expect(tooltipValue.isXValue).toBe(false);
     expect(tooltipValue.isHighlighted).toBe(false);
     expect(tooltipValue.color).toBe('blue');
     expect(tooltipValue.value).toBe('10');
+  });
+  test('format tooltip with custom series name', () => {
+    const seriesKey = ['y1'];
+    const customName = 'My Custom Series';
+    const geometry: BarGeometry = {
+      ...indexedGeometry,
+      geometryId: {
+        specId: SPEC_ID_1,
+        seriesKey,
+      },
+    };
+    const seriesKeyAsString = getColorValuesAsString(seriesKey, SPEC_ID_1);
+    const nameMap = new Map<string, string>([[seriesKeyAsString, customName]]);
+    const tooltipValue = formatTooltip(geometry, SPEC_1, false, false, nameMap, YAXIS_SPEC);
+    expect(tooltipValue).toBeDefined();
+    expect(tooltipValue.name).toBe(customName);
   });
   test('format y0 tooltip', () => {
     const geometry: BarGeometry = {
@@ -97,7 +114,7 @@ describe('Tooltip formatting', () => {
         accessor: 'y0',
       },
     };
-    const tooltipValue = formatTooltip(geometry, SPEC_1, false, false, YAXIS_SPEC);
+    const tooltipValue = formatTooltip(geometry, SPEC_1, false, false, new Map(), YAXIS_SPEC);
     expect(tooltipValue).toBeDefined();
     expect(tooltipValue.name).toBe('bar_1');
     expect(tooltipValue.isXValue).toBe(false);
@@ -113,7 +130,7 @@ describe('Tooltip formatting', () => {
         accessor: 'y0',
       },
     };
-    let tooltipValue = formatTooltip(geometry, SPEC_1, true, false, YAXIS_SPEC);
+    let tooltipValue = formatTooltip(geometry, SPEC_1, true, false, new Map(), YAXIS_SPEC);
     expect(tooltipValue).toBeDefined();
     expect(tooltipValue.name).toBe('bar_1');
     expect(tooltipValue.isXValue).toBe(true);
@@ -121,7 +138,7 @@ describe('Tooltip formatting', () => {
     expect(tooltipValue.color).toBe('blue');
     expect(tooltipValue.value).toBe('1');
     // disable any highlight on x value
-    tooltipValue = formatTooltip(geometry, SPEC_1, true, true, YAXIS_SPEC);
+    tooltipValue = formatTooltip(geometry, SPEC_1, true, true, new Map(), YAXIS_SPEC);
     expect(tooltipValue.isHighlighted).toBe(false);
   });
 });

--- a/src/chart_types/xy_chart/tooltip/tooltip.ts
+++ b/src/chart_types/xy_chart/tooltip/tooltip.ts
@@ -25,6 +25,7 @@ export function formatTooltip(
   spec: BasicSeriesSpec,
   isXValue: boolean,
   isHighlighted: boolean,
+  seriesNameMap: Map<string, string>,
   axisSpec?: AxisSpec,
 ): TooltipValue {
   const { id } = spec;
@@ -34,8 +35,12 @@ export function formatTooltip(
     geometryId: { seriesKey },
   } = searchIndexValue;
   const seriesKeyAsString = getColorValuesAsString(seriesKey, id);
+  const customName = seriesKey.length > 0 ? seriesNameMap.get(seriesKeyAsString) : '';
   let name: string | undefined;
-  if (seriesKey.length > 0) {
+
+  if (customName) {
+    name = customName;
+  } else if (seriesKey.length > 0) {
     name = seriesKey.join(' - ');
   } else {
     name = spec.name || `${spec.id}`;

--- a/src/chart_types/xy_chart/utils/series.test.ts
+++ b/src/chart_types/xy_chart/utils/series.test.ts
@@ -9,6 +9,8 @@ import {
   getSplittedSeries,
   RawDataSeries,
   splitSeries,
+  getSeriesNameMap,
+  getColorValuesAsString,
 } from './series';
 import { BasicSeriesSpec } from './specs';
 import { formatStackedDataSeriesValues } from './stacked_series_utils';
@@ -487,5 +489,40 @@ describe('Series', () => {
     undefinedSortedColorValues.set(spec2Id, dataSeriesValues2);
 
     expect(getSortedDataSeriesColorsValuesMap(colorValuesMap)).toEqual(undefinedSortedColorValues);
+  });
+  describe('getSeriesNameMap', () => {
+    const seriesSpecs = new Map<SpecId, BasicSeriesSpec>();
+    const customName = 'Custom series name';
+    const specId = getSpecId('spec');
+    const colorValues = ['y1', 'x1'];
+    const customSeriesNames = new Map<DataSeriesColorsValues, string>([
+      [
+        {
+          specId,
+          colorValues,
+        },
+        customName,
+      ],
+    ]);
+    const spec: BasicSeriesSpec = {
+      id: specId,
+      groupId: getGroupId('group'),
+      xScaleType: ScaleType.Linear,
+      yScaleType: ScaleType.Linear,
+      seriesType: 'bar',
+      xAccessor: 'x',
+      yAccessors: ['y1', 'y2'],
+      stackAccessors: ['x'],
+      yScaleToDataExtent: false,
+      data: TestDataset.BARCHART_2Y0G,
+      customSeriesNames,
+    };
+    seriesSpecs.set(spec.id, spec);
+    const nameMap = getSeriesNameMap(seriesSpecs);
+    const expectedMap = new Map<string, string>([[getColorValuesAsString(colorValues, specId), customName]]);
+
+    it('should return the expected name map', () => {
+      expect(nameMap).toEqual(expectedMap);
+    });
   });
 });

--- a/src/chart_types/xy_chart/utils/series.ts
+++ b/src/chart_types/xy_chart/utils/series.ts
@@ -368,3 +368,21 @@ export function getSeriesColorMap(
   });
   return seriesColorMap;
 }
+
+export function getSeriesNameMap(seriesSpecs: Map<SpecId, BasicSeriesSpec>): Map<string, string> {
+  const seriesColorMap = new Map<string, string>();
+
+  seriesSpecs.forEach(({ customSeriesNames }) => {
+    if (!customSeriesNames || customSeriesNames.size === 0) {
+      return seriesColorMap;
+    }
+
+    customSeriesNames.forEach((seriesNameKey, { colorValues, specId }) => {
+      const seriesKey = getColorValuesAsString(colorValues, specId);
+
+      seriesColorMap.set(seriesKey, seriesNameKey);
+    });
+  });
+
+  return seriesColorMap;
+}

--- a/src/chart_types/xy_chart/utils/specs.ts
+++ b/src/chart_types/xy_chart/utils/specs.ts
@@ -77,6 +77,8 @@ export interface SeriesSpec {
   data: Datum[];
   /** The type of series you are looking to render */
   seriesType: 'bar' | 'line' | 'area';
+  /** Custom naming for series */
+  customSeriesNames?: CustomSeriesNamesMap;
   /** Custom colors for series */
   customSeriesColors?: CustomSeriesColorsMap;
   /** If the series should appear in the legend
@@ -89,6 +91,7 @@ export interface SeriesSpec {
 }
 
 export type CustomSeriesColorsMap = Map<DataSeriesColorsValues, string>;
+export type CustomSeriesNamesMap = Map<DataSeriesColorsValues, string>;
 
 export interface SeriesAccessors {
   /** The field name of the x value on Datum object */

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -1,4 +1,4 @@
-import { boolean, color, number, select } from '@storybook/addon-knobs';
+import { boolean, color, number, select, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { switchTheme } from '../.storybook/theme_service';
@@ -24,6 +24,7 @@ import {
 } from '../src/';
 import * as TestDatasets from '../src/utils/data_samples/test_dataset';
 import { palettes } from '../src/utils/themes/colors';
+import { CustomSeriesNamesMap } from '../src/chart_types/xy_chart/utils/specs';
 
 function range(title: string, min: number, max: number, value: number, groupId?: string, step: number = 1) {
   return number(
@@ -431,12 +432,7 @@ storiesOf('Stylings', module)
     return (
       <Chart className={'story-chart'}>
         <Settings showLegend={true} legendPosition={Position.Right} />
-        <Axis
-          id={getAxisId('bottom')}
-          position={Position.Bottom}
-          // title={'Bottom axis'}
-          showOverlappingTicks={true}
-        />
+        <Axis id={getAxisId('bottom')} position={Position.Bottom} showOverlappingTicks={true} />
         <Axis
           id={getAxisId('left2')}
           title={'Left axis'}
@@ -462,6 +458,41 @@ storiesOf('Stylings', module)
           yAccessors={['y']}
           customSeriesColors={lineCustomSeriesColors}
           data={[{ x: 0, y: 3 }, { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 10 }]}
+        />
+      </Chart>
+    );
+  })
+  .add('custom series names', () => {
+    const colorValues = ['cloudflare.com', 'direct-cdn', 'y2'];
+    const barCustomSeriesNames: CustomSeriesNamesMap = new Map();
+    const barDataSeries: DataSeriesColorsValues = {
+      colorValues,
+      specId: getSpecId('bars'),
+    };
+
+    const customSeriesText = text(`Custom series name`, 'MY CUSTOM SERIES');
+    barCustomSeriesNames.set(barDataSeries, customSeriesText);
+
+    return (
+      <Chart className={'story-chart'}>
+        <Settings showLegend={true} legendPosition={Position.Right} />
+        <Axis id={getAxisId('bottom')} position={Position.Bottom} showOverlappingTicks={true} />
+        <Axis
+          id={getAxisId('left2')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bars')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y1', 'y2']}
+          splitSeriesAccessors={['g1', 'g2']}
+          customSeriesNames={barCustomSeriesNames}
+          data={TestDatasets.BARCHART_2Y2G}
         />
       </Chart>
     );


### PR DESCRIPTION
## Summary

Allow user to set custom names for series based on `DataSeriesColorsValues`.

The names are applied similarly to how `customSeriesColors` are applied using `DataSeriesColorsValues` in a `Map` tied to a label `string` key.

> Changes applied to both the tooltip and legend logic.

```tsx
const barCustomSeriesNames: CustomSeriesNamesMap = new Map();
const barDataSeries: DataSeriesColorsValues = {
  colorValues: ['cloudflare.com', 'direct-cdn', 'y2'],
  specId: getSpecId('bars'),
};
barCustomSeriesNames.set(barDataSeries, 'MY CUSTOM SERIES');

return (
  <Chart className="story-chart">
    {/* base config stuff */}

    <BarSeries
      id={getSpecId('bars')}
      xScaleType={ScaleType.Linear}
      yScaleType={ScaleType.Linear}
      xAccessor="x"
      yAccessors={['y1', 'y2']}
      splitSeriesAccessors={['g1', 'g2']}
      customSeriesNames={barCustomSeriesNames}
      data={TestDatasets.BARCHART_2Y2G}
    />
  </Chart>
)
```

### Result
<img width="776" alt="Screen Shot 2019-08-06 at 1 21 50 PM" src="https://user-images.githubusercontent.com/19007109/62565838-43bd9000-b84d-11e9-80ad-87a1a187107b.png">


#245

### Checklist

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
