### PR TITLE
fix(legend): disable fade other if legend item is not visible

### DIFF
--- a/src/chart_types/xy_chart/store/chart_state.test.ts
+++ b/src/chart_types/xy_chart/store/chart_state.test.ts
@@ -174,6 +174,33 @@ describe('Chart Store', () => {
     expect(outListener.mock.calls.length).toBe(1);
   });
 
+  test('do nothing when mouseover an hidden series', () => {
+    const legendListener = jest.fn(
+      (): void => {
+        return;
+      },
+    );
+    store.setOnLegendItemOverListener(legendListener);
+
+    store.legendItems = new Map([[firstLegendItem.key, firstLegendItem], [secondLegendItem.key, secondLegendItem]]);
+    store.deselectedDataSeries = [];
+    store.highlightedLegendItemKey.set(null);
+
+    store.toggleSeriesVisibility(firstLegendItem.key);
+    expect(store.deselectedDataSeries).toEqual([firstLegendItem.value]);
+
+    store.onLegendItemOver(firstLegendItem.key);
+    expect(store.highlightedLegendItemKey.get()).toBe(null);
+    store.onLegendItemOut();
+    store.toggleSeriesVisibility(firstLegendItem.key);
+    expect(store.deselectedDataSeries).toEqual([]);
+
+    store.onLegendItemOver(firstLegendItem.key);
+    expect(store.highlightedLegendItemKey.get()).toBe(firstLegendItem.key);
+
+    store.removeOnLegendItemOutListener();
+  });
+
   test('can respond to legend item click event', () => {
     const legendListener = jest.fn(
       (): void => {

--- a/src/chart_types/xy_chart/store/chart_state.ts
+++ b/src/chart_types/xy_chart/store/chart_state.ts
@@ -574,6 +574,12 @@ export class ChartStore {
   });
 
   onLegendItemOver = action((legendItemKey: string | null) => {
+    if (legendItemKey) {
+      const legendItem = this.legendItems.get(legendItemKey);
+      if (legendItem && findDataSeriesByColorValues(this.deselectedDataSeries, legendItem.value) > -1) {
+        return;
+      }
+    }
     this.highlightedLegendItemKey.set(legendItemKey);
 
     if (this.onLegendItemOverListener) {


### PR DESCRIPTION
## Summary

When hovering on a legend item that is currently hidden, don't fade the other series https://d.pr/free/i/DbbyWC

TODO

The current status correctly avoid hiding the other series when mouse over an hidden one:
![Oct-29-2019 18-07-38](https://user-images.githubusercontent.com/1421091/67791013-085ee600-fa77-11e9-9ced-28c1559a060b.gif)

What is missing is the following: fade in all the series right after I clicked a series in the legend. Currently, if you click to hide a series, the rendered series are in a fade status. We need to have a consistent behaviour and, right after a click I just want to hide the clicked series and also I want to see all the other clearly

wrong behaviour
![Oct-29-2019 18-11-35](https://user-images.githubusercontent.com/1421091/67791357-933fe080-fa77-11e9-932b-a49e713e539d.gif)


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
- [ ] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
