### PR TITLE
fix(annotations): markers shown in empty chart

### DIFF
--- a/src/components/annotation_tooltips.tsx
+++ b/src/components/annotation_tooltips.tsx
@@ -104,6 +104,12 @@ class AnnotationTooltipComponent extends React.Component<AnnotationTooltipProps>
   }
 
   render() {
+    const { chartStore } = this.props;
+
+    if (chartStore!.isChartEmpty.get()) {
+      return null;
+    }
+
     return (
       <React.Fragment>
         {this.renderAnnotationMarkers()}

--- a/stories/annotations.tsx
+++ b/stories/annotations.tsx
@@ -73,7 +73,7 @@ storiesOf('Annotations', module)
 
     return (
       <Chart className={'story-chart'}>
-        <Settings debug={boolean('debug', false)} rotation={chartRotation} />
+        <Settings showLegend debug={boolean('debug', false)} rotation={chartRotation} />
         <LineAnnotation
           annotationId={getAnnotationId('anno_1')}
           domainType={AnnotationDomainTypes.XDomain}


### PR DESCRIPTION
## Summary

Fix markers from showing in the empty chart state

closes #357

![Screen Recording 2019-08-27 at 09 15 PM](https://user-images.githubusercontent.com/19007109/63820693-d236a600-c90f-11e9-907a-ada0cd93b045.gif)


### Checklist

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
