### PR TITLE
feat: compute global y domain on multiple groups

### DIFF
--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -10,78 +10,79 @@ import {
   ScaleType,
   Settings,
   AreaSeries,
-  LineAnnotation,
-  getAnnotationId,
-  AnnotationDomainTypes,
   getGroupId,
 } from '../src';
 import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
-import { CursorEvent } from '../src/specs/settings';
-import { CursorUpdateListener } from '../src/chart_types/xy_chart/store/chart_state';
-import { Icon } from '../src/components/icons/icon';
-
 export class Playground extends React.Component {
   ref1 = React.createRef<Chart>();
   ref2 = React.createRef<Chart>();
   ref3 = React.createRef<Chart>();
 
-
   render() {
     return (
       <Chart>
-      <Settings
-        tooltip={{ type: 'vertical' }}
-        debug={false}
-        legendPosition={Position.Right}
-        showLegend={true}
-        rotation={0}
-      />
-      <Axis
-        id={getAxisId('timestamp')}
-        title="timestamp"
-        position={Position.Bottom}
-        tickFormat={niceTimeFormatter([1555819200000, 1555905600000])}
-      />
-      <Axis id={getAxisId('count')} title="count" position={Position.Left} tickFormat={(d) => d.toFixed(2)} />
-      <AreaSeries
-        id={getSpecId('dataset A1')}
-        xScaleType={ScaleType.Linear}
-        yScaleType={ScaleType.Linear}
-        data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0,50)}
-        xAccessor={0}
-        yAccessors={[1]}
-        stackAccessors={[0]}
-      />
-      <AreaSeries
-        id={getSpecId('dataset A2')}
-        xScaleType={ScaleType.Linear}
-        yScaleType={ScaleType.Linear}
-        data={KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0,50)}
-        xAccessor={0}
-        yAccessors={[1]}
-        stackAccessors={[0]}
-      />
-      <AreaSeries
-        id={getSpecId('dataset B1')}
-        groupId={getGroupId('aaa')}
-        useDefaultGroupDomain={true}
-        xScaleType={ScaleType.Time}
-        yScaleType={ScaleType.Linear}
-        data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0,50).map(d => [d[0], -d[1]])}
-        xAccessor={0}
-        yAccessors={[1]}
-        stackAccessors={[0]}
-      />
-      <AreaSeries
-        id={getSpecId('dataset B2')}
-        groupId={getGroupId('aaa')}
-        xScaleType={ScaleType.Time}
-        yScaleType={ScaleType.Linear}
-        data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0,50).map(d => [d[0], -d[1]])}
-        xAccessor={0}
-        yAccessors={[1]}
-        stackAccessors={[0]}
-      />
-    </Chart>);
+        <Settings
+          tooltip={{ type: 'vertical' }}
+          debug={false}
+          legendPosition={Position.Right}
+          showLegend={true}
+          rotation={0}
+        />
+        <Axis
+          id={getAxisId('timestamp')}
+          title="timestamp"
+          position={Position.Bottom}
+          tickFormat={niceTimeFormatter([1555819200000, 1555905600000])}
+        />
+        <Axis id={getAxisId('A axis')} title="A" position={Position.Left} tickFormat={(d) => `GA: ${d.toFixed(2)}`} />
+        <Axis
+          id={getAxisId('B axis')}
+          groupId={getGroupId('aaa')}
+          title="B"
+          hide={true}
+          position={Position.Left}
+          tickFormat={(d) => `GB: ${d.toFixed(2)}`}
+        />
+        <AreaSeries
+          id={getSpecId('dataset A1')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 50)}
+          xAccessor={0}
+          yAccessors={[1]}
+          stackAccessors={[0]}
+        />
+        <AreaSeries
+          id={getSpecId('dataset A2')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          data={KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 50)}
+          xAccessor={0}
+          yAccessors={[1]}
+          stackAccessors={[0]}
+        />
+        <AreaSeries
+          id={getSpecId('dataset B1')}
+          groupId={getGroupId('aaa')}
+          useDefaultGroupDomain={true}
+          xScaleType={ScaleType.Time}
+          yScaleType={ScaleType.Linear}
+          data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 50).map((d) => [d[0], -d[1]])}
+          xAccessor={0}
+          yAccessors={[1]}
+          stackAccessors={[0]}
+        />
+        <AreaSeries
+          id={getSpecId('dataset B2')}
+          groupId={getGroupId('aaa')}
+          xScaleType={ScaleType.Time}
+          yScaleType={ScaleType.Linear}
+          data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 50).map((d) => [d[0], -d[1]])}
+          xAccessor={0}
+          yAccessors={[1]}
+          stackAccessors={[0]}
+        />
+      </Chart>
+    );
   }
 }

