### PR TITLE
fix(crosshair): limit the width of the cursor band on edges

### DIFF
--- a/.playground/index.html
+++ b/.playground/index.html
@@ -25,7 +25,7 @@
         background: white;
         position: relative;
         width: 800px;
-        height: 150px;
+        height: 450px;
         margin: 10px;
       }
     </style>

--- a/.playground/index.html
+++ b/.playground/index.html
@@ -25,7 +25,7 @@
         background: white;
         position: relative;
         width: 800px;
-        height: 450px;
+        height: 150px;
         margin: 10px;
       }
     </style>

--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Axis, Chart, getAxisId, getSpecId, Position, ScaleType, Settings, BarSeries } from '../src';
+import { Axis, Chart, getAxisId, getSpecId, Position, ScaleType, Settings, HistogramBarSeries } from '../src';
 import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
 
 export class Playground extends React.Component {
@@ -7,10 +7,17 @@ export class Playground extends React.Component {
     return (
       <div className="chart">
         <Chart>
-          <Settings showLegend={true} />
+          <Settings
+            showLegend={true}
+            xDomain={{
+              min: KIBANA_METRICS.metrics.kibana_os_load[0].data[0][0] - 10000,
+              max: KIBANA_METRICS.metrics.kibana_os_load[0].data[18][0] + 10000,
+            }}
+            rotation={180}
+          />
           <Axis id={getAxisId('y')} position={Position.Left} />
           <Axis id={getAxisId('x')} position={Position.Bottom} />
-          <BarSeries
+          <HistogramBarSeries
             id={getSpecId('bar')}
             yScaleType={ScaleType.Linear}
             xScaleType={ScaleType.Time}

--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -13,7 +13,7 @@ export class Playground extends React.Component {
               min: KIBANA_METRICS.metrics.kibana_os_load[0].data[0][0] - 10000,
               max: KIBANA_METRICS.metrics.kibana_os_load[0].data[18][0] + 10000,
             }}
-            rotation={180}
+            rotation={0}
           />
           <Axis id={getAxisId('y')} position={Position.Left} />
           <Axis id={getAxisId('x')} position={Position.Bottom} />

--- a/src/chart_types/xy_chart/crosshair/crosshair_utils.linear_snap.test.ts
+++ b/src/chart_types/xy_chart/crosshair/crosshair_utils.linear_snap.test.ts
@@ -1472,4 +1472,72 @@ describe('Crosshair utils linear scale', () => {
       });
     });
   });
+
+  describe('BandPosition bar chart wwith limited edges', () => {
+    const chartDimensions: Dimensions = { top: 0, left: 0, width: 120, height: 100 };
+    test('cursor at begin of domain', () => {
+      const barSeriesScaleLimited = computeXScale({
+        xDomain: {
+          domain: [0.5, 3.5],
+          isBandScale: true,
+          minInterval: 1,
+          scaleType: ScaleType.Linear,
+          type: 'xDomain',
+        },
+        totalBarsInCluster: 1,
+        range: [0, 120],
+      });
+      const bandPosition = getCursorBandPosition(
+        0,
+        chartDimensions,
+        { x: 0, y: 0 },
+        {
+          value: 0,
+          withinBandwidth: true,
+        },
+        true,
+        barSeriesScaleLimited,
+        1,
+      );
+      expect(bandPosition).toEqual({
+        left: 0,
+        top: 0,
+        height: 100,
+        width: 15,
+        visible: true,
+      });
+    });
+    test('cursor at end of domain', () => {
+      const barSeriesScaleLimited = computeXScale({
+        xDomain: {
+          domain: [-0.5, 2.5],
+          isBandScale: true,
+          minInterval: 1,
+          scaleType: ScaleType.Linear,
+          type: 'xDomain',
+        },
+        totalBarsInCluster: barSeriesMap.size,
+        range: [0, 120],
+      });
+      const bandPosition = getCursorBandPosition(
+        0,
+        chartDimensions,
+        { x: 119, y: 0 },
+        {
+          value: 3,
+          withinBandwidth: true,
+        },
+        true,
+        barSeriesScaleLimited,
+        1,
+      );
+      expect(bandPosition).toEqual({
+        left: 105,
+        top: 0,
+        height: 100,
+        width: 15,
+        visible: true,
+      });
+    });
+  });
 });

