### PR TITLE
fix(renderer): stroke opacity

### DIFF
--- a/src/chart_types/xy_chart/rendering/rendering.ts
+++ b/src/chart_types/xy_chart/rendering/rendering.ts
@@ -34,6 +34,7 @@ export interface GeometryValue {
 /** Shared style properties for varies geometries */
 export interface GeometryStyle {
   opacity: number;
+  strokeOpacity?: number;
 }
 
 export type IndexedGeometry = PointGeometry | BarGeometry;
@@ -483,17 +484,20 @@ export function getGeometryStyle(
   geometryId: GeometryId,
   highlightedLegendItem: LegendItem | null,
   sharedThemeStyle: SharedGeometryStyle,
-  specOpacity?: number,
+  opacity?: number,
+  strokeOpacity?: number,
   individualHighlight?: { [key: string]: boolean },
 ): GeometryStyle {
-  const sharedStyle =
-    specOpacity == null
-      ? sharedThemeStyle
-      : {
-          ...sharedThemeStyle,
-          highlighted: { opacity: specOpacity },
-          default: { opacity: specOpacity },
-        };
+  const base = { opacity, strokeOpacity };
+  const sharedStyle = mergePartial<SharedGeometryStyle>(sharedThemeStyle, {
+    default: base,
+    highlighted: base,
+    unhighlighted: {
+      strokeOpacity: strokeOpacity
+        ? (strokeOpacity + sharedThemeStyle.unhighlighted.opacity) / 2
+        : sharedThemeStyle.unhighlighted.opacity,
+    },
+  });
 
   if (highlightedLegendItem != null) {
     const isPartOfHighlightedSeries = belongsToDataSeries(geometryId, highlightedLegendItem.value);

--- a/src/components/react_canvas/bar_geometries.tsx
+++ b/src/components/react_canvas/bar_geometries.tsx
@@ -5,7 +5,7 @@ import { animated, Spring } from 'react-spring/renderprops-konva.cjs';
 import { LegendItem } from '../../chart_types/xy_chart/legend/legend';
 import { BarGeometry, getGeometryStyle } from '../../chart_types/xy_chart/rendering/rendering';
 import { SharedGeometryStyle } from '../../utils/themes/theme';
-import { buildBarRenderProps } from './utils/rendering_props_utils';
+import { buildBarRenderProps, buildBarBorderRenderProps } from './utils/rendering_props_utils';
 
 interface BarGeometriesDataProps {
   animated?: boolean;
@@ -56,6 +56,7 @@ export class BarGeometries extends React.PureComponent<BarGeometriesDataProps, B
         this.props.highlightedLegendItem,
         sharedStyle,
         seriesStyle.rect.opacity,
+        seriesStyle.rectBorder.strokeOpacity,
         individualHighlight,
       );
       const key = `bar-${index}`;
@@ -65,6 +66,14 @@ export class BarGeometries extends React.PureComponent<BarGeometriesDataProps, B
           <Group key={index}>
             <Spring native from={{ y: y + height, height: 0 }} to={{ y, height }}>
               {(props: { y: number; height: number }) => {
+                const barPropsBorder = buildBarBorderRenderProps(
+                  x,
+                  props.y,
+                  width,
+                  props.height,
+                  seriesStyle.rectBorder,
+                  geometryStyle,
+                );
                 const barProps = buildBarRenderProps(
                   x,
                   props.y,
@@ -72,29 +81,26 @@ export class BarGeometries extends React.PureComponent<BarGeometriesDataProps, B
                   props.height,
                   color,
                   seriesStyle.rect,
-                  seriesStyle.rectBorder,
                   geometryStyle,
                 );
 
-                return <animated.Rect {...barProps} key={key} />;
+                return (
+                  <React.Fragment key={key}>
+                    <animated.Rect {...barProps} />
+                    {barPropsBorder && <animated.Rect {...barPropsBorder} />}
+                  </React.Fragment>
+                );
               }}
             </Spring>
           </Group>
         );
       } else {
-        const barProps = buildBarRenderProps(
-          x,
-          y,
-          width,
-          height,
-          color,
-          seriesStyle.rect,
-          seriesStyle.rectBorder,
-          geometryStyle,
-        );
+        const barPropsBorder = buildBarBorderRenderProps(x, y, width, height, seriesStyle.rectBorder, geometryStyle);
+        const barProps = buildBarRenderProps(x, y, width, height, color, seriesStyle.rect, geometryStyle);
         return (
-          <React.Fragment key={index}>
-            <Rect {...barProps} key={key} />
+          <React.Fragment key={key}>
+            <Rect {...barProps} />
+            {barPropsBorder && <Rect {...barPropsBorder} />}
           </React.Fragment>
         );
       }

--- a/src/components/react_canvas/utils/rendering_props_utils.ts
+++ b/src/components/react_canvas/utils/rendering_props_utils.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../utils/themes/theme';
 import { Dimensions } from '../../../utils/dimensions';
 import { GlobalKonvaElementProps } from '../globals';
+import { RectConfig } from 'konva';
 
 export interface PointStyleProps {
   radius: number;
@@ -338,7 +339,6 @@ export function buildAreaRenderProps(
  * @param height the height of the rect
  * @param color the computed color of the rect for this series
  * @param rectStyle the rect style
- * @param borderStyle the border rect style
  * @param geometryStyle the highlight geometry style
  */
 export function buildBarRenderProps(
@@ -348,19 +348,59 @@ export function buildBarRenderProps(
   height: number,
   color: string,
   rectStyle: RectStyle,
-  borderStyle: RectBorderStyle,
   geometryStyle: GeometryStyle,
-) {
+): RectConfig {
   return {
     x,
     y,
     width,
     height,
     fill: rectStyle.fill || color,
-    strokeWidth: borderStyle.strokeWidth,
-    stroke: borderStyle.stroke || 'transparent',
-    strokeEnabled: borderStyle.visible && borderStyle.strokeWidth > 0,
+    strokeEnabled: false,
     ...geometryStyle,
+    ...GlobalKonvaElementProps,
+  };
+}
+
+/**
+ * Return the rendering props for a bar. The color of the bar will be overwritten
+ * by the fill color of the rectStyle parameter if present
+ * @param x the x position of the rect
+ * @param y the y position of the rect
+ * @param width the width of the rect
+ * @param height the height of the rect
+ * @param color the computed color of the rect for this series
+ * @param rectStyle the rect style
+ * @param borderStyle the border rect style
+ * @param geometryStyle the highlight geometry style
+ */
+export function buildBarBorderRenderProps(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  borderStyle: RectBorderStyle,
+  geometryStyle: GeometryStyle,
+): RectConfig | null {
+  const { stroke, visible, strokeWidth } = borderStyle;
+
+  if (!visible || strokeWidth <= 0 || !stroke) {
+    return null;
+  }
+
+  const opacity = geometryStyle.strokeOpacity;
+
+  return {
+    x: x + strokeWidth / 2,
+    y: y + strokeWidth / 2,
+    width: width - strokeWidth,
+    height: height - strokeWidth,
+    fillEnabled: false,
+    strokeEnabled: true,
+    strokeWidth,
+    stroke,
+    ...geometryStyle,
+    opacity, // want to override opactiy of geometryStyle
     ...GlobalKonvaElementProps,
   };
 }

--- a/src/utils/themes/theme.ts
+++ b/src/utils/themes/theme.ts
@@ -164,12 +164,22 @@ export interface RectStyle {
 }
 
 export interface RectBorderStyle {
-  /** is the rect border visible or hidden ? */
+  /**
+   * Border visibility
+   */
   visible: boolean;
-  /** a static stroke color if defined, if not it will use the color of the series */
+  /**
+   * Border stroke color
+   */
   stroke?: string;
-  /** the stroke width of the rect border */
+  /**
+   * Border stroke width
+   */
   strokeWidth: number;
+  /**
+   * Border stroke opacity
+   */
+  strokeOpacity?: number;
 }
 export interface BarSeriesStyle {
   rect: RectStyle;


### PR DESCRIPTION
## Summary

Fix stoke opacity on bar charts.

Add a property for `strokeOpacity` on `RectBorderStyle`. Fallback uses `opacity` on `RectStyle`.

If `strokeOpacity` is provided the `unhighlighted` stoke opacity is averaged between the provided value and the global `unhighlighted` opacity value.

This change requires splitting the fill and stroke into __TWO__ seperate `Rect` elements as the [Konva](https://konvajs.org/) API does not allow for stroke opacity but forces inheritance from the fill opacity.

Currently, the `perfectDrawEnabled` is set to `false` which causes the border to overlap the fill. These changes inset the border/stroke inside of the filled rectangle/bar. https://konvajs.org/docs/performance/Disable_Perfect_Draw.html

![image](https://user-images.githubusercontent.com/19007109/63465685-6348e100-c427-11e9-87ce-84f7b93b80b9.png)


### Demo

![Screen Recording 2019-08-21 at 03 02 PM](https://user-images.githubusercontent.com/19007109/63465485-f9c8d280-c426-11e9-8b38-b6742d0bfef8.gif)

### Checklist
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