--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -9,10 +9,11 @@ import {
   Position,
   ScaleType,
   Settings,
-  BarSeries,
+  AreaSeries,
   LineAnnotation,
   getAnnotationId,
   AnnotationDomainTypes,
+  getGroupId,
 } from '../src';
 import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
 import { CursorEvent } from '../src/specs/settings';
@@ -24,94 +25,63 @@ export class Playground extends React.Component {
   ref2 = React.createRef<Chart>();
   ref3 = React.createRef<Chart>();
 
-  onCursorUpdate: CursorUpdateListener = (event?: CursorEvent) => {
-    this.ref1.current!.dispatchExternalCursorEvent(event);
-    this.ref2.current!.dispatchExternalCursorEvent(event);
-    this.ref3.current!.dispatchExternalCursorEvent(event);
-  };
 
   render() {
     return (
-      <>
-        {renderChart(
-          '1',
-          this.ref1,
-          KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 15),
-          this.onCursorUpdate,
-          true,
-        )}
-        {renderChart(
-          '2',
-          this.ref2,
-          KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15),
-          this.onCursorUpdate,
-          true,
-        )}
-        {renderChart('3', this.ref3, KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(15, 30), this.onCursorUpdate)}
-      </>
-    );
+      <Chart>
+      <Settings
+        tooltip={{ type: 'vertical' }}
+        debug={false}
+        legendPosition={Position.Right}
+        showLegend={true}
+        rotation={0}
+      />
+      <Axis
+        id={getAxisId('timestamp')}
+        title="timestamp"
+        position={Position.Bottom}
+        tickFormat={niceTimeFormatter([1555819200000, 1555905600000])}
+      />
+      <Axis id={getAxisId('count')} title="count" position={Position.Left} tickFormat={(d) => d.toFixed(2)} />
+      <AreaSeries
+        id={getSpecId('dataset A1')}
+        xScaleType={ScaleType.Linear}
+        yScaleType={ScaleType.Linear}
+        data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0,50)}
+        xAccessor={0}
+        yAccessors={[1]}
+        stackAccessors={[0]}
+      />
+      <AreaSeries
+        id={getSpecId('dataset A2')}
+        xScaleType={ScaleType.Linear}
+        yScaleType={ScaleType.Linear}
+        data={KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0,50)}
+        xAccessor={0}
+        yAccessors={[1]}
+        stackAccessors={[0]}
+      />
+      <AreaSeries
+        id={getSpecId('dataset B1')}
+        groupId={getGroupId('aaa')}
+        useDefaultGroupDomain={true}
+        xScaleType={ScaleType.Time}
+        yScaleType={ScaleType.Linear}
+        data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0,50).map(d => [d[0], -d[1]])}
+        xAccessor={0}
+        yAccessors={[1]}
+        stackAccessors={[0]}
+      />
+      <AreaSeries
+        id={getSpecId('dataset B2')}
+        groupId={getGroupId('aaa')}
+        xScaleType={ScaleType.Time}
+        yScaleType={ScaleType.Linear}
+        data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0,50).map(d => [d[0], -d[1]])}
+        xAccessor={0}
+        yAccessors={[1]}
+        stackAccessors={[0]}
+      />
+    </Chart>);
   }
