### PR TITLE
fix(scales): bisect correctly on continuous scales

### DIFF
--- a/.playground/index.html
+++ b/.playground/index.html
@@ -9,12 +9,12 @@
     <style>
       html,
       body {
-        background: darkgrey !important;
+        background: blanchedalmond !important;
         margin: 0;
         padding: 0;
       }
       #root {
-        background: white;
+        
         position: absolute;
         top: 10px;
         left: 10px;
@@ -22,9 +22,11 @@
         right: 10px;
       }
       .chart {
+        background: white;
         position: relative;
-        width: 100%;
-        height: 200px;
+        width: 800px;
+        height: 150px;
+        margin: 10px;
       }
     </style>
   </head>

--- a/.playground/index.html
+++ b/.playground/index.html
@@ -16,15 +16,15 @@
       #root {
         background: white;
         position: absolute;
-        top: 100px;
-        left: 100px;
-        bottom: 100px;
-        right: 100px;
+        top: 10px;
+        left: 10px;
+        bottom: 10px;
+        right: 10px;
       }
       .chart {
         position: relative;
         width: 100%;
-        height: 100%;
+        height: 200px;
       }
     </style>
   </head>

--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -13,6 +13,9 @@ import {
   LineAnnotation,
   getAnnotationId,
   AnnotationDomainTypes,
+  AreaSeries,
+  LineSeries,
+  TooltipType,
 } from '../src';
 import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
 import { CursorEvent } from '../src/specs/settings';
@@ -23,31 +26,57 @@ export class Playground extends React.Component {
   ref1 = React.createRef<Chart>();
   ref2 = React.createRef<Chart>();
   ref3 = React.createRef<Chart>();
+  ref4 = React.createRef<Chart>();
 
   onCursorUpdate: CursorUpdateListener = (event?: CursorEvent) => {
     this.ref1.current!.dispatchExternalCursorEvent(event);
     this.ref2.current!.dispatchExternalCursorEvent(event);
     this.ref3.current!.dispatchExternalCursorEvent(event);
+    this.ref4.current!.dispatchExternalCursorEvent(event);
   };
 
   render() {
     return (
       <>
         {renderChart(
-          '1',
+          '1 - top',
           this.ref1,
-          KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 15),
+          KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 20).filter((d, i) => i !== 1 && i !== 2),
+          ScaleType.Time,
           this.onCursorUpdate,
-          true,
+          2,
+          'line',
         )}
+
         {renderChart(
-          '2',
+          '2 - middle',
           this.ref2,
-          KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15),
+          KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(2, 15).filter((d, i) => i !== 5),
+          ScaleType.Time,
           this.onCursorUpdate,
-          true,
+          2,
+          'line',
         )}
-        {renderChart('3', this.ref3, KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(15, 30), this.onCursorUpdate)}
+
+        {renderChart(
+          '3 - bottom',
+          this.ref3,
+          KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 5),
+          ScaleType.Time,
+          this.onCursorUpdate,
+          4,
+          'bar',
+        )}
+
+        {renderChart(
+          '4 - mixed',
+          this.ref4,
+          KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 7),
+          ScaleType.Time,
+          this.onCursorUpdate,
+          1,
+          'mixed',
+        )}
       </>
     );
   }
@@ -57,60 +86,104 @@ function renderChart(
   key: string,
   ref: React.RefObject<Chart>,
   data: any,
+  scaleType: 'linear' | 'ordinal' | 'time',
   onCursorUpdate?: CursorUpdateListener,
-  timeSeries: boolean = false,
+  maxSeries: number = 4,
+  chartType: 'bar' | 'line' | 'area' | 'mixed' = 'bar',
 ) {
+  const formatter = niceTimeFormatter([data[0][0], data[data.length - 1][0]]);
   return (
     <div key={key} className="chart">
-      <Chart ref={ref}>
+      <Chart ref={ref} id={key}>
         <Settings
-          tooltip={{ type: 'vertical' }}
           debug={false}
           legendPosition={Position.Right}
           showLegend={true}
           onCursorUpdate={onCursorUpdate}
           rotation={0}
+          tooltip={{
+            type: TooltipType.VerticalCursor,
+            snap: true,
+          }}
+          theme={{
+            lineSeriesStyle: {
+              point: {
+                visible: true,
+                radius: 3,
+                strokeWidth: 1,
+              },
+            },
+            areaSeriesStyle: {
+              area: {
+                opacity: 0.4,
+              },
+            },
+          }}
         />
-        <Axis
-          id={getAxisId('timestamp')}
-          title="timestamp"
-          position={Position.Bottom}
-          tickFormat={niceTimeFormatter([1555819200000, 1555905600000])}
-        />
+        <Axis id={getAxisId('timestamp')} title="timestamp" position={Position.Bottom} tickFormat={formatter} />
         <Axis id={getAxisId('count')} title="count" position={Position.Left} tickFormat={(d) => d.toFixed(2)} />
         <LineAnnotation
           annotationId={getAnnotationId('annotation1')}
           domainType={AnnotationDomainTypes.XDomain}
           dataValues={[
             {
-              dataValue: KIBANA_METRICS.metrics.kibana_os_load[1].data[5][0],
+              dataValue: KIBANA_METRICS.metrics.kibana_os_load[1].data[0][0],
               details: 'tooltip 1',
             },
             {
-              dataValue: KIBANA_METRICS.metrics.kibana_os_load[1].data[9][0],
-              details: 'tooltip 2',
+              dataValue: KIBANA_METRICS.metrics.kibana_os_load[1].data[12][0],
+              details: `${formatter(KIBANA_METRICS.metrics.kibana_os_load[1].data[12][0])}`,
             },
           ]}
           hideLinesTooltips={true}
+          hideLines={true}
           marker={<Icon type="alert" />}
         />
-        <BarSeries
-          id={getSpecId('dataset A with long title')}
-          xScaleType={timeSeries ? ScaleType.Time : ScaleType.Linear}
-          yScaleType={ScaleType.Linear}
-          data={data}
-          xAccessor={0}
-          yAccessors={[1]}
-        />
-        <BarSeries
-          id={getSpecId('dataset B')}
-          xScaleType={ScaleType.Time}
-          yScaleType={ScaleType.Linear}
-          data={KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15)}
-          xAccessor={0}
-          yAccessors={[1]}
-          stackAccessors={[0]}
-        />
+        {(chartType === 'mixed' || chartType === 'line') &&
+          new Array(maxSeries).fill(0).map((d, k) => {
+            return (
+              <LineSeries
+                key={k}
+                id={getSpecId('dataset line' + k)}
+                xScaleType={scaleType}
+                yScaleType={ScaleType.Linear}
+                data={data.map((d, i) => [d[0], d[1] + 5 + +Math.sin((i * (k + 1)) % data.length) * 10])}
+                xAccessor={0}
+                yAccessors={[1]}
+              />
+            );
+          })}
+        {(chartType === 'mixed' || chartType === 'bar') &&
+          new Array(maxSeries).fill(0).map((d, k) => {
+            return (
+              <BarSeries
+                key={k}
+                id={getSpecId('dataset bar ' + k)}
+                xScaleType={scaleType}
+                yScaleType={ScaleType.Linear}
+                data={data.map((d, i) => [d[0], d[1] + 5 + Math.cos((i * (k + 1)) % data.length) * 5])}
+                xAccessor={0}
+                yAccessors={[1]}
+                sortIndex={-10}
+              />
+            );
+          })}
+        {(chartType === 'mixed' || chartType === 'area') &&
+          new Array(maxSeries).fill(0).map((d, k) => {
+            return (
+              <AreaSeries
+                key={k}
+                id={getSpecId('dataset area ' + k)}
+                xScaleType={scaleType}
+                yScaleType={ScaleType.Linear}
+                data={data.map((d, i) => [d[0], d[1] + 5 + Math.cos((i * (k + 1)) % data.length) * 3])}
+                xAccessor={0}
+                yAccessors={[1]}
+                sortIndex={-10}
+                stackAccessors={[0]}
+              />
+            );
+          })}
       </Chart>
     </div>
   );

