### PR TITLE
fix(reactive_chart): fix order of instantiation of onBruchEnd callback

### DIFF
--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -76,6 +76,10 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     },
   };
 
+  componentWillUnmount() {
+    window.removeEventListener('mouseup', this.onEndBrushing);
+  }
+
   renderBarSeries = (clippings: ContainerConfig): ReactiveChartElementIndex[] => {
     const { geometries, canDataBeAnimated, chartTheme } = this.props.chartStore!;
     if (!geometries) {
@@ -292,8 +296,6 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
     let y = 0;
     let width = 0;
     let height = 0;
-    // x = {chartDimensions.left + chartTransform.x};
-    // y = {chartDimensions.top + chartTransform.y};
     if (chartRotation === 0 || chartRotation === 180) {
       x = brushStart.x;
       y = chartDimensions.top + chartTransform.y;
@@ -320,12 +322,17 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
   onEndBrushing = () => {
     window.removeEventListener('mouseup', this.onEndBrushing);
     const { brushStart, brushEnd } = this.state;
-    this.props.chartStore!.onBrushEnd(brushStart, brushEnd);
-    this.setState(() => ({
-      brushing: false,
-      brushStart: { x: 0, y: 0 },
-      brushEnd: { x: 0, y: 0 },
-    }));
+
+    this.setState(
+      () => ({
+        brushing: false,
+        brushStart: { x: 0, y: 0 },
+        brushEnd: { x: 0, y: 0 },
+      }),
+      () => {
+        this.props.chartStore!.onBrushEnd(brushStart, brushEnd);
+      },
+    );
   };
   onBrushing = (event: { evt: MouseEvent }) => {
     if (!this.state.brushing) {


### PR DESCRIPTION
## Summary

This PR fixes an issue found in SIEM where the `onBrushEnd` callback triggers a URL change and thus a rerender of the page and `Chart` components on the page. The workaround solution was to add a `500ms` `setTimeout` to allow time for the state to update before calling the `onBrushEnd` callback.

The solution as suggested by @FrankHassanabad, is to invoke the `onBrushEnd` callback following the completion of the `setState` method.

fixes #360

## Screenshot
Notice no console errors when brushing chart and successful update of time range and chart.
![Screen Recording 2019-09-12 at 09 45 PM](https://user-images.githubusercontent.com/19007109/64834249-b89b8c80-d5a6-11e9-8448-664d3d9fc68a.gif)

Additionally, added `componentWillUnmount` method to ensure `window.removeEventListener` is called on `mouseup` event in the case where the `Chart` is unmounted before this event is called.
    
### Checklist

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
