### PR TITLE
feat: add cursor sync mechanism

### DIFF
--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -10,70 +10,87 @@ import {
   Position,
   ScaleType,
   Settings,
-  mergeWithDefaultTheme,
 } from '../src';
 import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
+import { CursorEvent } from '../src/specs/settings';
+import { CursorUpdateListener } from '../src/chart_types/xy_chart/store/chart_state';
 
 export class Playground extends React.Component {
+  ref1 = React.createRef<Chart>();
+  ref2 = React.createRef<Chart>();
+  ref3 = React.createRef<Chart>();
+
+  onCursorUpdate: CursorUpdateListener = (event?: CursorEvent) => {
+    this.ref1.current!.dispatchExternalCursorEvent(event);
+    this.ref2.current!.dispatchExternalCursorEvent(event);
+    this.ref3.current!.dispatchExternalCursorEvent(event);
+  };
+
   render() {
-    return <>{this.renderChart(Position.Right)}</>;
-  }
-  renderChart(legendPosition: Position) {
-    const theme = mergeWithDefaultTheme({
-      lineSeriesStyle: {
-        // area: {
-        //   fill: 'green',
-        //   opacity:0.2
-        // },
-        line: {
-          stroke: 'violet',
-          strokeWidth: 4,
-        },
-        point: {
-          fill: 'yellow',
-          stroke: 'black',
-          strokeWidth: 2,
-          radius: 6,
-        },
-      },
-    });
-    console.log(theme.areaSeriesStyle);
     return (
-      <div className="chart">
-        <Chart>
-          <Settings debug={false} showLegend={true} legendPosition={legendPosition} rotation={0} theme={theme} />
-          <Axis
-            id={getAxisId('timestamp')}
-            title="timestamp"
-            position={Position.Bottom}
-            tickFormat={niceTimeFormatter([1555819200000, 1555905600000])}
-          />
-          <Axis id={getAxisId('count')} title="count" position={Position.Left} tickFormat={(d) => d.toFixed(2)} />
-          <LineSeries
-            id={getSpecId('dataset A with long title')}
-            xScaleType={ScaleType.Time}
-            yScaleType={ScaleType.Linear}
-            data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 15)}
-            xAccessor={0}
-            lineSeriesStyle={{
-              line: {
-                stroke: 'red',
-                opacity: 1,
-              },
-            }}
-            yAccessors={[1]}
-          />
-          <LineSeries
-            id={getSpecId('dataset B')}
-            xScaleType={ScaleType.Time}
-            yScaleType={ScaleType.Linear}
-            data={KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15)}
-            xAccessor={0}
-            yAccessors={[1]}
-            stackAccessors={[0]}
-          />
-        </Chart>
-      </div>
+      <>
+        {renderChart(
+          '1',
+          this.ref1,
+          KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 15),
+          this.onCursorUpdate,
+          true,
+        )}
+        {renderChart(
+          '2',
+          this.ref2,
+          KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15),
+          this.onCursorUpdate,
+          true,
+        )}
+        {renderChart('2', this.ref3, KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(15, 30), this.onCursorUpdate)}
+      </>
     );
   }
+}
+
+function renderChart(
+  key: string,
+  ref: React.RefObject<Chart>,
+  data: any,
+  onCursorUpdate?: CursorUpdateListener,
+  timeSeries: boolean = false,
+) {
+  return (
+    <div key={key} className="chart">
+      <Chart ref={ref}>
+        <Settings tooltip={{ type: 'vertical' }} debug={false} showLegend={true} onCursorUpdate={onCursorUpdate} />
+        <Axis
+          id={getAxisId('timestamp')}
+          title="timestamp"
+          position={Position.Bottom}
+          tickFormat={niceTimeFormatter([1555819200000, 1555905600000])}
+        />
+        <Axis id={getAxisId('count')} title="count" position={Position.Left} tickFormat={(d) => d.toFixed(2)} />
+        <LineSeries
+          id={getSpecId('dataset A with long title')}
+          xScaleType={timeSeries ? ScaleType.Time : ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          data={data}
+          xAccessor={0}
+          lineSeriesStyle={{
+            line: {
+              stroke: 'red',
+              opacity: 1,
+            },
+          }}
+          yAccessors={[1]}
+        />
+        <LineSeries
+          id={getSpecId('dataset B')}
+          xScaleType={ScaleType.Time}
+          yScaleType={ScaleType.Linear}
+          data={KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15)}
+          xAccessor={0}
+          yAccessors={[1]}
+          stackAccessors={[0]}
+        />
+      </Chart>
+    </div>
+  );
 }

