### PR TITLE
feat(theme): multiple-partials

### DIFF
--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -52,9 +52,16 @@ function isTooltipType(config: TooltipType | TooltipProps): config is TooltipTyp
 export interface SettingSpecProps {
   chartStore?: ChartStore;
   /**
-   * Full or partial theme to be merged with base
+   * Partial theme to be merged with base
+   *
+   * or
+   *
+   * Array of partial themes to be merged with base
+   * index `0` being the hightest priority
+   *
+   * i.e. `[primary, secondary, tertiary]`
    */
-  theme?: Theme | PartialTheme;
+  theme?: PartialTheme | PartialTheme[];
   /**
    * Full default theme to use as base
    *
@@ -83,8 +90,14 @@ export interface SettingSpecProps {
   xDomain?: Domain | DomainRange;
 }
 
-function getTheme(baseTheme?: Theme, theme?: Theme | PartialTheme): Theme {
+function getTheme(baseTheme?: Theme, theme?: PartialTheme | PartialTheme[]): Theme {
   const base = baseTheme ? baseTheme : LIGHT_THEME;
+
+  if (Array.isArray(theme)) {
+    const [firstTheme, ...axillaryThemes] = theme;
+    return mergeWithDefaultTheme(firstTheme, base, axillaryThemes);
+  }
+
   return theme ? mergeWithDefaultTheme(theme, base) : base;
 }
 

--- a/src/utils/commons.test.ts
+++ b/src/utils/commons.test.ts
@@ -135,6 +135,120 @@ describe('commons utilities', () => {
       expect(base).toEqual(baseClone);
     });
 
+    describe('additionalPartials', () => {
+      test('should override string value in base with first partial value', () => {
+        const partial: PartialTestType = { string: 'test1' };
+        const partials: PartialTestType[] = [{ string: 'test2' }, { string: 'test3' }];
+        const newBase = mergePartial(base, partial, {}, partials);
+        expect(newBase).toEqual({
+          ...newBase,
+          string: partial.string,
+        });
+      });
+
+      test('should override string values in base with first and second partial value', () => {
+        const partial: PartialTestType = { number: 4 };
+        const partials: PartialTestType[] = [{ string: 'test2' }];
+        const newBase = mergePartial(base, partial, {}, partials);
+        expect(newBase).toEqual({
+          ...newBase,
+          number: partial.number,
+          string: partials[0].string,
+        });
+      });
+
+      test('should override string values in base with first, second and thrid partial value', () => {
+        const partial: PartialTestType = { number: 4 };
+        const partials: PartialTestType[] = [
+          { number: 10, string: 'test2' },
+          { number: 20, string: 'nope', boolean: true },
+        ];
+        const newBase = mergePartial(base, partial, {}, partials);
+        expect(newBase).toEqual({
+          ...newBase,
+          number: partial.number,
+          string: partials[0].string,
+          boolean: partials[1].boolean,
+        });
+      });
+
+      test('should override complex array value in base', () => {
+        const partial: PartialTestType = { array1: [{ string: 'test1' }] };
+        const partials: PartialTestType[] = [{ array1: [{ string: 'test2' }] }];
+        const newBase = mergePartial(base, partial, {}, partials);
+        expect(newBase).toEqual({
+          ...newBase,
+          array1: partial.array1,
+        });
+      });
+
+      test('should override complex array value in base second partial', () => {
+        const partial: PartialTestType = {};
+        const partials: PartialTestType[] = [{}, { array1: [{ string: 'test2' }] }];
+        const newBase = mergePartial(base, partial, {}, partials);
+        expect(newBase).toEqual({
+          ...newBase,
+          array1: partials[1].array1,
+        });
+      });
+
+      test('should override simple array value in base', () => {
+        const partial: PartialTestType = { array2: [4, 5, 6] };
+        const partials: PartialTestType[] = [{ array2: [7, 8, 9] }];
+        const newBase = mergePartial(base, partial, {}, partials);
+        expect(newBase).toEqual({
+          ...newBase,
+          array2: partial.array2,
+        });
+      });
+
+      test('should override simple array value in base with partial', () => {
+        const partial: PartialTestType = {};
+        const partials: PartialTestType[] = [{ array2: [7, 8, 9] }];
+        const newBase = mergePartial(base, partial, {}, partials);
+        expect(newBase).toEqual({
+          ...newBase,
+          array2: partials[0].array2,
+        });
+      });
+
+      test('should override simple array value in base with second partial', () => {
+        const partial: PartialTestType = {};
+        const partials: PartialTestType[] = [{}, { array2: [7, 8, 9] }];
+        const newBase = mergePartial(base, partial, {}, partials);
+        expect(newBase).toEqual({
+          ...newBase,
+          array2: partials![1].array2,
+        });
+      });
+
+      test('should override nested values in base', () => {
+        const partial: PartialTestType = { nested: { number: 5 } };
+        const partials: PartialTestType[] = [{ nested: { number: 10 } }];
+        const newBase = mergePartial(base, partial, {}, partials);
+        expect(newBase).toEqual({
+          ...newBase,
+          nested: {
+            ...newBase.nested,
+            number: partial!.nested!.number,
+          },
+        });
+      });
+
+      test('should override nested values from partial', () => {
+        const partial: PartialTestType = {};
+        const partials: PartialTestType[] = [{ nested: { number: 10 } }];
+        const newBase = mergePartial(base, partial, {}, partials);
+        expect(newBase).toEqual({
+          ...newBase,
+          nested: {
+            ...newBase.nested,
+            number: partials![0].nested!.number,
+          },
+        });
+      });
+    });
+
     describe('MergeOptions', () => {
       describe('mergeOptionalPartialValues', () => {
         interface OptionalTestType {
@@ -178,6 +292,19 @@ describe('commons utilities', () => {
                 value2: 10,
                 value3: 'bar',
               },
+            });
+          });
+
+          test('should merge optional params from partials', () => {
+            type PartialTestTypeOverride = PartialTestType & any;
+            const partial: PartialTestTypeOverride = { nick: 'test', number: 6 };
+            const partials: (PartialTestTypeOverride)[] = [{ string: 'test', foo: 'bar' }, { array3: [3, 3, 3] }];
+            const newBase = mergePartial(base, partial, { mergeOptionalPartialValues: true }, partials);
+            expect(newBase).toEqual({
+              ...newBase,
+              ...partial,
+              ...partials[0],
+              ...partials[1],
             });
           });
         });

--- a/src/utils/commons.test.ts
+++ b/src/utils/commons.test.ts
@@ -1,4 +1,12 @@
-import { clamp, compareByValueAsc, identity, mergePartial, RecursivePartial } from './commons';
+import {
+  clamp,
+  compareByValueAsc,
+  identity,
+  mergePartial,
+  RecursivePartial,
+  getPartialValue,
+  getAllKeys,
+} from './commons';
 
 describe('commons utilities', () => {
   test('can clamp a value to min max', () => {
@@ -27,6 +35,96 @@ describe('commons utilities', () => {
     expect(compareByValueAsc(10, 20)).toBeLessThan(0);
     expect(compareByValueAsc(20, 10)).toBeGreaterThan(0);
     expect(compareByValueAsc(10, 10)).toBe(0);
+  });
+
+  describe('getPartialValue', () => {
+    interface TestType {
+      foo: string;
+      bar: number;
+      test?: TestType;
+    }
+    const base: TestType = {
+      foo: 'elastic',
+      bar: 123,
+      test: {
+        foo: 'shay',
+        bar: 321,
+      },
+    };
+    const partial: RecursivePartial<TestType> = {
+      foo: 'elastic',
+    };
+
+    it('should return partial if it is defined', () => {
+      const result = getPartialValue(base, partial);
+
+      expect(result).toBe(partial);
+    });
+
+    it('should return base if partial is undefined', () => {
+      const result = getPartialValue(base);
+
+      expect(result).toBe(base);
+    });
+
+    it('should return extra partials if partial is undefined', () => {
+      const result = getPartialValue(base, undefined, [partial]);
+
+      expect(result).toBe(partial);
+    });
+
+    it('should return second partial if partial is undefined', () => {
+      // @ts-ignore
+      const result = getPartialValue(base, undefined, [undefined, partial]);
+
+      expect(result).toBe(partial);
+    });
+
+    it('should return base if no partials are defined', () => {
+      // @ts-ignore
+      const result = getPartialValue(base, undefined, [undefined, undefined]);
+
+      expect(result).toBe(base);
+    });
+  });
+
+  describe('getAllKeys', () => {
+    const object1 = {
+      key1: 1,
+      key2: 2,
+    };
+    const object2 = {
+      key3: 3,
+      key4: 4,
+    };
+    const object3 = {
+      key5: 5,
+      key6: 6,
+    };
+
+    it('should return all keys from single object', () => {
+      const result = getAllKeys(object1);
+
+      expect(result).toEqual(['key1', 'key2']);
+    });
+
+    it('should return all keys from all objects x 2', () => {
+      const result = getAllKeys(object1, [object2]);
+
+      expect(result).toEqual(['key1', 'key2', 'key3', 'key4']);
+    });
+
+    it('should return all keys from single objects x 3', () => {
+      const result = getAllKeys(object1, [object2, object3]);
+
+      expect(result).toEqual(['key1', 'key2', 'key3', 'key4', 'key5', 'key6']);
+    });
+
+    it('should return all keys from only defined objects', () => {
+      const result = getAllKeys(object1, [null, object2, {}, undefined]);
+
+      expect(result).toEqual(['key1', 'key2', 'key3', 'key4']);
+    });
   });
 
   describe('mergePartial', () => {

--- a/src/utils/commons.ts
+++ b/src/utils/commons.ts
@@ -60,19 +60,24 @@ export interface MergeOptions {
   mergeOptionalPartialValues?: boolean;
 }
 
-function getPartialValue<T>(base: T, partial?: RecursivePartial<T>, partials: RecursivePartial<T>[] = []): T {
+export function getPartialValue<T>(base: T, partial?: RecursivePartial<T>, partials: RecursivePartial<T>[] = []): T {
   const partialWithValue = partial !== undefined ? partial : partials.find((v) => v !== undefined);
   return partialWithValue !== undefined ? (partialWithValue as T) : base;
 }
 
-function getAllKey<T>(partial: T, partials: T[]): string[] {
-  return partials.reduce((keys, object) => {
-    if (object && typeof object === 'object') {
-      keys.push(...Object.keys(object));
+/**
+ * Returns all top-level keys from one or more objects
+ * @param object - first object to get keys
+ * @param objects
+ */
+export function getAllKeys(object: any, objects: any[] = []): string[] {
+  return objects.reduce((keys: any[], obj) => {
+    if (obj && typeof obj === 'object') {
+      keys.push(...Object.keys(obj));
     }
 
     return keys;
-  }, Object.keys(partial));
+  }, Object.keys(object));
 }
 
 /**
@@ -95,7 +100,7 @@ export function mergePartial<T>(
     const baseClone = { ...base };
 
     if (partial !== undefined && options.mergeOptionalPartialValues) {
-      getAllKey(partial, additionalPartials).forEach((key) => {
+      getAllKeys(partial, additionalPartials).forEach((key) => {
         if (!(key in baseClone)) {
           (baseClone as any)[key] =
             (partial as any)[key] !== undefined

--- a/src/utils/themes/theme.test.ts
+++ b/src/utils/themes/theme.test.ts
@@ -106,6 +106,12 @@ describe('Theme', () => {
   });
 
   describe('mergeWithDefaultTheme', () => {
+    it('should default to LIGHT_THEME', () => {
+      const partialTheme: PartialTheme = {};
+      const mergedTheme = mergeWithDefaultTheme(partialTheme);
+      expect(mergedTheme).toEqual(LIGHT_THEME);
+    });
+
     it('should merge partial theme: margins', () => {
       const customTheme = mergeWithDefaultTheme({
         chartMargins: {
@@ -372,10 +378,61 @@ describe('Theme', () => {
       expect(mergedTheme).toEqual(LIGHT_THEME);
     });
 
-    it('should default to LIGHT_THEME', () => {
-      const partialTheme: PartialTheme = {};
-      const mergedTheme = mergeWithDefaultTheme(partialTheme);
-      expect(mergedTheme).toEqual(LIGHT_THEME);
+    it('should merge partial theme wtih axillaryThemes', () => {
+      const customTheme = mergeWithDefaultTheme(
+        {
+          chartMargins: {
+            bottom: 123,
+          },
+        },
+        LIGHT_THEME,
+        [
+          {
+            chartMargins: {
+              top: 123,
+            },
+          },
+          {
+            chartMargins: {
+              left: 123,
+            },
+          },
+        ],
+      );
+      expect(customTheme.chartMargins).toBeDefined();
+      expect(customTheme.chartMargins.bottom).toBe(123);
+      expect(customTheme.chartMargins.top).toBe(123);
+      expect(customTheme.chartMargins.left).toBe(123);
+    });
+
+    it('should merge theme with axillaryThemes in spatial order priority', () => {
+      const customTheme = mergeWithDefaultTheme(
+        {
+          chartMargins: {
+            bottom: 1,
+          },
+        },
+        LIGHT_THEME,
+        [
+          {
+            chartMargins: {
+              top: 2,
+              bottom: 2,
+            },
+          },
+          {
+            chartMargins: {
+              top: 3,
+              left: 3,
+              bottom: 3,
+            },
+          },
+        ],
+      );
+      expect(customTheme.chartMargins).toBeDefined();
+      expect(customTheme.chartMargins.bottom).toBe(1);
+      expect(customTheme.chartMargins.top).toBe(2);
+      expect(customTheme.chartMargins.left).toBe(3);
     });
   });
 });

--- a/src/utils/themes/theme.ts
+++ b/src/utils/themes/theme.ts
@@ -277,6 +277,15 @@ export function mergeWithDefaultAnnotationRect(config?: Partial<RectAnnotationSt
   };
 }
 
+/**
+ * Merge theme or themes with a base theme
+ *
+ * priority is based on spatial order
+ *
+ * @param theme - primary partial theme
+ * @param defaultTheme - base theme
+ * @param axillaryThemes - additional themes to be merged
+ */
 export function mergeWithDefaultTheme(
   theme: PartialTheme,
   defaultTheme: Theme = LIGHT_THEME,

--- a/src/utils/themes/theme.ts
+++ b/src/utils/themes/theme.ts
@@ -277,6 +277,10 @@ export function mergeWithDefaultAnnotationRect(config?: Partial<RectAnnotationSt
   };
 }
 
