### PR TITLE
fix: remove clippings from chart

### DIFF
--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -380,15 +380,6 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         </div>
       );
     }
-    // disable clippings when debugging
-    const clippings = debug
-      ? {}
-      : {
-          clipX: 0,
-          clipY: 0,
-          clipWidth: [90, -90].includes(chartRotation) ? chartDimensions.height : chartDimensions.width,
-          clipHeight: [90, -90].includes(chartRotation) ? chartDimensions.width : chartDimensions.height,
-        };
 
     let brushProps = {};
     const isBrushEnabled = this.props.chartStore!.isBrushEnabled();
@@ -398,13 +389,6 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
         onMouseMove: this.onBrushing,
       };
     }
-
-    const layerClippings = {
-      clipX: chartDimensions.left,
-      clipY: chartDimensions.top,
-      clipWidth: chartDimensions.width,
-      clipHeight: chartDimensions.height,
-    };
 
     const className = classNames({
       'echChart--isBrushEnabled': this.props.chartStore!.isCrosshairCursorVisible.get(),
@@ -443,15 +427,17 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
           }}
           {...brushProps}
         >
-          <Layer hitGraphEnabled={false} listening={false} {...layerClippings}>
+          <Layer hitGraphEnabled={false} listening={false}>
             {this.renderGrids()}
+          </Layer>
+          <Layer hitGraphEnabled={false} listening={false}>
+            {this.renderAxes()}
           </Layer>
 
           <Layer
             x={chartDimensions.left + chartTransform.x}
             y={chartDimensions.top + chartTransform.y}
             rotation={chartRotation}
-            {...clippings}
             hitGraphEnabled={false}
             listening={false}
           >
@@ -468,10 +454,6 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
           )}
 
           <Layer hitGraphEnabled={false} listening={false}>
-            {this.renderAxes()}
-          </Layer>
-
-          <Layer hitGraphEnabled={false} listening={false} {...layerClippings}>
             {this.renderBarValues()}
           </Layer>
         </Stage>


### PR DESCRIPTION
## Summary

fix #20

This PR remove the clippings from the rendered geometries to allow full rendering elements on the edges.

It moves also the axis layer 1 level below the rendered geometries to clearly visualize the elements on top of the axis lines:

<img width="883" alt="Screenshot 2019-08-17 at 00 58 34" src="https://user-images.githubusercontent.com/1421091/63202497-393f9980-c08a-11e9-8940-e25fc791c137.png">

cc @cchaos: FYI the following is an example with the axis layers 1 level above the chart geometries, what do you think it's better: showing the axis behind the chart elements or in front of them?:
<img width="890" alt="Screenshot 2019-08-17 at 00 59 47" src="https://user-images.githubusercontent.com/1421091/63202538-65f3b100-c08a-11e9-884e-69728c29aed4.png">



### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- ~[ ] Unit tests were updated or added to match the most common scenarios~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