--- a/src/chart_types/xy_chart/annotations/annotation_utils.test.ts
+++ b/src/chart_types/xy_chart/annotations/annotation_utils.test.ts
@@ -33,7 +33,6 @@ import {
   getAnnotationLineTooltipTransform,
   getAnnotationLineTooltipXOffset,
   getAnnotationLineTooltipYOffset,
-  getNearestTick,
   getRotatedCursor,
   isBottomRectTooltip,
   isRightRectTooltip,
@@ -56,7 +55,7 @@ describe('annotation utils', () => {
       domain: continuousData,
       range: [minRange, maxRange],
     },
-    { bandwidth: 0, minInterval: 1 },
+    { bandwidth: 10, minInterval: 1 },
   );
 
   const ordinalData = ['a', 'b', 'c', 'd', 'a', 'b', 'c'];
@@ -1467,7 +1466,7 @@ describe('annotation utils', () => {
 
     expect(unrotated).toEqual([{ rect: { x: 0, y: 0, width: 25, height: 20 } }]);
   });
-  test('should validate scaled dataValues', () => {
+  test.only('should validate scaled dataValues', () => {
     // not aligned with tick
     expect(scaleAndValidateDatum('', ordinalScale, false)).toBe(null);
     expect(scaleAndValidateDatum('a', continuousScale, false)).toBe(null);
@@ -1482,7 +1481,10 @@ describe('annotation utils', () => {
     expect(scaleAndValidateDatum(0, continuousScale, false)).toBe(0);
 
     // aligned with tick
-    expect(scaleAndValidateDatum(1.25, continuousScale, true)).toBe(10);
+    expect(scaleAndValidateDatum(1.25, continuousScale, true)).toBe(12.5);
+    console.log(continuousScale.ticks());
+    console.log(continuousScale.tickValues);
+    console.log(continuousScale.range);
   });
   test('should determine if a point is within a rectangle annotation', () => {
     const cursorPosition = { x: 3, y: 4 };
@@ -1681,15 +1683,7 @@ describe('annotation utils', () => {
     expect(getRotatedCursor(rawCursorPosition, chartDimensions, -90)).toEqual({ x: 18, y: 9 });
     expect(getRotatedCursor(rawCursorPosition, chartDimensions, 180)).toEqual({ x: 9, y: 18 });
   });
-  test('should get nearest tick', () => {
-    const ticks = [0, 1, 2];
-    expect(getNearestTick(0.25, [], 1)).toBeUndefined();
-    expect(getNearestTick(0.25, [100], 1)).toBeUndefined();
-    expect(getNearestTick(0.25, ticks, 1)).toBe(0);
-    expect(getNearestTick(0.75, ticks, 1)).toBe(1);
-    expect(getNearestTick(0.5, ticks, 1)).toBe(1);
-    expect(getNearestTick(1.75, ticks, 1)).toBe(2);
-  });
+
   test('should compute cluster offset', () => {
     const singleBarCluster = 1;
     const multiBarCluster = 2;

--- a/src/chart_types/xy_chart/annotations/annotation_utils.test.ts
+++ b/src/chart_types/xy_chart/annotations/annotation_utils.test.ts
@@ -290,6 +290,7 @@ describe('annotation utils', () => {
         position: [0, 20, 20 + DEFAULT_LINE_OVERFLOW, 20],
         details: { detailsText: 'foo', headerText: '2' },
         tooltipLinePosition: [20, 0, 20, 20],
+        marker: undefined,
       },
     ];
     expect(dimensions).toEqual(expectedDimensions);
@@ -385,9 +386,10 @@ describe('annotation utils', () => {
     );
     const expectedDimensions = [
       {
-        position: [20, -DEFAULT_LINE_OVERFLOW, 20, 20],
+        position: [25, -DEFAULT_LINE_OVERFLOW, 25, 20],
         details: { detailsText: 'foo', headerText: '2' },
-        tooltipLinePosition: [20, 0, 20, 20],
+        tooltipLinePosition: [25, 0, 25, 20],
+        marker: undefined,
       },
     ];
     expect(dimensions).toEqual(expectedDimensions);
@@ -420,9 +422,10 @@ describe('annotation utils', () => {
     );
     const expectedDimensions = [
       {
-        position: [20, 0, 20, 20],
+        position: [25, 0, 25, 20],
         details: { detailsText: 'foo', headerText: '2' },
-        tooltipLinePosition: [20, 0, 20, 20],
+        tooltipLinePosition: [25, 0, 25, 20],
+        marker: undefined,
       },
     ];
     expect(dimensions).toEqual(expectedDimensions);
@@ -455,9 +458,10 @@ describe('annotation utils', () => {
     );
     const expectedDimensions = [
       {
-        position: [105, 0, 105, 20],
+        position: [110, 0, 110, 20],
         details: { detailsText: 'foo', headerText: '10.5' },
-        tooltipLinePosition: [105, 0, 105, 20],
+        tooltipLinePosition: [110, 0, 110, 20],
+        marker: undefined,
       },
     ];
     expect(dimensions).toEqual(expectedDimensions);
@@ -494,6 +498,7 @@ describe('annotation utils', () => {
         position: [12.5, -DEFAULT_LINE_OVERFLOW, 12.5, 10],
         details: { detailsText: 'foo', headerText: 'a' },
         tooltipLinePosition: [0, 12.5, 10, 12.5],
+        marker: undefined,
       },
     ];
     expect(dimensions).toEqual(expectedDimensions);
@@ -527,9 +532,10 @@ describe('annotation utils', () => {
     );
     const expectedDimensions = [
       {
-        position: [20, -DEFAULT_LINE_OVERFLOW, 20, 10],
+        position: [25, -DEFAULT_LINE_OVERFLOW, 25, 10],
         details: { detailsText: 'foo', headerText: '2' },
-        tooltipLinePosition: [0, 20, 10, 20],
+        tooltipLinePosition: [0, 25, 10, 25],
+        marker: undefined,
       },
     ];
     expect(dimensions).toEqual(expectedDimensions);
@@ -563,9 +569,10 @@ describe('annotation utils', () => {
     );
     const expectedDimensions = [
       {
-        position: [20, -DEFAULT_LINE_OVERFLOW, 20, 10],
+        position: [25, -DEFAULT_LINE_OVERFLOW, 25, 10],
         details: { detailsText: 'foo', headerText: '2' },
-        tooltipLinePosition: [0, 0, 10, 0],
+        tooltipLinePosition: [0, -5, 10, -5],
+        marker: undefined,
       },
     ];
     expect(dimensions).toEqual(expectedDimensions);
@@ -599,9 +606,10 @@ describe('annotation utils', () => {
     );
     const expectedDimensions = [
       {
-        position: [20, -DEFAULT_LINE_OVERFLOW, 20, 20],
+        position: [25, -DEFAULT_LINE_OVERFLOW, 25, 20],
         details: { detailsText: 'foo', headerText: '2' },
-        tooltipLinePosition: [20, 0, 20, 20],
+        tooltipLinePosition: [25, 0, 25, 20],
+        marker: undefined,
       },
     ];
     expect(dimensions).toEqual(expectedDimensions);
@@ -634,9 +642,10 @@ describe('annotation utils', () => {
     );
     const expectedDimensions = [
       {
-        position: [20, DEFAULT_LINE_OVERFLOW, 20, 20],
+        position: [25, DEFAULT_LINE_OVERFLOW, 25, 20],
         details: { detailsText: 'foo', headerText: '2' },
-        tooltipLinePosition: [20, DEFAULT_LINE_OVERFLOW, 20, 20],
+        tooltipLinePosition: [25, DEFAULT_LINE_OVERFLOW, 25, 20],
+        marker: undefined,
       },
     ];
     expect(dimensions).toEqual(expectedDimensions);
@@ -1466,7 +1475,7 @@ describe('annotation utils', () => {
 
     expect(unrotated).toEqual([{ rect: { x: 0, y: 0, width: 25, height: 20 } }]);
   });
-  test.only('should validate scaled dataValues', () => {
+  test('should validate scaled dataValues', () => {
     // not aligned with tick
     expect(scaleAndValidateDatum('', ordinalScale, false)).toBe(null);
     expect(scaleAndValidateDatum('a', continuousScale, false)).toBe(null);

--- a/src/chart_types/xy_chart/annotations/annotation_utils.test.ts
+++ b/src/chart_types/xy_chart/annotations/annotation_utils.test.ts
@@ -1482,9 +1482,6 @@ describe('annotation utils', () => {
 
     // aligned with tick
     expect(scaleAndValidateDatum(1.25, continuousScale, true)).toBe(12.5);
-    console.log(continuousScale.ticks());
-    console.log(continuousScale.tickValues);
-    console.log(continuousScale.range);
   });
   test('should determine if a point is within a rectangle annotation', () => {
     const cursorPosition = { x: 3, y: 4 };

--- a/src/chart_types/xy_chart/annotations/annotation_utils.ts
+++ b/src/chart_types/xy_chart/annotations/annotation_utils.ts
@@ -951,7 +951,6 @@ export function computeRectAnnotationTooltipState(
     const endY = startY + rect.height;
 
     const isWithinBounds = isWithinRectBounds(cursorPosition, { startX, endX, startY, endY });
-
     if (isWithinBounds) {
       annotationTooltipState.isVisible = true;
       annotationTooltipState.details = details;

--- a/src/chart_types/xy_chart/annotations/annotation_utils.ts
+++ b/src/chart_types/xy_chart/annotations/annotation_utils.ts
@@ -323,44 +323,9 @@ export function computeLineAnnotationDimensions(
   );
 }
 
-/**
- * Used when we need to snap values to the nearest tick edge, this performs a binary search for the nearest tick
- * @param dataValue - dataValue defined as an annotation cooordinate
- * @param ticks - ticks from the scale
- * @param minInterval - minInterva from the scale
- */
-export function getNearestTick(dataValue: number, ticks: number[], minInterval: number): number | undefined {
-  if (ticks.length === 0) {
-    return;
-  }
-
-  if (ticks.length === 1) {
-    if (Math.abs(dataValue - ticks[0]) <= minInterval / 2) {
-      return ticks[0];
-    }
-    return;
-  }
-
-  const numTicks = ticks.length - 1;
-  const midIdx = Math.ceil(numTicks / 2);
-  const midPoint = ticks[midIdx];
-
-  if (Math.abs(dataValue - midPoint) <= minInterval / 2) {
-    return midPoint;
-  }
-
-  if (dataValue > midPoint) {
-    return getNearestTick(dataValue, ticks.slice(midIdx, ticks.length), minInterval);
-  }
-
-  return getNearestTick(dataValue, ticks.slice(0, midIdx), minInterval);
-}
-
 export function scaleAndValidateDatum(dataValue: any, scale: Scale, alignWithTick: boolean): any | null {
   const isContinuous = scale.type !== ScaleType.Ordinal;
-  const value = isContinuous && alignWithTick ? getNearestTick(dataValue, scale.ticks(), scale.minInterval) : dataValue;
-  const scaledValue = scale.scale(value);
-
+  const scaledValue = scale.scale(dataValue);
   // d3.scale will return 0 for '', rendering the line incorrectly at 0
   if (isNaN(scaledValue) || (isContinuous && dataValue === '')) {
     return null;

--- a/src/chart_types/xy_chart/crosshair/crosshair_utils.linear_snap.test.ts
+++ b/src/chart_types/xy_chart/crosshair/crosshair_utils.linear_snap.test.ts
@@ -2,8 +2,8 @@ import { computeXScale } from '../utils/scales';
 import { BasicSeriesSpec } from '../utils/specs';
 import { Dimensions } from '../../../utils/dimensions';
 import { getGroupId, getSpecId } from '../../../utils/ids';
-import { ScaleType, Scale } from '../../../utils/scales/scales';
-import { getCursorBandPosition, getSnapPosition, getPosition } from './crosshair_utils';
+import { ScaleType } from '../../../utils/scales/scales';
+import { getCursorBandPosition, getSnapPosition } from './crosshair_utils';
 import { computeSeriesDomains } from '../store/utils';
 
 describe('Crosshair utils linear scale', () => {
@@ -200,48 +200,50 @@ describe('Crosshair utils linear scale', () => {
     const chartDimensions: Dimensions = { top: 0, left: 0, width: 120, height: 100 };
     const chartRotation = 0;
     const snapPosition = false;
+
     let bandPosition = getCursorBandPosition(
       chartRotation,
       chartDimensions,
       { x: 200, y: 0 },
+      lineSeriesScale.invertWithStep(200, [0, 1, 2]),
       snapPosition,
       lineSeriesScale,
-      [0, 1, 2],
       1,
     );
-    expect(bandPosition).toBeUndefined();
+    expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
+
     bandPosition = getCursorBandPosition(
       chartRotation,
       chartDimensions,
       { x: 0, y: 200 },
+      lineSeriesScale.invertWithStep(0, [0, 1, 2]),
       snapPosition,
       lineSeriesScale,
-      [0, 1, 2],
       1,
     );
-    expect(bandPosition).toBeUndefined();
+    expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
 
     bandPosition = getCursorBandPosition(
       chartRotation,
       chartDimensions,
       { x: -1, y: 0 },
+      lineSeriesScale.invertWithStep(-1, [0, 1, 2]),
       snapPosition,
       lineSeriesScale,
-      [0, 1, 2],
       1,
     );
-    expect(bandPosition).toBeUndefined();
+    expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
 
     bandPosition = getCursorBandPosition(
       chartRotation,
       chartDimensions,
       { x: 0, y: -1 },
+      lineSeriesScale.invertWithStep(0, [0, 1, 2]),
       snapPosition,
       lineSeriesScale,
-      [0, 1, 2],
       1,
     );
-    expect(bandPosition).toBeUndefined();
+    expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
   });
 
   describe('BandPosition line chart', () => {
@@ -256,9 +258,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 0 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -266,6 +268,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -274,9 +277,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 45 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -284,6 +287,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -292,9 +296,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 40, y: 0 },
+          lineSeriesScale.invertWithStep(40, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -302,6 +306,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -310,9 +315,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 90, y: 0 },
+          lineSeriesScale.invertWithStep(90, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -320,6 +325,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -328,12 +334,12 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 200, y: 0 },
+          lineSeriesScale.invertWithStep(200, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
-        expect(bandPosition).toBeUndefined();
+        expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
       });
     });
     describe('0 degree rotation, snap enabled', () => {
@@ -345,9 +351,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 0 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -355,6 +361,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -363,9 +370,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 45 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -373,6 +380,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -381,9 +389,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 20, y: 0 },
+          lineSeriesScale.invertWithStep(20, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -391,6 +399,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -399,9 +408,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 40, y: 0 },
+          lineSeriesScale.invertWithStep(40, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -409,6 +418,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -417,9 +427,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 95, y: 0 },
+          lineSeriesScale.invertWithStep(95, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -427,6 +437,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -435,12 +446,12 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 200, y: 0 },
+          lineSeriesScale.invertWithStep(200, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
-        expect(bandPosition).toBeUndefined();
+        expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
       });
     });
 
@@ -453,9 +464,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 0 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
 
@@ -464,6 +475,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -472,9 +484,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 45 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -482,6 +494,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -490,9 +503,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 40, y: 0 },
+          lineSeriesScale.invertWithStep(40, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -500,6 +513,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -508,9 +522,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 90, y: 0 },
+          lineSeriesScale.invertWithStep(90, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -518,6 +532,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -526,12 +541,12 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 200, y: 0 },
+          lineSeriesScale.invertWithStep(200, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
-        expect(bandPosition).toBeUndefined();
+        expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
       });
     });
 
@@ -544,9 +559,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 0 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -554,6 +569,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -562,9 +578,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 45 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -572,6 +588,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -580,9 +597,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 20, y: 0 },
+          lineSeriesScale.invertWithStep(20, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -590,6 +607,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -598,9 +616,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 40, y: 0 },
+          lineSeriesScale.invertWithStep(40, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -608,6 +626,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -616,9 +635,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 95, y: 0 },
+          lineSeriesScale.invertWithStep(95, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -626,6 +645,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 1,
+          visible: true,
         });
       });
 
@@ -634,12 +654,12 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 200, y: 0 },
+          lineSeriesScale.invertWithStep(200, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
-        expect(bandPosition).toBeUndefined();
+        expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
       });
     });
 
@@ -652,9 +672,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 0 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -662,6 +682,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -670,9 +691,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 45, y: 0 },
+          lineSeriesScale.invertWithStep(45, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -680,6 +701,7 @@ describe('Crosshair utils linear scale', () => {
           top: 45,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -688,9 +710,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 40 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -698,6 +720,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -706,9 +729,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 90 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -716,6 +739,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -724,12 +748,12 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 200 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
-        expect(bandPosition).toBeUndefined();
+        expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
       });
     });
 
@@ -742,9 +766,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 0 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -752,6 +776,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -760,9 +785,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 45, y: 0 },
+          lineSeriesScale.invertWithStep(45, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -770,6 +795,7 @@ describe('Crosshair utils linear scale', () => {
           top: 60,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -778,9 +804,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 20 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -788,6 +814,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -796,9 +823,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 40 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -806,6 +833,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -814,9 +842,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 95 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -824,6 +852,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -832,12 +861,12 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 200 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
-        expect(bandPosition).toBeUndefined();
+        expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
       });
     });
 
@@ -850,9 +879,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 0 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -860,6 +889,7 @@ describe('Crosshair utils linear scale', () => {
           top: 100,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -868,9 +898,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 45, y: 0 },
+          lineSeriesScale.invertWithStep(45, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -878,6 +908,7 @@ describe('Crosshair utils linear scale', () => {
           top: 55,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -886,9 +917,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 40 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -896,6 +927,7 @@ describe('Crosshair utils linear scale', () => {
           top: 100,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -904,9 +936,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 90 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -914,6 +946,7 @@ describe('Crosshair utils linear scale', () => {
           top: 100,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -922,12 +955,12 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 200 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
-        expect(bandPosition).toBeUndefined();
+        expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
       });
     });
 
@@ -940,9 +973,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 0 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -950,6 +983,7 @@ describe('Crosshair utils linear scale', () => {
           top: 100,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -958,9 +992,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 45, y: 0 },
+          lineSeriesScale.invertWithStep(45, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -968,6 +1002,7 @@ describe('Crosshair utils linear scale', () => {
           top: 40,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -976,9 +1011,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 20 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -986,6 +1021,7 @@ describe('Crosshair utils linear scale', () => {
           top: 100,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -994,9 +1030,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 40 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1004,6 +1040,7 @@ describe('Crosshair utils linear scale', () => {
           top: 100,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -1012,9 +1049,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 95 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1022,6 +1059,7 @@ describe('Crosshair utils linear scale', () => {
           top: 100,
           height: 1,
           width: 120,
+          visible: true,
         });
       });
 
@@ -1030,12 +1068,12 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 200 },
+          lineSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           lineSeriesScale,
-          [0, 1, 2],
           1,
         );
-        expect(bandPosition).toBeUndefined();
+        expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
       });
     });
   });
@@ -1051,9 +1089,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 0 },
+          barSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1061,6 +1099,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 40,
+          visible: true,
         });
       });
 
@@ -1069,9 +1108,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 45 },
+          barSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1079,6 +1118,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 40,
+          visible: true,
         });
       });
 
