### PR TITLE
feat(style): point style overrides for area and line charts

### DIFF
--- a/src/chart_types/xy_chart/domains/y_domain.ts
+++ b/src/chart_types/xy_chart/domains/y_domain.ts
@@ -16,14 +16,7 @@ export type YDomain = BaseDomain & {
 };
 export type YBasicSeriesSpec = Pick<
   BasicSeriesSpec,
-  | 'id'
-  | 'seriesType'
-  | 'yScaleType'
-  | 'groupId'
-  | 'stackAccessors'
-  | 'yScaleToDataExtent'
-  | 'styleAccessor'
-  | 'useDefaultGroupDomain'
+  'id' | 'seriesType' | 'yScaleType' | 'groupId' | 'stackAccessors' | 'yScaleToDataExtent' | 'useDefaultGroupDomain'
 > & { stackAsPercentage?: boolean };
 
 interface GroupSpecs {

--- a/src/chart_types/xy_chart/rendering/rendering.test.ts
+++ b/src/chart_types/xy_chart/rendering/rendering.test.ts
@@ -4,7 +4,7 @@ import {
   getGeometryStyle,
   isPointOnGeometry,
   PointGeometry,
-  getStyleOverrides,
+  getBarStyleOverrides,
   GeometryId,
 } from './rendering';
 import { BarSeriesStyle, SharedGeometryStyle } from '../../../utils/themes/theme';
@@ -169,7 +169,7 @@ describe('Rendering utils', () => {
     expect(noHover).toBe(sharedThemeStyle.highlighted);
   });
 
-  describe('getStyleOverrides', () => {
+  describe('getBarStyleOverrides', () => {
     let mockAccessor: jest.Mock;
 
     const sampleSeriesStyle: BarSeriesStyle = {
@@ -205,21 +205,21 @@ describe('Rendering utils', () => {
       mockAccessor = jest.fn();
     });
 
-    it('should return input seriesStyle if no styleAccessor is passed', () => {
-      const styleOverrides = getStyleOverrides(datum, geometryId, sampleSeriesStyle);
+    it('should return input seriesStyle if no barStyleAccessor is passed', () => {
+      const styleOverrides = getBarStyleOverrides(datum, geometryId, sampleSeriesStyle);
 
       expect(styleOverrides).toBe(sampleSeriesStyle);
     });
 
-    it('should return input seriesStyle if styleAccessor returns null', () => {
+    it('should return input seriesStyle if barStyleAccessor returns null', () => {
       mockAccessor.mockReturnValue(null);
-      const styleOverrides = getStyleOverrides(datum, geometryId, sampleSeriesStyle, mockAccessor);
+      const styleOverrides = getBarStyleOverrides(datum, geometryId, sampleSeriesStyle, mockAccessor);
 
       expect(styleOverrides).toBe(sampleSeriesStyle);
     });
 
-    it('should call styleAccessor with datum and geometryId', () => {
-      getStyleOverrides(datum, geometryId, sampleSeriesStyle, mockAccessor);
+    it('should call barStyleAccessor with datum and geometryId', () => {
+      getBarStyleOverrides(datum, geometryId, sampleSeriesStyle, mockAccessor);
 
       expect(mockAccessor).toBeCalledWith(datum, geometryId);
     });
@@ -227,7 +227,7 @@ describe('Rendering utils', () => {
     it('should return seriesStyle with updated fill color', () => {
       const color = 'blue';
       mockAccessor.mockReturnValue(color);
-      const styleOverrides = getStyleOverrides(datum, geometryId, sampleSeriesStyle, mockAccessor);
+      const styleOverrides = getBarStyleOverrides(datum, geometryId, sampleSeriesStyle, mockAccessor);
       const expectedStyles: BarSeriesStyle = {
         ...sampleSeriesStyle,
         rect: {
@@ -240,7 +240,7 @@ describe('Rendering utils', () => {
 
     it('should return a new seriesStyle object with color', () => {
       mockAccessor.mockReturnValue('blue');
-      const styleOverrides = getStyleOverrides(datum, geometryId, sampleSeriesStyle, mockAccessor);
+      const styleOverrides = getBarStyleOverrides(datum, geometryId, sampleSeriesStyle, mockAccessor);
 
       expect(styleOverrides).not.toBe(sampleSeriesStyle);
     });
@@ -255,7 +255,7 @@ describe('Rendering utils', () => {
         },
       };
       mockAccessor.mockReturnValue(partialStyle);
-      const styleOverrides = getStyleOverrides(datum, geometryId, sampleSeriesStyle, mockAccessor);
+      const styleOverrides = getBarStyleOverrides(datum, geometryId, sampleSeriesStyle, mockAccessor);
       const expectedStyles = mergePartial(sampleSeriesStyle, partialStyle, {
         mergeOptionalPartialValues: true,
       });
@@ -269,7 +269,7 @@ describe('Rendering utils', () => {
           fill: 'blue',
         },
       });
-      const styleOverrides = getStyleOverrides(datum, geometryId, sampleSeriesStyle, mockAccessor);
+      const styleOverrides = getBarStyleOverrides(datum, geometryId, sampleSeriesStyle, mockAccessor);
 
       expect(styleOverrides).not.toBe(sampleSeriesStyle);
     });

--- a/src/chart_types/xy_chart/store/chart_state.interactions.test.ts
+++ b/src/chart_types/xy_chart/store/chart_state.interactions.test.ts
@@ -290,7 +290,6 @@ function mouseOverTestSuite(scaleType: ScaleType) {
 
     store.annotationSpecs.set(rectAnnotationSpec.annotationId, rectAnnotationSpec);
     store.annotationDimensions.set(rectAnnotationSpec.annotationId, annotationDimensions);
-    debugger;
     // isHighlighted false, chart tooltip true; should show annotationTooltip only
     store.setCursorPosition(chartLeft + 51, chartTop + 1);
     expect(store.isTooltipVisible.get()).toBe(false);

--- a/src/chart_types/xy_chart/store/utils.ts
+++ b/src/chart_types/xy_chart/store/utils.ts
@@ -478,6 +478,7 @@ export function renderGeometries(
         ds.key,
         xScaleOffset,
         lineSeriesStyle,
+        spec.pointStyleAccessor,
       );
       lineGeometriesIndex = mergeGeometriesIndexes(lineGeometriesIndex, renderedLines.indexedGeometries);
       lines.push(renderedLines.lineGeometry);
@@ -504,6 +505,7 @@ export function renderGeometries(
         xScaleOffset,
         areaSeriesStyle,
         isStacked,
+        spec.pointStyleAccessor,
       );
       areaGeometriesIndex = mergeGeometriesIndexes(areaGeometriesIndex, renderedAreas.indexedGeometries);
       areas.push(renderedAreas.areaGeometry);

--- a/src/chart_types/xy_chart/utils/specs.ts
+++ b/src/chart_types/xy_chart/utils/specs.ts
@@ -5,6 +5,7 @@ import {
   LineSeriesStyle,
   RectAnnotationStyle,
   BarSeriesStyle,
+  PointStyle,
 } from '../../../utils/themes/theme';
 import { Accessor } from '../../../utils/accessor';
 import { Omit, RecursivePartial } from '../../../utils/commons';
@@ -19,8 +20,10 @@ export type Datum = any;
 export type Rotation = 0 | 90 | -90 | 180;
 export type Rendering = 'canvas' | 'svg';
 export type Color = string;
-export type StyleOverride = RecursivePartial<BarSeriesStyle> | Color | null;
-export type StyleAccessor = (datum: RawDataSeriesDatum, geometryId: GeometryId) => StyleOverride;
+export type BarStyleOverride = RecursivePartial<BarSeriesStyle> | Color | null;
+export type PointStyleOverride = RecursivePartial<PointStyle> | Color | null;
+export type BarStyleAccessor = (datum: RawDataSeriesDatum, geometryId: GeometryId) => BarStyleOverride;
+export type PointStyleAccessor = (datum: RawDataSeriesDatum, geometryId: GeometryId) => PointStyleOverride;
 export const DEFAULT_GLOBAL_ID = '__global__';
 
 interface DomainMinInterval {
@@ -104,8 +107,6 @@ export interface SeriesAccessors {
   splitSeriesAccessors?: Accessor[];
   /** An array of fields thats indicates the stack membership */
   stackAccessors?: Accessor[];
-  /** An optional functional accessor to return custom datum color or style */
-  styleAccessor?: StyleAccessor;
 }
 
 export interface SeriesScales {
@@ -148,6 +149,10 @@ export type BarSeriesSpec = BasicSeriesSpec & {
    * Stack each series in percentage for each point.
    */
   stackAsPercentage?: boolean;
+  /**
+   * An optional functional accessor to return custom color or style for bar datum
+   */
+  styleAccessor?: BarStyleAccessor;
 };
 
 /**
@@ -167,6 +172,10 @@ export type LineSeriesSpec = BasicSeriesSpec &
     seriesType: 'line';
     curve?: CurveType;
     lineSeriesStyle?: RecursivePartial<LineSeriesStyle>;
+    /**
+     * An optional functional accessor to return custom color or style for point datum
+     */
+    pointStyleAccessor?: PointStyleAccessor;
   };
 
 /**
@@ -183,6 +192,10 @@ export type AreaSeriesSpec = BasicSeriesSpec &
      * Stack each series in percentage for each point.
      */
     stackAsPercentage?: boolean;
+    /**
+     * An optional functional accessor to return custom color or style for point datum
+     */
+    pointStyleAccessor?: PointStyleAccessor;
   };
 
 interface HistogramConfig {

--- a/src/components/react_canvas/area_geometries.tsx
+++ b/src/components/react_canvas/area_geometries.tsx
@@ -9,7 +9,7 @@ import {
   getGeometryIdKey,
   GeometryId,
 } from '../../chart_types/xy_chart/rendering/rendering';
-import { SharedGeometryStyle } from '../../utils/themes/theme';
+import { SharedGeometryStyle, PointStyle } from '../../utils/themes/theme';
 import {
   buildAreaRenderProps,
   buildPointStyleProps,
@@ -17,6 +17,7 @@ import {
   PointStyleProps,
   buildLineRenderProps,
 } from './utils/rendering_props_utils';
+import { mergePartial } from '../../utils/commons';
 
 interface AreaGeometriesDataProps {
   animated?: boolean;
@@ -103,6 +104,14 @@ export class AreaGeometries extends React.PureComponent<AreaGeometriesDataProps,
     );
   };
 
+  private mergePointPropsWithOverrides(props: PointStyleProps, overrides?: Partial<PointStyle>): PointStyleProps {
+    if (!overrides) {
+      return props;
+    }
+
+    return mergePartial(props, overrides);
+  }
+
   private renderPoints = (
     areaPoints: PointGeometry[],
     areaIndex: number,
@@ -110,9 +119,10 @@ export class AreaGeometries extends React.PureComponent<AreaGeometriesDataProps,
     geometryId: GeometryId,
   ): JSX.Element[] => {
     return areaPoints.map((areaPoint, pointIndex) => {
-      const { x, y, transform } = areaPoint;
+      const { x, y, transform, styleOverrides } = areaPoint;
       const key = getGeometryIdKey(geometryId, `area-point-${areaIndex}-${pointIndex}-`);
-      const pointProps = buildPointRenderProps(transform.x + x, y, pointStyleProps);
+      const pointStyle = this.mergePointPropsWithOverrides(pointStyleProps, styleOverrides);
+      const pointProps = buildPointRenderProps(transform.x + x, y, pointStyle);
       return <Circle {...pointProps} key={key} />;
     });
   };

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -28,15 +28,12 @@ import {
   Settings,
   timeFormatter,
   TooltipType,
-  RecursivePartial,
 } from '../src';
 import * as TestDatasets from '../src/utils/data_samples/test_dataset';
 
 import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
 
 import { TEST_DATASET_DISCOVER } from '../src/utils/data_samples/test_dataset_discover_per_30s';
-import { StyleAccessor } from '../src/chart_types/xy_chart/utils/specs';
-import { BarSeriesStyle } from '../src/utils/themes/theme';
 
 const dateFormatter = timeFormatter('HH:mm:ss');
 
@@ -1788,39 +1785,6 @@ storiesOf('Bar Chart', module)
           yAccessors={[1]}
           data={data3}
           yScaleToDataExtent={false}
-        />
-      </Chart>
-    );
-  })
-  .add('styleAccessor overrides', () => {
-    const hasThreshold = boolean('threshold', true);
-    const threshold = number('min threshold', 4);
-    const style: RecursivePartial<BarSeriesStyle> = {
-      rect: {
-        opacity: 0.5,
-        fill: 'red',
-      },
-    };
-    const styleAccessor: StyleAccessor = (d, g) => (g.specId === getSpecId('bars') && d.y1! > threshold ? style : null);
-
-    return (
-      <Chart className="story-chart">
-        <Axis id={getAxisId('bottom')} position={Position.Bottom} title={'Bottom axis'} showOverlappingTicks={true} />
-        <Axis
-          id={getAxisId('left2')}
-          title={'Left axis'}
-          position={Position.Left}
-          tickFormat={(d: any) => Number(d).toFixed(2)}
-        />
-
-        <BarSeries
-          id={getSpecId('bars')}
-          xScaleType={ScaleType.Linear}
-          yScaleType={ScaleType.Linear}
-          xAccessor="x"
-          yAccessors={['y']}
-          styleAccessor={hasThreshold ? styleAccessor : undefined}
-          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
         />
       </Chart>
     );

--- a/stories/styling.tsx
+++ b/stories/styling.tsx
@@ -25,9 +25,12 @@ import {
   Theme,
   LIGHT_THEME,
   DARK_THEME,
+  BarSeriesStyle,
+  PointStyle,
 } from '../src/';
 import * as TestDatasets from '../src/utils/data_samples/test_dataset';
 import { palettes } from '../src/utils/themes/colors';
+import { BarStyleAccessor, PointStyleAccessor } from '../src/chart_types/xy_chart/utils/specs';
 
 function range(title: string, min: number, max: number, value: number, groupId?: string, step: number = 1) {
   return number(
@@ -855,6 +858,75 @@ storiesOf('Stylings', module)
           xAccessor="x"
           yAccessors={['y']}
           data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+        />
+      </Chart>
+    );
+  })
+  .add('Style Accessor Overrides', () => {
+    const hasThreshold = boolean('threshold', true);
+    const threshold = number('min threshold', 3);
+    const barStyle: RecursivePartial<BarSeriesStyle> = {
+      rect: {
+        opacity: 0.5,
+        fill: 'red',
+      },
+    };
+    const pointStyle: RecursivePartial<PointStyle> = {
+      fill: 'red',
+      radius: 10,
+    };
+    const barStyleAccessor: BarStyleAccessor = (d, g) =>
+      g.specId === getSpecId('bar') && d.y1! > threshold ? barStyle : null;
+    const pointStyleAccessor: PointStyleAccessor = (d, g) =>
+      (g.specId === getSpecId('line') || g.specId === getSpecId('area')) && d.y1! > threshold ? pointStyle : null;
+
+    return (
+      <Chart className="story-chart">
+        <Settings
+          theme={{
+            areaSeriesStyle: {
+              point: {
+                visible: true,
+              },
+            },
+          }}
+        />
+        <Axis id={getAxisId('bottom')} position={Position.Bottom} title={'Bottom axis'} showOverlappingTicks={true} />
+        <Axis
+          id={getAxisId('left')}
+          title={'Left axis'}
+          position={Position.Left}
+          tickFormat={(d: any) => Number(d).toFixed(2)}
+        />
+
+        <BarSeries
+          id={getSpecId('bar')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          styleAccessor={hasThreshold ? barStyleAccessor : undefined}
+          data={[{ x: 0, y: 2 }, { x: 1, y: 7 }, { x: 2, y: 3 }, { x: 3, y: 6 }]}
+        />
+
+        <LineSeries
+          id={getSpecId('line')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          pointStyleAccessor={hasThreshold ? pointStyleAccessor : undefined}
+          data={[{ x: 0, y: 1 }, { x: 1, y: 6 }, { x: 2, y: 2 }, { x: 3, y: 5 }]}
+        />
+
+        <AreaSeries
+          id={getSpecId('area')}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          pointStyleAccessor={hasThreshold ? pointStyleAccessor : undefined}
+          data={[{ x: 0, y: 0.5 }, { x: 1, y: 4 }, { x: 2, y: 1 }, { x: 3, y: 4 }]}
         />
       </Chart>
     );

--- a/wiki/overview.md
+++ b/wiki/overview.md
@@ -216,13 +216,26 @@ In the case of small multiples, each `SplittedSeries` computes its own x and y d
 
 ### Color/Style overrides
 
-Each `datum` of a **Bar Chart** data series can be assigned a custom color or style with the `styleAccessor` prop.
+#### BarSeries
+Each bar `datum` of a **Bar** data series can be assigned a custom color or style with the `styleAccessor` prop.
 
 The `styleAccessor` prop expects a callback function which will be called on _every_ `datum` in _every_ bar series with the signiture below. This callback should return a color `string` or a partial `BarSeriesStyle`, which will override any series-level styles for the respective `datum`. You are passed `geometryId` to identify the series the `datum` belongs to and the raw `datum` to derive conditions against.
 
 ```ts
-type StyleAccessor = (
+type BarStyleAccessor = (
   datum: RawDataSeriesDatum,
   geometryId: GeometryId,
 ) => RecursivePartial<BarSeriesStyle> | Color | null;
+```
+
+#### LineSeries and AreaSeries points
+Each point `datum` of a **Line** or **Area** data series can be assigned a custom color or style with the `pointStyleAccessor` prop.
+
+The `pointStyleAccessor` prop expects a callback function which will be called on _every_ `datum` in _every_ line or area series with the signiture below. This callback should return a color `string` or a partial `PointStyle`, which will override any series-level styles for the respective `datum`. You are passed `geometryId` to identify the series the `datum` belongs to and the raw `datum` to derive conditions against.
+
+```ts
+type PointStyleAccessor = (
+  datum: RawDataSeriesDatum,
+  geometryId: GeometryId,
+) => RecursivePartial<PointStyle> | Color | null;
 ```


### PR DESCRIPTION
## Summary

### Color/Style overrides

#### BarSeries
Each bar `datum` of a **Bar** data series can be assigned a custom color or style with the `styleAccessor` prop.

The `styleAccessor` prop expects a callback function which will be called on _every_ `datum` in _every_ bar series with the signiture below. This callback should return a color `string` or a partial `BarSeriesStyle`, which will override any series-level styles for the respective `datum`. You are passed `geometryId` to identify the series the `datum` belongs to and the raw `datum` to derive conditions against.

```ts
type BarStyleAccessor = (
  datum: RawDataSeriesDatum,
  geometryId: GeometryId,
) => RecursivePartial<BarSeriesStyle> | Color | null;
```

#### LineSeries and AreaSeries points
Each point `datum` of a **Line** or **Area** data series can be assigned a custom color or style with the `pointStyleAccessor` prop.

The `pointStyleAccessor` prop expects a callback function which will be called on _every_ `datum` in _every_ line or area series with the signiture below. This callback should return a color `string` or a partial `PointStyle`, which will override any series-level styles for the respective `datum`. You are passed `geometryId` to identify the series the `datum` belongs to and the raw `datum` to derive conditions against.

```ts
type PointStyleAccessor = (
  datum: RawDataSeriesDatum,
  geometryId: GeometryId,
) => RecursivePartial<PointStyle> | Color | null;
```

## Demo

![Screen Recording 2019-09-22 at 08 59 PM](https://user-images.githubusercontent.com/19007109/65398279-e6898980-dd7b-11e9-922a-fb66158b2903.gif)

### Checklist

- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
