### PR TITLE
fix(axis): limit chart dimensions to avoid axis labels overflow

### DIFF
--- a/src/chart_types/xy_chart/store/chart_state.ts
+++ b/src/chart_types/xy_chart/store/chart_state.ts
@@ -847,7 +847,7 @@ export class ChartStore {
     bboxCalculator.destroy();
 
     // // compute chart dimensions
-    this.chartDimensions = computeChartDimensions(
+    const computedChartDims = computeChartDimensions(
       this.parentDimensions,
       this.chartTheme,
       this.axesTicksDimensions,
@@ -855,6 +855,7 @@ export class ChartStore {
       this.showLegend.get() && !this.legendCollapsed.get(),
       this.legendPosition,
     );
+    this.chartDimensions = computedChartDims.chartDimensions;
 
     this.chartTransform = computeChartTransform(this.chartDimensions, this.chartRotation);
     this.brushExtent = computeBrushExtent(this.chartDimensions, this.chartRotation, this.chartTransform);
@@ -888,7 +889,7 @@ export class ChartStore {
 
     // // compute visible ticks and their positions
     const axisTicksPositions = getAxisTicksPositions(
-      this.chartDimensions,
+      computedChartDims,
       this.chartTheme,
       this.chartRotation,
       this.showLegend.get() && !this.legendCollapsed.get(),

--- a/src/chart_types/xy_chart/utils/__snapshots__/dimensions.test.ts.snap
+++ b/src/chart_types/xy_chart/utils/__snapshots__/dimensions.test.ts.snap
@@ -12,26 +12,26 @@ Object {
 exports[`Computed chart dimensions should be padded by a bottom axis 1`] = `
 Object {
   "height": 30,
-  "left": 20,
+  "left": 25,
   "top": 20,
-  "width": 60,
+  "width": 50,
 }
 `;
 
 exports[`Computed chart dimensions should be padded by a left axis 1`] = `
 Object {
-  "height": 60,
+  "height": 50,
   "left": 50,
-  "top": 20,
+  "top": 25,
   "width": 30,
 }
 `;
 
 exports[`Computed chart dimensions should be padded by a right axis 1`] = `
 Object {
-  "height": 60,
+  "height": 50,
   "left": 20,
-  "top": 20,
+  "top": 25,
   "width": 30,
 }
 `;
@@ -39,8 +39,8 @@ Object {
 exports[`Computed chart dimensions should be padded by a top axis 1`] = `
 Object {
   "height": 30,
-  "left": 20,
+  "left": 25,
   "top": 50,
-  "width": 60,
+  "width": 50,
 }
 `;

--- a/src/chart_types/xy_chart/utils/axis_utils.test.ts
+++ b/src/chart_types/xy_chart/utils/axis_utils.test.ts
@@ -565,18 +565,24 @@ describe('Axis computational utils', () => {
     const tickSize = 10;
     const tickPadding = 5;
     const tickPosition = 0;
-
+    const axisPosition = {
+      top: 0,
+      left: 0,
+      width: 100,
+      height: 100,
+    };
     const unrotatedLabelProps = getTickLabelProps(
       tickLabelRotation,
       tickSize,
       tickPadding,
       tickPosition,
       Position.Left,
+      axisPosition,
       axis1Dims,
     );
 
     expect(unrotatedLabelProps).toEqual({
-      x: -10,
+      x: 75,
       y: -5,
       align: 'right',
       verticalAlign: 'middle',
@@ -589,11 +595,12 @@ describe('Axis computational utils', () => {
       tickPadding,
       tickPosition,
       Position.Left,
+      axisPosition,
       axis1Dims,
     );
 
     expect(rotatedLabelProps).toEqual({
-      x: -10,
+      x: 75,
       y: -5,
       align: 'center',
       verticalAlign: 'middle',
@@ -605,6 +612,7 @@ describe('Axis computational utils', () => {
       tickPadding,
       tickPosition,
       Position.Right,
+      axisPosition,
       axis1Dims,
     );
 
@@ -622,6 +630,7 @@ describe('Axis computational utils', () => {
       tickPadding,
       tickPosition,
       Position.Right,
+      axisPosition,
       axis1Dims,
     );
 
@@ -638,6 +647,12 @@ describe('Axis computational utils', () => {
     const tickSize = 10;
     const tickPadding = 5;
     const tickPosition = 0;
+    const axisPosition = {
+      top: 0,
+      left: 0,
+      width: 100,
+      height: 100,
+    };
 
     const unrotatedLabelProps = getTickLabelProps(
       tickLabelRotation,
@@ -645,12 +660,13 @@ describe('Axis computational utils', () => {
       tickPadding,
       tickPosition,
       Position.Top,
+      axisPosition,
       axis1Dims,
     );
 
     expect(unrotatedLabelProps).toEqual({
       x: -5,
-      y: 0,
+      y: 75,
       align: 'center',
       verticalAlign: 'bottom',
     });
@@ -662,12 +678,13 @@ describe('Axis computational utils', () => {
       tickPadding,
       tickPosition,
       Position.Top,
+      axisPosition,
       axis1Dims,
     );
 
     expect(rotatedLabelProps).toEqual({
       x: -5,
-      y: 0,
+      y: 75,
       align: 'center',
       verticalAlign: 'middle',
     });
@@ -678,6 +695,7 @@ describe('Axis computational utils', () => {
       tickPadding,
       tickPosition,
       Position.Bottom,
+      axisPosition,
       axis1Dims,
     );
 
@@ -695,6 +713,7 @@ describe('Axis computational utils', () => {
       tickPadding,
       tickPosition,
       Position.Bottom,
+      axisPosition,
       axis1Dims,
     );
 
@@ -710,11 +729,11 @@ describe('Axis computational utils', () => {
     const tickPadding = 5;
     const tickSize = 10;
     const tickPosition = 10;
-    const maxLabelBboxHeight = 20;
+    const axisHeight = 20;
 
     const leftAxisTickLinePositions = getVerticalAxisTickLineProps(Position.Left, tickPadding, tickSize, tickPosition);
 
-    expect(leftAxisTickLinePositions).toEqual([5, 10, 15, 10]);
+    expect(leftAxisTickLinePositions).toEqual([5, 10, -5, 10]);
 
     const rightAxisTickLinePositions = getVerticalAxisTickLineProps(
       Position.Right,
@@ -725,22 +744,15 @@ describe('Axis computational utils', () => {
 
     expect(rightAxisTickLinePositions).toEqual([0, 10, 10, 10]);
 
-    const topAxisTickLinePositions = getHorizontalAxisTickLineProps(
-      Position.Top,
-      tickPadding,
-      tickSize,
-      tickPosition,
-      maxLabelBboxHeight,
-    );
+    const topAxisTickLinePositions = getHorizontalAxisTickLineProps(Position.Top, axisHeight, tickSize, tickPosition);
 
-    expect(topAxisTickLinePositions).toEqual([10, 25, 10, 35]);
+    expect(topAxisTickLinePositions).toEqual([10, 10, 10, 20]);
 
     const bottomAxisTickLinePositions = getHorizontalAxisTickLineProps(
       Position.Bottom,
-      tickPadding,
+      axisHeight,
       tickSize,
       tickPosition,
-      maxLabelBboxHeight,
     );
 
     expect(bottomAxisTickLinePositions).toEqual([10, 0, 10, 10]);
@@ -774,7 +786,10 @@ describe('Axis computational utils', () => {
     axisDims.set(verticalAxisSpecWTitle.id, axis1Dims);
 
     let axisTicksPosition = getAxisTicksPositions(
-      chartDim,
+      {
+        chartDimensions: chartDim,
+        leftMargin: 0,
+      },
       LIGHT_THEME,
       chartRotation,
       showLegend,
@@ -786,11 +801,10 @@ describe('Axis computational utils', () => {
       false,
     );
 
-    let left = 12 + 5 + 10 + 10; // font size + title padding + chart margin left + label width
     expect(axisTicksPosition.axisPositions.get(verticalAxisSpecWTitle.id)).toEqual({
       top: 0,
-      left,
-      width: 10,
+      left: 10,
+      width: 12 + 5 + 10 + 10 + 10,
       height: 100,
     });
 
@@ -799,7 +813,10 @@ describe('Axis computational utils', () => {
     axisDims.set(verticalAxisSpec.id, axis1Dims);
 
     axisTicksPosition = getAxisTicksPositions(
-      chartDim,
+      {
+        chartDimensions: chartDim,
+        leftMargin: 0,
+      },
       LIGHT_THEME,
       chartRotation,
       showLegend,
@@ -811,11 +828,10 @@ describe('Axis computational utils', () => {
       false,
     );
 
-    left = 0 + 10 + 10; // no title + chart margin left + label width
     expect(axisTicksPosition.axisPositions.get(verticalAxisSpecWTitle.id)).toEqual({
       top: 0,
-      left: 20,
-      width: 10,
+      left: 10,
+      width: 30,
       height: 100,
     });
   });
@@ -842,8 +858,8 @@ describe('Axis computational utils', () => {
     const expectedLeftAxisPosition = {
       dimensions: {
         height: 100,
-        width: 10,
-        left: 40,
+        width: 40,
+        left: 20,
         top: 0,
       },
       topIncrement: 0,
@@ -878,7 +894,7 @@ describe('Axis computational utils', () => {
     const expectedRightAxisPosition = {
       dimensions: {
         height: 100,
-        width: 10,
+        width: 40,
         left: 110,
         top: 0,
       },
@@ -913,10 +929,11 @@ describe('Axis computational utils', () => {
 
     const expectedTopAxisPosition = {
       dimensions: {
-        height: 10,
+        height:
+          axis1Dims.maxLabelBboxHeight + axisTitleHeight + horizontalAxisSpec.tickSize + horizontalAxisSpec.tickPadding,
         width: 100,
         left: 0,
-        top: 30,
+        top: cumTopSum + LIGHT_THEME.chartMargins.top,
       },
       topIncrement: 50,
       bottomIncrement: 0,
@@ -949,7 +966,7 @@ describe('Axis computational utils', () => {
 
     const expectedBottomAxisPosition = {
       dimensions: {
-        height: 10,
+        height: 40,
         width: 100,
         left: 0,
         top: 110,
@@ -975,7 +992,10 @@ describe('Axis computational utils', () => {
     axisDims.set(getAxisId('not_a_mapped_one'), axis1Dims);
 
     const axisTicksPosition = getAxisTicksPositions(
-      chartDim,
+      {
+        chartDimensions: chartDim,
+        leftMargin: 0,
+      },
       LIGHT_THEME,
       chartRotation,
       showLegend,
@@ -1006,7 +1026,10 @@ describe('Axis computational utils', () => {
     axisDims.set(verticalAxisSpec.id, axis1Dims);
 
     const axisTicksPosition = getAxisTicksPositions(
-      chartDim,
+      {
+        chartDimensions: chartDim,
+        leftMargin: 0,
+      },
       LIGHT_THEME,
       chartRotation,
       showLegend,
@@ -1036,7 +1059,10 @@ describe('Axis computational utils', () => {
     expect(axisTicksPosition.axisGridLinesPositions.get(verticalAxisSpec.id)).toEqual(expectedVerticalAxisGridLines);
 
     const axisTicksPositionWithTopLegend = getAxisTicksPositions(
-      chartDim,
+      {
+        chartDimensions: chartDim,
+        leftMargin: 0,
+      },
       LIGHT_THEME,
       chartRotation,
       showLegend,
@@ -1051,7 +1077,7 @@ describe('Axis computational utils', () => {
 
     const expectedPositionWithTopLegend = {
       height: 100,
-      width: 10,
+      width: 30,
       left: 100,
       top: 0,
     };
@@ -1063,7 +1089,10 @@ describe('Axis computational utils', () => {
     invalidSpecs.set(verticalAxisSpec.id, ungroupedAxisSpec);
     const computeScalelessSpec = () => {
       getAxisTicksPositions(
-        chartDim,
+        {
+          chartDimensions: chartDim,
+          leftMargin: 0,
+        },
         LIGHT_THEME,
         chartRotation,
         showLegend,

--- a/src/chart_types/xy_chart/utils/dimensions.test.ts
+++ b/src/chart_types/xy_chart/utils/dimensions.test.ts
@@ -67,7 +67,7 @@ describe('Computed chart dimensions', () => {
   test('should be equal to parent dimension with no axis minus margins', () => {
     const axisDims = new Map<AxisId, AxisTicksDimensions>();
     const axisSpecs = new Map<AxisId, AxisSpec>();
-    const chartDimensions = computeChartDimensions(parentDim, chartTheme, axisDims, axisSpecs, showLegend);
+    const { chartDimensions } = computeChartDimensions(parentDim, chartTheme, axisDims, axisSpecs, showLegend);
     expect(chartDimensions.left + chartDimensions.width).toBeLessThanOrEqual(parentDim.width);
     expect(chartDimensions.top + chartDimensions.height).toBeLessThanOrEqual(parentDim.height);
     expect(chartDimensions).toMatchSnapshot();
@@ -79,7 +79,7 @@ describe('Computed chart dimensions', () => {
     const axisSpecs = new Map<AxisId, AxisSpec>();
     axisDims.set(getAxisId('axis_1'), axis1Dims);
     axisSpecs.set(getAxisId('axis_1'), axisLeftSpec);
-    const chartDimensions = computeChartDimensions(parentDim, chartTheme, axisDims, axisSpecs, showLegend);
+    const { chartDimensions } = computeChartDimensions(parentDim, chartTheme, axisDims, axisSpecs, showLegend);
     expect(chartDimensions.left + chartDimensions.width).toBeLessThanOrEqual(parentDim.width);
     expect(chartDimensions.top + chartDimensions.height).toBeLessThanOrEqual(parentDim.height);
     expect(chartDimensions).toMatchSnapshot();
@@ -91,7 +91,7 @@ describe('Computed chart dimensions', () => {
     const axisSpecs = new Map<AxisId, AxisSpec>();
     axisDims.set(getAxisId('axis_1'), axis1Dims);
     axisSpecs.set(getAxisId('axis_1'), { ...axisLeftSpec, position: Position.Right });
-    const chartDimensions = computeChartDimensions(parentDim, chartTheme, axisDims, axisSpecs, showLegend);
+    const { chartDimensions } = computeChartDimensions(parentDim, chartTheme, axisDims, axisSpecs, showLegend);
     expect(chartDimensions.left + chartDimensions.width).toBeLessThanOrEqual(parentDim.width);
     expect(chartDimensions.top + chartDimensions.height).toBeLessThanOrEqual(parentDim.height);
     expect(chartDimensions).toMatchSnapshot();
@@ -106,7 +106,7 @@ describe('Computed chart dimensions', () => {
       ...axisLeftSpec,
       position: Position.Top,
     });
-    const chartDimensions = computeChartDimensions(parentDim, chartTheme, axisDims, axisSpecs, showLegend);
+    const { chartDimensions } = computeChartDimensions(parentDim, chartTheme, axisDims, axisSpecs, showLegend);
     expect(chartDimensions.left + chartDimensions.width).toBeLessThanOrEqual(parentDim.width);
     expect(chartDimensions.top + chartDimensions.height).toBeLessThanOrEqual(parentDim.height);
     expect(chartDimensions).toMatchSnapshot();
@@ -121,7 +121,7 @@ describe('Computed chart dimensions', () => {
       ...axisLeftSpec,
       position: Position.Bottom,
     });
-    const chartDimensions = computeChartDimensions(parentDim, chartTheme, axisDims, axisSpecs, showLegend);
+    const { chartDimensions } = computeChartDimensions(parentDim, chartTheme, axisDims, axisSpecs, showLegend);
     expect(chartDimensions.left + chartDimensions.width).toBeLessThanOrEqual(parentDim.width);
     expect(chartDimensions.top + chartDimensions.height).toBeLessThanOrEqual(parentDim.height);
     expect(chartDimensions).toMatchSnapshot();
@@ -137,10 +137,13 @@ describe('Computed chart dimensions', () => {
     const chartDimensions = computeChartDimensions(parentDim, chartTheme, axisDims, axisSpecs, showLegend);
 
     const expectedDims = {
-      height: 60,
-      width: 60,
-      left: 20,
-      top: 20,
+      chartDimensions: {
+        height: 60,
+        width: 60,
+        left: 20,
+        top: 20,
+      },
+      leftMargin: 10,
     };
 
     expect(chartDimensions).toEqual(expectedDims);

--- a/stories/axis.tsx
+++ b/stories/axis.tsx
@@ -105,6 +105,7 @@ storiesOf('Axis', module)
             max: 90,
             step: 1,
           })}
+          hide={boolean('hide bottom axis', false)}
           style={customStyle}
         />
         <Axis
@@ -119,6 +120,7 @@ storiesOf('Axis', module)
           })}
           tickFormat={(d) => Number(d).toFixed(2)}
           style={customStyle}
+          hide={boolean('hide left axis', false)}
         />
         <Axis
           id={getAxisId('top')}
@@ -132,6 +134,7 @@ storiesOf('Axis', module)
           })}
           tickFormat={(d) => Number(d).toFixed(2)}
           style={customStyle}
+          hide={boolean('hide top axis', false)}
         />
         <Axis
           id={getAxisId('right')}
@@ -145,6 +148,7 @@ storiesOf('Axis', module)
           })}
           tickFormat={(d) => Number(d).toFixed(2)}
           style={customStyle}
+          hide={boolean('hide right axis', false)}
         />
         <AreaSeries
           id={getSpecId('lines')}


### PR DESCRIPTION
## Summary

This PR limit the chart dimensions to include any overflowing axis label. It consider label padding, font size, text etc.

**from:**
<img width="561" alt="Screenshot 2019-08-15 at 02 18 37" src="https://user-images.githubusercontent.com/1421091/63064783-539b3b00-bf03-11e9-85a0-123513a9f6ae.png">
<img width="808" alt="Screenshot 2019-08-15 at 02 23 58" src="https://user-images.githubusercontent.com/1421091/63064868-c5738480-bf03-11e9-8b87-9b5ee06a1b28.png">

**to:**
<img width="424" alt="Screenshot 2019-08-15 at 02 18 50" src="https://user-images.githubusercontent.com/1421091/63064786-58f88580-bf03-11e9-88f5-894d5a46861d.png">
<img width="813" alt="Screenshot 2019-08-15 at 02 23 38" src="https://user-images.githubusercontent.com/1421091/63064872-ca383880-bf03-11e9-8c30-39f769e82e31.png">



### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
