### PR TITLE
fix(histogram): fix annotation and tooltip overflow with single value

### DIFF
--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -5,19 +5,17 @@ import {
   Chart,
   getAxisId,
   getSpecId,
-  niceTimeFormatter,
   Position,
   ScaleType,
   Settings,
-  BarSeries,
-  LineAnnotation,
+  RectAnnotation,
   getAnnotationId,
-  AnnotationDomainTypes,
+  HistogramBarSeries,
+  niceTimeFormatByDay,
+  timeFormatter,
 } from '../src';
-import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
 import { CursorEvent } from '../src/specs/settings';
 import { CursorUpdateListener } from '../src/chart_types/xy_chart/store/chart_state';
-import { Icon } from '../src/components/icons/icon';
 
 export class Playground extends React.Component {
   ref1 = React.createRef<Chart>();
@@ -32,86 +30,78 @@ export class Playground extends React.Component {
 
   render() {
     return (
-      <>
-        {renderChart(
-          '1',
-          this.ref1,
-          KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 15),
-          this.onCursorUpdate,
-          true,
-        )}
-        {renderChart(
-          '2',
-          this.ref2,
-          KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15),
-          this.onCursorUpdate,
-          true,
-        )}
-        {renderChart('3', this.ref3, KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(15, 30), this.onCursorUpdate)}
-      </>
+      <div className="chart">
+        <Chart size={{ height: 200 }}>
+          <Settings
+            tooltip={{ type: 'vertical' }}
+            debug={false}
+            legendPosition={Position.Right}
+            showLegend={true}
+            xDomain={{
+              min: 1566079200000,
+              max: 1566079200000,
+              minInterval: 86400000,
+            }}
+          />
+          <Axis id={getAxisId('count')} title="count" position={Position.Left} tickFormat={(d) => d.toFixed(2)} />
+          <Axis
+            id={getAxisId('timestamp')}
+            title="timestamp"
+            position={Position.Bottom}
+            tickFormat={timeFormatter(niceTimeFormatByDay(1))}
+          />
+          <RectAnnotation
+            annotationId={getAnnotationId('annotation1')}
+            dataValues={[
+              {
+                coordinates: {
+                  x0: 1566103254092,
+                },
+                details: `06:40`,
+              },
+            ]}
+            style={{
+              stroke: 'rgba(0, 0, 0, 0)',
+              strokeWidth: 1,
+              opacity: 0.5,
+              fill: 'rgba(200, 0, 0, 0.5)',
+            }}
+            zIndex={-2}
+          />
+          <RectAnnotation
+            annotationId={getAnnotationId('annotation2')}
+            dataValues={[
+              {
+                coordinates: {
+                  x1: 1566088404270,
+                },
+                details: `02:33`,
+              },
+            ]}
+            style={{
+              stroke: 'rgba(0, 0, 0, 0)',
+              strokeWidth: 1,
+              opacity: 0.5,
+              fill: 'rgba(0, 0, 200, 0.5)',
+            }}
+            zIndex={-2}
+          />
+          <HistogramBarSeries
+            id={getSpecId('dataset B')}
+            xScaleType={ScaleType.Time}
+            yScaleType={ScaleType.Linear}
+            data={[[1566079200000, 10]]}
+            xAccessor={0}
+            yAccessors={[1]}
+            timeZone={'local'}
+            barSeriesStyle={{
+              rect: {
+                opacity: 0.7,
+              },
+            }}
+          />
+        </Chart>
+      </div>
     );
   }
-}
-
-function renderChart(
-  key: string,
-  ref: React.RefObject<Chart>,
-  data: any,
-  onCursorUpdate?: CursorUpdateListener,
-  timeSeries: boolean = false,
-) {
-  return (
-    <div key={key} className="chart">
-      <Chart ref={ref}>
-        <Settings
-          tooltip={{ type: 'vertical' }}
-          debug={false}
-          legendPosition={Position.Right}
-          showLegend={true}
-          onCursorUpdate={onCursorUpdate}
-          rotation={0}
-        />
-        <Axis
-          id={getAxisId('timestamp')}
-          title="timestamp"
-          position={Position.Bottom}
-          tickFormat={niceTimeFormatter([1555819200000, 1555905600000])}
-        />
-        <Axis id={getAxisId('count')} title="count" position={Position.Left} tickFormat={(d) => d.toFixed(2)} />
-        <LineAnnotation
-          annotationId={getAnnotationId('annotation1')}
-          domainType={AnnotationDomainTypes.XDomain}
-          dataValues={[
-            {
-              dataValue: KIBANA_METRICS.metrics.kibana_os_load[1].data[5][0],
-              details: 'tooltip 1',
-            },
-            {
-              dataValue: KIBANA_METRICS.metrics.kibana_os_load[1].data[9][0],
-              details: 'tooltip 2',
-            },
-          ]}
-          hideLinesTooltips={true}
-          marker={<Icon type="alert" />}
-        />
-        <BarSeries
-          id={getSpecId('dataset A with long title')}
-          xScaleType={timeSeries ? ScaleType.Time : ScaleType.Linear}
-          yScaleType={ScaleType.Linear}
-          data={data}
-          xAccessor={0}
-          yAccessors={[1]}
-        />
-        <BarSeries
-          id={getSpecId('dataset B')}
-          xScaleType={ScaleType.Time}
-          yScaleType={ScaleType.Linear}
-          data={KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15)}
-          xAccessor={0}
-          yAccessors={[1]}
-          stackAccessors={[0]}
-        />
-      </Chart>
-    </div>
-  );
 }