@@ -1086,10 +1126,10 @@ describe('Crosshair utils linear scale', () => {
         let bandPosition = getCursorBandPosition(
           chartRotation,
           chartDimensions,
-          { x: 39, y: 0 },
+          { x: 40, y: 0 },
+          barSeriesScale.invertWithStep(40, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1097,14 +1137,15 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 40,
+          visible: true,
         });
         bandPosition = getCursorBandPosition(
           chartRotation,
           chartDimensions,
-          { x: 40, y: 0 },
+          { x: 41, y: 0 },
+          barSeriesScale.invertWithStep(41, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1112,6 +1153,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 40,
+          visible: true,
         });
       });
 
@@ -1120,9 +1162,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 90, y: 0 },
+          barSeriesScale.invertWithStep(90, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1130,6 +1172,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 40,
+          visible: true,
         });
       });
 
@@ -1138,12 +1181,12 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 200, y: 0 },
+          barSeriesScale.invertWithStep(200, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
-        expect(bandPosition).toBeUndefined();
+        expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
       });
     });
 
@@ -1156,9 +1199,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 0 },
+          barSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1166,6 +1209,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 40,
+          visible: true,
         });
       });
 
@@ -1174,9 +1218,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 45 },
+          barSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1184,6 +1228,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 40,
+          visible: true,
         });
       });
 
@@ -1191,10 +1236,10 @@ describe('Crosshair utils linear scale', () => {
         const bandPosition = getCursorBandPosition(
           chartRotation,
           chartDimensions,
-          { x: 40, y: 0 },
+          { x: 41, y: 0 },
+          barSeriesScale.invertWithStep(41, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1202,6 +1247,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 40,
+          visible: true,
         });
       });
 
@@ -1210,9 +1256,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 90, y: 0 },
+          barSeriesScale.invertWithStep(90, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1220,6 +1266,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 100,
           width: 40,
+          visible: true,
         });
       });
 
@@ -1228,12 +1275,12 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 200, y: 0 },
+          barSeriesScale.invertWithStep(200, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
-        expect(bandPosition).toBeUndefined();
+        expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
       });
     });
 
@@ -1246,9 +1293,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 0 },
+          barSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1256,6 +1303,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 40,
           width: 120,
+          visible: true,
         });
       });
 
@@ -1264,9 +1312,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 45, y: 0 },
+          barSeriesScale.invertWithStep(45, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1274,6 +1322,7 @@ describe('Crosshair utils linear scale', () => {
           top: 40,
           height: 40,
           width: 120,
+          visible: true,
         });
       });
 
@@ -1282,9 +1331,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 40 },
+          barSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1292,6 +1341,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 40,
           width: 120,
+          visible: true,
         });
       });
 
@@ -1300,9 +1350,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 90 },
+          barSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1310,6 +1360,7 @@ describe('Crosshair utils linear scale', () => {
           top: 0,
           height: 40,
           width: 120,
+          visible: true,
         });
       });
 
@@ -1318,12 +1369,12 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 200 },
+          barSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
-        expect(bandPosition).toBeUndefined();
+        expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
       });
     });
 
@@ -1336,9 +1387,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 0 },
+          barSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1346,6 +1397,7 @@ describe('Crosshair utils linear scale', () => {
           top: 60,
           height: 40,
           width: 120,
+          visible: true,
         });
       });
 
@@ -1354,9 +1406,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 45, y: 0 },
+          barSeriesScale.invertWithStep(45, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1364,6 +1416,7 @@ describe('Crosshair utils linear scale', () => {
           top: 20,
           height: 40,
           width: 120,
+          visible: true,
         });
       });
 
@@ -1372,9 +1425,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 40 },
+          barSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1382,6 +1435,7 @@ describe('Crosshair utils linear scale', () => {
           top: 60,
           height: 40,
           width: 120,
+          visible: true,
         });
       });
 
@@ -1390,9 +1444,9 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 90 },
+          barSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
         expect(bandPosition).toEqual({
@@ -1400,6 +1454,7 @@ describe('Crosshair utils linear scale', () => {
           top: 60,
           height: 40,
           width: 120,
+          visible: true,
         });
       });
 
@@ -1408,35 +1463,13 @@ describe('Crosshair utils linear scale', () => {
           chartRotation,
           chartDimensions,
           { x: 0, y: 200 },
+          barSeriesScale.invertWithStep(0, [0, 1, 2]),
           snapPosition,
           barSeriesScale,
-          [0, 1, 2],
           1,
         );
-        expect(bandPosition).toBeUndefined();
+        expect(bandPosition).toEqual({ height: 0, left: -1, top: -1, visible: false, width: 0 });
       });