--- a/src/chart_types/xy_chart/crosshair/crosshair_utils.linear_snap.test.ts
+++ b/src/chart_types/xy_chart/crosshair/crosshair_utils.linear_snap.test.ts
@@ -1474,7 +1474,7 @@ describe('Crosshair utils linear scale', () => {
   });
 
   describe('BandPosition bar chart wwith limited edges', () => {
-    const chartDimensions: Dimensions = { top: 0, left: 0, width: 120, height: 100 };
+    const chartDimensions: Dimensions = { top: 0, left: 0, width: 120, height: 120 };
     test('cursor at begin of domain', () => {
       const barSeriesScaleLimited = computeXScale({
         xDomain: {
@@ -1502,7 +1502,7 @@ describe('Crosshair utils linear scale', () => {
       expect(bandPosition).toEqual({
         left: 0,
         top: 0,
-        height: 100,
+        height: 120,
         width: 15,
         visible: true,
       });
@@ -1534,8 +1534,72 @@ describe('Crosshair utils linear scale', () => {
       expect(bandPosition).toEqual({
         left: 105,
         top: 0,
-        height: 100,
+        height: 120,
         width: 15,
+        visible: true,
+      });
+    });
+    test('cursor at top begin of domain', () => {
+      const barSeriesScaleLimited = computeXScale({
+        xDomain: {
+          domain: [0.5, 3.5],
+          isBandScale: true,
+          minInterval: 1,
+          scaleType: ScaleType.Linear,
+          type: 'xDomain',
+        },
+        totalBarsInCluster: 1,
+        range: [0, 120],
+      });
+      const bandPosition = getCursorBandPosition(
+        90,
+        chartDimensions,
+        { x: 0, y: 0 },
+        {
+          value: 0,
+          withinBandwidth: true,
+        },
+        true,
+        barSeriesScaleLimited,
+        1,
+      );
+      expect(bandPosition).toEqual({
+        left: 0,
+        top: 0,
+        height: 15,
+        width: 120,
+        visible: true,
+      });
+    });
+    test('cursor at top end of domain', () => {
+      const barSeriesScaleLimited = computeXScale({
+        xDomain: {
+          domain: [-0.5, 2.5],
+          isBandScale: true,
+          minInterval: 1,
+          scaleType: ScaleType.Linear,
+          type: 'xDomain',
+        },
+        totalBarsInCluster: barSeriesMap.size,
+        range: [0, 120],
+      });
+      const bandPosition = getCursorBandPosition(
+        90,
+        chartDimensions,
+        { x: 0, y: 119 },
+        {
+          value: 3,
+          withinBandwidth: true,
+        },
+        true,
+        barSeriesScaleLimited,
+        1,
+      );
+      expect(bandPosition).toEqual({
+        left: 0,
+        top: 105,
+        height: 15,
+        width: 120,
         visible: true,
       });
     });

--- a/src/chart_types/xy_chart/crosshair/crosshair_utils.ts
+++ b/src/chart_types/xy_chart/crosshair/crosshair_utils.ts
@@ -107,24 +107,36 @@ export function getCursorBandPosition(
 
   if (isHorizontalRotated) {
     const adjustedLeft = snapEnabled ? position : cursorPosition.x;
-    const leftPosition = chartRotation === 0 ? left + adjustedLeft : left + width - adjustedLeft - bandOffset;
-
+    let leftPosition = chartRotation === 0 ? left + adjustedLeft : left + width - adjustedLeft - bandOffset;
+    let adjustedWidth = band;
+    if (band > 1 && leftPosition + band > left + width) {
+      adjustedWidth = left + width - leftPosition;
+    } else if (band > 1 && leftPosition < left) {
+      adjustedWidth = band - (left - leftPosition);
+      leftPosition = left;
+    }
     return {
       top,
       left: leftPosition,
-      width: band,
+      width: adjustedWidth,
       height,
       visible: true,
     };
   } else {
     const adjustedTop = snapEnabled ? position : cursorPosition.x;
-    const topPosition = chartRotation === 90 ? top + adjustedTop : height + top - adjustedTop - bandOffset;
-
+    let topPosition = chartRotation === 90 ? top + adjustedTop : height + top - adjustedTop - bandOffset;
+    let adjustedHeight = band;
+    if (band > 1 && topPosition + band > top + height) {
+      adjustedHeight = band - (topPosition + band - (top + height));
+    } else if (band > 1 && topPosition < top) {
+      adjustedHeight = band - (top - topPosition);
+      topPosition = top;
+    }
     return {
       top: topPosition,
       left,
       width,
-      height: band,
+      height: adjustedHeight,
       visible: true,
     };
   }


### PR DESCRIPTION
## Summary

If the xDomain doesn't cover a full interval on the min or max edges, the crosshair is drawn outside the chart as shown in the screenshot.

This commit will fix that behaviour limiting the cursor band width and position to be
always inside the chart

fix #352

<img width="842" alt="Screenshot 2019-08-27 at 13 09 36" src="https://user-images.githubusercontent.com/1421091/63766667-f96b8400-c8cb-11e9-81dc-92e531ddc412.png">
<img width="821" alt="Screenshot 2019-08-27 at 13 09 41" src="https://user-images.githubusercontent.com/1421091/63766668-f96b8400-c8cb-11e9-89ce-6ed27de062f2.png">

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