--- a/src/chart_types/xy_chart/annotations/annotation_utils.test.ts
+++ b/src/chart_types/xy_chart/annotations/annotation_utils.test.ts
@@ -1384,14 +1384,14 @@ describe('annotation utils', () => {
     const dimensions = computeRectAnnotationDimensions(annotationRectangle, yScales, xScale, true, 0);
 
     const [dims1, dims2, dims3, dims4] = dimensions;
-    expect(dims1.rect.x).toBe(0);
+    expect(dims1.rect.x).toBe(10);
     expect(dims1.rect.y).toBe(0);
-    expect(dims1.rect.width).toBe(10);
+    expect(dims1.rect.width).toBeCloseTo(100);
     expect(dims1.rect.height).toBe(100);
 
-    expect(dims2.rect.x).toBe(10);
+    expect(dims2.rect.x).toBe(0);
     expect(dims2.rect.y).toBe(0);
-    expect(dims2.rect.width).toBeCloseTo(100);
+    expect(dims2.rect.width).toBe(10);
     expect(dims2.rect.height).toBe(100);
 
     expect(dims3.rect.x).toBe(0);
@@ -1425,8 +1425,8 @@ describe('annotation utils', () => {
     const dimensions = computeRectAnnotationDimensions(annotationRectangle, yScales, xScale, false, 0);
 
     const expectedDimensions = [
-      { rect: { x: 0, y: 0, width: 10, height: 100 } },
       { rect: { x: 10, y: 0, width: 90, height: 100 } },
+      { rect: { x: 0, y: 0, width: 10, height: 100 } },
       { rect: { x: 0, y: 0, width: 100, height: 10 } },
       { rect: { x: 0, y: 10, width: 100, height: 90 } },
     ];

--- a/src/chart_types/xy_chart/annotations/annotation_utils.ts
+++ b/src/chart_types/xy_chart/annotations/annotation_utils.ts
@@ -399,7 +399,6 @@ export function computeRectAnnotationDimensions(
   const yDomain = yScale.domain;
   const lastX = xDomain[xDomain.length - 1];
   const xMinInterval = xScale.minInterval;
-
   const rectsProps: AnnotationRectProps[] = [];
 
   dataValues.forEach((dataValue: RectAnnotationDatum) => {
@@ -410,15 +409,15 @@ export function computeRectAnnotationDimensions(
       return;
     }
 
-    if (x0 == null) {
+    if (x1 == null) {
       // if x1 is defined, we want the rect to draw to the end of the scale
       // if we're in histogram mode, extend domain end by min interval
-      x0 = enableHistogramMode ? lastX + xMinInterval : lastX;
+      x1 = enableHistogramMode && !xScale.isSingleValue() ? lastX + xMinInterval : lastX;
     }
 
-    if (x1 == null) {
+    if (x0 == null) {
       // if x0 is defined, we want the rect to draw to the start of the scale
-      x1 = xDomain[0];
+      x0 = xDomain[0];
     }
 
     if (y0 == null) {

--- a/src/chart_types/xy_chart/utils/scales.ts
+++ b/src/chart_types/xy_chart/utils/scales.ts
@@ -98,7 +98,15 @@ export function computeXScale(options: XScaleOptions): Scale {
           domain: adjustedDomain,
           range: [start, end],
         },
-        { bandwidth: bandwidth / totalBarsInCluster, minInterval, timeZone, totalBarsInCluster, barsPadding, ticks },
+        {
+          bandwidth: bandwidth / totalBarsInCluster,
+          minInterval,
+          timeZone,
+          totalBarsInCluster,
+          barsPadding,
+          ticks,
+          isSingleValueHistogram,
+        },
       );
 
       return scale;

--- a/src/utils/scales/scale_continuous.ts
+++ b/src/utils/scales/scale_continuous.ts
@@ -103,8 +103,18 @@ interface ScaleOptions {
    * @default 10
    */
   ticks: number;
+  /** true if the scale was adjusted to fit one single value histogram */
+  isSingleValueHistogram: boolean;
 }
-
+const defaultScaleOptions: ScaleOptions = {
+  bandwidth: 0,
+  minInterval: 0,
+  timeZone: 'utc',
+  totalBarsInCluster: 1,
+  barsPadding: 0,
+  ticks: 10,
+  isSingleValueHistogram: false,
+};
 export class ScaleContinuous implements Scale {
   readonly bandwidth: number;
   readonly totalBarsInCluster: number;
@@ -118,22 +128,21 @@ export class ScaleContinuous implements Scale {
   readonly tickValues: number[];
   readonly timeZone: string;
   readonly barsPadding: number;
+  readonly isSingleValueHistogram: boolean;
   private readonly d3Scale: any;
 
   constructor(scaleData: ScaleData, options?: Partial<ScaleOptions>) {
     const { type, domain, range } = scaleData;
-    const scaleOptions: ScaleOptions = mergePartial(
-      {
-        bandwidth: 0,
-        minInterval: 0,
-        timeZone: 'utc',
-        totalBarsInCluster: 1,
-        barsPadding: 0,
-        ticks: 10,
-      },
-      options,
-    );
-    const { bandwidth, minInterval, timeZone, totalBarsInCluster, barsPadding, ticks } = scaleOptions;
+    const {
+      bandwidth,
+      minInterval,
+      timeZone,
+      totalBarsInCluster,
+      barsPadding,
+      ticks,
+      isSingleValueHistogram,
+    } = mergePartial(defaultScaleOptions, options);
+
     this.d3Scale = SCALES[type]();
     if (type === ScaleType.Log) {
       this.domain = limitLogScaleDomain(domain);
@@ -154,6 +163,7 @@ export class ScaleContinuous implements Scale {
     this.isInverted = this.domain[0] > this.domain[1];
     this.timeZone = timeZone;
     this.totalBarsInCluster = totalBarsInCluster;
+    this.isSingleValueHistogram = isSingleValueHistogram;
     if (type === ScaleType.Time) {
       const startDomain = DateTime.fromMillis(this.domain[0], { zone: this.timeZone });
       const endDomain = DateTime.fromMillis(this.domain[1], { zone: this.timeZone });
@@ -227,6 +237,9 @@ export class ScaleContinuous implements Scale {
     return prevValue;
   }
   isSingleValue() {
+    if (this.isSingleValueHistogram) {
+      return true;
+    }
     if (this.domain.length < 2) {
       return true;
     }


### PR DESCRIPTION
## Summary

fix #342, fix #341 

This commit fix an issue where a rect annotation with x0 defined in a single value histogram, is
drawn outside the chart as shown in #341.
It also fix the tooltip rendering inside the chart: #342 

**before**
<img width="939" alt="Screenshot 2019-08-23 at 01 27 42" src="https://user-images.githubusercontent.com/1421091/63556869-acdc1d80-c546-11e9-9602-91cda79e2a7b.png">

**after**
<img width="891" alt="Screenshot 2019-08-23 at 01 04 38" src="https://user-images.githubusercontent.com/1421091/63556861-a5b50f80-c546-11e9-8957-67e21b392be8.png">


**BREAKING CHANGE**
The current coordinate configuration of a rect annotation seems inverted. From the rect annotation PR: https://github.com/elastic/elastic-charts/pull/180 I'm proposing to invert the x0 and x1 meaning on the annotation coordinate.
With `x0` I always think of the left hand side of a rectangle, and with `x1` the right hand side. 
So with that in mind I'd like to change that with 

| x0        | x1           | y0  |  y1  | render implications |
| ------------- |:-------------:|-----:|-----:|-----:|
| undefined    | undefined      |   undefined | undefined | no rendered annotation |
| **defined**    | undefined (coerced to x domain **end**)   |   undefined (coerced to y domain end) | undefined (coerced to y domain start) |  rect will be drawn from x0 to xDomain end with full chart height |
| undefined  (coerced to x domain start)   | **defined**      |   undefined  (coerced to y domain end) | undefined (coerced to y domain start) | rect will be drawn from x domain start to x1 with full chart height |
| undefined  (coerced to x domain start) | undefined (coerced to x domain end) |   **defined** | undefined (coerced to y domain start) | rect will be drawn from y domain start to y0 with full chart width |
| undefined (coerced to x domain start)  | undefined (coerced to x domain end) |   undefined  (coerced to y domain end) | **defined** | rect will be drawn from y1 to y domain end with full chart width |

@nickofthyme do you think we should to the same also for the y0 and y1 values?


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