-    });
-  });
-
-  describe('getPosition', () => {
-    // @ts-ignore
-    const scale: Scale = {
-      scale: jest.fn(),
-    };
-
-    beforeEach(() => {
-      (scale.scale as jest.Mock).mockClear();
-    });
-
-    it('should return value from scale', () => {
-      (scale.scale as jest.Mock).mockReturnValue(20);
-      const result = getPosition(10, scale);
-      expect(result).toBe(20);
-    });
-
-    it('should call scale with correct args', () => {
-      getPosition(10, scale);
-      expect(scale.scale).toBeCalledWith(10);
     });
   });
 });

--- a/src/chart_types/xy_chart/store/chart_state.interactions.test.ts
+++ b/src/chart_types/xy_chart/store/chart_state.interactions.test.ts
@@ -247,6 +247,38 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     expect(store.yScales).not.toBeUndefined();
   });
 
+  test('set cursor from external source', () => {
+    store.setCursorValue(0);
+    expect(store.externalCursorShown.get()).toBe(true);
+    expect(store.cursorBandPosition).toEqual({
+      height: 100,
+      left: 10,
+      top: 10,
+      visible: true,
+      width: 50,
+    });
+
+    store.setCursorValue(1);
+    expect(store.externalCursorShown.get()).toBe(true);
+    expect(store.cursorBandPosition).toEqual({
+      height: 100,
+      left: 60,
+      top: 10,
+      visible: true,
+      width: 50,
+    });
+
+    store.setCursorValue(2);
+    expect(store.externalCursorShown.get()).toBe(true);
+    // equal to the latest except the visiblility
+    expect(store.cursorBandPosition).toEqual({
+      height: 100,
+      left: 60,
+      top: 10,
+      visible: false,
+      width: 50,
+    });
+  });
   test('can determine which tooltip to display if chart & annotation tooltips possible', () => {
     const annotationDimensions = [{ rect: { x: 49, y: -1, width: 3, height: 99 } }];
     const rectAnnotationSpec: RectAnnotationSpec = {

--- a/src/chart_types/xy_chart/store/chart_state.interactions.test.ts
+++ b/src/chart_types/xy_chart/store/chart_state.interactions.test.ts
@@ -248,7 +248,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
   });
 
   test('can determine which tooltip to display if chart & annotation tooltips possible', () => {
-    const annotationDimensions = [{ rect: { x: 49, y: -1, width: 2, height: 99 } }];
+    const annotationDimensions = [{ rect: { x: 49, y: -1, width: 3, height: 99 } }];
     const rectAnnotationSpec: RectAnnotationSpec = {
       annotationId: getAnnotationId('rect'),
       groupId: GROUP_ID,
@@ -258,9 +258,9 @@ function mouseOverTestSuite(scaleType: ScaleType) {
 
     store.annotationSpecs.set(rectAnnotationSpec.annotationId, rectAnnotationSpec);
     store.annotationDimensions.set(rectAnnotationSpec.annotationId, annotationDimensions);
-
+    debugger;
     // isHighlighted false, chart tooltip true; should show annotationTooltip only
-    store.setCursorPosition(chartLeft + 50, chartTop + 0);
+    store.setCursorPosition(chartLeft + 51, chartTop + 1);
     expect(store.isTooltipVisible.get()).toBe(false);
   });
 
@@ -308,8 +308,12 @@ function mouseOverTestSuite(scaleType: ScaleType) {
   });
 
   test('can hover top-right corner of the first bar', () => {
-    store.setCursorPosition(chartLeft + 49, chartTop + 0);
-    expect(store.cursorPosition).toEqual({ x: 49, y: 0 });
+    let scaleOffset = 0;
+    if (scaleType !== ScaleType.Ordinal) {
+      scaleOffset = 1;
+    }
+    store.setCursorPosition(chartLeft + 49 + scaleOffset, chartTop + 0);
+    expect(store.cursorPosition).toEqual({ x: 49 + scaleOffset, y: 0 });
     expect(store.cursorBandPosition.left).toBe(chartLeft + 0);
     expect(store.cursorBandPosition.width).toBe(50);
     expect(store.isTooltipVisible.get()).toBe(true);
@@ -319,8 +323,8 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     expect(onOutListener).toBeCalledTimes(0);
     expect(onOverListener.mock.calls[0][0]).toEqual([indexedGeom1Red.value]);
 
-    store.setCursorPosition(chartLeft + 50, chartTop + 0);
-    expect(store.cursorPosition).toEqual({ x: 50, y: 0 });
+    store.setCursorPosition(chartLeft + 50 + scaleOffset, chartTop + 0);
+    expect(store.cursorPosition).toEqual({ x: 50 + scaleOffset, y: 0 });
     expect(store.cursorBandPosition.left).toBe(chartLeft + 50);
     expect(store.cursorBandPosition.width).toBe(50);
     expect(store.isTooltipVisible.get()).toBe(true);
@@ -331,8 +335,12 @@ function mouseOverTestSuite(scaleType: ScaleType) {
   });
 
   test('can hover bottom-right corner of the first bar', () => {
-    store.setCursorPosition(chartLeft + 49, chartTop + 99);
-    expect(store.cursorPosition).toEqual({ x: 49, y: 99 });
+    let scaleOffset = 0;
+    if (scaleType !== ScaleType.Ordinal) {
+      scaleOffset = 1;
+    }
+    store.setCursorPosition(chartLeft + 49 + scaleOffset, chartTop + 99);
+    expect(store.cursorPosition).toEqual({ x: 49 + scaleOffset, y: 99 });
     expect(store.cursorBandPosition.left).toBe(chartLeft + 0);
     expect(store.cursorBandPosition.width).toBe(50);
     expect(store.isTooltipVisible.get()).toBe(true);
@@ -342,8 +350,8 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     expect(onOutListener).toBeCalledTimes(0);
     expect(onOverListener.mock.calls[0][0]).toEqual([indexedGeom1Red.value]);
 
-    store.setCursorPosition(chartLeft + 50, chartTop + 99);
-    expect(store.cursorPosition).toEqual({ x: 50, y: 99 });
+    store.setCursorPosition(chartLeft + 50 + scaleOffset, chartTop + 99);
+    expect(store.cursorPosition).toEqual({ x: 50 + scaleOffset, y: 99 });
     expect(store.cursorBandPosition.left).toBe(chartLeft + 50);
     expect(store.cursorBandPosition.width).toBe(50);
     expect(store.isTooltipVisible.get()).toBe(true);

--- a/src/chart_types/xy_chart/store/chart_state.test.ts
+++ b/src/chart_types/xy_chart/store/chart_state.test.ts
@@ -1008,47 +1008,4 @@ describe('Chart Store', () => {
       expect(store.activeChartId).toBeUndefined();
     });
   });
-
-  describe('setCursorValue', () => {
-    const getPosition = jest.fn();
-    // TODO: fix mocking implementation
-    jest.doMock('../crosshair/crosshair_utils', () => ({
-      getPosition,
-    }));
-
-    const scale = new ScaleContinuous({ type: ScaleType.Linear, domain: [0, 100], range: [0, 100] });
-    beforeEach(() => {
-      // @ts-ignore
-      store.setCursorPosition = jest.fn();
-    });
-
-    it('should not call setCursorPosition if xScale is not defined', () => {
-      store.xScale = undefined;
-      store.setCursorValue(1);
-      expect(store.setCursorPosition).not.toBeCalled();
-    });
-
-    it.skip('should call getPosition with args', () => {
-      (getPosition as jest.Mock).mockReturnValue(undefined);
-      store.xScale = scale;
-      store.setCursorValue(1);
-      expect(getPosition).toBeCalledWith(1, store.xScale);
-    });
-
-    it.skip('should not call setCursorPosition if xPosition is not defined', () => {
-      store.xScale = scale;
-      (getPosition as jest.Mock).mockReturnValue(undefined);
-      store.setCursorValue(1);
-      expect(store.setCursorPosition).not.toBeCalled();
-    });
-
-    it('should call setCursorPosition with correct args', () => {
-      store.xScale = scale;
-      store.chartDimensions.left = 10;
-      store.chartDimensions.top = 10;
-      (getPosition as jest.Mock).mockReturnValue(20);
-      store.setCursorValue(20);
-      expect(store.setCursorPosition).toBeCalledWith(30, 10, false);
-    });
-  });
 });

--- a/src/chart_types/xy_chart/store/chart_state.timescales.test.ts
+++ b/src/chart_types/xy_chart/store/chart_state.timescales.test.ts
@@ -153,13 +153,13 @@ describe('Render chart', () => {
       expect(store.xScale!.invert(0)).toBe(date1);
       expect(store.xScale!.invert(50)).toBe(date2);
       expect(store.xScale!.invert(100)).toBe(date3);
-      expect(store.xScale!.invertWithStep(5, xValues)).toBe(date1);
-      expect(store.xScale!.invertWithStep(20, xValues)).toBe(date1);
-      expect(store.xScale!.invertWithStep(30, xValues)).toBe(date2);
-      expect(store.xScale!.invertWithStep(50, xValues)).toBe(date2);
-      expect(store.xScale!.invertWithStep(70, xValues)).toBe(date2);
-      expect(store.xScale!.invertWithStep(80, xValues)).toBe(date3);
-      expect(store.xScale!.invertWithStep(100, xValues)).toBe(date3);
+      expect(store.xScale!.invertWithStep(5, xValues)).toEqual({ value: date1, withinBandwidth: true });
+      expect(store.xScale!.invertWithStep(20, xValues)).toEqual({ value: date1, withinBandwidth: true });
+      expect(store.xScale!.invertWithStep(30, xValues)).toEqual({ value: date2, withinBandwidth: true });
+      expect(store.xScale!.invertWithStep(50, xValues)).toEqual({ value: date2, withinBandwidth: true });
+      expect(store.xScale!.invertWithStep(70, xValues)).toEqual({ value: date2, withinBandwidth: true });
+      expect(store.xScale!.invertWithStep(80, xValues)).toEqual({ value: date3, withinBandwidth: true });
+      expect(store.xScale!.invertWithStep(100, xValues)).toEqual({ value: date3, withinBandwidth: true });
     });
     test('check mouse position correctly return inverted value', () => {
       store.setCursorPosition(15, 10); // check first valid tooltip

--- a/src/chart_types/xy_chart/store/chart_state.ts
+++ b/src/chart_types/xy_chart/store/chart_state.ts
@@ -276,7 +276,7 @@ export class ChartStore {
 
     const xPosition = this.xScale.pureScale(value);
 
-    if (xPosition > this.chartDimensions.width + this.chartDimensions.left) {
+    if (xPosition == null || xPosition > this.chartDimensions.width + this.chartDimensions.left) {
       this.clearTooltipAndHighlighted();
       return;
     }
@@ -315,6 +315,7 @@ export class ChartStore {
     if (!this.seriesDomainsAndData || this.tooltipType.get() === TooltipType.None) {
       return;
     }
+    this.externalCursorShown.set(false);
 
     // get positions relative to chart
     let xPos = x - this.chartDimensions.left;
@@ -359,10 +360,6 @@ export class ChartStore {
         value: xValue.value,
       });
     }
-    // if (!xValue.withinBandwidth) {
-    //   this.clearTooltipAndHighlighted();
-    //   return;
-    // }
 
     // update che cursorBandPosition based on chart configuration
     const isLineAreaOnly = isLineAreaOnlyChart(this.seriesSpecs);

--- a/src/chart_types/xy_chart/store/chart_state.ts
+++ b/src/chart_types/xy_chart/store/chart_state.ts
@@ -70,12 +70,7 @@ import {
   computeAnnotationDimensions,
   computeAnnotationTooltipState,
 } from '../annotations/annotation_utils';
-import {
-  getCursorBandPosition,
-  getCursorLinePosition,
-  getTooltipPosition,
-  getPosition,
-} from '../crosshair/crosshair_utils';
+import { getCursorBandPosition, getCursorLinePosition, getTooltipPosition } from '../crosshair/crosshair_utils';
 import {
   BrushExtent,
   computeBrushExtent,
@@ -116,6 +111,9 @@ export type LegendItemListener = (dataSeriesIdentifiers: DataSeriesColorsValues 
 export type CursorUpdateListener = (event?: CursorEvent) => void;
 
 export class ChartStore {
+  constructor(id?: string) {
+    this.id = id || uuid.v4();
+  }
   debug = false;
   id = uuid.v4();
   specsInitialized = observable.box(false);
@@ -195,12 +193,17 @@ export class ChartStore {
   cursorPosition = observable.object<{ x: number; y: number }>({ x: -1, y: -1 }, undefined, {
     deep: false,
   });
-  cursorBandPosition = observable.object<Dimensions>({ top: -1, left: -1, height: -1, width: -1 }, undefined, {
-    deep: false,
-  });
+  cursorBandPosition = observable.object<Dimensions & { visible: boolean }>(
+    { top: -1, left: -1, height: -1, width: -1, visible: false },
+    undefined,
+    {
+      deep: false,
+    },
+  );
   cursorLinePosition = observable.object<Dimensions>({ top: -1, left: -1, height: -1, width: -1 }, undefined, {
     deep: false,
   });
+  externalCursorShown = observable.box(false);
 
   onElementClickListener?: ElementClickListener;
   onElementOverListener?: ElementOverListener;
@@ -265,19 +268,42 @@ export class ChartStore {
   /**
    * set the x value of the cursor
    */
-  setCursorValue = (value: string | number) => {
+  setCursorValue = action((value: string | number) => {
     if (!this.xScale) {
       return;
     }
+    this.externalCursorShown.set(true);
 
-    const xPosition = getPosition(value, this.xScale);
+    const xPosition = this.xScale.pureScale(value);
 
-    if (xPosition === undefined) {
+    if (xPosition > this.chartDimensions.width + this.chartDimensions.left) {
+      this.clearTooltipAndHighlighted();
       return;
     }
 
-    this.setCursorPosition(xPosition + this.chartDimensions.left, this.chartDimensions.top, false);
-  };
+    const isLineAreaOnly = isLineAreaOnlyChart(this.seriesSpecs);
+
+    const updatedCursorBand = getCursorBandPosition(
+      this.chartRotation,
+      this.chartDimensions,
+      { x: xPosition, y: 0 },
+      {
+        value,
+        withinBandwidth: true,
+      },
+      this.isTooltipSnapEnabled.get(),
+      this.xScale,
+      isLineAreaOnly ? 1 : this.totalBarsInCluster,
+    );
+    if (xPosition === undefined) {
+      return;
+    }
+    if (updatedCursorBand.visible === false) {
+      this.clearTooltipAndHighlighted();
+      return;
+    }
+    Object.assign(this.cursorBandPosition, updatedCursorBand);
+  });
 
   /**
    * x and y values are relative to the container.
@@ -293,7 +319,6 @@ export class ChartStore {
     // get positions relative to chart
     let xPos = x - this.chartDimensions.left;
     let yPos = y - this.chartDimensions.top;
-
     // limit cursorPosition to chartDimensions
     // note: to debug and inspect tooltip html, just comment the following ifs
     if (xPos < 0 || xPos >= this.chartDimensions.width) {
@@ -307,6 +332,9 @@ export class ChartStore {
 
     // hide tooltip if outside chart dimensions
     if (yPos === -1 || xPos === -1) {
+      if (this.onCursorUpdateListener && this.isActiveChart.get()) {
+        this.onCursorUpdateListener();
+      }
       this.clearTooltipAndHighlighted();
       return;
     }
@@ -323,18 +351,18 @@ export class ChartStore {
 
     // invert the cursor position to get the scale value
     const xValue = this.xScale.invertWithStep(xAxisCursorPosition, this.geometriesIndexKeys);
-
     if (updateCursor && this.onCursorUpdateListener) {
-      // Get non-stepped xValue
-      const value = this.xScale.invert(xAxisCursorPosition);
-
       this.onCursorUpdateListener({
         chartId: this.id,
         scale: this.xScale.type,
         unit: this.xScale.unit,
-        value,
+        value: xValue.value,
       });
     }
+    // if (!xValue.withinBandwidth) {
+    //   this.clearTooltipAndHighlighted();
+    //   return;
+    // }
 
     // update che cursorBandPosition based on chart configuration
     const isLineAreaOnly = isLineAreaOnlyChart(this.seriesSpecs);
@@ -342,12 +370,12 @@ export class ChartStore {
       this.chartRotation,
       this.chartDimensions,
       { x: xAxisCursorPosition, y: yAxisCursorPosition },
+      xValue,
       this.isTooltipSnapEnabled.get(),
       this.xScale,
-      this.geometriesIndexKeys,
       isLineAreaOnly ? 1 : this.totalBarsInCluster,
     );
-    if (updatedCursorBand === undefined) {
+    if (updatedCursorBand.visible === false) {
       this.clearTooltipAndHighlighted();
       return;
     }
@@ -367,7 +395,7 @@ export class ChartStore {
     );
 
     // get the elements on at this cursor position
-    const elements = this.geometriesIndex.get(xValue);
+    const elements = this.geometriesIndex.get(xValue.value);
 
     // if no element, hide everything
     if (!elements || elements.length === 0) {
@@ -521,8 +549,7 @@ export class ChartStore {
     return (
       !this.isBrushing.get() &&
       isCrosshairTooltipType(this.tooltipType.get()) &&
-      this.cursorPosition.x > -1 &&
-      this.cursorPosition.y > -1
+      (this.externalCursorShown.get() || (this.cursorPosition.x > -1 && this.cursorPosition.y > -1))
     );
   });
 
@@ -539,9 +566,7 @@ export class ChartStore {
     this.highlightedGeometries.clear();
     this.tooltipData.clear();
 
-    if (this.onCursorUpdateListener && this.isActiveChart.get()) {
-      this.onCursorUpdateListener();
-    }
+    Object.assign(this.cursorBandPosition, { visible: false });
   });
 
   setShowLegend = action((showLegend: boolean) => {
@@ -664,8 +689,8 @@ export class ChartStore {
       return;
     }
     this.isBrushing.set(false);
-    const minValue = start.x < end.x ? start.x : end.x;
-    const maxValue = start.x > end.x ? start.x : end.x;
+    const minValue = Math.min(start.x, end.x);
+    const maxValue = Math.max(start.x, end.x);
     if (maxValue === minValue) {
       // if 0 size brush, avoid computing the value
       return;

--- a/src/chart_types/xy_chart/utils/scales.test.ts
+++ b/src/chart_types/xy_chart/utils/scales.test.ts
@@ -24,8 +24,8 @@ describe('Series scales', () => {
   test('should compute X Scale linear min, max with bands', () => {
     const scale = computeXScale({ xDomain: xDomainLinear, totalBarsInCluster: 1, range: [0, 120] });
     const expectedBandwidth = 120 / 4;
-    expect(scale.bandwidth).toBe(expectedBandwidth);
-    expect(scale.scale(0)).toBe(expectedBandwidth * 0);
+    expect(scale.bandwidth).toBe(120 / 4);
+    expect(scale.scale(0)).toBe(0);
     expect(scale.scale(1)).toBe(expectedBandwidth * 1);
     expect(scale.scale(2)).toBe(expectedBandwidth * 2);
     expect(scale.scale(3)).toBe(expectedBandwidth * 3);
@@ -65,6 +65,7 @@ describe('Series scales', () => {
       });
       expect(scale.bandwidth).toBe(maxRange);
       expect(scale.domain).toEqual([singleDomainValue, singleDomainValue + minInterval]);
+      // reducing of 1 pixel the range for band scale
       expect(scale.range).toEqual([0, maxRange]);
     });
 

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -23,6 +23,7 @@ interface ChartProps {
   renderer: 'svg' | 'canvas';
   size?: ChartSize;
   className?: string;
+  id?: string;
 }
 
 interface ChartState {
@@ -36,7 +37,7 @@ export class Chart extends React.Component<ChartProps, ChartState> {
   private chartSpecStore: ChartStore;
   constructor(props: any) {
     super(props);
-    this.chartSpecStore = new ChartStore();
+    this.chartSpecStore = new ChartStore(props.id);
     this.state = {
       legendPosition: this.chartSpecStore.legendPosition.get(),
     };
@@ -63,9 +64,7 @@ export class Chart extends React.Component<ChartProps, ChartState> {
     const isActiveChart = this.chartSpecStore.isActiveChart.get();
 
     if (!event) {
-      if (!isActiveChart) {
-        this.chartSpecStore.setCursorPosition(-1, -1);
-      }
+      this.chartSpecStore.externalCursorShown.set(false);
     } else {
       if (
         !isActiveChart &&

--- a/src/components/crosshair.tsx
+++ b/src/components/crosshair.tsx
@@ -23,7 +23,6 @@ class CrosshairComponent extends React.Component<CrosshairProps> {
     if (!isCrosshairVisible.get()) {
       return <div className="echCrosshair" />;
     }
-
     return (
       <div className="echCrosshair">
         {this.renderBand()}
@@ -37,15 +36,18 @@ class CrosshairComponent extends React.Component<CrosshairProps> {
       chartTheme: {
         crosshair: { band },
       },
-      cursorBandPosition,
+      cursorBandPosition: { top, left, width, height, visible },
       tooltipType,
     } = this.props.chartStore!;
-
-    if (!canRenderBand(tooltipType.get(), band.visible)) {
+    if (!visible || !canRenderBand(tooltipType.get(), band.visible)) {
       return null;
     }
+
     const style: CSSProperties = {
-      ...cursorBandPosition,
+      top,
+      left,
+      width,
+      height,
       background: band.fill,
     };
 

--- a/src/utils/scales/scale_band.ts
+++ b/src/utils/scales/scale_band.ts
@@ -52,6 +52,9 @@ export class ScaleBand implements Scale {
   scale(value: any) {
     return this.d3Scale(value);
   }
+  pureScale(value: any) {
+    return this.d3Scale(value);
+  }
 
   ticks() {
     return this.domain;
@@ -60,7 +63,10 @@ export class ScaleBand implements Scale {
     return this.invertedScale(value);
   }
   invertWithStep(value: any) {
-    return this.invertedScale(value);
+    return {
+      value: this.invertedScale(value),
+      withinBandwidth: true,
+    };
   }
   isSingleValue() {
     return this.domain.length < 2;

--- a/src/utils/scales/scale_continuous.test.ts
+++ b/src/utils/scales/scale_continuous.test.ts
@@ -48,25 +48,25 @@ describe('Scale Continuous', () => {
     const range: [number, number] = [0, 2];
     const scaleLinear = new ScaleContinuous({ type: ScaleType.Linear, domain, range });
     expect(scaleLinear.bandwidth).toBe(0);
-    expect(scaleLinear.invertWithStep(0, data)).toBe(0);
-    expect(scaleLinear.invertWithStep(0.1, data)).toBe(0);
+    expect(scaleLinear.invertWithStep(0, data)).toEqual({ value: 0, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(0.1, data)).toEqual({ value: 0, withinBandwidth: true });
 
-    expect(scaleLinear.invertWithStep(0.4, data)).toBe(0.5);
-    expect(scaleLinear.invertWithStep(0.5, data)).toBe(0.5);
-    expect(scaleLinear.invertWithStep(0.6, data)).toBe(0.5);
+    expect(scaleLinear.invertWithStep(0.4, data)).toEqual({ value: 0.5, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(0.5, data)).toEqual({ value: 0.5, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(0.6, data)).toEqual({ value: 0.5, withinBandwidth: true });
 
-    expect(scaleLinear.invertWithStep(0.7, data)).toBe(0.8);
-    expect(scaleLinear.invertWithStep(0.8, data)).toBe(0.8);
-    expect(scaleLinear.invertWithStep(0.9, data)).toBe(0.8);
+    expect(scaleLinear.invertWithStep(0.7, data)).toEqual({ value: 0.8, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(0.8, data)).toEqual({ value: 0.8, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(0.9, data)).toEqual({ value: 0.8, withinBandwidth: true });
 
-    expect(scaleLinear.invertWithStep(2, data)).toBe(2);
+    expect(scaleLinear.invertWithStep(2, data)).toEqual({ value: 2, withinBandwidth: true });
 
-    expect(scaleLinear.invertWithStep(1.7, data)).toBe(2);
+    expect(scaleLinear.invertWithStep(1.7, data)).toEqual({ value: 2, withinBandwidth: true });
 
-    expect(scaleLinear.invertWithStep(0.8 + (2 - 0.8) / 2, data)).toBe(0.8);
-    expect(scaleLinear.invertWithStep(0.8 + (2 - 0.8) / 2 - 0.01, data)).toBe(0.8);
+    expect(scaleLinear.invertWithStep(0.8 + (2 - 0.8) / 2, data)).toEqual({ value: 0.8, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(0.8 + (2 - 0.8) / 2 - 0.01, data)).toEqual({ value: 0.8, withinBandwidth: true });
 
-    expect(scaleLinear.invertWithStep(0.8 + (2 - 0.8) / 2 + 0.01, data)).toBe(2);
+    expect(scaleLinear.invertWithStep(0.8 + (2 - 0.8) / 2 + 0.01, data)).toEqual({ value: 2, withinBandwidth: true });
   });
   test('invert with step x value on linear band scale', () => {
     const data = [0, 1, 2];
@@ -78,17 +78,18 @@ describe('Scale Continuous', () => {
       type: 'xDomain',
     };
 
-    const scaleLinear = computeXScale({ xDomain, totalBarsInCluster: 1, range: [0, 120], barsPadding: 0 });
-    expect(scaleLinear.bandwidth).toBe(40);
-    expect(scaleLinear.invertWithStep(0, data)).toBe(0);
-    expect(scaleLinear.invertWithStep(40, data)).toBe(1);
+    const scaleLinear = computeXScale({ xDomain, totalBarsInCluster: 1, range: [0, 119], barsPadding: 0 });
+    expect(scaleLinear.bandwidth).toBe(119 / 3);
+    expect(scaleLinear.invertWithStep(0, data)).toEqual({ value: 0, withinBandwidth: true });
 
-    expect(scaleLinear.invertWithStep(41, data)).toBe(1);
-    expect(scaleLinear.invertWithStep(79, data)).toBe(1);
+    expect(scaleLinear.invertWithStep(40, data)).toEqual({ value: 1, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(41, data)).toEqual({ value: 1, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(79, data)).toEqual({ value: 1, withinBandwidth: true });
 
-    expect(scaleLinear.invertWithStep(80, data)).toBe(2);
-    expect(scaleLinear.invertWithStep(81, data)).toBe(2);
-    expect(scaleLinear.invertWithStep(120, data)).toBe(2);
+    expect(scaleLinear.invertWithStep(80, data)).toEqual({ value: 2, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(81, data)).toEqual({ value: 2, withinBandwidth: true });
+
+    expect(scaleLinear.invertWithStep(120, data)).toEqual({ value: 3, withinBandwidth: false });
   });
   test('can get the right x value on linear scale with regular band 1', () => {
     const domain = [0, 100];
@@ -102,15 +103,13 @@ describe('Scale Continuous', () => {
       { bandwidth: 10, minInterval: 10 },
     );
     expect(scaleLinear.bandwidth).toBe(10);
-    expect(scaleLinear.invertWithStep(0, data)).toBe(0);
-    expect(scaleLinear.invertWithStep(10, data)).toBe(10);
-    expect(scaleLinear.invertWithStep(20, data)).toBe(20);
-    expect(scaleLinear.invertWithStep(90, data)).toBe(90);
+    expect(scaleLinear.invertWithStep(0, data)).toEqual({ value: 0, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(10, data)).toEqual({ value: 10, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(20, data)).toEqual({ value: 20, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(90, data)).toEqual({ value: 90, withinBandwidth: true });
   });
   test('can get the right x value on linear scale with band', () => {
     const data = [0, 10, 20, 50, 90];
-    // we tweak the maxRange removing the bandwidth to correctly compute
-    // a band linear scale in computeXScale
 
     const xDomain: XDomain = {
       domain: [0, 100],
@@ -119,28 +118,33 @@ describe('Scale Continuous', () => {
       scaleType: ScaleType.Linear,
       type: 'xDomain',
     };
+    // we tweak the maxRange removing the bandwidth to correctly compute
+    // a band linear scale in computeXScale
+    const scaleLinear = computeXScale({ xDomain, totalBarsInCluster: 1, range: [0, 109], barsPadding: 0 });
+    expect(scaleLinear.bandwidth).toBe(109 / 11);
 
-    const scaleLinear = computeXScale({ xDomain, totalBarsInCluster: 1, range: [0, 110], barsPadding: 0 });
-    // const scaleLinear = new ScaleContinuous({type: ScaleType.Linear, domain, range}, 10, 10);
-    expect(scaleLinear.bandwidth).toBe(10);
+    expect(scaleLinear.invertWithStep(0, data)).toEqual({ value: 0, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(9, data)).toEqual({ value: 0, withinBandwidth: true });
 
-    expect(scaleLinear.invertWithStep(0, data)).toBe(0);
-    expect(scaleLinear.invertWithStep(5, data)).toBe(0);
-    expect(scaleLinear.invertWithStep(9, data)).toBe(0);
+    expect(scaleLinear.invertWithStep(10, data)).toEqual({ value: 10, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(19, data)).toEqual({ value: 10, withinBandwidth: true });
 
-    expect(scaleLinear.invertWithStep(10, data)).toBe(10);
-    expect(scaleLinear.invertWithStep(11, data)).toBe(10);
-    expect(scaleLinear.invertWithStep(19, data)).toBe(10);
+    expect(scaleLinear.invertWithStep(20, data)).toEqual({ value: 20, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(29, data)).toEqual({ value: 20, withinBandwidth: true });
 
-    expect(scaleLinear.invertWithStep(20, data)).toBe(20);
-    expect(scaleLinear.invertWithStep(21, data)).toBe(20);
-    expect(scaleLinear.invertWithStep(25, data)).toBe(20);
-    expect(scaleLinear.invertWithStep(29, data)).toBe(20);
-    expect(scaleLinear.invertWithStep(30, data)).toBe(20);
-    expect(scaleLinear.invertWithStep(39, data)).toBe(20);
-    expect(scaleLinear.invertWithStep(40, data)).toBe(50);
-    expect(scaleLinear.invertWithStep(50, data)).toBe(50);
-    expect(scaleLinear.invertWithStep(90, data)).toBe(90);
+    expect(scaleLinear.invertWithStep(30, data)).toEqual({ value: 30, withinBandwidth: false });
+    expect(scaleLinear.invertWithStep(39, data)).toEqual({ value: 30, withinBandwidth: false });
+
+    expect(scaleLinear.invertWithStep(40, data)).toEqual({ value: 40, withinBandwidth: false });
+
+    expect(scaleLinear.invertWithStep(50, data)).toEqual({ value: 50, withinBandwidth: true });
+    expect(scaleLinear.invertWithStep(59, data)).toEqual({ value: 50, withinBandwidth: true });
+
+    expect(scaleLinear.invertWithStep(60, data)).toEqual({ value: 60, withinBandwidth: false });
+
+    expect(scaleLinear.invertWithStep(90, data)).toEqual({ value: 90, withinBandwidth: true });
+
+    expect(scaleLinear.invertWithStep(100, data)).toEqual({ value: 100, withinBandwidth: false });
   });
 
   describe('isSingleValue', () => {

--- a/src/utils/scales/scale_continuous.ts
+++ b/src/utils/scales/scale_continuous.ts
@@ -186,7 +186,12 @@ export class ScaleContinuous implements Scale {
   scale(value: any) {
     return this.d3Scale(value) + (this.bandwidthPadding / 2) * this.totalBarsInCluster;
   }
-
+  pureScale(value: any) {
+    if (this.bandwidth === 0) {
+      return this.d3Scale(value);
+    }
+    return this.d3Scale(value + this.minInterval / 2);
+  }
   ticks() {
     return this.tickValues;
   }
@@ -197,34 +202,44 @@ export class ScaleContinuous implements Scale {
     }
     return invertedValue;
   }
-  invertWithStep(value: number, data: number[]): any {
-    const invertedValue = this.invert(value - this.bandwidth / 2);
-    const leftIndex = bisectLeft(data, invertedValue);
+  invertWithStep(
+    value: number,
+    data: number[],
+  ): {
+    value: any;
+    withinBandwidth: boolean;
+  } {
+    const invertedValue = this.invert(value);
+    const bisectValue = this.bandwidth === 0 ? invertedValue + this.minInterval / 2 : invertedValue;
+    const leftIndex = bisectLeft(data, bisectValue);
+    // console.log({ invertedValue, bisectValue, leftIndex });
     if (leftIndex === 0) {
-      // is equal or less than the first value
-      const prevValue1 = data[leftIndex];
-      if (data.length === 0) {
-        return prevValue1;
-      }
-      const nextValue1 = data[leftIndex + 1];
-      const nextDiff1 = Math.abs(nextValue1 - invertedValue);
-      const prevDiff1 = Math.abs(invertedValue - prevValue1);
-      if (nextDiff1 < prevDiff1) {
-        return nextValue1;
-      }
-      return prevValue1;
+      return {
+        value: data[0],
+        withinBandwidth: true,
+      };
     }
-    if (leftIndex === data.length) {
-      return data[leftIndex - 1];
+    const currentValue = data[leftIndex - 1];
+    // pure linear scale
+    if (this.minInterval === 0) {
+      const nextValue = data[leftIndex];
+      const nextDiff = Math.abs(nextValue - invertedValue);
+      const prevDiff = Math.abs(invertedValue - currentValue);
+      return {
+        value: nextDiff <= prevDiff ? nextValue : currentValue,
+        withinBandwidth: true,
+      };
     }
-    const nextValue = data[leftIndex];
-    const prevValue = data[leftIndex - 1];
-    const nextDiff = Math.abs(nextValue - invertedValue);
-    const prevDiff = Math.abs(invertedValue - prevValue);
-    if (nextDiff <= prevDiff) {
-      return nextValue;
+    if (invertedValue - currentValue <= this.minInterval) {
+      return {
+        value: currentValue,
+        withinBandwidth: true,
+      };
     }
-    return prevValue;
+    return {
+      value: currentValue + this.minInterval * Math.floor((invertedValue - currentValue) / this.minInterval),
+      withinBandwidth: false,
+    };
   }
   isSingleValue() {
     if (this.domain.length < 2) {

--- a/src/utils/scales/scale_continuous.ts
+++ b/src/utils/scales/scale_continuous.ts
@@ -212,7 +212,7 @@ export class ScaleContinuous implements Scale {
     const invertedValue = this.invert(value);
     const bisectValue = this.bandwidth === 0 ? invertedValue + this.minInterval / 2 : invertedValue;
     const leftIndex = bisectLeft(data, bisectValue);
-    // console.log({ invertedValue, bisectValue, leftIndex });
+
     if (leftIndex === 0) {
       return {
         value: data[0],

--- a/src/utils/scales/scale_time.test.ts
+++ b/src/utils/scales/scale_time.test.ts
@@ -72,7 +72,7 @@ describe('[Scale Time] - timezones', () => {
       const data = [startTime, midTime, endTime];
       const domain = [startTime, endTime];
       const minRange = 0;
-      const maxRange = 100;
+      const maxRange = 99;
       const minInterval = (endTime - startTime) / 2;
       const scale = new ScaleContinuous(
         {
@@ -83,15 +83,15 @@ describe('[Scale Time] - timezones', () => {
         { bandwidth: undefined, minInterval, timeZone: 'local' },
       );
       expect(scale.invert(0)).toBe(startTime);
-      expect(scale.invert(50)).toBe(midTime);
-      expect(scale.invert(100)).toBe(endTime);
-      expect(scale.invertWithStep(0, data)).toBe(startTime);
-      expect(scale.invertWithStep(24, data)).toBe(startTime);
-      expect(scale.invertWithStep(25, data)).toBe(midTime);
-      expect(scale.invertWithStep(50, data)).toBe(midTime);
-      expect(scale.invertWithStep(74, data)).toBe(midTime);
-      expect(scale.invertWithStep(76, data)).toBe(endTime);
-      expect(scale.invertWithStep(100, data)).toBe(endTime);
+      expect(scale.invert(49.5)).toBe(midTime);
+      expect(scale.invert(99)).toBe(endTime);
+      expect(scale.invertWithStep(0, data)).toEqual({ value: startTime, withinBandwidth: true });
+      expect(scale.invertWithStep(24, data)).toEqual({ value: startTime, withinBandwidth: true });
+      expect(scale.invertWithStep(25, data)).toEqual({ value: midTime, withinBandwidth: true });
+      expect(scale.invertWithStep(50, data)).toEqual({ value: midTime, withinBandwidth: true });
+      expect(scale.invertWithStep(74, data)).toEqual({ value: midTime, withinBandwidth: true });
+      expect(scale.invertWithStep(76, data)).toEqual({ value: endTime, withinBandwidth: true });
+      expect(scale.invertWithStep(100, data)).toEqual({ value: endTime, withinBandwidth: true });
       expect(scale.tickValues.length).toBe(9);
       expect(scale.tickValues[0]).toEqual(startTime);
       expect(scale.tickValues[4]).toEqual(midTime);
@@ -104,22 +104,22 @@ describe('[Scale Time] - timezones', () => {
       const data = [startTime, midTime, endTime];
       const domain = [startTime, endTime];
       const minRange = 0;
-      const maxRange = 100;
+      const maxRange = 99;
       const minInterval = (endTime - startTime) / 2;
       const scale = new ScaleContinuous(
         { type: ScaleType.Time, domain, range: [minRange, maxRange] },
         { bandwidth: undefined, minInterval, timeZone: 'utc' },
       );
       expect(scale.invert(0)).toBe(startTime);
-      expect(scale.invert(50)).toBe(midTime);
-      expect(scale.invert(100)).toBe(endTime);
-      expect(scale.invertWithStep(0, data)).toBe(startTime);
-      expect(scale.invertWithStep(24, data)).toBe(startTime);
-      expect(scale.invertWithStep(25, data)).toBe(midTime);
-      expect(scale.invertWithStep(50, data)).toBe(midTime);
-      expect(scale.invertWithStep(74, data)).toBe(midTime);
-      expect(scale.invertWithStep(75, data)).toBe(endTime);
-      expect(scale.invertWithStep(100, data)).toBe(endTime);
+      expect(scale.invert(49.5)).toBe(midTime);
+      expect(scale.invert(99)).toBe(endTime);
+      expect(scale.invertWithStep(0, data)).toEqual({ value: startTime, withinBandwidth: true });
+      expect(scale.invertWithStep(24, data)).toEqual({ value: startTime, withinBandwidth: true });
+      expect(scale.invertWithStep(25, data)).toEqual({ value: midTime, withinBandwidth: true });
+      expect(scale.invertWithStep(50, data)).toEqual({ value: midTime, withinBandwidth: true });
+      expect(scale.invertWithStep(74, data)).toEqual({ value: midTime, withinBandwidth: true });
+      expect(scale.invertWithStep(75, data)).toEqual({ value: endTime, withinBandwidth: true });
+      expect(scale.invertWithStep(100, data)).toEqual({ value: endTime, withinBandwidth: true });
       expect(scale.tickValues.length).toBe(9);
       expect(scale.tickValues[0]).toEqual(startTime);
       expect(scale.tickValues[4]).toEqual(midTime);
@@ -132,7 +132,7 @@ describe('[Scale Time] - timezones', () => {
       const data = [startTime, midTime, endTime];
       const domain = [startTime, endTime];
       const minRange = 0;
-      const maxRange = 100;
+      const maxRange = 99;
       const minInterval = (endTime - startTime) / 2;
       const scale = new ScaleContinuous(
         {
@@ -143,15 +143,17 @@ describe('[Scale Time] - timezones', () => {
         { bandwidth: undefined, minInterval, timeZone: 'utc+8' },
       );
       expect(scale.invert(0)).toBe(startTime);
-      expect(scale.invert(50)).toBe(midTime);
-      expect(scale.invert(100)).toBe(endTime);
-      expect(scale.invertWithStep(0, data)).toBe(startTime);
-      expect(scale.invertWithStep(24, data)).toBe(startTime);
-      expect(scale.invertWithStep(25, data)).toBe(midTime);
-      expect(scale.invertWithStep(50, data)).toBe(midTime);
-      expect(scale.invertWithStep(74, data)).toBe(midTime);
-      expect(scale.invertWithStep(75, data)).toBe(endTime);
-      expect(scale.invertWithStep(100, data)).toBe(endTime);
+      expect(scale.invert(49.5)).toBe(midTime);
+      expect(scale.invert(99)).toBe(endTime);
+      expect(scale.invertWithStep(0, data)).toEqual({ value: startTime, withinBandwidth: true });
+      expect(scale.invertWithStep(24, data)).toEqual({ value: startTime, withinBandwidth: true });
+
+      expect(scale.invertWithStep(25, data)).toEqual({ value: midTime, withinBandwidth: true });
+      expect(scale.invertWithStep(50, data)).toEqual({ value: midTime, withinBandwidth: true });
+      expect(scale.invertWithStep(74, data)).toEqual({ value: midTime, withinBandwidth: true });
+
+      expect(scale.invertWithStep(75, data)).toEqual({ value: endTime, withinBandwidth: true });
+      expect(scale.invertWithStep(100, data)).toEqual({ value: endTime, withinBandwidth: true });
       expect(scale.tickValues.length).toBe(9);
       expect(scale.tickValues[0]).toEqual(startTime);
       expect(scale.tickValues[4]).toEqual(midTime);
@@ -164,7 +166,7 @@ describe('[Scale Time] - timezones', () => {
       const data = [startTime, midTime, endTime];
       const domain = [startTime, endTime];
       const minRange = 0;
-      const maxRange = 100;
+      const maxRange = 99;
       const minInterval = (endTime - startTime) / 2;
       const scale = new ScaleContinuous(
         {
@@ -175,15 +177,18 @@ describe('[Scale Time] - timezones', () => {
         { bandwidth: undefined, minInterval, timeZone: 'utc-8' },
       );
       expect(scale.invert(0)).toBe(startTime);
-      expect(scale.invert(50)).toBe(midTime);
-      expect(scale.invert(100)).toBe(endTime);
-      expect(scale.invertWithStep(0, data)).toBe(startTime);
-      expect(scale.invertWithStep(24, data)).toBe(startTime);
-      expect(scale.invertWithStep(25, data)).toBe(midTime);
-      expect(scale.invertWithStep(50, data)).toBe(midTime);
-      expect(scale.invertWithStep(74, data)).toBe(midTime);
-      expect(scale.invertWithStep(75, data)).toBe(endTime);
-      expect(scale.invertWithStep(100, data)).toBe(endTime);
+      expect(scale.invert(49.5)).toBe(midTime);
+      expect(scale.invert(99)).toBe(endTime);
+
+      expect(scale.invertWithStep(0, data)).toEqual({ value: startTime, withinBandwidth: true });
+      expect(scale.invertWithStep(24, data)).toEqual({ value: startTime, withinBandwidth: true });
+
+      expect(scale.invertWithStep(25, data)).toEqual({ value: midTime, withinBandwidth: true });
+      expect(scale.invertWithStep(50, data)).toEqual({ value: midTime, withinBandwidth: true });
+      expect(scale.invertWithStep(74, data)).toEqual({ value: midTime, withinBandwidth: true });
+
+      expect(scale.invertWithStep(75, data)).toEqual({ value: endTime, withinBandwidth: true });
+      expect(scale.invertWithStep(100, data)).toEqual({ value: endTime, withinBandwidth: true });
       expect(scale.tickValues.length).toBe(9);
       expect(scale.tickValues[0]).toEqual(startTime);
       expect(scale.tickValues[4]).toEqual(midTime);
@@ -200,7 +205,7 @@ describe('[Scale Time] - timezones', () => {
         const data = [startTime, midTime, endTime];
         const domain = [startTime, endTime];
         const minRange = 0;
-        const maxRange = 100;
+        const maxRange = 99;
         const minInterval = (endTime - startTime) / 2;
         const scale = new ScaleContinuous(
           { type: ScaleType.Time, domain, range: [minRange, maxRange] },
@@ -210,15 +215,15 @@ describe('[Scale Time] - timezones', () => {
           return DateTime.fromMillis(d, { zone: timezone }).toISO();
         };
         expect(scale.invert(0)).toBe(startTime);
-        expect(scale.invert(50)).toBe(midTime);
-        expect(scale.invert(100)).toBe(endTime);
-        expect(scale.invertWithStep(0, data)).toBe(startTime);
-        expect(scale.invertWithStep(24, data)).toBe(startTime);
-        expect(scale.invertWithStep(25, data)).toBe(midTime);
-        expect(scale.invertWithStep(50, data)).toBe(midTime);
-        expect(scale.invertWithStep(74, data)).toBe(midTime);
-        expect(scale.invertWithStep(75, data)).toBe(endTime);
-        expect(scale.invertWithStep(100, data)).toBe(endTime);
+        expect(scale.invert(49.5)).toBe(midTime);
+        expect(scale.invert(99)).toBe(endTime);
+        expect(scale.invertWithStep(0, data)).toEqual({ value: startTime, withinBandwidth: true });
+        expect(scale.invertWithStep(24, data)).toEqual({ value: startTime, withinBandwidth: true });
+        expect(scale.invertWithStep(25, data)).toEqual({ value: midTime, withinBandwidth: true });
+        expect(scale.invertWithStep(50, data)).toEqual({ value: midTime, withinBandwidth: true });
+        expect(scale.invertWithStep(74, data)).toEqual({ value: midTime, withinBandwidth: true });
+        expect(scale.invertWithStep(75, data)).toEqual({ value: endTime, withinBandwidth: true });
+        expect(scale.invertWithStep(100, data)).toEqual({ value: endTime, withinBandwidth: true });
         expect(scale.tickValues.length).toBe(9);
         expect(scale.tickValues[0]).toEqual(startTime);
         expect(scale.tickValues[4]).toEqual(midTime);

--- a/src/utils/scales/scales.test.ts
+++ b/src/utils/scales/scales.test.ts
@@ -153,12 +153,13 @@ describe('Scale Test', () => {
       { bandwidth, minInterval: 1 },
     );
     const ordinalScale = new ScaleBand(domainOrdinal, [minRange, maxRange]);
-    expect(ordinalScale.invertWithStep(0)).toBe(0);
-    expect(ordinalScale.invertWithStep(40)).toBe(1);
-    expect(ordinalScale.invertWithStep(80)).toBe(2);
-    expect(linearScale.invertWithStep(0, data)).toBe(0);
-    expect(linearScale.invertWithStep(40, data)).toBe(1);
-    expect(linearScale.invertWithStep(80, data)).toBe(2);
+    expect(ordinalScale.invertWithStep(0)).toEqual({ value: 0, withinBandwidth: true });
+    expect(ordinalScale.invertWithStep(40)).toEqual({ value: 1, withinBandwidth: true });
+    expect(ordinalScale.invertWithStep(80)).toEqual({ value: 2, withinBandwidth: true });
+    // linear scale have 1 pixel difference...
+    expect(linearScale.invertWithStep(0, data)).toEqual({ value: 0, withinBandwidth: true });
+    expect(linearScale.invertWithStep(41, data)).toEqual({ value: 1, withinBandwidth: true });
+    expect(linearScale.invertWithStep(81, data)).toEqual({ value: 2, withinBandwidth: true });
   });
   test('compare ordinal scale and linear/band 2 bars', () => {
     const dataLinear = [0, 1];
@@ -181,12 +182,13 @@ describe('Scale Test', () => {
     expect(linearScale.scale(0)).toBe(0);
     expect(linearScale.scale(1)).toBe(50);
 
-    expect(ordinalScale.invertWithStep(0)).toBe(0);
-    expect(ordinalScale.invertWithStep(50)).toBe(1);
-    expect(ordinalScale.invertWithStep(100)).toBe(1);
-    expect(linearScale.invertWithStep(0, dataLinear)).toBe(0);
-    expect(linearScale.invertWithStep(50, dataLinear)).toBe(1);
-    expect(linearScale.invertWithStep(100, dataLinear)).toBe(1);
+    expect(ordinalScale.invertWithStep(0)).toEqual({ value: 0, withinBandwidth: true });
+    expect(ordinalScale.invertWithStep(50)).toEqual({ value: 1, withinBandwidth: true });
+    expect(ordinalScale.invertWithStep(100)).toEqual({ value: 1, withinBandwidth: true });
+    // linear scale have 1 pixel difference...
+    expect(linearScale.invertWithStep(0, dataLinear)).toEqual({ value: 0, withinBandwidth: true });
+    expect(linearScale.invertWithStep(51, dataLinear)).toEqual({ value: 1, withinBandwidth: true });
+    expect(linearScale.invertWithStep(100, dataLinear)).toEqual({ value: 1, withinBandwidth: true });
     expect(linearScale.bandwidth).toBe(50);
     expect(linearScale.range).toEqual([0, 50]);
   });

--- a/src/utils/scales/scales.ts
+++ b/src/utils/scales/scales.ts
@@ -3,8 +3,15 @@ export interface Scale {
   range: number[];
   ticks: () => any[];
   scale: (value: any) => number;
+  pureScale: (value: any) => number;
   invert: (value: number) => any;
-  invertWithStep: (value: number, data: any[]) => any;
+  invertWithStep: (
+    value: number,
+    data: any[],
+  ) => {
+    value: any;
+    withinBandwidth: boolean;
+  };
   isSingleValue: () => boolean;
   bandwidth: number;
   minInterval: number;

--- a/src/utils/themes/light_theme.ts
+++ b/src/utils/themes/light_theme.ts
@@ -101,12 +101,12 @@ export const LIGHT_THEME: Theme = {
   },
   crosshair: {
     band: {
-      fill: 'black',
+      fill: 'gray',
       visible: true,
     },
     line: {
-      stroke: 'black',
-      strokeWidth: 2,
+      stroke: 'gray',
+      strokeWidth: 1,
       dash: [5, 5],
       visible: true,
     },

--- a/src/utils/themes/light_theme.ts
+++ b/src/utils/themes/light_theme.ts
@@ -101,12 +101,12 @@ export const LIGHT_THEME: Theme = {
   },
   crosshair: {
     band: {
-      fill: 'lightgray',
+      fill: 'black',
       visible: true,
     },
     line: {
-      stroke: 'gray',
-      strokeWidth: 1,
+      stroke: 'black',
+      strokeWidth: 2,
       dash: [5, 5],
       visible: true,
     },

--- a/stories/interactions.tsx
+++ b/stories/interactions.tsx
@@ -438,13 +438,18 @@ storiesOf('Interactions', module)
     );
   })
   .add('brush selection tool on time charts', () => {
-    const now = DateTime.fromISO('2019-01-11T00:00:00.000Z').toMillis();
+    const now = DateTime.fromISO('2019-01-11T00:00:00.000')
+      .setZone('utc+1')
+      .toMillis();
     const oneDay = 1000 * 60 * 60 * 24;
+    const formatter = niceTimeFormatter([now, now + oneDay * 5]);
     return (
       <Chart className={'story-chart'}>
         <Settings
           debug={boolean('debug', false)}
-          onBrushEnd={action('onBrushEnd')}
+          onBrushEnd={(start, end) => {
+            action('onBrushEnd')(formatter(start), formatter(end));
+          }}
           onElementClick={action('onElementClick')}
         />
         <Axis
@@ -452,7 +457,7 @@ storiesOf('Interactions', module)
           position={Position.Bottom}
           title={'bottom'}
           showOverlappingTicks={true}
-          tickFormat={niceTimeFormatter([now, now + oneDay * 5])}
+          tickFormat={formatter}
         />
         <Axis id={getAxisId('left')} title={'left'} position={Position.Left} tickFormat={(d) => Number(d).toFixed(2)} />
 


### PR DESCRIPTION
## Summary

fix #227, fix #221, fix #347

This commit fix the wrong behaviour of the current invertWithStep implementation.

![Aug-25-2019 22-25-39](https://user-images.githubusercontent.com/1421091/63655362-7e995080-c787-11e9-81ad-32c6734d41c8.gif)

![Aug-25-2019 22-26-52](https://user-images.githubusercontent.com/1421091/63655364-81944100-c787-11e9-9d36-1e6ffaa9e403.gif)

It also fix the behaviour of cursor sync between charts with only lines and charts with only bars and empty intervals.


![Aug-25-2019 22-25-02](https://user-images.githubusercontent.com/1421091/63655375-a092d300-c787-11e9-8b25-152e8168e07e.gif)

It finally fix also the missing line/rect annotation that are dependent on ticks to be shown. The PR removed the dependency with the ticks and allows us to place correctly the annotations depending on chart type


**Notes**
I've the impression that we need an absolute refactoring of the current scale system for linear band scales. The current implementation is a bit hacky because it's a mix of a linear scale adapted to work as a band/ordinal scale.
Right now these two scales differs by 1 pixel, it's not noticeable but it create a bit of confusion on the code and testing.

The playground is updated with an example of multi-chart synched with various configurations


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
