### PR TITLE
chore(.eslintrc): remove comma-dangle from eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,7 +46,6 @@ module.exports = {
         ignoreRestSiblings: true,
       },
     ],
-    'comma-dangle': ['error', 'always-multiline'],
     'sort-keys': 'off',
     'import/no-default-export': 'error',
     'import/no-unresolved': 'error',


### PR DESCRIPTION
## Summary

In speaking with @nickofthyme, this is a PR to address removing the `'comma-dangle': ['error', 'always-multiline']` from eslintrc.js 

Prevents this 👇 
![Screen Recording 2019-09-25 at 11 32 AM](https://user-images.githubusercontent.com/19007109/65620875-418fcc00-df88-11e9-8d18-af856d59463b.gif)


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~~- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~~
~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11]~~(https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
~~- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials~~
~~- [ ] Unit tests were updated or added to match the most common scenarios~~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