--- a/src/chart_types/xy_chart/crosshair/crosshair_utils.linear_snap.test.ts
+++ b/src/chart_types/xy_chart/crosshair/crosshair_utils.linear_snap.test.ts
@@ -2,8 +2,8 @@ import { computeXScale } from '../utils/scales';
 import { BasicSeriesSpec } from '../utils/specs';
 import { Dimensions } from '../../../utils/dimensions';
 import { getGroupId, getSpecId } from '../../../utils/ids';
-import { ScaleType } from '../../../utils/scales/scales';
-import { getCursorBandPosition, getSnapPosition } from './crosshair_utils';
+import { ScaleType, Scale } from '../../../utils/scales/scales';
+import { getCursorBandPosition, getSnapPosition, getPosition } from './crosshair_utils';
 import { computeSeriesDomains } from '../store/utils';
 
 describe('Crosshair utils linear scale', () => {
@@ -1395,6 +1395,28 @@ describe('Crosshair utils linear scale', () => {
         );
         expect(bandPosition).toBeUndefined();
       });
+    });
+  });
+
+  describe('getPosition', () => {
+    // @ts-ignore
+    const scale: Scale = {
+      scale: jest.fn(),
+    };
+
+    beforeEach(() => {
+      (scale.scale as jest.Mock).mockClear();
+    });
+
+    it('should return value from scale', () => {
+      (scale.scale as jest.Mock).mockReturnValue(20);
+      const result = getPosition(10, scale);
+      expect(result).toBe(20);
+    });
+
+    it('should call scale with correct args', () => {
+      getPosition(10, scale);
+      expect(scale.scale).toBeCalledWith(10);
     });
   });
 });

