### PR TITLE
fix(rendering): out-of-domain rendering of points/bars/lines/areas

### DIFF
--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -1,50 +1,75 @@
 import React, { Fragment } from 'react';
-import { Axis, Chart, getAxisId, getSpecId, Position, ScaleType, Settings, BarSeries } from '../src';
+import {
+  Axis,
+  Chart,
+  getAxisId,
+  getSpecId,
+  Position,
+  ScaleType,
+  Settings,
+  BarSeries,
+  LineSeries,
+  AreaSeries,
+} from '../src';
 
 export class Playground extends React.Component {
   render() {
     return (
       <Fragment>
         <div className="chart">
-          <Chart>
+          <Chart className="story-chart">
             <Settings
-              showLegend={true}
               theme={{
-                axes: {
-                  gridLineStyle: {
-                    horizontal: {
-                      stroke: 'red',
-                      strokeWidth: 0.5,
-                      opacity: 1,
-                      dash: [0, 0],
-                    },
-                    vertical: {
-                      stroke: 'blue',
-                      strokeWidth: 0.5,
-                      opacity: 1,
-                      dash: [4, 4],
-                    },
+                areaSeriesStyle: {
+                  point: {
+                    visible: true,
                   },
                 },
               }}
+              xDomain={{
+                max: 3.8,
+              }}
             />
             <Axis
-              id={getAxisId('y')}
+              id={getAxisId('bottom')}
+              position={Position.Bottom}
+              title={'Bottom axis'}
+              showOverlappingTicks={true}
+            />
+            <Axis
+              id={getAxisId('left')}
+              title={'Left axis'}
               position={Position.Left}
               domain={{
-                min: 50,
-                max: 250,
+                max: 5,
               }}
-              showGridLines
             />
-            <Axis showGridLines id={getAxisId('x')} position={Position.Bottom} />
+
             <BarSeries
               id={getSpecId('bar')}
-              yScaleType={ScaleType.Linear}
               xScaleType={ScaleType.Linear}
+              yScaleType={ScaleType.Linear}
               xAccessor={0}
               yAccessors={[1]}
-              data={[[0, 100], [1, 50], [3, 400], [4, 250], [5, 235]]}
+              data={[[0, 1], [1, 2], [2, 10], [3, 4], [4, 5]]}
+            />
+
+            <LineSeries
+              id={getSpecId('line')}
+              xScaleType={ScaleType.Linear}
+              yScaleType={ScaleType.Linear}
+              xAccessor={0}
+              yAccessors={[1]}
+              data={[[0, 1], [1, 2], [2, 10], [3, 4], [4, 5]]}
+            />
+
+            <AreaSeries
+              id={getSpecId('area')}
+              xScaleType={ScaleType.Linear}
+              yScaleType={ScaleType.Linear}
+              xAccessor={0}
+              yAccessors={[1]}
+              data={[[0, 1], [1, 2], [2, 10], [3, 4], [4, 5]]}
             />
           </Chart>
         </div>

--- a/src/chart_types/xy_chart/store/utils.test.ts
+++ b/src/chart_types/xy_chart/store/utils.test.ts
@@ -373,8 +373,8 @@ describe('Chart State utils', () => {
         false,
       );
       expect(geometries.geometriesCounts.bars).toBe(8);
-      expect(geometries.geometriesCounts.linePoints).toBe(6);
-      expect(geometries.geometriesCounts.areasPoints).toBe(6);
+      expect(geometries.geometriesCounts.linePoints).toBe(8);
+      expect(geometries.geometriesCounts.areasPoints).toBe(8);
       expect(geometries.geometriesCounts.lines).toBe(2);
       expect(geometries.geometriesCounts.areas).toBe(2);
     });
@@ -561,8 +561,8 @@ describe('Chart State utils', () => {
         false,
       );
       expect(geometries.geometriesCounts.bars).toBe(8);
-      expect(geometries.geometriesCounts.linePoints).toBe(6);
-      expect(geometries.geometriesCounts.areasPoints).toBe(6);
+      expect(geometries.geometriesCounts.linePoints).toBe(8);
+      expect(geometries.geometriesCounts.areasPoints).toBe(8);
       expect(geometries.geometriesCounts.lines).toBe(2);
       expect(geometries.geometriesCounts.areas).toBe(2);
     });

--- a/src/utils/scales/scale_band.test.ts
+++ b/src/utils/scales/scale_band.test.ts
@@ -28,6 +28,14 @@ describe('Scale Band', () => {
     expect(scale.scale('c')).toBe(50);
     expect(scale.scale('d')).toBe(75);
   });
+  it('is value within domain', () => {
+    const scale = new ScaleBand(['a', 'b', 'c', 'd'], [0, 100]);
+    expect(scale.bandwidth).toBe(25);
+    expect(scale.isValueInDomain('a')).toBe(true);
+    expect(scale.isValueInDomain('b')).toBe(true);
+    expect(scale.isValueInDomain('z')).toBe(false);
+    expect(scale.isValueInDomain(null)).toBe(false);
+  });
   it('shall scale a any domain', () => {
     const scale = new ScaleBand(['a', 1, null, 'd', undefined], [0, 100]);
     expect(scale.bandwidth).toBe(20);

--- a/src/utils/scales/scale_band.ts
+++ b/src/utils/scales/scale_band.ts
@@ -71,6 +71,9 @@ export class ScaleBand implements Scale {
   isSingleValue() {
     return this.domain.length < 2;
   }
+  isValueInDomain(value: any) {
+    return this.domain.includes(value);
+  }
 }
 
 export function isOrdinalScale(scale: Scale): scale is ScaleBand {

--- a/src/utils/scales/scale_continuous.test.ts
+++ b/src/utils/scales/scale_continuous.test.ts
@@ -16,6 +16,16 @@ describe('Scale Continuous', () => {
     expect(scale.invert(50)).toBe(1);
     expect(scale.invert(100)).toBe(2);
   });
+  test('is value within domain', () => {
+    const domain: Domain = [0, 2];
+    const minRange = 0;
+    const maxRange = 100;
+    const scale = new ScaleContinuous({ type: ScaleType.Linear, domain, range: [minRange, maxRange] });
+    expect(scale.isValueInDomain(0)).toBe(true);
+    expect(scale.isValueInDomain(2)).toBe(true);
+    expect(scale.isValueInDomain(-1)).toBe(false);
+    expect(scale.isValueInDomain(3)).toBe(false);
+  });
   test('shall invert on continuous scale time', () => {
     const startTime = DateTime.fromISO('2019-01-01T00:00:00.000', { zone: 'utc' });
     const midTime = DateTime.fromISO('2019-01-02T00:00:00.000', { zone: 'utc' });

--- a/src/utils/scales/scale_continuous.ts
+++ b/src/utils/scales/scale_continuous.ts
@@ -269,6 +269,9 @@ export class ScaleContinuous implements Scale {
     const max = this.domain[this.domain.length - 1];
     return max === min;
   }
+  isValueInDomain(value: number) {
+    return value >= this.domain[0] && value <= this.domain[1];
+  }
 }
 
 export function isContinuousScale(scale: Scale): scale is ScaleContinuous {

--- a/src/utils/scales/scales.ts
+++ b/src/utils/scales/scales.ts
@@ -13,6 +13,8 @@ export interface Scale {
     withinBandwidth: boolean;
   };
   isSingleValue: () => boolean;
+  /** Check if the passed value is within the scale domain */
+  isValueInDomain: (value: any) => boolean;
   bandwidth: number;
   minInterval: number;
   type: ScaleType;


### PR DESCRIPTION
## Summary
On a previous PR: https://github.com/elastic/elastic-charts/pull/355 we fixed the clipping of
elements on the chart edges. This introduced an unwanted bug where we where removing from the chart also points that are within the chart range itself. Instead of checking if a geometry position is
within the range of the scale, this PR checks for the value to be within the domain of the scale.

fix #386

On the following examples (the same that comes with the playground) the X domain is limited to a max value of 3.8. This will remove the bar that is at position 4, the point at position 4 and limit the line to the last valid value (3).

In contrast from the current(master) version where the bar at position 4 is displayed together with a non-delimited line that goes from 3 to "somewhere"
**from:**
<img width="825" alt="Screenshot 2019-09-27 at 14 41 47" src="https://user-images.githubusercontent.com/1421091/65770383-44c8ba80-e136-11e9-87fe-83423810bab7.png">


In this PR we remove everything that is after the point 3.8, removing also the line segment that connect the 3rd point with the "removed" 4th.

**to:**
<img width="824" alt="Screenshot 2019-09-27 at 14 42 21" src="https://user-images.githubusercontent.com/1421091/65770368-3b3f5280-e136-11e9-83fd-c61941ae7efc.png">


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