-}
-
-function renderChart(
-  key: string,
-  ref: React.RefObject<Chart>,
-  data: any,
-  onCursorUpdate?: CursorUpdateListener,
-  timeSeries: boolean = false,
-) {
-  return (
-    <div key={key} className="chart">
-      <Chart ref={ref}>
-        <Settings
-          tooltip={{ type: 'vertical' }}
-          debug={false}
-          legendPosition={Position.Right}
-          showLegend={true}
-          onCursorUpdate={onCursorUpdate}
-          rotation={0}
-        />
-        <Axis
-          id={getAxisId('timestamp')}
-          title="timestamp"
-          position={Position.Bottom}
-          tickFormat={niceTimeFormatter([1555819200000, 1555905600000])}
-        />
-        <Axis id={getAxisId('count')} title="count" position={Position.Left} tickFormat={(d) => d.toFixed(2)} />
-        <LineAnnotation
-          annotationId={getAnnotationId('annotation1')}
-          domainType={AnnotationDomainTypes.XDomain}
-          dataValues={[
-            {
-              dataValue: KIBANA_METRICS.metrics.kibana_os_load[1].data[5][0],
-              details: 'tooltip 1',
-            },
-            {
-              dataValue: KIBANA_METRICS.metrics.kibana_os_load[1].data[9][0],
-              details: 'tooltip 2',
-            },
-          ]}
-          hideLinesTooltips={true}
-          marker={<Icon type="alert" />}
-        />
-        <BarSeries
-          id={getSpecId('dataset A with long title')}
-          xScaleType={timeSeries ? ScaleType.Time : ScaleType.Linear}
-          yScaleType={ScaleType.Linear}
-          data={data}
-          xAccessor={0}
-          yAccessors={[1]}
-        />
-        <BarSeries
-          id={getSpecId('dataset B')}
-          xScaleType={ScaleType.Time}
-          yScaleType={ScaleType.Linear}
-          data={KIBANA_METRICS.metrics.kibana_os_load[1].data.slice(0, 15)}
-          xAccessor={0}
-          yAccessors={[1]}
-          stackAccessors={[0]}
-        />
-      </Chart>
-    </div>
-  );
 }

--- a/src/chart_types/xy_chart/domains/y_domain.ts
+++ b/src/chart_types/xy_chart/domains/y_domain.ts
@@ -1,5 +1,5 @@
-import { BasicSeriesSpec, DomainRange } from '../utils/specs';
-import { GroupId, SpecId } from '../../../utils/ids';
+import { BasicSeriesSpec, DomainRange, DEFAULT_GLOBAL_ID } from '../utils/specs';
+import { GroupId, SpecId, getGroupId } from '../../../utils/ids';
 import { ScaleContinuousType, ScaleType } from '../../../utils/scales/scales';
 import { isCompleteBound, isLowerBound, isUpperBound } from '../utils/axis_utils';
 import { BaseDomain } from './domain';
@@ -16,8 +16,21 @@ export type YDomain = BaseDomain & {
 };
 export type YBasicSeriesSpec = Pick<
   BasicSeriesSpec,
-  'id' | 'seriesType' | 'yScaleType' | 'groupId' | 'stackAccessors' | 'yScaleToDataExtent' | 'styleAccessor'
+  | 'id'
+  | 'seriesType'
+  | 'yScaleType'
+  | 'groupId'
+  | 'stackAccessors'
+  | 'yScaleToDataExtent'
+  | 'styleAccessor'
+  | 'useDefaultGroupDomain'
 > & { stackAsPercentage?: boolean };