--- a/src/chart_types/xy_chart/crosshair/crosshair_utils.ts
+++ b/src/chart_types/xy_chart/crosshair/crosshair_utils.ts
@@ -10,6 +10,10 @@ export interface SnappedPosition {
 
 export const DEFAULT_SNAP_POSITION_BAND = 1;
 
+export function getPosition(value: string | number, scale: Scale): number | undefined {
+  return scale.scale(value);
+}
+
 export function getSnapPosition(
   value: string | number,
   scale: Scale,

--- a/src/chart_types/xy_chart/rendering/rendering.ts
+++ b/src/chart_types/xy_chart/rendering/rendering.ts
@@ -513,7 +513,6 @@ export function isPointOnGeometry(
   xCoordinate: number,
   yCoordinate: number,
   indexedGeometry: BarGeometry | PointGeometry,
-  isActiveChart: boolean,
 ) {
   const { x, y } = indexedGeometry;
   if (isPointGeometry(indexedGeometry)) {
@@ -522,10 +521,9 @@ export function isPointOnGeometry(
       yCoordinate >= y - radius &&
       yCoordinate <= y + radius &&
       xCoordinate >= x + transform.x - radius &&
-      xCoordinate <= x + transform.x + radius &&
-      isActiveChart
+      xCoordinate <= x + transform.x + radius
     );
   }
   const { width, height } = indexedGeometry;
-  return yCoordinate >= y && yCoordinate <= y + height && xCoordinate >= x && xCoordinate <= x + width && isActiveChart;
+  return yCoordinate >= y && yCoordinate <= y + height && xCoordinate >= x && xCoordinate <= x + width;
 }

--- a/src/chart_types/xy_chart/rendering/rendering.ts
+++ b/src/chart_types/xy_chart/rendering/rendering.ts
@@ -513,6 +513,7 @@ export function isPointOnGeometry(
   xCoordinate: number,
   yCoordinate: number,
   indexedGeometry: BarGeometry | PointGeometry,
+  isActiveChart: boolean,
 ) {
   const { x, y } = indexedGeometry;
   if (isPointGeometry(indexedGeometry)) {
@@ -521,9 +522,10 @@ export function isPointOnGeometry(
       yCoordinate >= y - radius &&
       yCoordinate <= y + radius &&
       xCoordinate >= x + transform.x - radius &&
-      xCoordinate <= x + transform.x + radius
+      xCoordinate <= x + transform.x + radius &&
+      isActiveChart
     );
   }
   const { width, height } = indexedGeometry;
-  return yCoordinate >= y && yCoordinate <= y + height && xCoordinate >= x && xCoordinate <= x + width;
+  return yCoordinate >= y && yCoordinate <= y + height && xCoordinate >= x && xCoordinate <= x + width && isActiveChart;
 }

--- a/src/chart_types/xy_chart/store/chart_state.test.ts
+++ b/src/chart_types/xy_chart/store/chart_state.test.ts
@@ -623,6 +623,9 @@ describe('Chart Store', () => {
   });
 
   describe('can use a custom tooltip header formatter', () => {
+    jest.unmock('../crosshair/crosshair_utils');
+    jest.resetModules();
+
     beforeEach(() => {
       const axisSpec: AxisSpec = {
         id: AXIS_ID,
@@ -967,22 +970,45 @@ describe('Chart Store', () => {
   });
 
   describe('setCursorValue', () => {
-    const mock = jest.fn();
+    const getPosition = jest.fn();
+    // TODO: fix mocking implementation
+    jest.doMock('../crosshair/crosshair_utils', () => ({
+      getPosition,
+    }));
 
+    const scale = new ScaleContinuous(ScaleType.Linear, [0, 100], [0, 100]);
     beforeEach(() => {
       // @ts-ignore
-      store.setCursorPosition = mock;
+      store.setCursorPosition = jest.fn();
     });
 
     it('should not call setCursorPosition if xScale is not defined', () => {
       store.xScale = undefined;
       store.setCursorValue(1);
-      expect(mock).not.toBeCalled();
+      expect(store.setCursorPosition).not.toBeCalled();
     });
 
-    it('should not call setCursorPosition if xPosition is not defined', () => {
+    it.skip('should call getPosition with args', () => {
+      (getPosition as jest.Mock).mockReturnValue(undefined);
+      store.xScale = scale;
       store.setCursorValue(1);
-      expect(mock).not.toBeCalled();
+      expect(getPosition).toBeCalledWith(1, store.xScale);
+    });
+
+    it.skip('should not call setCursorPosition if xPosition is not defined', () => {
+      store.xScale = scale;
+      (getPosition as jest.Mock).mockReturnValue(undefined);
+      store.setCursorValue(1);
+      expect(store.setCursorPosition).not.toBeCalled();
+    });
+
+    it('should call setCursorPosition with correct args', () => {
+      store.xScale = scale;
+      store.chartDimensions.left = 10;
+      store.chartDimensions.top = 10;
+      (getPosition as jest.Mock).mockReturnValue(20);
+      store.setCursorValue(20);
+      expect(store.setCursorPosition).toBeCalledWith(30, 10, false);
     });
   });
 });

--- a/src/chart_types/xy_chart/store/chart_state.ts
+++ b/src/chart_types/xy_chart/store/chart_state.ts
@@ -278,7 +278,7 @@ export class ChartStore {
 
     const xPosition = getPosition(value, this.xScale);
 
-    if (!xPosition) {
+    if (xPosition === undefined) {
       return;
     }
 

--- a/src/chart_types/xy_chart/store/chart_state.ts
+++ b/src/chart_types/xy_chart/store/chart_state.ts
@@ -404,7 +404,10 @@ export class ChartStore {
 
         // check if the pointer is on the geometry
         let isHighlighted = false;
-        if (isPointerOnGeometry(xAxisCursorPosition, yAxisCursorPosition, indexedGeometry, this.isActiveChart.get())) {
+        if (
+          this.isActiveChart.get() &&
+          isPointerOnGeometry(xAxisCursorPosition, yAxisCursorPosition, indexedGeometry)
+        ) {
           isHighlighted = true;
           oneHighlighted = true;
           newHighlightedGeometries.push(indexedGeometry);

--- a/src/chart_types/xy_chart/store/chart_state.ts
+++ b/src/chart_types/xy_chart/store/chart_state.ts
@@ -331,9 +331,12 @@ export class ChartStore {
     const xValue = this.xScale.invertWithStep(xAxisCursorPosition, this.geometriesIndexKeys);
 
     if (updateCursor && this.onCursorUpdateListener) {
+      // Get non-stepped xValue
+      const value = this.xScale.invert(xAxisCursorPosition);
+
       this.onCursorUpdateListener({
         chartId: this.id,
-        value: xValue,
+        value,
       });
     }
 

--- a/src/chart_types/xy_chart/store/chart_state.ts
+++ b/src/chart_types/xy_chart/store/chart_state.ts
@@ -1,4 +1,6 @@
 import { action, computed, IObservableValue, observable } from 'mobx';
+import * as uuid from 'uuid';
+
 import {
   AxisLinePosition,
   AxisTick,
@@ -63,13 +65,18 @@ import {
   TooltipValueFormatter,
 } from '../utils/interactions';
 import { Scale, ScaleType } from '../../../utils/scales/scales';
-import { DEFAULT_TOOLTIP_SNAP, DEFAULT_TOOLTIP_TYPE } from '../../../specs/settings';
+import { DEFAULT_TOOLTIP_SNAP, DEFAULT_TOOLTIP_TYPE, Cursor } from '../../../specs/settings';
 import {
   AnnotationDimensions,
   computeAnnotationDimensions,
   computeAnnotationTooltipState,
 } from '../annotations/annotation_utils';
-import { getCursorBandPosition, getCursorLinePosition, getTooltipPosition } from '../crosshair/crosshair_utils';
+import {
+  getCursorBandPosition,
+  getCursorLinePosition,
+  getTooltipPosition,
+  getPosition,
+} from '../crosshair/crosshair_utils';
 import {
   BrushExtent,
   computeBrushExtent,
@@ -106,9 +113,11 @@ export type ElementClickListener = (values: GeometryValue[]) => void;
 export type ElementOverListener = (values: GeometryValue[]) => void;
 export type BrushEndListener = (min: number, max: number) => void;
 export type LegendItemListener = (dataSeriesIdentifiers: DataSeriesColorsValues | null) => void;
+export type CursorUpdateListener = (cursor?: Cursor) => void;
 
 export class ChartStore {
   debug = false;
+  id = uuid.v4();
   specsInitialized = observable.box(false);
   initialized = observable.box(false);
   enableHistogramMode = observable.box(false);
@@ -154,6 +163,7 @@ export class ChartStore {
 
   seriesSpecs: Map<SpecId, BasicSeriesSpec> = new Map(); // readed from jsx
   isChartEmpty: boolean = true;
+  activeChartId?: string;
   seriesDomainsAndData?: SeriesDomainsAndData; // computed
   xScale?: Scale;
   yScales?: Map<GroupId, Scale>;
@@ -201,6 +211,7 @@ export class ChartStore {
   onLegendItemPlusClickListener?: LegendItemListener;
   onLegendItemMinusClickListener?: LegendItemListener;
   onLegendItemVisibilityToggleClickListener?: LegendItemListener;
+  onCursorUpdateListener?: CursorUpdateListener;
 
   geometries: {
     points: PointGeometry[];
@@ -234,8 +245,7 @@ export class ChartStore {
    * determine if crosshair cursor should be visible based on cursor position and brush enablement
    */
   isCrosshairCursorVisible = computed(() => {
-    const xPos = this.cursorPosition.x;
-    const yPos = this.cursorPosition.y;
+    const { x: xPos, y: yPos } = this.cursorPosition;
 
     if (yPos < 0 || xPos < 0) {
       return false;
@@ -245,9 +255,40 @@ export class ChartStore {
   });
 
   /**
+   * determine if chart is currently active
+   */
+  isActiveChart = computed(() => {
+    return !this.activeChartId ? true : this.activeChartId === this.id;
+  });
+
+  /**
+   * set activeChartId
+   */
+  setActiveChartId = (chartId?: string) => {
+    this.activeChartId = chartId;
+  };
+
+  /**
+   * set the x value of the cursor
+   */
+  setCursorValue = (value: string | number) => {
+    if (!this.xScale) {
+      return;
+    }
+
+    const xPosition = getPosition(value, this.xScale);
+
+    if (!xPosition) {
+      return;
+    }
+
+    this.setCursorPosition(xPosition + this.chartDimensions.left, this.chartDimensions.top, false);
+  };
+
+  /**
    * x and y values are relative to the container.
    */
-  setCursorPosition = action((x: number, y: number) => {
+  setCursorPosition = action((x: number, y: number, updateCursor: boolean = true) => {
     this.rawCursorPosition.x = x;
     this.rawCursorPosition.y = y;
 
@@ -287,8 +328,14 @@ export class ChartStore {
     }
 
     // invert the cursor position to get the scale value
-
     const xValue = this.xScale.invertWithStep(xAxisCursorPosition, this.geometriesIndexKeys);
+
+    if (updateCursor && this.onCursorUpdateListener) {
+      this.onCursorUpdateListener({
+        chartId: this.id,
+        value: xValue,
+      });
+    }
 
     // update che cursorBandPosition based on chart configuration
     const isLineAreaOnly = isLineAreaOnlyChart(this.seriesSpecs);
@@ -354,7 +401,7 @@ export class ChartStore {
 
         // check if the pointer is on the geometry
         let isHighlighted = false;
-        if (isPointerOnGeometry(xAxisCursorPosition, yAxisCursorPosition, indexedGeometry)) {
+        if (isPointerOnGeometry(xAxisCursorPosition, yAxisCursorPosition, indexedGeometry, this.isActiveChart.get())) {
           isHighlighted = true;
           oneHighlighted = true;
           newHighlightedGeometries.push(indexedGeometry);
@@ -470,9 +517,11 @@ export class ChartStore {
       this.tooltipType.get() !== TooltipType.None &&
       this.cursorPosition.x > -1 &&
       this.cursorPosition.y > -1 &&
-      this.tooltipData.length > 0
+      this.tooltipData.length > 0 &&
+      this.isActiveChart.get()
     );
   });
+
   isCrosshairVisible = computed(() => {
     return (
       !this.isBrushing.get() &&
@@ -496,6 +545,10 @@ export class ChartStore {
     this.tooltipData.clear();
 
     document.body.style.cursor = 'default';
+
+    if (this.onCursorUpdateListener && this.isActiveChart.get()) {
+      this.onCursorUpdateListener();
+    }
   });
 
   setShowLegend = action((showLegend: boolean) => {
@@ -666,6 +719,9 @@ export class ChartStore {
   setOnLegendItemMinusClickListener(listener: LegendItemListener) {
     this.onLegendItemMinusClickListener = listener;
   }
+  setOnCursorUpdateListener(listener: CursorUpdateListener) {
+    this.onCursorUpdateListener = listener;
+  }
   removeElementClickListener() {
     this.onElementClickListener = undefined;
   }
@@ -686,6 +742,9 @@ export class ChartStore {
   }
   removeOnLegendItemMinusClickListener() {
     this.onLegendItemMinusClickListener = undefined;
+  }
+  removeOnCursorUpdateListener() {
+    this.onCursorUpdateListener = undefined;
   }
 
   isBrushEnabled(): boolean {
@@ -846,7 +905,7 @@ export class ChartStore {
     });
     bboxCalculator.destroy();
 
-    // // compute chart dimensions
+    // compute chart dimensions
     this.chartDimensions = computeChartDimensions(
       this.parentDimensions,
       this.chartTheme,
@@ -873,7 +932,6 @@ export class ChartStore {
     );
 
     // tslint:disable-next-line:no-console
-    // console.log({ seriesGeometries });
     this.geometries = seriesGeometries.geometries;
     this.xScale = seriesGeometries.scales.xScale;
 
@@ -886,7 +944,7 @@ export class ChartStore {
     this.geometriesIndex = seriesGeometries.geometriesIndex;
     this.geometriesIndexKeys = [...this.geometriesIndex.keys()].sort(compareByValueAsc);
 
-    // // compute visible ticks and their positions
+    // compute visible ticks and their positions
     const axisTicksPositions = getAxisTicksPositions(
       this.chartDimensions,
       this.chartTheme,
@@ -902,7 +960,6 @@ export class ChartStore {
       barsPadding,
     );
     // tslint:disable-next-line:no-console
-    // console.log({axisTicksPositions});
     this.axesPositions = axisTicksPositions.axisPositions;
     this.axesTicks = axisTicksPositions.axisTicks;
     this.axesVisibleTicks = axisTicksPositions.axisVisibleTicks;

--- a/src/chart_types/xy_chart/store/chart_state.ts
+++ b/src/chart_types/xy_chart/store/chart_state.ts
@@ -65,7 +65,7 @@ import {
   TooltipValueFormatter,
 } from '../utils/interactions';
 import { Scale, ScaleType } from '../../../utils/scales/scales';
-import { DEFAULT_TOOLTIP_SNAP, DEFAULT_TOOLTIP_TYPE, Cursor } from '../../../specs/settings';
+import { DEFAULT_TOOLTIP_SNAP, DEFAULT_TOOLTIP_TYPE, CursorEvent } from '../../../specs/settings';
 import {
   AnnotationDimensions,
   computeAnnotationDimensions,
@@ -113,7 +113,7 @@ export type ElementClickListener = (values: GeometryValue[]) => void;
 export type ElementOverListener = (values: GeometryValue[]) => void;
 export type BrushEndListener = (min: number, max: number) => void;
 export type LegendItemListener = (dataSeriesIdentifiers: DataSeriesColorsValues | null) => void;
-export type CursorUpdateListener = (cursor?: Cursor) => void;
+export type CursorUpdateListener = (event?: CursorEvent) => void;
 
 export class ChartStore {
   debug = false;
@@ -336,6 +336,8 @@ export class ChartStore {
 
       this.onCursorUpdateListener({
         chartId: this.id,
+        scale: this.xScale.type,
+        unit: this.xScale.unit,
         value,
       });
     }

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -11,8 +11,8 @@ import { Highlighter } from './highlighter';
 import { Legend } from './legend/legend';
 import { LegendButton } from './legend/legend_button';
 import { ReactiveChart as ReactChart } from './react_canvas/reactive_chart';
-// import { ReactiveChart as SVGChart } from './svg/reactive_chart';
 import { Tooltips } from './tooltips';
+import { CursorEvent } from '../specs/settings';
 
 interface ChartProps {
   /** The type of rendered
@@ -34,6 +34,26 @@ export class Chart extends React.Component<ChartProps> {
     this.chartSpecStore = new ChartStore();
     this.legendId = htmlIdGenerator()('legend');
   }
+
+  dispatchExternalCursorEvent(event?: CursorEvent) {
+    this.chartSpecStore.setActiveChartId(event && event.chartId);
+    const isActiveChart = this.chartSpecStore.isActiveChart.get();
+
+    if (!event) {
+      if (!isActiveChart) {
+        this.chartSpecStore.setCursorPosition(-1, -1);
+      }
+    } else {
+      if (
+        !isActiveChart &&
+        this.chartSpecStore.xScale!.type === event.scale &&
+        (!event.unit || event.unit === this.chartSpecStore.xScale!.unit)
+      ) {
+        this.chartSpecStore.setCursorValue(event.value);
+      }
+    }
+  }
+
   render() {
     const { renderer, size, className } = this.props;
     let containerStyle: CSSProperties;

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -47,7 +47,7 @@ export class Chart extends React.Component<ChartProps> {
       if (
         !isActiveChart &&
         this.chartSpecStore.xScale!.type === event.scale &&
-        (!event.unit || event.unit === this.chartSpecStore.xScale!.unit)
+        (event.unit === undefined || event.unit === this.chartSpecStore.xScale!.unit)
       ) {
         this.chartSpecStore.setCursorValue(event.value);
       }

--- a/src/specs/index.ts
+++ b/src/specs/index.ts
@@ -1,3 +1,3 @@
-export { Settings } from './settings';
+export { Settings, CursorEvent } from './settings';
 // XY chart specs
 export * from '../chart_types/xy_chart/specs';

--- a/src/specs/settings.test.tsx
+++ b/src/specs/settings.test.tsx
@@ -125,6 +125,9 @@ describe('Settings spec component', () => {
     const onLegendEvent = (): void => {
       return;
     };
+    const onCursorUpdateEvent = (): void => {
+      return;
+    };
 
     const chartStoreListeners = {
       onElementClick,
@@ -136,6 +139,7 @@ describe('Settings spec component', () => {
       onLegendItemClick: onLegendEvent,
       onLegendItemPlusClick: onLegendEvent,
       onLegendItemMinusClick: onLegendEvent,
+      onCursorUpdate: onCursorUpdateEvent,
     };
 
     mount(<SettingsComponent chartStore={chartStore} {...chartStoreListeners} />);
@@ -148,6 +152,7 @@ describe('Settings spec component', () => {
     expect(chartStore.onLegendItemClickListener).toEqual(onLegendEvent);
     expect(chartStore.onLegendItemPlusClickListener).toEqual(onLegendEvent);
     expect(chartStore.onLegendItemMinusClickListener).toEqual(onLegendEvent);
+    expect(chartStore.onCursorUpdateListener).toEqual(onCursorUpdateEvent);
   });
 
   test('should allow partial theme', () => {

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -26,6 +26,11 @@ interface TooltipProps {
   headerFormatter?: TooltipValueFormatter;
 }
 
+/**
+ * Event used to syncronize cursors between Charts.
+ *
+ * fired as callback argument for `CursorUpdateListener`
+ */
 export interface CursorEvent {
   chartId: string;
   scale: ScaleTypes;
@@ -34,7 +39,7 @@ export interface CursorEvent {
    * unit for event (i.e. `time`, `feet`, `count`, etc.)
    */
   unit?: string;
-  value: number;
+  value: number | string;
 }
 
 function isTooltipProps(config: TooltipType | TooltipProps): config is TooltipProps {

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -15,6 +15,7 @@ import {
   LegendItemListener,
   CursorUpdateListener,
 } from '../chart_types/xy_chart/store/chart_state';
+import { ScaleTypes } from '../utils/scales/scales';
 
 export const DEFAULT_TOOLTIP_TYPE = TooltipType.VerticalCursor;
 export const DEFAULT_TOOLTIP_SNAP = true;
@@ -25,8 +26,14 @@ interface TooltipProps {
   headerFormatter?: TooltipValueFormatter;
 }
 
-export interface Cursor {
+export interface CursorEvent {
   chartId: string;
+  scale: ScaleTypes;
+  /**
+   * @todo
+   * unit for event (i.e. `time`, `feet`, `count`, etc.)
+   */
+  unit?: string;
   value: number;
 }
 
@@ -62,7 +69,6 @@ export interface SettingSpecProps {
   onLegendItemMinusClick?: LegendItemListener;
   onCursorUpdate?: CursorUpdateListener;
   xDomain?: Domain | DomainRange;
-  activeCursor?: Cursor;
 }
 
 function getTheme(theme?: Theme | PartialTheme, baseThemeType: BaseThemeType = BaseThemeTypes.Light): Theme {
@@ -96,7 +102,6 @@ function updateChartStore(props: SettingSpecProps) {
     onLegendItemMinusClick,
     onLegendItemPlusClick,
     onCursorUpdate,
-    activeCursor,
     debug,
     xDomain,
   } = props;
@@ -117,14 +122,6 @@ function updateChartStore(props: SettingSpecProps) {
     chartStore.tooltipHeaderFormatter = headerFormatter;
   } else if (tooltip && isTooltipType(tooltip)) {
     chartStore.tooltipType.set(tooltip);
-  }
-
-  chartStore.setActiveChartId(activeCursor && activeCursor.chartId);
-
-  if (!activeCursor) {
-    chartStore.setCursorPosition(-1, -1);
-  } else if (!chartStore.isActiveChart.get()) {
-    chartStore.setCursorValue(activeCursor.value);
   }
 
   chartStore.setShowLegend(showLegend);

--- a/src/utils/scales/scales.ts
+++ b/src/utils/scales/scales.ts
@@ -9,6 +9,11 @@ export interface Scale {
   bandwidth: number;
   minInterval: number;
   type: ScaleType;
+  /**
+   * @todo
+   * designates unit of scale to compare to other Chart axis
+   */
+  unit?: string;
   isInverted: boolean;
   barsPadding: number;
 }


### PR DESCRIPTION
## Summary

Add `CursorUpdateListener` as props on `Settings` component to allow `Chart` consumer to synchronize cursors across multiple `Chart`s by calling `dispatchExternalCursorEvent` on the `Chart` ref to update cursor value.

Issue #83 

### Demo
![Screen Recording 2019-08-12 at 06 32 PM](https://user-images.githubusercontent.com/19007109/62905328-9b696900-bd2f-11e9-99ea-b5d17c194356.gif)


### Checklist
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials (*Not able to easily add story with 2 `Chart`s sharing state*)
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