-export function mergeWithDefaultTheme(theme: PartialTheme, defaultTheme: Theme = LIGHT_THEME): Theme {
-  return mergePartial(defaultTheme, theme, { mergeOptionalPartialValues: true });
+export function mergeWithDefaultTheme(
+  theme: PartialTheme,
+  defaultTheme: Theme = LIGHT_THEME,
+  axillaryThemes: PartialTheme[] = [],
+): Theme {
+  return mergePartial(defaultTheme, theme, { mergeOptionalPartialValues: true }, axillaryThemes);
 }

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -443,7 +443,7 @@ storiesOf('Stylings', module)
       </Chart>
     );
   })
-  .add('partial custom theme with baseThemeType', () => {
+  .add('partial custom theme', () => {
     const customPartialTheme: PartialTheme = {
       barSeriesStyle: {
         rectBorder: {
@@ -455,7 +455,7 @@ storiesOf('Stylings', module)
 
     return (
       <Chart className="story-chart">
-        <Settings showLegend theme={customPartialTheme} baseTheme={LIGHT_THEME} legendPosition={Position.Right} />
+        <Settings showLegend theme={customPartialTheme} legendPosition={Position.Right} />
         <Axis id={getAxisId('bottom')} position={Position.Bottom} title="Bottom axis" showOverlappingTicks={true} />
         <Axis
           id={getAxisId('left2')}
@@ -523,6 +523,59 @@ storiesOf('Stylings', module)
       </Chart>
     );
   })
+  .add(
+    'multiple custom partial themes',
+    () => {
+      const primaryTheme: PartialTheme = {
+        barSeriesStyle: {
+          rect: {
+            fill: color('bar fill - primary theme', 'red'),
+          },
+        },
+      };
+      const secondaryTheme: PartialTheme = {
+        barSeriesStyle: {
+          rect: {
+            fill: color('bar fill - secondary theme', 'blue'),
+            opacity: range('bar opacity - secondary theme', 0.1, 1, 0.7, undefined, 0.1),
+          },
+        },
+      };
+
+      return (
+        <Chart className="story-chart">
+          <Settings showLegend theme={[primaryTheme, secondaryTheme]} legendPosition={Position.Right} />
+          <Axis id={getAxisId('bottom')} position={Position.Bottom} title="Bottom axis" showOverlappingTicks={true} />
+          <Axis
+            id={getAxisId('left2')}
+            title="Left axis"
+            position={Position.Left}
+            tickFormat={(d) => Number(d).toFixed(2)}
+          />
+          <Axis id={getAxisId('top')} position={Position.Top} title="Top axis" showOverlappingTicks={true} />
+          <Axis
+            id={getAxisId('right')}
+            title="Right axis"
+            position={Position.Right}
+            tickFormat={(d) => Number(d).toFixed(2)}
+          />
+          <BarSeries
+            id={getSpecId('bars')}
+            xScaleType={ScaleType.Linear}
+            yScaleType={ScaleType.Linear}
+            xAccessor="x"
+            yAccessors={['y']}
+            splitSeriesAccessors={['g']}
+            stackAccessors={['x']}
+            data={data1}
+          />
+        </Chart>
+      );
+    },
+    {
+      info: 'Notice that the secondary theme bar fill has no effect as the primary value takes priority',
+    },
+  )
   .add('custom series colors through spec props', () => {
     const barCustomSeriesColors: CustomSeriesColorsMap = new Map();
     const barDataSeriesColorValues: DataSeriesColorsValues = {


### PR DESCRIPTION
## Summary

Allow single or multiple partial themes to be passed as props to Settings component

closes #344

Take multiple `PartialThemes` and merge them into a base `Theme` in one step.

`theme` props now accepts `PartialTheme` or `PartialTheme[]`

```tsx
const EUI_OVERRIDES = {
  barSeriesStyle: {
    rect: {
      fill: 'red',
      opacity: 0.5,
  },
}
const overrides = {
  barSeriesStyle: {
    rect: {
      fill: 'blue',
  },
}

render () {
  <Chart>
    <Settings theme={[overrides, EUI_OVERRIDES]} />
    ...
  </Chart>
}
```

The above example will resolve to the following `PartialTheme` to be merged with the `baseTheme`.

```ts
const finalTheme = {
  barSeriesStyle: {
    rect: {
      fill: 'blue', // color from overrides takes precedence  
      opacity: 0.5,
  },
}
```

### Checklist

- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
