### PR TITLE
build(eslint): enable linting hidden folders

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+!/.storybook
+!/.playground
+


### PR DESCRIPTION
## Summary

ESlint by default ignore folders with a name that start with a dot like .storybook and .playground.
This will un-ignore those folders allowing eslint capabilities on editor also on these folders.
see https://github.com/eslint/eslint/issues/8429#issuecomment-355967308


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- ~[ ] Unit tests were updated or added to match the most common scenarios~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
