### PR TITLE
feat(axis): option to hide duplicate axes

### DIFF
--- a/src/chart_types/xy_chart/store/chart_state.ts
+++ b/src/chart_types/xy_chart/store/chart_state.ts
@@ -134,7 +134,7 @@ export const isDuplicateAxis = (
     ) {
       const spec = specMap.get(axisId);
 
-      if (spec && spec.position === position && ((!title && !spec.title) || title === spec.title)) {
+      if (spec && spec.position === position && title === spec.title) {
         hasDuplicate = true;
       }
     }

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -3,7 +3,7 @@ import { inject, observer } from 'mobx-react';
 import { ContainerConfig } from 'konva';
 import { Layer, Rect, Stage } from 'react-konva';
 
-import { AnnotationId, AxisId } from '../../utils/ids';
+import { AnnotationId } from '../../utils/ids';
 import { isLineAnnotation, isRectAnnotation, AxisSpec } from '../../chart_types/xy_chart/utils/specs';
 import { LineAnnotationStyle, RectAnnotationStyle, mergeGridLineConfigs } from '../../utils/themes/theme';
 import {
@@ -37,8 +37,8 @@ interface ReactiveChartState {
   };
 }
 
-interface AxisConfig {
-  id: AxisId;
+interface AxisProps {
+  key: string;
   axisSpec: AxisSpec;
   axisTicksDimensions: AxisTicksDimensions;
   axisPosition: Dimensions;
@@ -163,20 +163,20 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     ];
   };
 
-  getAxes = (): AxisConfig[] => {
+  getAxes = (): AxisProps[] => {
     const { axesVisibleTicks, axesSpecs, axesTicksDimensions, axesPositions } = this.props.chartStore!;
     const ids = [...axesVisibleTicks.keys()];
 
     return ids
       .map((id) => ({
-        id,
+        key: `axis-${id}`,
         ticks: axesVisibleTicks.get(id),
         axisSpec: axesSpecs.get(id),
         axisTicksDimensions: axesTicksDimensions.get(id),
         axisPosition: axesPositions.get(id),
       }))
       .filter(
-        (config: Partial<AxisConfig>): config is AxisConfig => {
+        (config: Partial<AxisProps>): config is AxisProps => {
           const { ticks, axisSpec, axisTicksDimensions, axisPosition } = config;
 
           return Boolean(ticks && axisSpec && axisTicksDimensions && axisPosition);
@@ -188,17 +188,8 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     const { chartTheme, debug, chartDimensions } = this.props.chartStore!;
     const axes = this.getAxes();
 
-    return axes.map(({ id, ticks, axisSpec, axisTicksDimensions, axisPosition }) => (
-      <Axis
-        key={`axis-${id}`}
-        axisSpec={axisSpec}
-        axisTicksDimensions={axisTicksDimensions}
-        axisPosition={axisPosition}
-        ticks={ticks}
-        chartTheme={chartTheme}
-        debug={debug}
-        chartDimensions={chartDimensions}
-      />
+    return axes.map(({ key, ...axisProps }) => (
+      <Axis {...axisProps} key={key} chartTheme={chartTheme} debug={debug} chartDimensions={chartDimensions} />
     ));
   };
 

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -167,27 +167,21 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     const { axesVisibleTicks, axesSpecs, axesTicksDimensions, axesPositions } = this.props.chartStore!;
     const ids = [...axesVisibleTicks.keys()];
 
-    return ids.reduce(
-      (acc, id) => {
-        const ticks = axesVisibleTicks.get(id);
-        const axisSpec = axesSpecs.get(id);
-        const axisTicksDimensions = axesTicksDimensions.get(id);
-        const axisPosition = axesPositions.get(id);
+    return ids
+      .map((id) => ({
+        id,
+        ticks: axesVisibleTicks.get(id),
+        axisSpec: axesSpecs.get(id),
+        axisTicksDimensions: axesTicksDimensions.get(id),
+        axisPosition: axesPositions.get(id),
+      }))
+      .filter(
+        (config: Partial<AxisConfig>): config is AxisConfig => {
+          const { ticks, axisSpec, axisTicksDimensions, axisPosition } = config;
 
-        if (ticks && axisSpec && axisTicksDimensions && axisPosition) {
-          acc.push({
-            id,
-            ticks,
-            axisSpec,
-            axisTicksDimensions,
-            axisPosition,
-          });
-        }
-
-        return acc;
-      },
-      [] as AxisConfig[],
-    );
+          return Boolean(ticks && axisSpec && axisTicksDimensions && axisPosition);
+        },
+      );
   };
 
   renderAxes = (): JSX.Element[] => {

--- a/src/specs/settings.test.tsx
+++ b/src/specs/settings.test.tsx
@@ -79,6 +79,7 @@ describe('Settings spec component', () => {
         snap: false,
       },
       legendPosition: Position.Bottom,
+      hideDuplicateAxes: false,
       showLegendDisplayValue: false,
       debug: true,
       xDomain: { min: 0, max: 10 },
@@ -183,6 +184,7 @@ describe('Settings spec component', () => {
       },
       legendPosition: Position.Bottom,
       showLegendDisplayValue: false,
+      hideDuplicateAxes: false,
       debug: true,
       xDomain: { min: 0, max: 10 },
     };

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -78,6 +78,12 @@ export interface SettingSpecProps {
   debug: boolean;
   legendPosition?: Position;
   showLegendDisplayValue: boolean;
+  /**
+   * Removes duplicate axes
+   *
+   * Compares title, position and first & last tick labels
+   */
+  hideDuplicateAxes: boolean;
   onElementClick?: ElementClickListener;
   onElementOver?: ElementOverListener;
   onElementOut?: () => undefined | void;
@@ -130,6 +136,7 @@ function updateChartStore(props: SettingSpecProps) {
     debug,
     xDomain,
     resizeDebounce,
+    hideDuplicateAxes,
   } = props;
 
   if (!chartStore) {
@@ -142,6 +149,7 @@ function updateChartStore(props: SettingSpecProps) {
   chartStore.animateData = animateData;
   chartStore.debug = debug;
   chartStore.resizeDebounce = resizeDebounce!;
+  chartStore.hideDuplicateAxes = hideDuplicateAxes;
 
   if (tooltip && isTooltipProps(tooltip)) {
     const { type, snap, headerFormatter } = tooltip;
@@ -203,6 +211,7 @@ export class SettingsComponent extends PureComponent<SettingSpecProps> {
     showLegend: false,
     resizeDebounce: 10,
     debug: false,
+    hideDuplicateAxes: false,
     tooltip: {
       type: DEFAULT_TOOLTIP_TYPE,
       snap: DEFAULT_TOOLTIP_SNAP,

--- a/stories/scales.tsx
+++ b/stories/scales.tsx
@@ -1,8 +1,8 @@
-import { select } from '@storybook/addon-knobs';
+import { select, boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import { DateTime } from 'luxon';
 import React from 'react';
-import { Axis, Chart, getAxisId, getSpecId, LineSeries, Position, ScaleType } from '../src';
+import { Axis, Chart, getAxisId, getSpecId, LineSeries, Position, ScaleType, Settings } from '../src';
 
 const today = new Date().getTime();
 const UTC_DATE = DateTime.fromISO('2019-01-01T00:00:00.000Z').toMillis();
@@ -199,6 +199,40 @@ storiesOf('Scales', module)
         text: `You can visualize data in a different timezone than your local or UTC zones.
         Specify the \`timeZone={'utc-6'}\` property with the correct timezone and
         remember to apply the same timezone also to each formatted tick in \`tickFormat\` `,
+      },
+    },
+  )
+  .add(
+    'Remove duplicate scales',
+    () => {
+      return (
+        <Chart className={'story-chart'}>
+          <Settings hideDuplicateAxes={boolean('hideDuplicateAxes', true)} />
+          <Axis id={getAxisId('bottom')} position={Position.Bottom} />
+          <Axis id={getAxisId('y1')} position={Position.Left} tickFormat={(d) => `${d}%`} />
+          <Axis id={getAxisId('y2')} position={Position.Left} tickFormat={(d) => `${d}%`} />
+          <Axis
+            title="Axis - Different title"
+            id={getAxisId('y3')}
+            position={Position.Left}
+            tickFormat={(d) => `${d}%`}
+          />
+          <Axis domain={{ min: 0 }} id={getAxisId('y4')} position={Position.Left} tickFormat={(d) => `${d}%`} />
+          <LineSeries
+            id={getSpecId('lines')}
+            xScaleType={ScaleType.Time}
+            yScaleType={ScaleType.Linear}
+            xAccessor={0}
+            yAccessors={[1]}
+            timeZone={'utc-6'}
+            data={[[1, 62], [2, 56], [3, 41], [4, 62], [5, 90]]}
+          />
+        </Chart>
+      );
+    },
+    {
+      info: {
+        text: '`hideDuplicateAxes` will remove redundant axes that have the same min and max labels and position',
       },
     },
   );


### PR DESCRIPTION
## Summary

Adds prop `hideDuplicateAxes` to settings to hide axes based on tick labels, position and title.

* Refactor axes render function.

Axis will be hidden if all of the following conditions are true:
- The first and last tick labels (with applied `tickFormat`) match
- The `length` of the ticks match
- The `titles` match, can be both `undefined`
- The `position` on the spec match

closes #368

![Screen Recording 2019-09-10 at 05 37 PM](https://user-images.githubusercontent.com/19007109/64655388-be03a600-d3f1-11e9-84d3-7222b5d0be5c.gif)


### Checklist
- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
