### PR TITLE
fix(crosshair): hide band when chart is empty

### DIFF
--- a/src/components/_container.scss
+++ b/src/components/_container.scss
@@ -23,6 +23,7 @@
   right: 0;
   left: 0;
   box-sizing: border-box;
+  user-select: none;
 }
 
 .echChartResizer {

--- a/src/components/crosshair.tsx
+++ b/src/components/crosshair.tsx
@@ -8,8 +8,8 @@ interface CrosshairProps {
   chartStore?: ChartStore;
 }
 
-function canRenderBand(type: TooltipType, visible: boolean, chartEmpty: boolean) {
-  return visible && !chartEmpty && (type === TooltipType.Crosshairs || type === TooltipType.VerticalCursor);
+function canRenderBand(type: TooltipType, visible: boolean) {
+  return visible && (type === TooltipType.Crosshairs || type === TooltipType.VerticalCursor);
 }
 function canRenderHelpLine(type: TooltipType, visible: boolean) {
   return visible && type === TooltipType.Crosshairs;
@@ -39,10 +39,9 @@ class CrosshairComponent extends React.Component<CrosshairProps> {
       },
       cursorBandPosition,
       tooltipType,
-      isChartEmpty,
     } = this.props.chartStore!;
 
-    if (!canRenderBand(tooltipType.get(), band.visible, isChartEmpty)) {
+    if (!canRenderBand(tooltipType.get(), band.visible)) {
       return null;
     }
     const style: CSSProperties = {

--- a/src/components/crosshair.tsx
+++ b/src/components/crosshair.tsx
@@ -8,8 +8,8 @@ interface CrosshairProps {
   chartStore?: ChartStore;
 }
 
-function canRenderBand(type: TooltipType, visible: boolean) {
-  return visible && (type === TooltipType.Crosshairs || type === TooltipType.VerticalCursor);
+function canRenderBand(type: TooltipType, visible: boolean, chartEmpty: boolean) {
+  return visible && !chartEmpty && (type === TooltipType.Crosshairs || type === TooltipType.VerticalCursor);
 }
 function canRenderHelpLine(type: TooltipType, visible: boolean) {
   return visible && type === TooltipType.Crosshairs;
@@ -39,9 +39,10 @@ class CrosshairComponent extends React.Component<CrosshairProps> {
       },
       cursorBandPosition,
       tooltipType,
+      isChartEmpty,
     } = this.props.chartStore!;
 
-    if (!canRenderBand(tooltipType.get(), band.visible)) {
+    if (!canRenderBand(tooltipType.get(), band.visible, isChartEmpty)) {
       return null;
     }
     const style: CSSProperties = {

--- a/src/components/react_canvas/chart_container.tsx
+++ b/src/components/react_canvas/chart_container.tsx
@@ -14,7 +14,7 @@ class ChartContainerComponent extends React.Component<ReactiveChartProps> {
     if (!chartInitialized.get()) {
       return null;
     }
-    const { setCursorPosition } = this.props.chartStore!;
+    const { setCursorPosition, isChartEmpty } = this.props.chartStore!;
     return (
       <div
         className="echChartCursorContainer"
@@ -22,7 +22,9 @@ class ChartContainerComponent extends React.Component<ReactiveChartProps> {
           cursor: this.props.chartStore!.chartCursor.get(),
         }}
         onMouseMove={({ nativeEvent: { offsetX, offsetY } }) => {
-          setCursorPosition(offsetX, offsetY);
+          if (!isChartEmpty) {
+            setCursorPosition(offsetX, offsetY);
+          }
         }}
         onMouseLeave={() => {
           setCursorPosition(-1, -1);


### PR DESCRIPTION
## Summary

Hide chart band when chart is empty

## After changes
![Screen Recording 2019-08-21 at 08 32 PM](https://user-images.githubusercontent.com/19007109/63479207-dddb2600-c452-11e9-833b-fafc7c5a56a4.gif)


fix #337 

Fix `user-select` issue in safari. This was allowing the user to click and drag the chart to highlight the whole chart section.

![Screen Recording 2019-08-21 at 08 31 PM](https://user-images.githubusercontent.com/19007109/63479170-af5d4b00-c452-11e9-8319-377f9d86874d.gif)

### Checklist

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
