### PR TITLE
fix: default theme

### DIFF
--- a/src/chart_types/xy_chart/store/chart_state.test.ts
+++ b/src/chart_types/xy_chart/store/chart_state.test.ts
@@ -20,7 +20,6 @@ import { ChartStore } from './chart_state';
 
 describe('Chart Store', () => {
   let store = new ChartStore();
-  store.chartTheme = LIGHT_THEME;
 
   const SPEC_ID = getSpecId('spec_1');
   const AXIS_ID = getAxisId('axis_1');
@@ -68,7 +67,6 @@ describe('Chart Store', () => {
   };
   beforeEach(() => {
     store = new ChartStore();
-    store.chartTheme = LIGHT_THEME;
     store.updateParentDimensions(600, 600, 0, 0);
     store.computeChart();
   });

--- a/src/chart_types/xy_chart/store/chart_state.ts
+++ b/src/chart_types/xy_chart/store/chart_state.ts
@@ -92,6 +92,7 @@ import {
   Transform,
   updateDeselectedDataSeries,
 } from './utils';
+import { LIGHT_THEME } from '../../../utils/themes/light_theme';
 
 export interface Point {
   x: number;
@@ -149,10 +150,7 @@ export class ChartStore {
 
   chartRotation: Rotation = 0; // updated from jsx
   chartRendering: Rendering = 'canvas'; // updated from jsx
-  /**
-   * Chart theme to be set from Settings.tsx
-   */
-  chartTheme!: Theme;
+  chartTheme: Theme = LIGHT_THEME;
   axesSpecs: Map<AxisId, AxisSpec> = new Map(); // readed from jsx
   axesTicksDimensions: Map<AxisId, AxisTicksDimensions> = new Map(); // computed
   axesPositions: Map<AxisId, Dimensions> = new Map(); // computed

--- a/src/specs/settings.test.tsx
+++ b/src/specs/settings.test.tsx
@@ -6,6 +6,7 @@ import { TooltipType } from '../chart_types/xy_chart/utils/interactions';
 import { ChartStore } from '../chart_types/xy_chart/store/chart_state';
 import { DEFAULT_TOOLTIP_SNAP, DEFAULT_TOOLTIP_TYPE, SettingsComponent, SettingSpecProps } from './settings';
 import { PartialTheme } from '../utils/themes/theme';
+import { LIGHT_THEME } from '../utils/themes/light_theme';
 
 describe('Settings spec component', () => {
   test('should update store on mount if spec has a chart store', () => {
@@ -55,7 +56,7 @@ describe('Settings spec component', () => {
   test('should set chart properties on chart store', () => {
     const chartStore = new ChartStore();
 
-    expect(chartStore.chartTheme).toBeUndefined();
+    expect(chartStore.chartTheme).toEqual(LIGHT_THEME);
     expect(chartStore.chartRotation).toBe(0);
     expect(chartStore.chartRendering).toBe('canvas');
     expect(chartStore.animateData).toBe(false);
@@ -162,7 +163,7 @@ describe('Settings spec component', () => {
       },
     };
 
-    expect(chartStore.chartTheme).toBeUndefined();
+    expect(chartStore.chartTheme).toEqual(LIGHT_THEME);
 
     const updatedProps: SettingSpecProps = {
       theme: partialTheme,


### PR DESCRIPTION
## Summary

Revert default theme changes in `chart_state`

![image](https://user-images.githubusercontent.com/19007109/63466981-0b5fa980-c42a-11e9-8482-4b569b0cfc48.png)


### Checklist
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