+
+interface GroupSpecs {
+  isPercentageStack: boolean;
+  stacked: YBasicSeriesSpec[];
+  nonStacked: YBasicSeriesSpec[];
+}
 
 export function mergeYDomain(
   dataSeries: Map<SpecId, RawDataSeries[]>,
@@ -26,71 +39,102 @@ export function mergeYDomain(
 ): YDomain[] {
   // group specs by group ids
   const specsByGroupIds = splitSpecsByGroupId(specs);
-
   const specsByGroupIdsEntries = [...specsByGroupIds.entries()];
+  const globalId = getGroupId(DEFAULT_GLOBAL_ID);
 
-  const yDomains = specsByGroupIdsEntries.map(
-    ([groupId, groupSpecs]): YDomain => {
-      const groupYScaleType = coerceYScaleTypes([...groupSpecs.stacked, ...groupSpecs.nonStacked]);
-      const { isPercentageStack } = groupSpecs;
+  const yDomains = specsByGroupIdsEntries.map<YDomain>(([groupId, groupSpecs]) => {
+    const customDomain = domainsByGroupId.get(groupId);
+    return mergeYDomainForGroup(dataSeries, groupId, groupSpecs, customDomain);
+  });
 
-      let domain: number[];
-      if (isPercentageStack) {
-        domain = computeContinuousDataDomain([0, 1], identity);
-      } else {
-        // compute stacked domain
-        const isStackedScaleToExtent = groupSpecs.stacked.some((spec) => {
-          return spec.yScaleToDataExtent;
-        });
-        const stackedDataSeries = getDataSeriesOnGroup(dataSeries, groupSpecs.stacked);
-        const stackedDomain = computeYStackedDomain(stackedDataSeries, isStackedScaleToExtent);
-
-        // compute non stacked domain
-        const isNonStackedScaleToExtent = groupSpecs.nonStacked.some((spec) => {
-          return spec.yScaleToDataExtent;
-        });
-        const nonStackedDataSeries = getDataSeriesOnGroup(dataSeries, groupSpecs.nonStacked);
-        const nonStackedDomain = computeYNonStackedDomain(nonStackedDataSeries, isNonStackedScaleToExtent);
-
-        // merge stacked and non stacked domain together
-        domain = computeContinuousDataDomain(
-          [...stackedDomain, ...nonStackedDomain],
-          identity,
-          isStackedScaleToExtent || isNonStackedScaleToExtent,
-        );
-
-        const [computedDomainMin, computedDomainMax] = domain;
-
-        const customDomain = domainsByGroupId.get(groupId);
-
-        if (customDomain && isCompleteBound(customDomain)) {
-          // Don't need to check min > max because this has been validated on axis domain merge
-          domain = [customDomain.min, customDomain.max];
-        } else if (customDomain && isLowerBound(customDomain)) {
-          if (customDomain.min > computedDomainMax) {
-            throw new Error(`custom yDomain for ${groupId} is invalid, custom min is greater than computed max`);
-          }
-
-          domain = [customDomain.min, computedDomainMax];
-        } else if (customDomain && isUpperBound(customDomain)) {
-          if (computedDomainMin > customDomain.max) {
-            throw new Error(`custom yDomain for ${groupId} is invalid, computed min is greater than custom max`);
-          }
-
-          domain = [computedDomainMin, customDomain.max];
-        }
-      }
+  const globalGroupIds: GroupId[] = [];
+  specsByGroupIdsEntries.forEach(([groupId, groupSpecs]) => {
+    if (
+      groupId === globalId ||
+      groupSpecs.nonStacked.some((spec) => Boolean(spec.useDefaultGroupDomain)) ||
+      groupSpecs.stacked.some((spec) => Boolean(spec.useDefaultGroupDomain))
+    ) {
+      globalGroupIds.push(groupId);
+    }
+  });
+  //
+  const globalYDomains = yDomains.filter((domain) => globalGroupIds.includes(domain.groupId));
+  let globalYDomain = [Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER];
+  globalYDomains.forEach((domain) => {
+    globalYDomain = [Math.min(globalYDomain[0], domain.domain[0]), Math.max(globalYDomain[1], domain.domain[1])];
+  });
+  console.log({ globalYDomains });
+  return yDomains.map((domain) => {
+    if (globalGroupIds.includes(domain.groupId)) {
       return {
-        type: 'yDomain',
-        isBandScale: false,
-        scaleType: groupYScaleType,
-        groupId,
-        domain,
+        ...domain,
+        domain: globalYDomain,
       };
-    },
-  );
+    }
+    return domain;
+  });
+}
 
-  return yDomains;
+function mergeYDomainForGroup(
+  dataSeries: Map<SpecId, RawDataSeries[]>,
+  groupId: GroupId,
+  groupSpecs: GroupSpecs,
+  customDomain?: DomainRange,
+): YDomain {
+  const groupYScaleType = coerceYScaleTypes([...groupSpecs.stacked, ...groupSpecs.nonStacked]);
+  const { isPercentageStack } = groupSpecs;
+
+  let domain: number[];
+  if (isPercentageStack) {
+    domain = computeContinuousDataDomain([0, 1], identity);
+  } else {
+    // compute stacked domain
+    const isStackedScaleToExtent = groupSpecs.stacked.some((spec) => {
+      return spec.yScaleToDataExtent;
+    });
+    const stackedDataSeries = getDataSeriesOnGroup(dataSeries, groupSpecs.stacked);
+    const stackedDomain = computeYStackedDomain(stackedDataSeries, isStackedScaleToExtent);
+
+    // compute non stacked domain
+    const isNonStackedScaleToExtent = groupSpecs.nonStacked.some((spec) => {
+      return spec.yScaleToDataExtent;
+    });
+    const nonStackedDataSeries = getDataSeriesOnGroup(dataSeries, groupSpecs.nonStacked);
+    const nonStackedDomain = computeYNonStackedDomain(nonStackedDataSeries, isNonStackedScaleToExtent);
+
+    // merge stacked and non stacked domain together
+    domain = computeContinuousDataDomain(
+      [...stackedDomain, ...nonStackedDomain],
+      identity,
+      isStackedScaleToExtent || isNonStackedScaleToExtent,
+    );
+
+    const [computedDomainMin, computedDomainMax] = domain;
+
+    if (customDomain && isCompleteBound(customDomain)) {
+      // Don't need to check min > max because this has been validated on axis domain merge
+      domain = [customDomain.min, customDomain.max];
+    } else if (customDomain && isLowerBound(customDomain)) {
+      if (customDomain.min > computedDomainMax) {
+        throw new Error(`custom yDomain for ${groupId} is invalid, custom min is greater than computed max`);
+      }
+
+      domain = [customDomain.min, computedDomainMax];
+    } else if (customDomain && isUpperBound(customDomain)) {
+      if (computedDomainMin > customDomain.max) {
+        throw new Error(`custom yDomain for ${groupId} is invalid, computed min is greater than custom max`);
+      }
+
+      domain = [computedDomainMin, customDomain.max];
+    }
+  }
+  return {
+    type: 'yDomain',
+    isBandScale: false,
+    scaleType: groupYScaleType,
+    groupId: groupId,
+    domain,
+  };
 }
 
 export function getDataSeriesOnGroup(

--- a/src/chart_types/xy_chart/specs/area_series.tsx
+++ b/src/chart_types/xy_chart/specs/area_series.tsx
@@ -1,6 +1,6 @@
 import { inject } from 'mobx-react';
 import { PureComponent } from 'react';
-import { AreaSeriesSpec, HistogramModeAlignments } from '../utils/specs';
+import { AreaSeriesSpec, HistogramModeAlignments, DEFAULT_GLOBAL_ID } from '../utils/specs';
 import { getGroupId } from '../../../utils/ids';
 import { ScaleType } from '../../../utils/scales/scales';
 import { SpecProps } from '../../../specs/specs_parser';
@@ -10,7 +10,7 @@ type AreaSpecProps = SpecProps & AreaSeriesSpec;
 export class AreaSeriesSpecComponent extends PureComponent<AreaSpecProps> {
   static defaultProps: Partial<AreaSpecProps> = {
     seriesType: 'area',
-    groupId: getGroupId('__global__'),
+    groupId: getGroupId(DEFAULT_GLOBAL_ID),
     xScaleType: ScaleType.Ordinal,
     yScaleType: ScaleType.Linear,
     xAccessor: 'x',

--- a/src/chart_types/xy_chart/specs/axis.tsx
+++ b/src/chart_types/xy_chart/specs/axis.tsx
@@ -1,6 +1,6 @@
 import { inject } from 'mobx-react';
 import { PureComponent } from 'react';
-import { AxisSpec as AxisSpecType, Position } from '../utils/specs';
+import { AxisSpec as AxisSpecType, Position, DEFAULT_GLOBAL_ID } from '../utils/specs';
 import { getGroupId } from '../../../utils/ids';
 import { SpecProps } from '../../../specs/specs_parser';
 
@@ -8,7 +8,7 @@ type AxisSpecProps = SpecProps & AxisSpecType;
 
 class AxisSpec extends PureComponent<AxisSpecProps> {
   static defaultProps: Partial<AxisSpecProps> = {
-    groupId: getGroupId('__global__'),
+    groupId: getGroupId(DEFAULT_GLOBAL_ID),
     hide: false,
     showOverlappingTicks: false,
     showOverlappingLabels: false,

--- a/src/chart_types/xy_chart/specs/bar_series.tsx
+++ b/src/chart_types/xy_chart/specs/bar_series.tsx
@@ -1,6 +1,6 @@
 import { inject } from 'mobx-react';
 import { PureComponent } from 'react';
-import { BarSeriesSpec } from '../utils/specs';
+import { BarSeriesSpec, DEFAULT_GLOBAL_ID } from '../utils/specs';
 import { getGroupId } from '../../../utils/ids';
 import { ScaleType } from '../../../utils/scales/scales';
 import { SpecProps } from '../../../specs/specs_parser';
@@ -10,7 +10,7 @@ type BarSpecProps = SpecProps & BarSeriesSpec;
 export class BarSeriesSpecComponent extends PureComponent<BarSpecProps> {
   static defaultProps: Partial<BarSpecProps> = {
     seriesType: 'bar',
-    groupId: getGroupId('__global__'),
+    groupId: getGroupId(DEFAULT_GLOBAL_ID),
     xScaleType: ScaleType.Ordinal,
     yScaleType: ScaleType.Linear,
     xAccessor: 'x',

--- a/src/chart_types/xy_chart/specs/histogram_bar_series.tsx
+++ b/src/chart_types/xy_chart/specs/histogram_bar_series.tsx
@@ -1,6 +1,6 @@
 import { inject } from 'mobx-react';
 import { PureComponent } from 'react';
-import { HistogramBarSeriesSpec } from '../utils/specs';
+import { HistogramBarSeriesSpec, DEFAULT_GLOBAL_ID } from '../utils/specs';
 import { getGroupId } from '../../../utils/ids';
 import { ScaleType } from '../../../utils/scales/scales';
 import { SpecProps } from '../../../specs/specs_parser';
@@ -10,7 +10,7 @@ type HistogramBarSpecProps = SpecProps & HistogramBarSeriesSpec;
 export class HistogramBarSeriesSpecComponent extends PureComponent<HistogramBarSpecProps> {
   static defaultProps: Partial<HistogramBarSpecProps> = {
     seriesType: 'bar',
-    groupId: getGroupId('__global__'),
+    groupId: getGroupId(DEFAULT_GLOBAL_ID),
     xScaleType: ScaleType.Ordinal,
     yScaleType: ScaleType.Linear,
     xAccessor: 'x',

--- a/src/chart_types/xy_chart/specs/line_annotation.tsx
+++ b/src/chart_types/xy_chart/specs/line_annotation.tsx
@@ -1,6 +1,6 @@
 import { inject } from 'mobx-react';
 import React, { createRef, CSSProperties, PureComponent } from 'react';
-import { LineAnnotationSpec } from '../utils/specs';
+import { LineAnnotationSpec, DEFAULT_GLOBAL_ID } from '../utils/specs';
 import { DEFAULT_ANNOTATION_LINE_STYLE } from '../../../utils/themes/theme';
 import { getGroupId } from '../../../utils/ids';
 import { SpecProps } from '../../../specs/specs_parser';
@@ -9,7 +9,7 @@ type LineAnnotationProps = SpecProps & LineAnnotationSpec;
 
 export class LineAnnotationSpecComponent extends PureComponent<LineAnnotationProps> {
   static defaultProps: Partial<LineAnnotationProps> = {
-    groupId: getGroupId('__global__'),
+    groupId: getGroupId(DEFAULT_GLOBAL_ID),
     annotationType: 'line',
     style: DEFAULT_ANNOTATION_LINE_STYLE,
     hideLines: false,

--- a/src/chart_types/xy_chart/specs/line_series.tsx
+++ b/src/chart_types/xy_chart/specs/line_series.tsx
@@ -1,6 +1,6 @@
 import { inject } from 'mobx-react';
 import { PureComponent } from 'react';
-import { HistogramModeAlignments, LineSeriesSpec } from '../utils/specs';
+import { HistogramModeAlignments, LineSeriesSpec, DEFAULT_GLOBAL_ID } from '../utils/specs';
 import { getGroupId } from '../../../utils/ids';
 import { ScaleType } from '../../../utils/scales/scales';
 import { SpecProps } from '../../../specs/specs_parser';
@@ -10,7 +10,7 @@ type LineSpecProps = SpecProps & LineSeriesSpec;
 export class LineSeriesSpecComponent extends PureComponent<LineSpecProps> {
   static defaultProps: Partial<LineSpecProps> = {
     seriesType: 'line',
-    groupId: getGroupId('__global__'),
+    groupId: getGroupId(DEFAULT_GLOBAL_ID),
     xScaleType: ScaleType.Ordinal,
     yScaleType: ScaleType.Linear,
     xAccessor: 'x',

--- a/src/chart_types/xy_chart/specs/rect_annotation.tsx
+++ b/src/chart_types/xy_chart/specs/rect_annotation.tsx
@@ -1,6 +1,6 @@
 import { inject } from 'mobx-react';
 import { PureComponent } from 'react';
-import { RectAnnotationSpec } from '../utils/specs';
+import { RectAnnotationSpec, DEFAULT_GLOBAL_ID } from '../utils/specs';
 import { getGroupId } from '../../../utils/ids';
 import { SpecProps } from '../../../specs/specs_parser';
 
@@ -8,7 +8,7 @@ type RectAnnotationProps = SpecProps & RectAnnotationSpec;
 
 export class RectAnnotationSpecComponent extends PureComponent<RectAnnotationProps> {
   static defaultProps: Partial<RectAnnotationProps> = {
-    groupId: getGroupId('__global__'),
+    groupId: getGroupId(DEFAULT_GLOBAL_ID),
     annotationType: 'rectangle',
     zIndex: -1,
   };

--- a/src/chart_types/xy_chart/utils/specs.ts
+++ b/src/chart_types/xy_chart/utils/specs.ts
@@ -21,6 +21,7 @@ export type Rendering = 'canvas' | 'svg';
 export type Color = string;
 export type StyleOverride = RecursivePartial<BarSeriesStyle> | Color | null;
 export type StyleAccessor = (datum: RawDataSeriesDatum, geometryId: GeometryId) => StyleOverride;
+export const DEFAULT_GLOBAL_ID = '__global__';
 
 interface DomainMinInterval {
   /** Custom minInterval for the domain which will affect data bucket size.
@@ -73,6 +74,8 @@ export interface SeriesSpec {
    * @default __global__
    */
   groupId: GroupId;
+  /** when using a different groupId this option will allow compute in the same domain of the global domain */
+  useDefaultGroupDomain?: boolean;
   /** An array of data */
   data: Datum[];
   /** The type of series you are looking to render */

--- a/src/components/react_canvas/area_geometries.tsx
+++ b/src/components/react_canvas/area_geometries.tsx
@@ -47,67 +47,7 @@ export class AreaGeometries extends React.PureComponent<AreaGeometriesDataProps,
     );
   }
   private renderAreaGeoms = (): JSX.Element[] => {
-    const { sharedStyle, highlightedLegendItem } = this.props;
-    const areas = this.props.areas.reduce<{
-      stacked: AreaGeometry[];
-      nonStacked: AreaGeometry[];
-    }>(
-      (acc, area) => {
-        if (area.isStacked) {
-          acc.stacked.push(area);
-        } else {
-          acc.nonStacked.push(area);
-        }
-        return acc;
-      },
-
-      { stacked: [], nonStacked: [] },
-    );
-
-    return [
-      ...this.renderStackedAreas(areas.stacked, sharedStyle, highlightedLegendItem),
-      ...this.renderNonStackedAreas(areas.nonStacked, sharedStyle, highlightedLegendItem),
-    ];
-  };
-  renderStackedAreas = (
-    areas: AreaGeometry[],
-    sharedStyle: SharedGeometryStyle,
-    highlightedLegendItem: LegendItem | null,
-  ): JSX.Element[] => {
-    const elements: JSX.Element[] = [];
-    areas.forEach((glyph) => {
-      const { seriesAreaStyle } = glyph;
-      if (seriesAreaStyle.visible) {
-        elements.push(this.renderArea(glyph, sharedStyle, highlightedLegendItem));
-      }
-    });
-    areas.forEach((glyph, i) => {
-      const { seriesAreaLineStyle } = glyph;
-      if (seriesAreaLineStyle.visible) {
-        elements.push(...this.renderAreaLines(glyph, i, sharedStyle, highlightedLegendItem));
-      }
-    });
-    areas.forEach((glyph, i) => {
-      const { seriesPointStyle, geometryId } = glyph;
-      if (seriesPointStyle.visible) {
-        const customOpacity = seriesPointStyle ? seriesPointStyle.opacity : undefined;
-        const geometryStyle = getGeometryStyle(
-          geometryId,
-          this.props.highlightedLegendItem,
-          sharedStyle,
-          customOpacity,
-        );
-        const pointStyleProps = buildPointStyleProps(glyph.color, seriesPointStyle, geometryStyle);
-        elements.push(...this.renderPoints(glyph.points, i, pointStyleProps, glyph.geometryId));
-      }
-    });
-    return elements;
-  };
-  renderNonStackedAreas = (
-    areas: AreaGeometry[],
-    sharedStyle: SharedGeometryStyle,
-    highlightedLegendItem: LegendItem | null,
-  ): JSX.Element[] => {
+    const { sharedStyle, highlightedLegendItem, areas } = this.props;
     return areas.reduce<JSX.Element[]>((acc, glyph, i) => {
       const { seriesAreaLineStyle, seriesAreaStyle, seriesPointStyle, geometryId } = glyph;
       if (seriesAreaStyle.visible) {


### PR DESCRIPTION
## Summary

fix #169, fix #185

This feature allows to compute the global Y domain on multiple groups ids.
It collect all the groupIds Y domains and extend them to the max extent.

This provide an easier way to add multiple groups but keep the same domain without need of external domain computation etc.

<img width="1083" alt="Screenshot 2019-08-26 at 02 44 45" src="https://user-images.githubusercontent.com/1421091/63658617-64be3480-c7ac-11e9-84bd-333604ef67df.png">

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
