### PR TITLE
feat: banded legend values

### DIFF
--- a/src/chart_types/xy_chart/legend/legend.test.ts
+++ b/src/chart_types/xy_chart/legend/legend.test.ts
@@ -4,6 +4,16 @@ import { computeLegend, getSeriesColorLabel } from './legend';
 import { DataSeriesColorsValues } from '../utils/series';
 import { AxisSpec, BasicSeriesSpec, Position } from '../utils/specs';
 
+const nullDisplayValue = {
+  formatted: {
+    y0: null,
+    y1: null,
+  },
+  raw: {
+    y0: null,
+    y1: null,
+  },
+};
 const colorValues1a = {
   specId: getSpecId('spec1'),
   colorValues: [],
@@ -86,7 +96,7 @@ describe('Legends', () => {
         isSeriesVisible: true,
         isLegendItemVisible: true,
         key: 'colorSeries1a',
-        displayValue: {},
+        displayValue: nullDisplayValue,
       },
     ];
     expect(Array.from(legend.values())).toEqual(expected);
@@ -103,7 +113,7 @@ describe('Legends', () => {
         isSeriesVisible: true,
         isLegendItemVisible: true,
         key: 'colorSeries1a',
-        displayValue: {},
+        displayValue: nullDisplayValue,
       },
       {
         color: 'blue',
@@ -112,7 +122,7 @@ describe('Legends', () => {
         isSeriesVisible: true,
         isLegendItemVisible: true,
         key: 'colorSeries1b',
-        displayValue: {},
+        displayValue: nullDisplayValue,
       },
     ];
     expect(Array.from(legend.values())).toEqual(expected);
@@ -129,7 +139,7 @@ describe('Legends', () => {
         isSeriesVisible: true,
         isLegendItemVisible: true,
         key: 'colorSeries1a',
-        displayValue: {},
+        displayValue: nullDisplayValue,
       },
       {
         color: 'green',
@@ -138,7 +148,7 @@ describe('Legends', () => {
         isSeriesVisible: true,
         isLegendItemVisible: true,
         key: 'colorSeries2a',
-        displayValue: {},
+        displayValue: nullDisplayValue,
       },
     ];
     expect(Array.from(legend.values())).toEqual(expected);
@@ -160,7 +170,7 @@ describe('Legends', () => {
         isSeriesVisible: true,
         isLegendItemVisible: true,
         key: 'colorSeries1a',
-        displayValue: {},
+        displayValue: nullDisplayValue,
       },
     ];
     expect(Array.from(legend.values())).toEqual(expected);

--- a/src/chart_types/xy_chart/legend/legend.ts
+++ b/src/chart_types/xy_chart/legend/legend.ts
@@ -1,4 +1,4 @@
-import { getAxesSpecForSpecId } from '../store/utils';
+import { getAxesSpecForSpecId, LastValues } from '../store/utils';
 import { identity } from '../../../utils/commons';
 import { AxisId, SpecId } from '../../../utils/ids';
 import {
@@ -6,19 +6,38 @@ import {
   findDataSeriesByColorValues,
   getSortedDataSeriesColorsValuesMap,
 } from '../utils/series';
-import { AxisSpec, BasicSeriesSpec } from '../utils/specs';
+import { AxisSpec, BasicSeriesSpec, Postfixes, isAreaSeriesSpec, isBarSeriesSpec } from '../utils/specs';
+import { Y0_ACCESSOR_POSTFIX, Y1_ACCESSOR_POSTFIX } from '../tooltip/tooltip';
 
-export interface LegendItem {
+export interface FormatedLastValues {
+  y0: number | string | null;
+  y1: number | string | null;
+}
+
+export type LegendItem = Postfixes & {
   key: string;
   color: string;
   label: string;
   value: DataSeriesColorsValues;
   isSeriesVisible?: boolean;
+  banded?: boolean;
   isLegendItemVisible?: boolean;
   displayValue: {
-    raw: any;
-    formatted: any;
+    raw: LastValues;
+    formatted: FormatedLastValues;
   };
+};
+
+export function getPostfix(spec: BasicSeriesSpec): Postfixes {
+  if (isAreaSeriesSpec(spec) || isBarSeriesSpec(spec)) {
+    const { y0AccessorFormat = Y0_ACCESSOR_POSTFIX, y1AccessorFormat = Y1_ACCESSOR_POSTFIX } = spec;
+    return {
+      y0AccessorFormat,
+      y1AccessorFormat,
+    };
+  }
+
+  return {};
 }
 
 export function computeLegend(
@@ -33,10 +52,11 @@ export function computeLegend(
   const sortedSeriesColors = getSortedDataSeriesColorsValuesMap(seriesColor);
 
   sortedSeriesColors.forEach((series, key) => {
-    const spec = specs.get(series.specId);
+    const { banded, specId, lastValue, colorValues } = series;
+    const spec = specs.get(specId);
     const color = seriesColorMap.get(key) || defaultColor;
     const hasSingleSeries = seriesColor.size === 1;
-    const label = getSeriesColorLabel(series.colorValues, hasSingleSeries, spec);
+    const label = getSeriesColorLabel(colorValues, hasSingleSeries, spec);
     const isSeriesVisible = deselectedDataSeries ? findDataSeriesByColorValues(deselectedDataSeries, series) < 0 : true;
 
     if (!label || !spec) {
@@ -46,21 +66,30 @@ export function computeLegend(
     // Use this to get axis spec w/ tick formatter
     const { yAxis } = getAxesSpecForSpecId(axesSpecs, spec.groupId);
     const formatter = yAxis ? yAxis.tickFormat : identity;
-
     const { hideInLegend } = spec;
 
-    legendItems.set(key, {
+    const legendItem: LegendItem = {
       key,
       color,
       label,
+      banded,
       value: series,
       isSeriesVisible,
       isLegendItemVisible: !hideInLegend,
       displayValue: {
-        raw: series.lastValue,
-        formatted: isSeriesVisible ? formatter(series.lastValue) : undefined,
+        raw: {
+          y0: lastValue && lastValue.y0 !== null ? lastValue.y0 : null,
+          y1: lastValue && lastValue.y1 !== null ? lastValue.y1 : null,
+        },
+        formatted: {
+          y0: isSeriesVisible && lastValue && lastValue.y0 !== null ? formatter(lastValue.y0) : null,
+          y1: isSeriesVisible && lastValue && lastValue.y1 !== null ? formatter(lastValue.y1) : null,
+        },
       },
-    });
+      ...getPostfix(spec),
+    };
+
+    legendItems.set(key, legendItem);
   });
   return legendItems;
 }

--- a/src/chart_types/xy_chart/rendering/rendering.test.ts
+++ b/src/chart_types/xy_chart/rendering/rendering.test.ts
@@ -103,8 +103,14 @@ describe('Rendering utils', () => {
       isSeriesVisible: true,
       isLegendItemVisible: true,
       displayValue: {
-        raw: '',
-        formatted: '',
+        formatted: {
+          y0: null,
+          y1: null,
+        },
+        raw: {
+          y0: null,
+          y1: null,
+        },
       },
     };
 

--- a/src/chart_types/xy_chart/store/__snapshots__/utils.test.ts.snap
+++ b/src/chart_types/xy_chart/store/__snapshots__/utils.test.ts.snap
@@ -147,7 +147,7 @@ Array [
             "initialY0": null,
             "initialY1": 1,
             "x": 0,
-            "y0": 0,
+            "y0": null,
             "y1": 1,
           },
           Object {
@@ -159,7 +159,7 @@ Array [
             "initialY0": null,
             "initialY1": 2,
             "x": 1,
-            "y0": 0,
+            "y0": null,
             "y1": 2,
           },
           Object {
@@ -171,7 +171,7 @@ Array [
             "initialY0": null,
             "initialY1": 3,
             "x": 2,
-            "y0": 0,
+            "y0": null,
             "y1": 3,
           },
           Object {
@@ -183,7 +183,7 @@ Array [
             "initialY0": null,
             "initialY1": 4,
             "x": 3,
-            "y0": 0,
+            "y0": null,
             "y1": 4,
           },
         ],

--- a/src/chart_types/xy_chart/store/chart_state.test.ts
+++ b/src/chart_types/xy_chart/store/chart_state.test.ts
@@ -1,5 +1,5 @@
 import { LegendItem } from '../legend/legend';
-import { GeometryValue, IndexedGeometry } from '../rendering/rendering';
+import { GeometryValue, IndexedGeometry, AccessorType } from '../rendering/rendering';
 import {
   AnnotationDomainTypes,
   AnnotationSpec,
@@ -48,8 +48,14 @@ describe('Chart Store', () => {
       colorValues: [],
     },
     displayValue: {
-      raw: 'last',
-      formatted: 'formatted-last',
+      raw: {
+        y1: null,
+        y0: null,
+      },
+      formatted: {
+        y1: 'formatted-last',
+        y0: null,
+      },
     },
   };
 
@@ -62,8 +68,14 @@ describe('Chart Store', () => {
       colorValues: [],
     },
     displayValue: {
-      raw: 'last',
-      formatted: 'formatted-last',
+      raw: {
+        y1: null,
+        y0: null,
+      },
+      formatted: {
+        y1: 'formatted-last',
+        y0: null,
+      },
     },
   };
   beforeEach(() => {
@@ -1039,7 +1051,7 @@ describe('Chart Store', () => {
       isHighlighted: false,
       isXValue: true,
       seriesKey: 'headerSeries',
-      yAccessor: 'y',
+      yAccessor: AccessorType.Y0,
     };
 
     store.tooltipData.replace([headerValue]);
@@ -1052,13 +1064,17 @@ describe('Chart Store', () => {
       isHighlighted: false,
       isXValue: false,
       seriesKey: 'seriesKey',
-      yAccessor: 'y',
+      yAccessor: AccessorType.Y1,
     };
     store.tooltipData.replace([headerValue, tooltipValue]);
 
     const expectedTooltipValues = new Map();
-    expectedTooltipValues.set('seriesKey', 123);
-    expect(store.legendItemTooltipValues.get()).toEqual(expectedTooltipValues);
+    expectedTooltipValues.set('seriesKey', {
+      y0: undefined,
+      y1: 123,
+    });
+    const t = store.legendItemTooltipValues.get();
+    expect(t).toEqual(expectedTooltipValues);
   });
   describe('can determine if crosshair cursor is visible', () => {
     const brushEndListener = (): void => {

--- a/src/chart_types/xy_chart/store/utils.test.ts
+++ b/src/chart_types/xy_chart/store/utils.test.ts
@@ -1203,16 +1203,16 @@ describe('Chart State utils', () => {
       key: 'specId:{bars},colors:{a}',
       color: '#1EA593',
       label: 'a',
-      value: { specId: getSpecId('bars'), colorValues: ['a'], lastValue: 6 },
-      displayValue: { raw: 6, formatted: '6.00' },
+      value: { specId: getSpecId('bars'), colorValues: ['a'], lastValue: { y0: null, y1: 6 } },
+      displayValue: { raw: { y0: null, y1: 6 }, formatted: { y0: null, y1: '6.00' } },
       isSeriesVisible: false,
     });
     legendItems1.set('specId:{bars},colors:{b}', {
       key: 'specId:{bars},colors:{b}',
       color: '#2B70F7',
       label: 'b',
-      value: { specId: getSpecId('bars'), colorValues: ['b'], lastValue: 2 },
-      displayValue: { raw: 2, formatted: '2.00' },
+      value: { specId: getSpecId('bars'), colorValues: ['b'], lastValue: { y0: null, y1: 2 } },
+      displayValue: { raw: { y0: null, y1: 2 }, formatted: { y0: null, y1: '2.00' } },
       isSeriesVisible: false,
     });
     expect(isAllSeriesDeselected(legendItems1)).toBe(true);
@@ -1223,16 +1223,16 @@ describe('Chart State utils', () => {
       key: 'specId:{bars},colors:{a}',
       color: '#1EA593',
       label: 'a',
-      value: { specId: getSpecId('bars'), colorValues: ['a'], lastValue: 6 },
-      displayValue: { raw: 6, formatted: '6.00' },
+      value: { specId: getSpecId('bars'), colorValues: ['a'], lastValue: { y0: null, y1: 6 } },
+      displayValue: { raw: { y0: null, y1: 6 }, formatted: { y0: null, y1: '6.00' } },
       isSeriesVisible: true,
     });
     legendItems2.set('specId:{bars},colors:{b}', {
       key: 'specId:{bars},colors:{b}',
       color: '#2B70F7',
       label: 'b',
-      value: { specId: getSpecId('bars'), colorValues: ['b'], lastValue: 2 },
-      displayValue: { raw: 2, formatted: '2.00' },
+      value: { specId: getSpecId('bars'), colorValues: ['b'], lastValue: { y0: null, y1: 2 } },
+      displayValue: { raw: { y0: null, y1: 2 }, formatted: { y0: null, y1: '2.00' } },
       isSeriesVisible: false,
     });
     expect(isAllSeriesDeselected(legendItems2)).toBe(false);

--- a/src/chart_types/xy_chart/utils/__snapshots__/series.test.ts.snap
+++ b/src/chart_types/xy_chart/utils/__snapshots__/series.test.ts.snap
@@ -1278,7 +1278,7 @@ Array [
         "initialY0": null,
         "initialY1": 0,
         "x": 0,
-        "y0": 0,
+        "y0": null,
         "y1": 0,
       },
       Object {
@@ -1286,7 +1286,7 @@ Array [
         "initialY0": null,
         "initialY1": 1,
         "x": 1,
-        "y0": 0,
+        "y0": null,
         "y1": 1,
       },
       Object {
@@ -1294,7 +1294,7 @@ Array [
         "initialY0": null,
         "initialY1": 2,
         "x": 2,
-        "y0": 0,
+        "y0": null,
         "y1": 2,
       },
       Object {
@@ -1302,7 +1302,7 @@ Array [
         "initialY0": null,
         "initialY1": 3,
         "x": 3,
-        "y0": 0,
+        "y0": null,
         "y1": 3,
       },
       Object {
@@ -1310,7 +1310,7 @@ Array [
         "initialY0": null,
         "initialY1": 4,
         "x": 4,
-        "y0": 0,
+        "y0": null,
         "y1": 4,
       },
       Object {
@@ -1318,7 +1318,7 @@ Array [
         "initialY0": null,
         "initialY1": 5,
         "x": 5,
-        "y0": 0,
+        "y0": null,
         "y1": 5,
       },
       Object {
@@ -1326,7 +1326,7 @@ Array [
         "initialY0": null,
         "initialY1": 6,
         "x": 6,
-        "y0": 0,
+        "y0": null,
         "y1": 6,
       },
       Object {
@@ -1334,7 +1334,7 @@ Array [
         "initialY0": null,
         "initialY1": 7,
         "x": 7,
-        "y0": 0,
+        "y0": null,
         "y1": 7,
       },
       Object {
@@ -1342,7 +1342,7 @@ Array [
         "initialY0": null,
         "initialY1": 8,
         "x": 8,
-        "y0": 0,
+        "y0": null,
         "y1": 8,
       },
       Object {
@@ -1350,7 +1350,7 @@ Array [
         "initialY0": null,
         "initialY1": 9,
         "x": 9,
-        "y0": 0,
+        "y0": null,
         "y1": 9,
       },
       Object {
@@ -1358,7 +1358,7 @@ Array [
         "initialY0": null,
         "initialY1": 10,
         "x": 10,
-        "y0": 0,
+        "y0": null,
         "y1": 10,
       },
       Object {
@@ -1366,7 +1366,7 @@ Array [
         "initialY0": null,
         "initialY1": 11,
         "x": 11,
-        "y0": 0,
+        "y0": null,
         "y1": 11,
       },
       Object {
@@ -1374,7 +1374,7 @@ Array [
         "initialY0": null,
         "initialY1": 12,
         "x": 12,
-        "y0": 0,
+        "y0": null,
         "y1": 12,
       },
       Object {
@@ -1382,7 +1382,7 @@ Array [
         "initialY0": null,
         "initialY1": 13,
         "x": 13,
-        "y0": 0,
+        "y0": null,
         "y1": 13,
       },
       Object {
@@ -1390,7 +1390,7 @@ Array [
         "initialY0": null,
         "initialY1": 14,
         "x": 14,
-        "y0": 0,
+        "y0": null,
         "y1": 14,
       },
       Object {
@@ -1398,7 +1398,7 @@ Array [
         "initialY0": null,
         "initialY1": 15,
         "x": 15,
-        "y0": 0,
+        "y0": null,
         "y1": 15,
       },
       Object {
@@ -1406,7 +1406,7 @@ Array [
         "initialY0": null,
         "initialY1": 16,
         "x": 16,
-        "y0": 0,
+        "y0": null,
         "y1": 16,
       },
       Object {
@@ -1414,7 +1414,7 @@ Array [
         "initialY0": null,
         "initialY1": 17,
         "x": 17,
-        "y0": 0,
+        "y0": null,
         "y1": 17,
       },
       Object {
@@ -1422,7 +1422,7 @@ Array [
         "initialY0": null,
         "initialY1": 18,
         "x": 18,
-        "y0": 0,
+        "y0": null,
         "y1": 18,
       },
       Object {
@@ -1430,7 +1430,7 @@ Array [
         "initialY0": null,
         "initialY1": 19,
         "x": 19,
-        "y0": 0,
+        "y0": null,
         "y1": 19,
       },
       Object {
@@ -1438,7 +1438,7 @@ Array [
         "initialY0": null,
         "initialY1": 20,
         "x": 20,
-        "y0": 0,
+        "y0": null,
         "y1": 20,
       },
       Object {
@@ -1446,7 +1446,7 @@ Array [
         "initialY0": null,
         "initialY1": 21,
         "x": 21,
-        "y0": 0,
+        "y0": null,
         "y1": 21,
       },
       Object {
@@ -1454,7 +1454,7 @@ Array [
         "initialY0": null,
         "initialY1": 22,
         "x": 22,
-        "y0": 0,
+        "y0": null,
         "y1": 22,
       },
       Object {
@@ -1462,7 +1462,7 @@ Array [
         "initialY0": null,
         "initialY1": 23,
         "x": 23,
-        "y0": 0,
+        "y0": null,
         "y1": 23,
       },
       Object {
@@ -1470,7 +1470,7 @@ Array [
         "initialY0": null,
         "initialY1": 24,
         "x": 24,
-        "y0": 0,
+        "y0": null,
         "y1": 24,
       },
       Object {
@@ -1478,7 +1478,7 @@ Array [
         "initialY0": null,
         "initialY1": 25,
         "x": 25,
-        "y0": 0,
+        "y0": null,
         "y1": 25,
       },
       Object {
@@ -1486,7 +1486,7 @@ Array [
         "initialY0": null,
         "initialY1": 26,
         "x": 26,
-        "y0": 0,
+        "y0": null,
         "y1": 26,
       },
       Object {
@@ -1494,7 +1494,7 @@ Array [
         "initialY0": null,
         "initialY1": 27,
         "x": 27,
-        "y0": 0,
+        "y0": null,
         "y1": 27,
       },
       Object {
@@ -1502,7 +1502,7 @@ Array [
         "initialY0": null,
         "initialY1": 28,
         "x": 28,
-        "y0": 0,
+        "y0": null,
         "y1": 28,
       },
       Object {
@@ -1510,7 +1510,7 @@ Array [
         "initialY0": null,
         "initialY1": 29,
         "x": 29,
-        "y0": 0,
+        "y0": null,
         "y1": 29,
       },
       Object {
@@ -1518,7 +1518,7 @@ Array [
         "initialY0": null,
         "initialY1": 30,
         "x": 30,
-        "y0": 0,
+        "y0": null,
         "y1": 30,
       },
       Object {
@@ -1526,7 +1526,7 @@ Array [
         "initialY0": null,
         "initialY1": 31,
         "x": 31,
-        "y0": 0,
+        "y0": null,
         "y1": 31,
       },
       Object {
@@ -1534,7 +1534,7 @@ Array [
         "initialY0": null,
         "initialY1": 32,
         "x": 32,
-        "y0": 0,
+        "y0": null,
         "y1": 32,
       },
       Object {
@@ -1542,7 +1542,7 @@ Array [
         "initialY0": null,
         "initialY1": 33,
         "x": 33,
-        "y0": 0,
+        "y0": null,
         "y1": 33,
       },
       Object {
@@ -1550,7 +1550,7 @@ Array [
         "initialY0": null,
         "initialY1": 34,
         "x": 34,
-        "y0": 0,
+        "y0": null,
         "y1": 34,
       },
       Object {
@@ -1558,7 +1558,7 @@ Array [
         "initialY0": null,
         "initialY1": 35,
         "x": 35,
-        "y0": 0,
+        "y0": null,
         "y1": 35,
       },
       Object {
@@ -1566,7 +1566,7 @@ Array [
         "initialY0": null,
         "initialY1": 36,
         "x": 36,
-        "y0": 0,
+        "y0": null,
         "y1": 36,
       },
       Object {
@@ -1574,7 +1574,7 @@ Array [
         "initialY0": null,
         "initialY1": 37,
         "x": 37,
-        "y0": 0,
+        "y0": null,
         "y1": 37,
       },
       Object {
@@ -1582,7 +1582,7 @@ Array [
         "initialY0": null,
         "initialY1": 38,
         "x": 38,
-        "y0": 0,
+        "y0": null,
         "y1": 38,
       },
       Object {
@@ -1590,7 +1590,7 @@ Array [
         "initialY0": null,
         "initialY1": 39,
         "x": 39,
-        "y0": 0,
+        "y0": null,
         "y1": 39,
       },
       Object {
@@ -1598,7 +1598,7 @@ Array [
         "initialY0": null,
         "initialY1": 40,
         "x": 40,
-        "y0": 0,
+        "y0": null,
         "y1": 40,
       },
       Object {
@@ -1606,7 +1606,7 @@ Array [
         "initialY0": null,
         "initialY1": 41,
         "x": 41,
-        "y0": 0,
+        "y0": null,
         "y1": 41,
       },
       Object {
@@ -1614,7 +1614,7 @@ Array [
         "initialY0": null,
         "initialY1": 42,
         "x": 42,
-        "y0": 0,
+        "y0": null,
         "y1": 42,
       },
       Object {
@@ -1622,7 +1622,7 @@ Array [
         "initialY0": null,
         "initialY1": 43,
         "x": 43,
-        "y0": 0,
+        "y0": null,
         "y1": 43,
       },
       Object {
@@ -1630,7 +1630,7 @@ Array [
         "initialY0": null,
         "initialY1": 44,
         "x": 44,
-        "y0": 0,
+        "y0": null,
         "y1": 44,
       },
       Object {
@@ -1638,7 +1638,7 @@ Array [
         "initialY0": null,
         "initialY1": 45,
         "x": 45,
-        "y0": 0,
+        "y0": null,
         "y1": 45,
       },
       Object {
@@ -1646,7 +1646,7 @@ Array [
         "initialY0": null,
         "initialY1": 46,
         "x": 46,
-        "y0": 0,
+        "y0": null,
         "y1": 46,
       },
       Object {
@@ -1654,7 +1654,7 @@ Array [
         "initialY0": null,
         "initialY1": 47,
         "x": 47,
-        "y0": 0,
+        "y0": null,
         "y1": 47,
       },
       Object {
@@ -1662,7 +1662,7 @@ Array [
         "initialY0": null,
         "initialY1": 48,
         "x": 48,
-        "y0": 0,
+        "y0": null,
         "y1": 48,
       },
       Object {
@@ -1670,7 +1670,7 @@ Array [
         "initialY0": null,
         "initialY1": 49,
         "x": 49,
-        "y0": 0,
+        "y0": null,
         "y1": 49,
       },
       Object {
@@ -1678,7 +1678,7 @@ Array [
         "initialY0": null,
         "initialY1": 50,
         "x": 50,
-        "y0": 0,
+        "y0": null,
         "y1": 50,
       },
       Object {
@@ -1686,7 +1686,7 @@ Array [
         "initialY0": null,
         "initialY1": 51,
         "x": 51,
-        "y0": 0,
+        "y0": null,
         "y1": 51,
       },
       Object {
@@ -1694,7 +1694,7 @@ Array [
         "initialY0": null,
         "initialY1": 52,
         "x": 52,
-        "y0": 0,
+        "y0": null,
         "y1": 52,
       },
       Object {
@@ -1702,7 +1702,7 @@ Array [
         "initialY0": null,
         "initialY1": 53,
         "x": 53,
-        "y0": 0,
+        "y0": null,
         "y1": 53,
       },
       Object {
@@ -1710,7 +1710,7 @@ Array [
         "initialY0": null,
         "initialY1": 54,
         "x": 54,
-        "y0": 0,
+        "y0": null,
         "y1": 54,
       },
       Object {
@@ -1718,7 +1718,7 @@ Array [
         "initialY0": null,
         "initialY1": 55,
         "x": 55,
-        "y0": 0,
+        "y0": null,
         "y1": 55,
       },
       Object {
@@ -1726,7 +1726,7 @@ Array [
         "initialY0": null,
         "initialY1": 56,
         "x": 56,
-        "y0": 0,
+        "y0": null,
         "y1": 56,
       },
       Object {
@@ -1734,7 +1734,7 @@ Array [
         "initialY0": null,
         "initialY1": 57,
         "x": 57,
-        "y0": 0,
+        "y0": null,
         "y1": 57,
       },
       Object {
@@ -1742,7 +1742,7 @@ Array [
         "initialY0": null,
         "initialY1": 58,
         "x": 58,
-        "y0": 0,
+        "y0": null,
         "y1": 58,
       },
       Object {
@@ -1750,7 +1750,7 @@ Array [
         "initialY0": null,
         "initialY1": 59,
         "x": 59,
-        "y0": 0,
+        "y0": null,
         "y1": 59,
       },
       Object {
@@ -1758,7 +1758,7 @@ Array [
         "initialY0": null,
         "initialY1": 60,
         "x": 60,
-        "y0": 0,
+        "y0": null,
         "y1": 60,
       },
       Object {
@@ -1766,7 +1766,7 @@ Array [
         "initialY0": null,
         "initialY1": 61,
         "x": 61,
-        "y0": 0,
+        "y0": null,
         "y1": 61,
       },
       Object {
@@ -1774,7 +1774,7 @@ Array [
         "initialY0": null,
         "initialY1": 62,
         "x": 62,
-        "y0": 0,
+        "y0": null,
         "y1": 62,
       },
       Object {
@@ -1782,7 +1782,7 @@ Array [
         "initialY0": null,
         "initialY1": 63,
         "x": 63,
-        "y0": 0,
+        "y0": null,
         "y1": 63,
       },
       Object {
@@ -1790,7 +1790,7 @@ Array [
         "initialY0": null,
         "initialY1": 64,
         "x": 64,
-        "y0": 0,
+        "y0": null,
         "y1": 64,
       },
       Object {
@@ -1798,7 +1798,7 @@ Array [
         "initialY0": null,
         "initialY1": 65,
         "x": 65,
-        "y0": 0,
+        "y0": null,
         "y1": 65,
       },
       Object {
@@ -1806,7 +1806,7 @@ Array [
         "initialY0": null,
         "initialY1": 66,
         "x": 66,
-        "y0": 0,
+        "y0": null,
         "y1": 66,
       },
       Object {
@@ -1814,7 +1814,7 @@ Array [
         "initialY0": null,
         "initialY1": 67,
         "x": 67,
-        "y0": 0,
+        "y0": null,
         "y1": 67,
       },
       Object {
@@ -1822,7 +1822,7 @@ Array [
         "initialY0": null,
         "initialY1": 68,
         "x": 68,
-        "y0": 0,
+        "y0": null,
         "y1": 68,
       },
       Object {
@@ -1830,7 +1830,7 @@ Array [
         "initialY0": null,
         "initialY1": 69,
         "x": 69,
-        "y0": 0,
+        "y0": null,
         "y1": 69,
       },
       Object {
@@ -1838,7 +1838,7 @@ Array [
         "initialY0": null,
         "initialY1": 70,
         "x": 70,
-        "y0": 0,
+        "y0": null,
         "y1": 70,
       },
       Object {
@@ -1846,7 +1846,7 @@ Array [
         "initialY0": null,
         "initialY1": 71,
         "x": 71,
-        "y0": 0,
+        "y0": null,
         "y1": 71,
       },
       Object {
@@ -1854,7 +1854,7 @@ Array [
         "initialY0": null,
         "initialY1": 72,
         "x": 72,
-        "y0": 0,
+        "y0": null,
         "y1": 72,
       },
       Object {
@@ -1862,7 +1862,7 @@ Array [
         "initialY0": null,
         "initialY1": 73,
         "x": 73,
-        "y0": 0,
+        "y0": null,
         "y1": 73,
       },
       Object {
@@ -1870,7 +1870,7 @@ Array [
         "initialY0": null,
         "initialY1": 74,
         "x": 74,
-        "y0": 0,
+        "y0": null,
         "y1": 74,
       },
       Object {
@@ -1878,7 +1878,7 @@ Array [
         "initialY0": null,
         "initialY1": 75,
         "x": 75,
-        "y0": 0,
+        "y0": null,
         "y1": 75,
       },
       Object {
@@ -1886,7 +1886,7 @@ Array [
         "initialY0": null,
         "initialY1": 76,
         "x": 76,
-        "y0": 0,
+        "y0": null,
         "y1": 76,
       },
       Object {
@@ -1894,7 +1894,7 @@ Array [
         "initialY0": null,
         "initialY1": 77,
         "x": 77,
-        "y0": 0,
+        "y0": null,
         "y1": 77,
       },
       Object {
@@ -1902,7 +1902,7 @@ Array [
         "initialY0": null,
         "initialY1": 78,
         "x": 78,
-        "y0": 0,
+        "y0": null,
         "y1": 78,
       },
       Object {
@@ -1910,7 +1910,7 @@ Array [
         "initialY0": null,
         "initialY1": 79,
         "x": 79,
-        "y0": 0,
+        "y0": null,
         "y1": 79,
       },
       Object {
@@ -1918,7 +1918,7 @@ Array [
         "initialY0": null,
         "initialY1": 80,
         "x": 80,
-        "y0": 0,
+        "y0": null,
         "y1": 80,
       },
       Object {
@@ -1926,7 +1926,7 @@ Array [
         "initialY0": null,
         "initialY1": 81,
         "x": 81,
-        "y0": 0,
+        "y0": null,
         "y1": 81,
       },
       Object {
@@ -1934,7 +1934,7 @@ Array [
         "initialY0": null,
         "initialY1": 82,
         "x": 82,
-        "y0": 0,
+        "y0": null,
         "y1": 82,
       },
       Object {
@@ -1942,7 +1942,7 @@ Array [
         "initialY0": null,
         "initialY1": 83,
         "x": 83,
-        "y0": 0,
+        "y0": null,
         "y1": 83,
       },
       Object {
@@ -1950,7 +1950,7 @@ Array [
         "initialY0": null,
         "initialY1": 84,
         "x": 84,
-        "y0": 0,
+        "y0": null,
         "y1": 84,
       },
       Object {
@@ -1958,7 +1958,7 @@ Array [
         "initialY0": null,
         "initialY1": 85,
         "x": 85,
-        "y0": 0,
+        "y0": null,
         "y1": 85,
       },
       Object {
@@ -1966,7 +1966,7 @@ Array [
         "initialY0": null,
         "initialY1": 86,
         "x": 86,
-        "y0": 0,
+        "y0": null,
         "y1": 86,
       },
       Object {
@@ -1974,7 +1974,7 @@ Array [
         "initialY0": null,
         "initialY1": 87,
         "x": 87,
-        "y0": 0,
+        "y0": null,
         "y1": 87,
       },
       Object {
@@ -1982,7 +1982,7 @@ Array [
         "initialY0": null,
         "initialY1": 88,
         "x": 88,
-        "y0": 0,
+        "y0": null,
         "y1": 88,
       },
       Object {
@@ -1990,7 +1990,7 @@ Array [
         "initialY0": null,
         "initialY1": 89,
         "x": 89,
-        "y0": 0,
+        "y0": null,
         "y1": 89,
       },
       Object {
@@ -1998,7 +1998,7 @@ Array [
         "initialY0": null,
         "initialY1": 90,
         "x": 90,
-        "y0": 0,
+        "y0": null,
         "y1": 90,
       },
       Object {
@@ -2006,7 +2006,7 @@ Array [
         "initialY0": null,
         "initialY1": 91,
         "x": 91,
-        "y0": 0,
+        "y0": null,
         "y1": 91,
       },
       Object {
@@ -2014,7 +2014,7 @@ Array [
         "initialY0": null,
         "initialY1": 92,
         "x": 92,
-        "y0": 0,
+        "y0": null,
         "y1": 92,
       },
       Object {
@@ -2022,7 +2022,7 @@ Array [
         "initialY0": null,
         "initialY1": 93,
         "x": 93,
-        "y0": 0,
+        "y0": null,
         "y1": 93,
       },
       Object {
@@ -2030,7 +2030,7 @@ Array [
         "initialY0": null,
         "initialY1": 94,
         "x": 94,
-        "y0": 0,
+        "y0": null,
         "y1": 94,
       },
       Object {
@@ -2038,7 +2038,7 @@ Array [
         "initialY0": null,
         "initialY1": 95,
         "x": 95,
-        "y0": 0,
+        "y0": null,
         "y1": 95,
       },
       Object {
@@ -2046,7 +2046,7 @@ Array [
         "initialY0": null,
         "initialY1": 96,
         "x": 96,
-        "y0": 0,
+        "y0": null,
         "y1": 96,
       },
       Object {
@@ -2054,7 +2054,7 @@ Array [
         "initialY0": null,
         "initialY1": 97,
         "x": 97,
-        "y0": 0,
+        "y0": null,
         "y1": 97,
       },
       Object {
@@ -2062,7 +2062,7 @@ Array [
         "initialY0": null,
         "initialY1": 98,
         "x": 98,
-        "y0": 0,
+        "y0": null,
         "y1": 98,
       },
       Object {
@@ -2070,7 +2070,7 @@ Array [
         "initialY0": null,
         "initialY1": 99,
         "x": 99,
-        "y0": 0,
+        "y0": null,
         "y1": 99,
       },
       Object {
@@ -2078,7 +2078,7 @@ Array [
         "initialY0": null,
         "initialY1": 100,
         "x": 100,
-        "y0": 0,
+        "y0": null,
         "y1": 100,
       },
       Object {
@@ -2086,7 +2086,7 @@ Array [
         "initialY0": null,
         "initialY1": 101,
         "x": 101,
-        "y0": 0,
+        "y0": null,
         "y1": 101,
       },
       Object {
@@ -2094,7 +2094,7 @@ Array [
         "initialY0": null,
         "initialY1": 102,
         "x": 102,
-        "y0": 0,
+        "y0": null,
         "y1": 102,
       },
       Object {
@@ -2102,7 +2102,7 @@ Array [
         "initialY0": null,
         "initialY1": 103,
         "x": 103,
-        "y0": 0,
+        "y0": null,
         "y1": 103,
       },
       Object {
@@ -2110,7 +2110,7 @@ Array [
         "initialY0": null,
         "initialY1": 104,
         "x": 104,
-        "y0": 0,
+        "y0": null,
         "y1": 104,
       },
       Object {
@@ -2118,7 +2118,7 @@ Array [
         "initialY0": null,
         "initialY1": 105,
         "x": 105,
-        "y0": 0,
+        "y0": null,
         "y1": 105,
       },
       Object {
@@ -2126,7 +2126,7 @@ Array [
         "initialY0": null,
         "initialY1": 106,
         "x": 106,
-        "y0": 0,
+        "y0": null,
         "y1": 106,
       },
       Object {
@@ -2134,7 +2134,7 @@ Array [
         "initialY0": null,
         "initialY1": 107,
         "x": 107,
-        "y0": 0,
+        "y0": null,
         "y1": 107,
       },
       Object {
@@ -2142,7 +2142,7 @@ Array [
         "initialY0": null,
         "initialY1": 108,
         "x": 108,
-        "y0": 0,
+        "y0": null,
         "y1": 108,
       },
       Object {
@@ -2150,7 +2150,7 @@ Array [
         "initialY0": null,
         "initialY1": 109,
         "x": 109,
-        "y0": 0,
+        "y0": null,
         "y1": 109,
       },
       Object {
@@ -2158,7 +2158,7 @@ Array [
         "initialY0": null,
         "initialY1": 110,
         "x": 110,
-        "y0": 0,
+        "y0": null,
         "y1": 110,
       },
       Object {
@@ -2166,7 +2166,7 @@ Array [
         "initialY0": null,
         "initialY1": 111,
         "x": 111,
-        "y0": 0,
+        "y0": null,
         "y1": 111,
       },
       Object {
@@ -2174,7 +2174,7 @@ Array [
         "initialY0": null,
         "initialY1": 112,
         "x": 112,
-        "y0": 0,
+        "y0": null,
         "y1": 112,
       },
       Object {
@@ -2182,7 +2182,7 @@ Array [
         "initialY0": null,
         "initialY1": 113,
         "x": 113,
-        "y0": 0,
+        "y0": null,
         "y1": 113,
       },
       Object {
@@ -2190,7 +2190,7 @@ Array [
         "initialY0": null,
         "initialY1": 114,
         "x": 114,
-        "y0": 0,
+        "y0": null,
         "y1": 114,
       },
       Object {
@@ -2198,7 +2198,7 @@ Array [
         "initialY0": null,
         "initialY1": 115,
         "x": 115,
-        "y0": 0,
+        "y0": null,
         "y1": 115,
       },
       Object {
@@ -2206,7 +2206,7 @@ Array [
         "initialY0": null,
         "initialY1": 116,
         "x": 116,
-        "y0": 0,
+        "y0": null,
         "y1": 116,
       },
       Object {
@@ -2214,7 +2214,7 @@ Array [
         "initialY0": null,
         "initialY1": 117,
         "x": 117,
-        "y0": 0,
+        "y0": null,
         "y1": 117,
       },
       Object {
@@ -2222,7 +2222,7 @@ Array [
         "initialY0": null,
         "initialY1": 118,
         "x": 118,
-        "y0": 0,
+        "y0": null,
         "y1": 118,
       },
       Object {
@@ -2230,7 +2230,7 @@ Array [
         "initialY0": null,
         "initialY1": 119,
         "x": 119,
-        "y0": 0,
+        "y0": null,
         "y1": 119,
       },
       Object {
@@ -2238,7 +2238,7 @@ Array [
         "initialY0": null,
         "initialY1": 120,
         "x": 120,
-        "y0": 0,
+        "y0": null,
         "y1": 120,
       },
       Object {
@@ -2246,7 +2246,7 @@ Array [
         "initialY0": null,
         "initialY1": 121,
         "x": 121,
-        "y0": 0,
+        "y0": null,
         "y1": 121,
       },
       Object {
@@ -2254,7 +2254,7 @@ Array [
         "initialY0": null,
         "initialY1": 122,
         "x": 122,
-        "y0": 0,
+        "y0": null,
         "y1": 122,
       },
       Object {
@@ -2262,7 +2262,7 @@ Array [
         "initialY0": null,
         "initialY1": 123,
         "x": 123,
-        "y0": 0,
+        "y0": null,
         "y1": 123,
       },
       Object {
@@ -2270,7 +2270,7 @@ Array [
         "initialY0": null,
         "initialY1": 124,
         "x": 124,
-        "y0": 0,
+        "y0": null,
         "y1": 124,
       },
       Object {
@@ -2278,7 +2278,7 @@ Array [
         "initialY0": null,
         "initialY1": 125,
         "x": 125,
-        "y0": 0,
+        "y0": null,
         "y1": 125,
       },
       Object {
@@ -2286,7 +2286,7 @@ Array [
         "initialY0": null,
         "initialY1": 126,
         "x": 126,
-        "y0": 0,
+        "y0": null,
         "y1": 126,
       },
       Object {
@@ -2294,7 +2294,7 @@ Array [
         "initialY0": null,
         "initialY1": 127,
         "x": 127,
-        "y0": 0,
+        "y0": null,
         "y1": 127,
       },
       Object {
@@ -2302,7 +2302,7 @@ Array [
         "initialY0": null,
         "initialY1": 128,
         "x": 128,
-        "y0": 0,
+        "y0": null,
         "y1": 128,
       },
       Object {
@@ -2310,7 +2310,7 @@ Array [
         "initialY0": null,
         "initialY1": 129,
         "x": 129,
-        "y0": 0,
+        "y0": null,
         "y1": 129,
       },
       Object {
@@ -2318,7 +2318,7 @@ Array [
         "initialY0": null,
         "initialY1": 130,
         "x": 130,
-        "y0": 0,
+        "y0": null,
         "y1": 130,
       },
       Object {
@@ -2326,7 +2326,7 @@ Array [
         "initialY0": null,
         "initialY1": 131,
         "x": 131,
-        "y0": 0,
+        "y0": null,
         "y1": 131,
       },
       Object {
@@ -2334,7 +2334,7 @@ Array [
         "initialY0": null,
         "initialY1": 132,
         "x": 132,
-        "y0": 0,
+        "y0": null,
         "y1": 132,
       },
       Object {
@@ -2342,7 +2342,7 @@ Array [
         "initialY0": null,
         "initialY1": 133,
         "x": 133,
-        "y0": 0,
+        "y0": null,
         "y1": 133,
       },
       Object {
@@ -2350,7 +2350,7 @@ Array [
         "initialY0": null,
         "initialY1": 134,
         "x": 134,
-        "y0": 0,
+        "y0": null,
         "y1": 134,
       },
       Object {
@@ -2358,7 +2358,7 @@ Array [
         "initialY0": null,
         "initialY1": 135,
         "x": 135,
-        "y0": 0,
+        "y0": null,
         "y1": 135,
       },
       Object {
@@ -2366,7 +2366,7 @@ Array [
         "initialY0": null,
         "initialY1": 136,
         "x": 136,
-        "y0": 0,
+        "y0": null,
         "y1": 136,
       },
       Object {
@@ -2374,7 +2374,7 @@ Array [
         "initialY0": null,
         "initialY1": 137,
         "x": 137,
-        "y0": 0,
+        "y0": null,
         "y1": 137,
       },
       Object {
@@ -2382,7 +2382,7 @@ Array [
         "initialY0": null,
         "initialY1": 138,
         "x": 138,
-        "y0": 0,
+        "y0": null,
         "y1": 138,
       },
       Object {
@@ -2390,7 +2390,7 @@ Array [
         "initialY0": null,
         "initialY1": 139,
         "x": 139,
-        "y0": 0,
+        "y0": null,
         "y1": 139,
       },
       Object {
@@ -2398,7 +2398,7 @@ Array [
         "initialY0": null,
         "initialY1": 140,
         "x": 140,
-        "y0": 0,
+        "y0": null,
         "y1": 140,
       },
       Object {
@@ -2406,7 +2406,7 @@ Array [
         "initialY0": null,
         "initialY1": 141,
         "x": 141,
-        "y0": 0,
+        "y0": null,
         "y1": 141,
       },
       Object {
@@ -2414,7 +2414,7 @@ Array [
         "initialY0": null,
         "initialY1": 142,
         "x": 142,
-        "y0": 0,
+        "y0": null,
         "y1": 142,
       },
       Object {
@@ -2422,7 +2422,7 @@ Array [
         "initialY0": null,
         "initialY1": 143,
         "x": 143,
-        "y0": 0,
+        "y0": null,
         "y1": 143,
       },
       Object {
@@ -2430,7 +2430,7 @@ Array [
         "initialY0": null,
         "initialY1": 144,
         "x": 144,
-        "y0": 0,
+        "y0": null,
         "y1": 144,
       },
       Object {
@@ -2438,7 +2438,7 @@ Array [
         "initialY0": null,
         "initialY1": 145,
         "x": 145,
-        "y0": 0,
+        "y0": null,
         "y1": 145,
       },
       Object {
@@ -2446,7 +2446,7 @@ Array [
         "initialY0": null,
         "initialY1": 146,
         "x": 146,
-        "y0": 0,
+        "y0": null,
         "y1": 146,
       },
       Object {
@@ -2454,7 +2454,7 @@ Array [
         "initialY0": null,
         "initialY1": 147,
         "x": 147,
-        "y0": 0,
+        "y0": null,
         "y1": 147,
       },
       Object {
@@ -2462,7 +2462,7 @@ Array [
         "initialY0": null,
         "initialY1": 148,
         "x": 148,
-        "y0": 0,
+        "y0": null,
         "y1": 148,
       },
       Object {
@@ -2470,7 +2470,7 @@ Array [
         "initialY0": null,
         "initialY1": 149,
         "x": 149,
-        "y0": 0,
+        "y0": null,
         "y1": 149,
       },
       Object {
@@ -2478,7 +2478,7 @@ Array [
         "initialY0": null,
         "initialY1": 150,
         "x": 150,
-        "y0": 0,
+        "y0": null,
         "y1": 150,
       },
       Object {
@@ -2486,7 +2486,7 @@ Array [
         "initialY0": null,
         "initialY1": 151,
         "x": 151,
-        "y0": 0,
+        "y0": null,
         "y1": 151,
       },
       Object {
@@ -2494,7 +2494,7 @@ Array [
         "initialY0": null,
         "initialY1": 152,
         "x": 152,
-        "y0": 0,
+        "y0": null,
         "y1": 152,
       },
       Object {
@@ -2502,7 +2502,7 @@ Array [
         "initialY0": null,
         "initialY1": 153,
         "x": 153,
-        "y0": 0,
+        "y0": null,
         "y1": 153,
       },
       Object {
@@ -2510,7 +2510,7 @@ Array [
         "initialY0": null,
         "initialY1": 154,
         "x": 154,
-        "y0": 0,
+        "y0": null,
         "y1": 154,
       },
       Object {
@@ -2518,7 +2518,7 @@ Array [
         "initialY0": null,
         "initialY1": 155,
         "x": 155,
-        "y0": 0,
+        "y0": null,
         "y1": 155,
       },
       Object {
@@ -2526,7 +2526,7 @@ Array [
         "initialY0": null,
         "initialY1": 156,
         "x": 156,
-        "y0": 0,
+        "y0": null,
         "y1": 156,
       },
       Object {
@@ -2534,7 +2534,7 @@ Array [
         "initialY0": null,
         "initialY1": 157,
         "x": 157,
-        "y0": 0,
+        "y0": null,
         "y1": 157,
       },
       Object {
@@ -2542,7 +2542,7 @@ Array [
         "initialY0": null,
         "initialY1": 158,
         "x": 158,
-        "y0": 0,
+        "y0": null,
         "y1": 158,
       },
       Object {
@@ -2550,7 +2550,7 @@ Array [
         "initialY0": null,
         "initialY1": 159,
         "x": 159,
-        "y0": 0,
+        "y0": null,
         "y1": 159,
       },
       Object {
@@ -2558,7 +2558,7 @@ Array [
         "initialY0": null,
         "initialY1": 160,
         "x": 160,
-        "y0": 0,
+        "y0": null,
         "y1": 160,
       },
       Object {
@@ -2566,7 +2566,7 @@ Array [
         "initialY0": null,
         "initialY1": 161,
         "x": 161,
-        "y0": 0,
+        "y0": null,
         "y1": 161,
       },
       Object {
@@ -2574,7 +2574,7 @@ Array [
         "initialY0": null,
         "initialY1": 162,
         "x": 162,
-        "y0": 0,
+        "y0": null,
         "y1": 162,
       },
       Object {
@@ -2582,7 +2582,7 @@ Array [
         "initialY0": null,
         "initialY1": 163,
         "x": 163,
-        "y0": 0,
+        "y0": null,
         "y1": 163,
       },
       Object {
@@ -2590,7 +2590,7 @@ Array [
         "initialY0": null,
         "initialY1": 164,
         "x": 164,
-        "y0": 0,
+        "y0": null,
         "y1": 164,
       },
       Object {
@@ -2598,7 +2598,7 @@ Array [
         "initialY0": null,
         "initialY1": 165,
         "x": 165,
-        "y0": 0,
+        "y0": null,
         "y1": 165,
       },
       Object {
@@ -2606,7 +2606,7 @@ Array [
         "initialY0": null,
         "initialY1": 166,
         "x": 166,
-        "y0": 0,
+        "y0": null,
         "y1": 166,
       },
       Object {
@@ -2614,7 +2614,7 @@ Array [
         "initialY0": null,
         "initialY1": 167,
         "x": 167,
-        "y0": 0,
+        "y0": null,
         "y1": 167,
       },
       Object {
@@ -2622,7 +2622,7 @@ Array [
         "initialY0": null,
         "initialY1": 168,
         "x": 168,
-        "y0": 0,
+        "y0": null,
         "y1": 168,
       },
       Object {
@@ -2630,7 +2630,7 @@ Array [
         "initialY0": null,
         "initialY1": 169,
         "x": 169,
-        "y0": 0,
+        "y0": null,
         "y1": 169,
       },
       Object {
@@ -2638,7 +2638,7 @@ Array [
         "initialY0": null,
         "initialY1": 170,
         "x": 170,
-        "y0": 0,
+        "y0": null,
         "y1": 170,
       },
       Object {
@@ -2646,7 +2646,7 @@ Array [
         "initialY0": null,
         "initialY1": 171,
         "x": 171,
-        "y0": 0,
+        "y0": null,
         "y1": 171,
       },
       Object {
@@ -2654,7 +2654,7 @@ Array [
         "initialY0": null,
         "initialY1": 172,
         "x": 172,
-        "y0": 0,
+        "y0": null,
         "y1": 172,
       },
       Object {
@@ -2662,7 +2662,7 @@ Array [
         "initialY0": null,
         "initialY1": 173,
         "x": 173,
-        "y0": 0,
+        "y0": null,
         "y1": 173,
       },
       Object {
@@ -2670,7 +2670,7 @@ Array [
         "initialY0": null,
         "initialY1": 174,
         "x": 174,
-        "y0": 0,
+        "y0": null,
         "y1": 174,
       },
       Object {
@@ -2678,7 +2678,7 @@ Array [
         "initialY0": null,
         "initialY1": 175,
         "x": 175,
-        "y0": 0,
+        "y0": null,
         "y1": 175,
       },
       Object {
@@ -2686,7 +2686,7 @@ Array [
         "initialY0": null,
         "initialY1": 176,
         "x": 176,
-        "y0": 0,
+        "y0": null,
         "y1": 176,
       },
       Object {
@@ -2694,7 +2694,7 @@ Array [
         "initialY0": null,
         "initialY1": 177,
         "x": 177,
-        "y0": 0,
+        "y0": null,
         "y1": 177,
       },
       Object {
@@ -2702,7 +2702,7 @@ Array [
         "initialY0": null,
         "initialY1": 178,
         "x": 178,
-        "y0": 0,
+        "y0": null,
         "y1": 178,
       },
       Object {
@@ -2710,7 +2710,7 @@ Array [
         "initialY0": null,
         "initialY1": 179,
         "x": 179,
-        "y0": 0,
+        "y0": null,
         "y1": 179,
       },
       Object {
@@ -2718,7 +2718,7 @@ Array [
         "initialY0": null,
         "initialY1": 180,
         "x": 180,
-        "y0": 0,
+        "y0": null,
         "y1": 180,
       },
       Object {
@@ -2726,7 +2726,7 @@ Array [
         "initialY0": null,
         "initialY1": 181,
         "x": 181,
-        "y0": 0,
+        "y0": null,
         "y1": 181,
       },
       Object {
@@ -2734,7 +2734,7 @@ Array [
         "initialY0": null,
         "initialY1": 182,
         "x": 182,
-        "y0": 0,
+        "y0": null,
         "y1": 182,
       },
       Object {
@@ -2742,7 +2742,7 @@ Array [
         "initialY0": null,
         "initialY1": 183,
         "x": 183,
-        "y0": 0,
+        "y0": null,
         "y1": 183,
       },
       Object {
@@ -2750,7 +2750,7 @@ Array [
         "initialY0": null,
         "initialY1": 184,
         "x": 184,
-        "y0": 0,
+        "y0": null,
         "y1": 184,
       },
       Object {
@@ -2758,7 +2758,7 @@ Array [
         "initialY0": null,
         "initialY1": 185,
         "x": 185,
-        "y0": 0,
+        "y0": null,
         "y1": 185,
       },
       Object {
@@ -2766,7 +2766,7 @@ Array [
         "initialY0": null,
         "initialY1": 186,
         "x": 186,
-        "y0": 0,
+        "y0": null,
         "y1": 186,
       },
       Object {
@@ -2774,7 +2774,7 @@ Array [
         "initialY0": null,
         "initialY1": 187,
         "x": 187,
-        "y0": 0,
+        "y0": null,
         "y1": 187,
       },
       Object {
@@ -2782,7 +2782,7 @@ Array [
         "initialY0": null,
         "initialY1": 188,
         "x": 188,
-        "y0": 0,
+        "y0": null,
         "y1": 188,
       },
       Object {
@@ -2790,7 +2790,7 @@ Array [
         "initialY0": null,
         "initialY1": 189,
         "x": 189,
-        "y0": 0,
+        "y0": null,
         "y1": 189,
       },
       Object {
@@ -2798,7 +2798,7 @@ Array [
         "initialY0": null,
         "initialY1": 190,
         "x": 190,
-        "y0": 0,
+        "y0": null,
         "y1": 190,
       },
       Object {
@@ -2806,7 +2806,7 @@ Array [
         "initialY0": null,
         "initialY1": 191,
         "x": 191,
-        "y0": 0,
+        "y0": null,
         "y1": 191,
       },
       Object {
@@ -2814,7 +2814,7 @@ Array [
         "initialY0": null,
         "initialY1": 192,
         "x": 192,
-        "y0": 0,
+        "y0": null,
         "y1": 192,
       },
       Object {
@@ -2822,7 +2822,7 @@ Array [
         "initialY0": null,
         "initialY1": 193,
         "x": 193,
-        "y0": 0,
+        "y0": null,
         "y1": 193,
       },
       Object {
@@ -2830,7 +2830,7 @@ Array [
         "initialY0": null,
         "initialY1": 194,
         "x": 194,
-        "y0": 0,
+        "y0": null,
         "y1": 194,
       },
       Object {
@@ -2838,7 +2838,7 @@ Array [
         "initialY0": null,
         "initialY1": 195,
         "x": 195,
-        "y0": 0,
+        "y0": null,
         "y1": 195,
       },
       Object {
@@ -2846,7 +2846,7 @@ Array [
         "initialY0": null,
         "initialY1": 196,
         "x": 196,
-        "y0": 0,
+        "y0": null,
         "y1": 196,
       },
       Object {
@@ -2854,7 +2854,7 @@ Array [
         "initialY0": null,
         "initialY1": 197,
         "x": 197,
-        "y0": 0,
+        "y0": null,
         "y1": 197,
       },
       Object {
@@ -2862,7 +2862,7 @@ Array [
         "initialY0": null,
         "initialY1": 198,
         "x": 198,
-        "y0": 0,
+        "y0": null,
         "y1": 198,
       },
       Object {
@@ -2870,7 +2870,7 @@ Array [
         "initialY0": null,
         "initialY1": 199,
         "x": 199,
-        "y0": 0,
+        "y0": null,
         "y1": 199,
       },
       Object {
@@ -2878,7 +2878,7 @@ Array [
         "initialY0": null,
         "initialY1": 200,
         "x": 200,
-        "y0": 0,
+        "y0": null,
         "y1": 200,
       },
       Object {
@@ -2886,7 +2886,7 @@ Array [
         "initialY0": null,
         "initialY1": 201,
         "x": 201,
-        "y0": 0,
+        "y0": null,
         "y1": 201,
       },
       Object {
@@ -2894,7 +2894,7 @@ Array [
         "initialY0": null,
         "initialY1": 202,
         "x": 202,
-        "y0": 0,
+        "y0": null,
         "y1": 202,
       },
       Object {
@@ -2902,7 +2902,7 @@ Array [
         "initialY0": null,
         "initialY1": 203,
         "x": 203,
-        "y0": 0,
+        "y0": null,
         "y1": 203,
       },
       Object {
@@ -2910,7 +2910,7 @@ Array [
         "initialY0": null,
         "initialY1": 204,
         "x": 204,
-        "y0": 0,
+        "y0": null,
         "y1": 204,
       },
       Object {
@@ -2918,7 +2918,7 @@ Array [
         "initialY0": null,
         "initialY1": 205,
         "x": 205,
-        "y0": 0,
+        "y0": null,
         "y1": 205,
       },
       Object {
@@ -2926,7 +2926,7 @@ Array [
         "initialY0": null,
         "initialY1": 206,
         "x": 206,
-        "y0": 0,
+        "y0": null,
         "y1": 206,
       },
       Object {
@@ -2934,7 +2934,7 @@ Array [
         "initialY0": null,
         "initialY1": 207,
         "x": 207,
-        "y0": 0,
+        "y0": null,
         "y1": 207,
       },
       Object {
@@ -2942,7 +2942,7 @@ Array [
         "initialY0": null,
         "initialY1": 208,
         "x": 208,
-        "y0": 0,
+        "y0": null,
         "y1": 208,
       },
       Object {
@@ -2950,7 +2950,7 @@ Array [
         "initialY0": null,
         "initialY1": 209,
         "x": 209,
-        "y0": 0,
+        "y0": null,
         "y1": 209,
       },
       Object {
@@ -2958,7 +2958,7 @@ Array [
         "initialY0": null,
         "initialY1": 210,
         "x": 210,
-        "y0": 0,
+        "y0": null,
         "y1": 210,
       },
       Object {
@@ -2966,7 +2966,7 @@ Array [
         "initialY0": null,
         "initialY1": 211,
         "x": 211,
-        "y0": 0,
+        "y0": null,
         "y1": 211,
       },
       Object {
@@ -2974,7 +2974,7 @@ Array [
         "initialY0": null,
         "initialY1": 212,
         "x": 212,
-        "y0": 0,
+        "y0": null,
         "y1": 212,
       },
       Object {
@@ -2982,7 +2982,7 @@ Array [
         "initialY0": null,
         "initialY1": 213,
         "x": 213,
-        "y0": 0,
+        "y0": null,
         "y1": 213,
       },
       Object {
@@ -2990,7 +2990,7 @@ Array [
         "initialY0": null,
         "initialY1": 214,
         "x": 214,
-        "y0": 0,
+        "y0": null,
         "y1": 214,
       },
       Object {
@@ -2998,7 +2998,7 @@ Array [
         "initialY0": null,
         "initialY1": 215,
         "x": 215,
-        "y0": 0,
+        "y0": null,
         "y1": 215,
       },
       Object {
@@ -3006,7 +3006,7 @@ Array [
         "initialY0": null,
         "initialY1": 216,
         "x": 216,
-        "y0": 0,
+        "y0": null,
         "y1": 216,
       },
       Object {
@@ -3014,7 +3014,7 @@ Array [
         "initialY0": null,
         "initialY1": 217,
         "x": 217,
-        "y0": 0,
+        "y0": null,
         "y1": 217,
       },
       Object {
@@ -3022,7 +3022,7 @@ Array [
         "initialY0": null,
         "initialY1": 218,
         "x": 218,
-        "y0": 0,
+        "y0": null,
         "y1": 218,
       },
       Object {
@@ -3030,7 +3030,7 @@ Array [
         "initialY0": null,
         "initialY1": 219,
         "x": 219,
-        "y0": 0,
+        "y0": null,
         "y1": 219,
       },
       Object {
@@ -3038,7 +3038,7 @@ Array [
         "initialY0": null,
         "initialY1": 220,
         "x": 220,
-        "y0": 0,
+        "y0": null,
         "y1": 220,
       },
       Object {
@@ -3046,7 +3046,7 @@ Array [
         "initialY0": null,
         "initialY1": 221,
         "x": 221,
-        "y0": 0,
+        "y0": null,
         "y1": 221,
       },
       Object {
@@ -3054,7 +3054,7 @@ Array [
         "initialY0": null,
         "initialY1": 222,
         "x": 222,
-        "y0": 0,
+        "y0": null,
         "y1": 222,
       },
       Object {
@@ -3062,7 +3062,7 @@ Array [
         "initialY0": null,
         "initialY1": 223,
         "x": 223,
-        "y0": 0,
+        "y0": null,
         "y1": 223,
       },
       Object {
@@ -3070,7 +3070,7 @@ Array [
         "initialY0": null,
         "initialY1": 224,
         "x": 224,
-        "y0": 0,
+        "y0": null,
         "y1": 224,
       },
       Object {
@@ -3078,7 +3078,7 @@ Array [
         "initialY0": null,
         "initialY1": 225,
         "x": 225,
-        "y0": 0,
+        "y0": null,
         "y1": 225,
       },
       Object {
@@ -3086,7 +3086,7 @@ Array [
         "initialY0": null,
         "initialY1": 226,
         "x": 226,
-        "y0": 0,
+        "y0": null,
         "y1": 226,
       },
       Object {
@@ -3094,7 +3094,7 @@ Array [
         "initialY0": null,
         "initialY1": 227,
         "x": 227,
-        "y0": 0,
+        "y0": null,
         "y1": 227,
       },
       Object {
@@ -3102,7 +3102,7 @@ Array [
         "initialY0": null,
         "initialY1": 228,
         "x": 228,
-        "y0": 0,
+        "y0": null,
         "y1": 228,
       },
       Object {
@@ -3110,7 +3110,7 @@ Array [
         "initialY0": null,
         "initialY1": 229,
         "x": 229,
-        "y0": 0,
+        "y0": null,
         "y1": 229,
       },
       Object {
@@ -3118,7 +3118,7 @@ Array [
         "initialY0": null,
         "initialY1": 230,
         "x": 230,
-        "y0": 0,
+        "y0": null,
         "y1": 230,
       },
       Object {
@@ -3126,7 +3126,7 @@ Array [
         "initialY0": null,
         "initialY1": 231,
         "x": 231,
-        "y0": 0,
+        "y0": null,
         "y1": 231,
       },
       Object {
@@ -3134,7 +3134,7 @@ Array [
         "initialY0": null,
         "initialY1": 232,
         "x": 232,
-        "y0": 0,
+        "y0": null,
         "y1": 232,
       },
       Object {
@@ -3142,7 +3142,7 @@ Array [
         "initialY0": null,
         "initialY1": 233,
         "x": 233,
-        "y0": 0,
+        "y0": null,
         "y1": 233,
       },
       Object {
@@ -3150,7 +3150,7 @@ Array [
         "initialY0": null,
         "initialY1": 234,
         "x": 234,
-        "y0": 0,
+        "y0": null,
         "y1": 234,
       },
       Object {
@@ -3158,7 +3158,7 @@ Array [
         "initialY0": null,
         "initialY1": 235,
         "x": 235,
-        "y0": 0,
+        "y0": null,
         "y1": 235,
       },
       Object {
@@ -3166,7 +3166,7 @@ Array [
         "initialY0": null,
         "initialY1": 236,
         "x": 236,
-        "y0": 0,
+        "y0": null,
         "y1": 236,
       },
       Object {
@@ -3174,7 +3174,7 @@ Array [
         "initialY0": null,
         "initialY1": 237,
         "x": 237,
-        "y0": 0,
+        "y0": null,
         "y1": 237,
       },
       Object {
@@ -3182,7 +3182,7 @@ Array [
         "initialY0": null,
         "initialY1": 238,
         "x": 238,
-        "y0": 0,
+        "y0": null,
         "y1": 238,
       },
       Object {
@@ -3190,7 +3190,7 @@ Array [
         "initialY0": null,
         "initialY1": 239,
         "x": 239,
-        "y0": 0,
+        "y0": null,
         "y1": 239,
       },
       Object {
@@ -3198,7 +3198,7 @@ Array [
         "initialY0": null,
         "initialY1": 240,
         "x": 240,
-        "y0": 0,
+        "y0": null,
         "y1": 240,
       },
       Object {
@@ -3206,7 +3206,7 @@ Array [
         "initialY0": null,
         "initialY1": 241,
         "x": 241,
-        "y0": 0,
+        "y0": null,
         "y1": 241,
       },
       Object {
@@ -3214,7 +3214,7 @@ Array [
         "initialY0": null,
         "initialY1": 242,
         "x": 242,
-        "y0": 0,
+        "y0": null,
         "y1": 242,
       },
       Object {
@@ -3222,7 +3222,7 @@ Array [
         "initialY0": null,
         "initialY1": 243,
         "x": 243,
-        "y0": 0,
+        "y0": null,
         "y1": 243,
       },
       Object {
@@ -3230,7 +3230,7 @@ Array [
         "initialY0": null,
         "initialY1": 244,
         "x": 244,
-        "y0": 0,
+        "y0": null,
         "y1": 244,
       },
       Object {
@@ -3238,7 +3238,7 @@ Array [
         "initialY0": null,
         "initialY1": 245,
         "x": 245,
-        "y0": 0,
+        "y0": null,
         "y1": 245,
       },
       Object {
@@ -3246,7 +3246,7 @@ Array [
         "initialY0": null,
         "initialY1": 246,
         "x": 246,
-        "y0": 0,
+        "y0": null,
         "y1": 246,
       },
       Object {
@@ -3254,7 +3254,7 @@ Array [
         "initialY0": null,
         "initialY1": 247,
         "x": 247,
-        "y0": 0,
+        "y0": null,
         "y1": 247,
       },
       Object {
@@ -3262,7 +3262,7 @@ Array [
         "initialY0": null,
         "initialY1": 248,
         "x": 248,
-        "y0": 0,
+        "y0": null,
         "y1": 248,
       },
       Object {
@@ -3270,7 +3270,7 @@ Array [
         "initialY0": null,
         "initialY1": 249,
         "x": 249,
-        "y0": 0,
+        "y0": null,
         "y1": 249,
       },
       Object {
@@ -3278,7 +3278,7 @@ Array [
         "initialY0": null,
         "initialY1": 250,
         "x": 250,
-        "y0": 0,
+        "y0": null,
         "y1": 250,
       },
       Object {
@@ -3286,7 +3286,7 @@ Array [
         "initialY0": null,
         "initialY1": 251,
         "x": 251,
-        "y0": 0,
+        "y0": null,
         "y1": 251,
       },
       Object {
@@ -3294,7 +3294,7 @@ Array [
         "initialY0": null,
         "initialY1": 252,
         "x": 252,
-        "y0": 0,
+        "y0": null,
         "y1": 252,
       },
       Object {
@@ -3302,7 +3302,7 @@ Array [
         "initialY0": null,
         "initialY1": 253,
         "x": 253,
-        "y0": 0,
+        "y0": null,
         "y1": 253,
       },
       Object {
@@ -3310,7 +3310,7 @@ Array [
         "initialY0": null,
         "initialY1": 254,
         "x": 254,
-        "y0": 0,
+        "y0": null,
         "y1": 254,
       },
       Object {
@@ -3318,7 +3318,7 @@ Array [
         "initialY0": null,
         "initialY1": 255,
         "x": 255,
-        "y0": 0,
+        "y0": null,
         "y1": 255,
       },
       Object {
@@ -3326,7 +3326,7 @@ Array [
         "initialY0": null,
         "initialY1": 256,
         "x": 256,
-        "y0": 0,
+        "y0": null,
         "y1": 256,
       },
       Object {
@@ -3334,7 +3334,7 @@ Array [
         "initialY0": null,
         "initialY1": 257,
         "x": 257,
-        "y0": 0,
+        "y0": null,
         "y1": 257,
       },
       Object {
@@ -3342,7 +3342,7 @@ Array [
         "initialY0": null,
         "initialY1": 258,
         "x": 258,
-        "y0": 0,
+        "y0": null,
         "y1": 258,
       },
       Object {
@@ -3350,7 +3350,7 @@ Array [
         "initialY0": null,
         "initialY1": 259,
         "x": 259,
-        "y0": 0,
+        "y0": null,
         "y1": 259,
       },
       Object {
@@ -3358,7 +3358,7 @@ Array [
         "initialY0": null,
         "initialY1": 260,
         "x": 260,
-        "y0": 0,
+        "y0": null,
         "y1": 260,
       },
       Object {
@@ -3366,7 +3366,7 @@ Array [
         "initialY0": null,
         "initialY1": 261,
         "x": 261,
-        "y0": 0,
+        "y0": null,
         "y1": 261,
       },
       Object {
@@ -3374,7 +3374,7 @@ Array [
         "initialY0": null,
         "initialY1": 262,
         "x": 262,
-        "y0": 0,
+        "y0": null,
         "y1": 262,
       },
       Object {
@@ -3382,7 +3382,7 @@ Array [
         "initialY0": null,
         "initialY1": 263,
         "x": 263,
-        "y0": 0,
+        "y0": null,
         "y1": 263,
       },
       Object {
@@ -3390,7 +3390,7 @@ Array [
         "initialY0": null,
         "initialY1": 264,
         "x": 264,
-        "y0": 0,
+        "y0": null,
         "y1": 264,
       },
       Object {
@@ -3398,7 +3398,7 @@ Array [
         "initialY0": null,
         "initialY1": 265,
         "x": 265,
-        "y0": 0,
+        "y0": null,
         "y1": 265,
       },
       Object {
@@ -3406,7 +3406,7 @@ Array [
         "initialY0": null,
         "initialY1": 266,
         "x": 266,
-        "y0": 0,
+        "y0": null,
         "y1": 266,
       },
       Object {
@@ -3414,7 +3414,7 @@ Array [
         "initialY0": null,
         "initialY1": 267,
         "x": 267,
-        "y0": 0,
+        "y0": null,
         "y1": 267,
       },
       Object {
@@ -3422,7 +3422,7 @@ Array [
         "initialY0": null,
         "initialY1": 268,
         "x": 268,
-        "y0": 0,
+        "y0": null,
         "y1": 268,
       },
       Object {
@@ -3430,7 +3430,7 @@ Array [
         "initialY0": null,
         "initialY1": 269,
         "x": 269,
-        "y0": 0,
+        "y0": null,
         "y1": 269,
       },
       Object {
@@ -3438,7 +3438,7 @@ Array [
         "initialY0": null,
         "initialY1": 270,
         "x": 270,
-        "y0": 0,
+        "y0": null,
         "y1": 270,
       },
       Object {
@@ -3446,7 +3446,7 @@ Array [
         "initialY0": null,
         "initialY1": 271,
         "x": 271,
-        "y0": 0,
+        "y0": null,
         "y1": 271,
       },
       Object {
@@ -3454,7 +3454,7 @@ Array [
         "initialY0": null,
         "initialY1": 272,
         "x": 272,
-        "y0": 0,
+        "y0": null,
         "y1": 272,
       },
       Object {
@@ -3462,7 +3462,7 @@ Array [
         "initialY0": null,
         "initialY1": 273,
         "x": 273,
-        "y0": 0,
+        "y0": null,
         "y1": 273,
       },
       Object {
@@ -3470,7 +3470,7 @@ Array [
         "initialY0": null,
         "initialY1": 274,
         "x": 274,
-        "y0": 0,
+        "y0": null,
         "y1": 274,
       },
       Object {
@@ -3478,7 +3478,7 @@ Array [
         "initialY0": null,
         "initialY1": 275,
         "x": 275,
-        "y0": 0,
+        "y0": null,
         "y1": 275,
       },
       Object {
@@ -3486,7 +3486,7 @@ Array [
         "initialY0": null,
         "initialY1": 276,
         "x": 276,
-        "y0": 0,
+        "y0": null,
         "y1": 276,
       },
       Object {
@@ -3494,7 +3494,7 @@ Array [
         "initialY0": null,
         "initialY1": 277,
         "x": 277,
-        "y0": 0,
+        "y0": null,
         "y1": 277,
       },
       Object {
@@ -3502,7 +3502,7 @@ Array [
         "initialY0": null,
         "initialY1": 278,
         "x": 278,
-        "y0": 0,
+        "y0": null,
         "y1": 278,
       },
       Object {
@@ -3510,7 +3510,7 @@ Array [
         "initialY0": null,
         "initialY1": 279,
         "x": 279,
-        "y0": 0,
+        "y0": null,
         "y1": 279,
       },
       Object {
@@ -3518,7 +3518,7 @@ Array [
         "initialY0": null,
         "initialY1": 280,
         "x": 280,
-        "y0": 0,
+        "y0": null,
         "y1": 280,
       },
       Object {
@@ -3526,7 +3526,7 @@ Array [
         "initialY0": null,
         "initialY1": 281,
         "x": 281,
-        "y0": 0,
+        "y0": null,
         "y1": 281,
       },
       Object {
@@ -3534,7 +3534,7 @@ Array [
         "initialY0": null,
         "initialY1": 282,
         "x": 282,
-        "y0": 0,
+        "y0": null,
         "y1": 282,
       },
       Object {
@@ -3542,7 +3542,7 @@ Array [
         "initialY0": null,
         "initialY1": 283,
         "x": 283,
-        "y0": 0,
+        "y0": null,
         "y1": 283,
       },
       Object {
@@ -3550,7 +3550,7 @@ Array [
         "initialY0": null,
         "initialY1": 284,
         "x": 284,
-        "y0": 0,
+        "y0": null,
         "y1": 284,
       },
       Object {
@@ -3558,7 +3558,7 @@ Array [
         "initialY0": null,
         "initialY1": 285,
         "x": 285,
-        "y0": 0,
+        "y0": null,
         "y1": 285,
       },
       Object {
@@ -3566,7 +3566,7 @@ Array [
         "initialY0": null,
         "initialY1": 286,
         "x": 286,
-        "y0": 0,
+        "y0": null,
         "y1": 286,
       },
       Object {
@@ -3574,7 +3574,7 @@ Array [
         "initialY0": null,
         "initialY1": 287,
         "x": 287,
-        "y0": 0,
+        "y0": null,
         "y1": 287,
       },
       Object {
@@ -3582,7 +3582,7 @@ Array [
         "initialY0": null,
         "initialY1": 288,
         "x": 288,
-        "y0": 0,
+        "y0": null,
         "y1": 288,
       },
       Object {
@@ -3590,7 +3590,7 @@ Array [
         "initialY0": null,
         "initialY1": 289,
         "x": 289,
-        "y0": 0,
+        "y0": null,
         "y1": 289,
       },
       Object {
@@ -3598,7 +3598,7 @@ Array [
         "initialY0": null,
         "initialY1": 290,
         "x": 290,
-        "y0": 0,
+        "y0": null,
         "y1": 290,
       },
       Object {
@@ -3606,7 +3606,7 @@ Array [
         "initialY0": null,
         "initialY1": 291,
         "x": 291,
-        "y0": 0,
+        "y0": null,
         "y1": 291,
       },
       Object {
@@ -3614,7 +3614,7 @@ Array [
         "initialY0": null,
         "initialY1": 292,
         "x": 292,
-        "y0": 0,
+        "y0": null,
         "y1": 292,
       },
       Object {
@@ -3622,7 +3622,7 @@ Array [
         "initialY0": null,
         "initialY1": 293,
         "x": 293,
-        "y0": 0,
+        "y0": null,
         "y1": 293,
       },
       Object {
@@ -3630,7 +3630,7 @@ Array [
         "initialY0": null,
         "initialY1": 294,
         "x": 294,
-        "y0": 0,
+        "y0": null,
         "y1": 294,
       },
       Object {
@@ -3638,7 +3638,7 @@ Array [
         "initialY0": null,
         "initialY1": 295,
         "x": 295,
-        "y0": 0,
+        "y0": null,
         "y1": 295,
       },
       Object {
@@ -3646,7 +3646,7 @@ Array [
         "initialY0": null,
         "initialY1": 296,
         "x": 296,
-        "y0": 0,
+        "y0": null,
         "y1": 296,
       },
       Object {
@@ -3654,7 +3654,7 @@ Array [
         "initialY0": null,
         "initialY1": 297,
         "x": 297,
-        "y0": 0,
+        "y0": null,
         "y1": 297,
       },
       Object {
@@ -3662,7 +3662,7 @@ Array [
         "initialY0": null,
         "initialY1": 298,
         "x": 298,
-        "y0": 0,
+        "y0": null,
         "y1": 298,
       },
       Object {
@@ -3670,7 +3670,7 @@ Array [
         "initialY0": null,
         "initialY1": 299,
         "x": 299,
-        "y0": 0,
+        "y0": null,
         "y1": 299,
       },
       Object {
@@ -3678,7 +3678,7 @@ Array [
         "initialY0": null,
         "initialY1": 300,
         "x": 300,
-        "y0": 0,
+        "y0": null,
         "y1": 300,
       },
       Object {
@@ -3686,7 +3686,7 @@ Array [
         "initialY0": null,
         "initialY1": 301,
         "x": 301,
-        "y0": 0,
+        "y0": null,
         "y1": 301,
       },
       Object {
@@ -3694,7 +3694,7 @@ Array [
         "initialY0": null,
         "initialY1": 302,
         "x": 302,
-        "y0": 0,
+        "y0": null,
         "y1": 302,
       },
       Object {
@@ -3702,7 +3702,7 @@ Array [
         "initialY0": null,
         "initialY1": 303,
         "x": 303,
-        "y0": 0,
+        "y0": null,
         "y1": 303,
       },
       Object {
@@ -3710,7 +3710,7 @@ Array [
         "initialY0": null,
         "initialY1": 304,
         "x": 304,
-        "y0": 0,
+        "y0": null,
         "y1": 304,
       },
       Object {
@@ -3718,7 +3718,7 @@ Array [
         "initialY0": null,
         "initialY1": 305,
         "x": 305,
-        "y0": 0,
+        "y0": null,
         "y1": 305,
       },
       Object {
@@ -3726,7 +3726,7 @@ Array [
         "initialY0": null,
         "initialY1": 306,
         "x": 306,
-        "y0": 0,
+        "y0": null,
         "y1": 306,
       },
       Object {
@@ -3734,7 +3734,7 @@ Array [
         "initialY0": null,
         "initialY1": 307,
         "x": 307,
-        "y0": 0,
+        "y0": null,
         "y1": 307,
       },
       Object {
@@ -3742,7 +3742,7 @@ Array [
         "initialY0": null,
         "initialY1": 308,
         "x": 308,
-        "y0": 0,
+        "y0": null,
         "y1": 308,
       },
       Object {
@@ -3750,7 +3750,7 @@ Array [
         "initialY0": null,
         "initialY1": 309,
         "x": 309,
-        "y0": 0,
+        "y0": null,
         "y1": 309,
       },
       Object {
@@ -3758,7 +3758,7 @@ Array [
         "initialY0": null,
         "initialY1": 310,
         "x": 310,
-        "y0": 0,
+        "y0": null,
         "y1": 310,
       },
       Object {
@@ -3766,7 +3766,7 @@ Array [
         "initialY0": null,
         "initialY1": 311,
         "x": 311,
-        "y0": 0,
+        "y0": null,
         "y1": 311,
       },
       Object {
@@ -3774,7 +3774,7 @@ Array [
         "initialY0": null,
         "initialY1": 312,
         "x": 312,
-        "y0": 0,
+        "y0": null,
         "y1": 312,
       },
       Object {
@@ -3782,7 +3782,7 @@ Array [
         "initialY0": null,
         "initialY1": 313,
         "x": 313,
-        "y0": 0,
+        "y0": null,
         "y1": 313,
       },
       Object {
@@ -3790,7 +3790,7 @@ Array [
         "initialY0": null,
         "initialY1": 314,
         "x": 314,
-        "y0": 0,
+        "y0": null,
         "y1": 314,
       },
       Object {
@@ -3798,7 +3798,7 @@ Array [
         "initialY0": null,
         "initialY1": 315,
         "x": 315,
-        "y0": 0,
+        "y0": null,
         "y1": 315,
       },
       Object {
@@ -3806,7 +3806,7 @@ Array [
         "initialY0": null,
         "initialY1": 316,
         "x": 316,
-        "y0": 0,
+        "y0": null,
         "y1": 316,
       },
       Object {
@@ -3814,7 +3814,7 @@ Array [
         "initialY0": null,
         "initialY1": 317,
         "x": 317,
-        "y0": 0,
+        "y0": null,
         "y1": 317,
       },
       Object {
@@ -3822,7 +3822,7 @@ Array [
         "initialY0": null,
         "initialY1": 318,
         "x": 318,
-        "y0": 0,
+        "y0": null,
         "y1": 318,
       },
       Object {
@@ -3830,7 +3830,7 @@ Array [
         "initialY0": null,
         "initialY1": 319,
         "x": 319,
-        "y0": 0,
+        "y0": null,
         "y1": 319,
       },
       Object {
@@ -3838,7 +3838,7 @@ Array [
         "initialY0": null,
         "initialY1": 320,
         "x": 320,
-        "y0": 0,
+        "y0": null,
         "y1": 320,
       },
       Object {
@@ -3846,7 +3846,7 @@ Array [
         "initialY0": null,
         "initialY1": 321,
         "x": 321,
-        "y0": 0,
+        "y0": null,
         "y1": 321,
       },
       Object {
@@ -3854,7 +3854,7 @@ Array [
         "initialY0": null,
         "initialY1": 322,
         "x": 322,
-        "y0": 0,
+        "y0": null,
         "y1": 322,
       },
       Object {
@@ -3862,7 +3862,7 @@ Array [
         "initialY0": null,
         "initialY1": 323,
         "x": 323,
-        "y0": 0,
+        "y0": null,
         "y1": 323,
       },
       Object {
@@ -3870,7 +3870,7 @@ Array [
         "initialY0": null,
         "initialY1": 324,
         "x": 324,
-        "y0": 0,
+        "y0": null,
         "y1": 324,
       },
       Object {
@@ -3878,7 +3878,7 @@ Array [
         "initialY0": null,
         "initialY1": 325,
         "x": 325,
-        "y0": 0,
+        "y0": null,
         "y1": 325,
       },
       Object {
@@ -3886,7 +3886,7 @@ Array [
         "initialY0": null,
         "initialY1": 326,
         "x": 326,
-        "y0": 0,
+        "y0": null,
         "y1": 326,
       },
       Object {
@@ -3894,7 +3894,7 @@ Array [
         "initialY0": null,
         "initialY1": 327,
         "x": 327,
-        "y0": 0,
+        "y0": null,
         "y1": 327,
       },
       Object {
@@ -3902,7 +3902,7 @@ Array [
         "initialY0": null,
         "initialY1": 328,
         "x": 328,
-        "y0": 0,
+        "y0": null,
         "y1": 328,
       },
       Object {
@@ -3910,7 +3910,7 @@ Array [
         "initialY0": null,
         "initialY1": 329,
         "x": 329,
-        "y0": 0,
+        "y0": null,
         "y1": 329,
       },
       Object {
@@ -3918,7 +3918,7 @@ Array [
         "initialY0": null,
         "initialY1": 330,
         "x": 330,
-        "y0": 0,
+        "y0": null,
         "y1": 330,
       },
       Object {
@@ -3926,7 +3926,7 @@ Array [
         "initialY0": null,
         "initialY1": 331,
         "x": 331,
-        "y0": 0,
+        "y0": null,
         "y1": 331,
       },
       Object {
@@ -3934,7 +3934,7 @@ Array [
         "initialY0": null,
         "initialY1": 332,
         "x": 332,
-        "y0": 0,
+        "y0": null,
         "y1": 332,
       },
       Object {
@@ -3942,7 +3942,7 @@ Array [
         "initialY0": null,
         "initialY1": 333,
         "x": 333,
-        "y0": 0,
+        "y0": null,
         "y1": 333,
       },
       Object {
@@ -3950,7 +3950,7 @@ Array [
         "initialY0": null,
         "initialY1": 334,
         "x": 334,
-        "y0": 0,
+        "y0": null,
         "y1": 334,
       },
       Object {
@@ -3958,7 +3958,7 @@ Array [
         "initialY0": null,
         "initialY1": 335,
         "x": 335,
-        "y0": 0,
+        "y0": null,
         "y1": 335,
       },
       Object {
@@ -3966,7 +3966,7 @@ Array [
         "initialY0": null,
         "initialY1": 336,
         "x": 336,
-        "y0": 0,
+        "y0": null,
         "y1": 336,
       },
       Object {
@@ -3974,7 +3974,7 @@ Array [
         "initialY0": null,
         "initialY1": 337,
         "x": 337,
-        "y0": 0,
+        "y0": null,
         "y1": 337,
       },
       Object {
@@ -3982,7 +3982,7 @@ Array [
         "initialY0": null,
         "initialY1": 338,
         "x": 338,
-        "y0": 0,
+        "y0": null,
         "y1": 338,
       },
       Object {
@@ -3990,7 +3990,7 @@ Array [
         "initialY0": null,
         "initialY1": 339,
         "x": 339,
-        "y0": 0,
+        "y0": null,
         "y1": 339,
       },
       Object {
@@ -3998,7 +3998,7 @@ Array [
         "initialY0": null,
         "initialY1": 340,
         "x": 340,
-        "y0": 0,
+        "y0": null,
         "y1": 340,
       },
       Object {
@@ -4006,7 +4006,7 @@ Array [
         "initialY0": null,
         "initialY1": 341,
         "x": 341,
-        "y0": 0,
+        "y0": null,
         "y1": 341,
       },
       Object {
@@ -4014,7 +4014,7 @@ Array [
         "initialY0": null,
         "initialY1": 342,
         "x": 342,
-        "y0": 0,
+        "y0": null,
         "y1": 342,
       },
       Object {
@@ -4022,7 +4022,7 @@ Array [
         "initialY0": null,
         "initialY1": 343,
         "x": 343,
-        "y0": 0,
+        "y0": null,
         "y1": 343,
       },
       Object {
@@ -4030,7 +4030,7 @@ Array [
         "initialY0": null,
         "initialY1": 344,
         "x": 344,
-        "y0": 0,
+        "y0": null,
         "y1": 344,
       },
       Object {
@@ -4038,7 +4038,7 @@ Array [
         "initialY0": null,
         "initialY1": 345,
         "x": 345,
-        "y0": 0,
+        "y0": null,
         "y1": 345,
       },
       Object {
@@ -4046,7 +4046,7 @@ Array [
         "initialY0": null,
         "initialY1": 346,
         "x": 346,
-        "y0": 0,
+        "y0": null,
         "y1": 346,
       },
       Object {
@@ -4054,7 +4054,7 @@ Array [
         "initialY0": null,
         "initialY1": 347,
         "x": 347,
-        "y0": 0,
+        "y0": null,
         "y1": 347,
       },
       Object {
@@ -4062,7 +4062,7 @@ Array [
         "initialY0": null,
         "initialY1": 348,
         "x": 348,
-        "y0": 0,
+        "y0": null,
         "y1": 348,
       },
       Object {
@@ -4070,7 +4070,7 @@ Array [
         "initialY0": null,
         "initialY1": 349,
         "x": 349,
-        "y0": 0,
+        "y0": null,
         "y1": 349,
       },
       Object {
@@ -4078,7 +4078,7 @@ Array [
         "initialY0": null,
         "initialY1": 350,
         "x": 350,
-        "y0": 0,
+        "y0": null,
         "y1": 350,
       },
       Object {
@@ -4086,7 +4086,7 @@ Array [
         "initialY0": null,
         "initialY1": 351,
         "x": 351,
-        "y0": 0,
+        "y0": null,
         "y1": 351,
       },
       Object {
@@ -4094,7 +4094,7 @@ Array [
         "initialY0": null,
         "initialY1": 352,
         "x": 352,
-        "y0": 0,
+        "y0": null,
         "y1": 352,
       },
       Object {
@@ -4102,7 +4102,7 @@ Array [
         "initialY0": null,
         "initialY1": 353,
         "x": 353,
-        "y0": 0,
+        "y0": null,
         "y1": 353,
       },
       Object {
@@ -4110,7 +4110,7 @@ Array [
         "initialY0": null,
         "initialY1": 354,
         "x": 354,
-        "y0": 0,
+        "y0": null,
         "y1": 354,
       },
       Object {
@@ -4118,7 +4118,7 @@ Array [
         "initialY0": null,
         "initialY1": 355,
         "x": 355,
-        "y0": 0,
+        "y0": null,
         "y1": 355,
       },
       Object {
@@ -4126,7 +4126,7 @@ Array [
         "initialY0": null,
         "initialY1": 356,
         "x": 356,
-        "y0": 0,
+        "y0": null,
         "y1": 356,
       },
       Object {
@@ -4134,7 +4134,7 @@ Array [
         "initialY0": null,
         "initialY1": 357,
         "x": 357,
-        "y0": 0,
+        "y0": null,
         "y1": 357,
       },
       Object {
@@ -4142,7 +4142,7 @@ Array [
         "initialY0": null,
         "initialY1": 358,
         "x": 358,
-        "y0": 0,
+        "y0": null,
         "y1": 358,
       },
       Object {
@@ -4150,7 +4150,7 @@ Array [
         "initialY0": null,
         "initialY1": 359,
         "x": 359,
-        "y0": 0,
+        "y0": null,
         "y1": 359,
       },
       Object {
@@ -4158,7 +4158,7 @@ Array [
         "initialY0": null,
         "initialY1": 360,
         "x": 360,
-        "y0": 0,
+        "y0": null,
         "y1": 360,
       },
       Object {
@@ -4166,7 +4166,7 @@ Array [
         "initialY0": null,
         "initialY1": 361,
         "x": 361,
-        "y0": 0,
+        "y0": null,
         "y1": 361,
       },
       Object {
@@ -4174,7 +4174,7 @@ Array [
         "initialY0": null,
         "initialY1": 362,
         "x": 362,
-        "y0": 0,
+        "y0": null,
         "y1": 362,
       },
       Object {
@@ -4182,7 +4182,7 @@ Array [
         "initialY0": null,
         "initialY1": 363,
         "x": 363,
-        "y0": 0,
+        "y0": null,
         "y1": 363,
       },
       Object {
@@ -4190,7 +4190,7 @@ Array [
         "initialY0": null,
         "initialY1": 364,
         "x": 364,
-        "y0": 0,
+        "y0": null,
         "y1": 364,
       },
       Object {
@@ -4198,7 +4198,7 @@ Array [
         "initialY0": null,
         "initialY1": 365,
         "x": 365,
-        "y0": 0,
+        "y0": null,
         "y1": 365,
       },
       Object {
@@ -4206,7 +4206,7 @@ Array [
         "initialY0": null,
         "initialY1": 366,
         "x": 366,
-        "y0": 0,
+        "y0": null,
         "y1": 366,
       },
       Object {
@@ -4214,7 +4214,7 @@ Array [
         "initialY0": null,
         "initialY1": 367,
         "x": 367,
-        "y0": 0,
+        "y0": null,
         "y1": 367,
       },
       Object {
@@ -4222,7 +4222,7 @@ Array [
         "initialY0": null,
         "initialY1": 368,
         "x": 368,
-        "y0": 0,
+        "y0": null,
         "y1": 368,
       },
       Object {
@@ -4230,7 +4230,7 @@ Array [
         "initialY0": null,
         "initialY1": 369,
         "x": 369,
-        "y0": 0,
+        "y0": null,
         "y1": 369,
       },
       Object {
@@ -4238,7 +4238,7 @@ Array [
         "initialY0": null,
         "initialY1": 370,
         "x": 370,
-        "y0": 0,
+        "y0": null,
         "y1": 370,
       },
       Object {
@@ -4246,7 +4246,7 @@ Array [
         "initialY0": null,
         "initialY1": 371,
         "x": 371,
-        "y0": 0,
+        "y0": null,
         "y1": 371,
       },
       Object {
@@ -4254,7 +4254,7 @@ Array [
         "initialY0": null,
         "initialY1": 372,
         "x": 372,
-        "y0": 0,
+        "y0": null,
         "y1": 372,
       },
       Object {
@@ -4262,7 +4262,7 @@ Array [
         "initialY0": null,
         "initialY1": 373,
         "x": 373,
-        "y0": 0,
+        "y0": null,
         "y1": 373,
       },
       Object {
@@ -4270,7 +4270,7 @@ Array [
         "initialY0": null,
         "initialY1": 374,
         "x": 374,
-        "y0": 0,
+        "y0": null,
         "y1": 374,
       },
       Object {
@@ -4278,7 +4278,7 @@ Array [
         "initialY0": null,
         "initialY1": 375,
         "x": 375,
-        "y0": 0,
+        "y0": null,
         "y1": 375,
       },
       Object {
@@ -4286,7 +4286,7 @@ Array [
         "initialY0": null,
         "initialY1": 376,
         "x": 376,
-        "y0": 0,
+        "y0": null,
         "y1": 376,
       },
       Object {
@@ -4294,7 +4294,7 @@ Array [
         "initialY0": null,
         "initialY1": 377,
         "x": 377,
-        "y0": 0,
+        "y0": null,
         "y1": 377,
       },
       Object {
@@ -4302,7 +4302,7 @@ Array [
         "initialY0": null,
         "initialY1": 378,
         "x": 378,
-        "y0": 0,
+        "y0": null,
         "y1": 378,
       },
       Object {
@@ -4310,7 +4310,7 @@ Array [
         "initialY0": null,
         "initialY1": 379,
         "x": 379,
-        "y0": 0,
+        "y0": null,
         "y1": 379,
       },
       Object {
@@ -4318,7 +4318,7 @@ Array [
         "initialY0": null,
         "initialY1": 380,
         "x": 380,
-        "y0": 0,
+        "y0": null,
         "y1": 380,
       },
       Object {
@@ -4326,7 +4326,7 @@ Array [
         "initialY0": null,
         "initialY1": 381,
         "x": 381,
-        "y0": 0,
+        "y0": null,
         "y1": 381,
       },
       Object {
@@ -4334,7 +4334,7 @@ Array [
         "initialY0": null,
         "initialY1": 382,
         "x": 382,
-        "y0": 0,
+        "y0": null,
         "y1": 382,
       },
       Object {
@@ -4342,7 +4342,7 @@ Array [
         "initialY0": null,
         "initialY1": 383,
         "x": 383,
-        "y0": 0,
+        "y0": null,
         "y1": 383,
       },
       Object {
@@ -4350,7 +4350,7 @@ Array [
         "initialY0": null,
         "initialY1": 384,
         "x": 384,
-        "y0": 0,
+        "y0": null,
         "y1": 384,
       },
       Object {
@@ -4358,7 +4358,7 @@ Array [
         "initialY0": null,
         "initialY1": 385,
         "x": 385,
-        "y0": 0,
+        "y0": null,
         "y1": 385,
       },
       Object {
@@ -4366,7 +4366,7 @@ Array [
         "initialY0": null,
         "initialY1": 386,
         "x": 386,
-        "y0": 0,
+        "y0": null,
         "y1": 386,
       },
       Object {
@@ -4374,7 +4374,7 @@ Array [
         "initialY0": null,
         "initialY1": 387,
         "x": 387,
-        "y0": 0,
+        "y0": null,
         "y1": 387,
       },
       Object {
@@ -4382,7 +4382,7 @@ Array [
         "initialY0": null,
         "initialY1": 388,
         "x": 388,
-        "y0": 0,
+        "y0": null,
         "y1": 388,
       },
       Object {
@@ -4390,7 +4390,7 @@ Array [
         "initialY0": null,
         "initialY1": 389,
         "x": 389,
-        "y0": 0,
+        "y0": null,
         "y1": 389,
       },
       Object {
@@ -4398,7 +4398,7 @@ Array [
         "initialY0": null,
         "initialY1": 390,
         "x": 390,
-        "y0": 0,
+        "y0": null,
         "y1": 390,
       },
       Object {
@@ -4406,7 +4406,7 @@ Array [
         "initialY0": null,
         "initialY1": 391,
         "x": 391,
-        "y0": 0,
+        "y0": null,
         "y1": 391,
       },
       Object {
@@ -4414,7 +4414,7 @@ Array [
         "initialY0": null,
         "initialY1": 392,
         "x": 392,
-        "y0": 0,
+        "y0": null,
         "y1": 392,
       },
       Object {
@@ -4422,7 +4422,7 @@ Array [
         "initialY0": null,
         "initialY1": 393,
         "x": 393,
-        "y0": 0,
+        "y0": null,
         "y1": 393,
       },
       Object {
@@ -4430,7 +4430,7 @@ Array [
         "initialY0": null,
         "initialY1": 394,
         "x": 394,
-        "y0": 0,
+        "y0": null,
         "y1": 394,
       },
       Object {
@@ -4438,7 +4438,7 @@ Array [
         "initialY0": null,
         "initialY1": 395,
         "x": 395,
-        "y0": 0,
+        "y0": null,
         "y1": 395,
       },
       Object {
@@ -4446,7 +4446,7 @@ Array [
         "initialY0": null,
         "initialY1": 396,
         "x": 396,
-        "y0": 0,
+        "y0": null,
         "y1": 396,
       },
       Object {
@@ -4454,7 +4454,7 @@ Array [
         "initialY0": null,
         "initialY1": 397,
         "x": 397,
-        "y0": 0,
+        "y0": null,
         "y1": 397,
       },
       Object {
@@ -4462,7 +4462,7 @@ Array [
         "initialY0": null,
         "initialY1": 398,
         "x": 398,
-        "y0": 0,
+        "y0": null,
         "y1": 398,
       },
       Object {
@@ -4470,7 +4470,7 @@ Array [
         "initialY0": null,
         "initialY1": 399,
         "x": 399,
-        "y0": 0,
+        "y0": null,
         "y1": 399,
       },
       Object {
@@ -4478,7 +4478,7 @@ Array [
         "initialY0": null,
         "initialY1": 400,
         "x": 400,
-        "y0": 0,
+        "y0": null,
         "y1": 400,
       },
       Object {
@@ -4486,7 +4486,7 @@ Array [
         "initialY0": null,
         "initialY1": 401,
         "x": 401,
-        "y0": 0,
+        "y0": null,
         "y1": 401,
       },
       Object {
@@ -4494,7 +4494,7 @@ Array [
         "initialY0": null,
         "initialY1": 402,
         "x": 402,
-        "y0": 0,
+        "y0": null,
         "y1": 402,
       },
       Object {
@@ -4502,7 +4502,7 @@ Array [
         "initialY0": null,
         "initialY1": 403,
         "x": 403,
-        "y0": 0,
+        "y0": null,
         "y1": 403,
       },
       Object {
@@ -4510,7 +4510,7 @@ Array [
         "initialY0": null,
         "initialY1": 404,
         "x": 404,
-        "y0": 0,
+        "y0": null,
         "y1": 404,
       },
       Object {
@@ -4518,7 +4518,7 @@ Array [
         "initialY0": null,
         "initialY1": 405,
         "x": 405,
-        "y0": 0,
+        "y0": null,
         "y1": 405,
       },
       Object {
@@ -4526,7 +4526,7 @@ Array [
         "initialY0": null,
         "initialY1": 406,
         "x": 406,
-        "y0": 0,
+        "y0": null,
         "y1": 406,
       },
       Object {
@@ -4534,7 +4534,7 @@ Array [
         "initialY0": null,
         "initialY1": 407,
         "x": 407,
-        "y0": 0,
+        "y0": null,
         "y1": 407,
       },
       Object {
@@ -4542,7 +4542,7 @@ Array [
         "initialY0": null,
         "initialY1": 408,
         "x": 408,
-        "y0": 0,
+        "y0": null,
         "y1": 408,
       },
       Object {
@@ -4550,7 +4550,7 @@ Array [
         "initialY0": null,
         "initialY1": 409,
         "x": 409,
-        "y0": 0,
+        "y0": null,
         "y1": 409,
       },
       Object {
@@ -4558,7 +4558,7 @@ Array [
         "initialY0": null,
         "initialY1": 410,
         "x": 410,
-        "y0": 0,
+        "y0": null,
         "y1": 410,
       },
       Object {
@@ -4566,7 +4566,7 @@ Array [
         "initialY0": null,
         "initialY1": 411,
         "x": 411,
-        "y0": 0,
+        "y0": null,
         "y1": 411,
       },
       Object {
@@ -4574,7 +4574,7 @@ Array [
         "initialY0": null,
         "initialY1": 412,
         "x": 412,
-        "y0": 0,
+        "y0": null,
         "y1": 412,
       },
       Object {
@@ -4582,7 +4582,7 @@ Array [
         "initialY0": null,
         "initialY1": 413,
         "x": 413,
-        "y0": 0,
+        "y0": null,
         "y1": 413,
       },
       Object {
@@ -4590,7 +4590,7 @@ Array [
         "initialY0": null,
         "initialY1": 414,
         "x": 414,
-        "y0": 0,
+        "y0": null,
         "y1": 414,
       },
       Object {
@@ -4598,7 +4598,7 @@ Array [
         "initialY0": null,
         "initialY1": 415,
         "x": 415,
-        "y0": 0,
+        "y0": null,
         "y1": 415,
       },
       Object {
@@ -4606,7 +4606,7 @@ Array [
         "initialY0": null,
         "initialY1": 416,
         "x": 416,
-        "y0": 0,
+        "y0": null,
         "y1": 416,
       },
       Object {
@@ -4614,7 +4614,7 @@ Array [
         "initialY0": null,
         "initialY1": 417,
         "x": 417,
-        "y0": 0,
+        "y0": null,
         "y1": 417,
       },
       Object {
@@ -4622,7 +4622,7 @@ Array [
         "initialY0": null,
         "initialY1": 418,
         "x": 418,
-        "y0": 0,
+        "y0": null,
         "y1": 418,
       },
       Object {
@@ -4630,7 +4630,7 @@ Array [
         "initialY0": null,
         "initialY1": 419,
         "x": 419,
-        "y0": 0,
+        "y0": null,
         "y1": 419,
       },
       Object {
@@ -4638,7 +4638,7 @@ Array [
         "initialY0": null,
         "initialY1": 420,
         "x": 420,
-        "y0": 0,
+        "y0": null,
         "y1": 420,
       },
       Object {
@@ -4646,7 +4646,7 @@ Array [
         "initialY0": null,
         "initialY1": 421,
         "x": 421,
-        "y0": 0,
+        "y0": null,
         "y1": 421,
       },
       Object {
@@ -4654,7 +4654,7 @@ Array [
         "initialY0": null,
         "initialY1": 422,
         "x": 422,
-        "y0": 0,
+        "y0": null,
         "y1": 422,
       },
       Object {
@@ -4662,7 +4662,7 @@ Array [
         "initialY0": null,
         "initialY1": 423,
         "x": 423,
-        "y0": 0,
+        "y0": null,
         "y1": 423,
       },
       Object {
@@ -4670,7 +4670,7 @@ Array [
         "initialY0": null,
         "initialY1": 424,
         "x": 424,
-        "y0": 0,
+        "y0": null,
         "y1": 424,
       },
       Object {
@@ -4678,7 +4678,7 @@ Array [
         "initialY0": null,
         "initialY1": 425,
         "x": 425,
-        "y0": 0,
+        "y0": null,
         "y1": 425,
       },
       Object {
@@ -4686,7 +4686,7 @@ Array [
         "initialY0": null,
         "initialY1": 426,
         "x": 426,
-        "y0": 0,
+        "y0": null,
         "y1": 426,
       },
       Object {
@@ -4694,7 +4694,7 @@ Array [
         "initialY0": null,
         "initialY1": 427,
         "x": 427,
-        "y0": 0,
+        "y0": null,
         "y1": 427,
       },
       Object {
@@ -4702,7 +4702,7 @@ Array [
         "initialY0": null,
         "initialY1": 428,
         "x": 428,
-        "y0": 0,
+        "y0": null,
         "y1": 428,
       },
       Object {
@@ -4710,7 +4710,7 @@ Array [
         "initialY0": null,
         "initialY1": 429,
         "x": 429,
-        "y0": 0,
+        "y0": null,
         "y1": 429,
       },
       Object {
@@ -4718,7 +4718,7 @@ Array [
         "initialY0": null,
         "initialY1": 430,
         "x": 430,
-        "y0": 0,
+        "y0": null,
         "y1": 430,
       },
       Object {
@@ -4726,7 +4726,7 @@ Array [
         "initialY0": null,
         "initialY1": 431,
         "x": 431,
-        "y0": 0,
+        "y0": null,
         "y1": 431,
       },
       Object {
@@ -4734,7 +4734,7 @@ Array [
         "initialY0": null,
         "initialY1": 432,
         "x": 432,
-        "y0": 0,
+        "y0": null,
         "y1": 432,
       },
       Object {
@@ -4742,7 +4742,7 @@ Array [
         "initialY0": null,
         "initialY1": 433,
         "x": 433,
-        "y0": 0,
+        "y0": null,
         "y1": 433,
       },
       Object {
@@ -4750,7 +4750,7 @@ Array [
         "initialY0": null,
         "initialY1": 434,
         "x": 434,
-        "y0": 0,
+        "y0": null,
         "y1": 434,
       },
       Object {
@@ -4758,7 +4758,7 @@ Array [
         "initialY0": null,
         "initialY1": 435,
         "x": 435,
-        "y0": 0,
+        "y0": null,
         "y1": 435,
       },
       Object {
@@ -4766,7 +4766,7 @@ Array [
         "initialY0": null,
         "initialY1": 436,
         "x": 436,
-        "y0": 0,
+        "y0": null,
         "y1": 436,
       },
       Object {
@@ -4774,7 +4774,7 @@ Array [
         "initialY0": null,
         "initialY1": 437,
         "x": 437,
-        "y0": 0,
+        "y0": null,
         "y1": 437,
       },
       Object {
@@ -4782,7 +4782,7 @@ Array [
         "initialY0": null,
         "initialY1": 438,
         "x": 438,
-        "y0": 0,
+        "y0": null,
         "y1": 438,
       },
       Object {
@@ -4790,7 +4790,7 @@ Array [
         "initialY0": null,
         "initialY1": 439,
         "x": 439,
-        "y0": 0,
+        "y0": null,
         "y1": 439,
       },
       Object {
@@ -4798,7 +4798,7 @@ Array [
         "initialY0": null,
         "initialY1": 440,
         "x": 440,
-        "y0": 0,
+        "y0": null,
         "y1": 440,
       },
       Object {
@@ -4806,7 +4806,7 @@ Array [
         "initialY0": null,
         "initialY1": 441,
         "x": 441,
-        "y0": 0,
+        "y0": null,
         "y1": 441,
       },
       Object {
@@ -4814,7 +4814,7 @@ Array [
         "initialY0": null,
         "initialY1": 442,
         "x": 442,
-        "y0": 0,
+        "y0": null,
         "y1": 442,
       },
       Object {
@@ -4822,7 +4822,7 @@ Array [
         "initialY0": null,
         "initialY1": 443,
         "x": 443,
-        "y0": 0,
+        "y0": null,
         "y1": 443,
       },
       Object {
@@ -4830,7 +4830,7 @@ Array [
         "initialY0": null,
         "initialY1": 444,
         "x": 444,
-        "y0": 0,
+        "y0": null,
         "y1": 444,
       },
       Object {
@@ -4838,7 +4838,7 @@ Array [
         "initialY0": null,
         "initialY1": 445,
         "x": 445,
-        "y0": 0,
+        "y0": null,
         "y1": 445,
       },
       Object {
@@ -4846,7 +4846,7 @@ Array [
         "initialY0": null,
         "initialY1": 446,
         "x": 446,
-        "y0": 0,
+        "y0": null,
         "y1": 446,
       },
       Object {
@@ -4854,7 +4854,7 @@ Array [
         "initialY0": null,
         "initialY1": 447,
         "x": 447,
-        "y0": 0,
+        "y0": null,
         "y1": 447,
       },
       Object {
@@ -4862,7 +4862,7 @@ Array [
         "initialY0": null,
         "initialY1": 448,
         "x": 448,
-        "y0": 0,
+        "y0": null,
         "y1": 448,
       },
       Object {
@@ -4870,7 +4870,7 @@ Array [
         "initialY0": null,
         "initialY1": 449,
         "x": 449,
-        "y0": 0,
+        "y0": null,
         "y1": 449,
       },
       Object {
@@ -4878,7 +4878,7 @@ Array [
         "initialY0": null,
         "initialY1": 450,
         "x": 450,
-        "y0": 0,
+        "y0": null,
         "y1": 450,
       },
       Object {
@@ -4886,7 +4886,7 @@ Array [
         "initialY0": null,
         "initialY1": 451,
         "x": 451,
-        "y0": 0,
+        "y0": null,
         "y1": 451,
       },
       Object {
@@ -4894,7 +4894,7 @@ Array [
         "initialY0": null,
         "initialY1": 452,
         "x": 452,
-        "y0": 0,
+        "y0": null,
         "y1": 452,
       },
       Object {
@@ -4902,7 +4902,7 @@ Array [
         "initialY0": null,
         "initialY1": 453,
         "x": 453,
-        "y0": 0,
+        "y0": null,
         "y1": 453,
       },
       Object {
@@ -4910,7 +4910,7 @@ Array [
         "initialY0": null,
         "initialY1": 454,
         "x": 454,
-        "y0": 0,
+        "y0": null,
         "y1": 454,
       },
       Object {
@@ -4918,7 +4918,7 @@ Array [
         "initialY0": null,
         "initialY1": 455,
         "x": 455,
-        "y0": 0,
+        "y0": null,
         "y1": 455,
       },
       Object {
@@ -4926,7 +4926,7 @@ Array [
         "initialY0": null,
         "initialY1": 456,
         "x": 456,
-        "y0": 0,
+        "y0": null,
         "y1": 456,
       },
       Object {
@@ -4934,7 +4934,7 @@ Array [
         "initialY0": null,
         "initialY1": 457,
         "x": 457,
-        "y0": 0,
+        "y0": null,
         "y1": 457,
       },
       Object {
@@ -4942,7 +4942,7 @@ Array [
         "initialY0": null,
         "initialY1": 458,
         "x": 458,
-        "y0": 0,
+        "y0": null,
         "y1": 458,
       },
       Object {
@@ -4950,7 +4950,7 @@ Array [
         "initialY0": null,
         "initialY1": 459,
         "x": 459,
-        "y0": 0,
+        "y0": null,
         "y1": 459,
       },
       Object {
@@ -4958,7 +4958,7 @@ Array [
         "initialY0": null,
         "initialY1": 460,
         "x": 460,
-        "y0": 0,
+        "y0": null,
         "y1": 460,
       },
       Object {
@@ -4966,7 +4966,7 @@ Array [
         "initialY0": null,
         "initialY1": 461,
         "x": 461,
-        "y0": 0,
+        "y0": null,
         "y1": 461,
       },
       Object {
@@ -4974,7 +4974,7 @@ Array [
         "initialY0": null,
         "initialY1": 462,
         "x": 462,
-        "y0": 0,
+        "y0": null,
         "y1": 462,
       },
       Object {
@@ -4982,7 +4982,7 @@ Array [
         "initialY0": null,
         "initialY1": 463,
         "x": 463,
-        "y0": 0,
+        "y0": null,
         "y1": 463,
       },
       Object {
@@ -4990,7 +4990,7 @@ Array [
         "initialY0": null,
         "initialY1": 464,
         "x": 464,
-        "y0": 0,
+        "y0": null,
         "y1": 464,
       },
       Object {
@@ -4998,7 +4998,7 @@ Array [
         "initialY0": null,
         "initialY1": 465,
         "x": 465,
-        "y0": 0,
+        "y0": null,
         "y1": 465,
       },
       Object {
@@ -5006,7 +5006,7 @@ Array [
         "initialY0": null,
         "initialY1": 466,
         "x": 466,
-        "y0": 0,
+        "y0": null,
         "y1": 466,
       },
       Object {
@@ -5014,7 +5014,7 @@ Array [
         "initialY0": null,
         "initialY1": 467,
         "x": 467,
-        "y0": 0,
+        "y0": null,
         "y1": 467,
       },
       Object {
@@ -5022,7 +5022,7 @@ Array [
         "initialY0": null,
         "initialY1": 468,
         "x": 468,
-        "y0": 0,
+        "y0": null,
         "y1": 468,
       },
       Object {
@@ -5030,7 +5030,7 @@ Array [
         "initialY0": null,
         "initialY1": 469,
         "x": 469,
-        "y0": 0,
+        "y0": null,
         "y1": 469,
       },
       Object {
@@ -5038,7 +5038,7 @@ Array [
         "initialY0": null,
         "initialY1": 470,
         "x": 470,
-        "y0": 0,
+        "y0": null,
         "y1": 470,
       },
       Object {
@@ -5046,7 +5046,7 @@ Array [
         "initialY0": null,
         "initialY1": 471,
         "x": 471,
-        "y0": 0,
+        "y0": null,
         "y1": 471,
       },
       Object {
@@ -5054,7 +5054,7 @@ Array [
         "initialY0": null,
         "initialY1": 472,
         "x": 472,
-        "y0": 0,
+        "y0": null,
         "y1": 472,
       },
       Object {
@@ -5062,7 +5062,7 @@ Array [
         "initialY0": null,
         "initialY1": 473,
         "x": 473,
-        "y0": 0,
+        "y0": null,
         "y1": 473,
       },
       Object {
@@ -5070,7 +5070,7 @@ Array [
         "initialY0": null,
         "initialY1": 474,
         "x": 474,
-        "y0": 0,
+        "y0": null,
         "y1": 474,
       },
       Object {
@@ -5078,7 +5078,7 @@ Array [
         "initialY0": null,
         "initialY1": 475,
         "x": 475,
-        "y0": 0,
+        "y0": null,
         "y1": 475,
       },
       Object {
@@ -5086,7 +5086,7 @@ Array [
         "initialY0": null,
         "initialY1": 476,
         "x": 476,
-        "y0": 0,
+        "y0": null,
         "y1": 476,
       },
       Object {
@@ -5094,7 +5094,7 @@ Array [
         "initialY0": null,
         "initialY1": 477,
         "x": 477,
-        "y0": 0,
+        "y0": null,
         "y1": 477,
       },
       Object {
@@ -5102,7 +5102,7 @@ Array [
         "initialY0": null,
         "initialY1": 478,
         "x": 478,
-        "y0": 0,
+        "y0": null,
         "y1": 478,
       },
       Object {
@@ -5110,7 +5110,7 @@ Array [
         "initialY0": null,
         "initialY1": 479,
         "x": 479,
-        "y0": 0,
+        "y0": null,
         "y1": 479,
       },
       Object {
@@ -5118,7 +5118,7 @@ Array [
         "initialY0": null,
         "initialY1": 480,
         "x": 480,
-        "y0": 0,
+        "y0": null,
         "y1": 480,
       },
       Object {
@@ -5126,7 +5126,7 @@ Array [
         "initialY0": null,
         "initialY1": 481,
         "x": 481,
-        "y0": 0,
+        "y0": null,
         "y1": 481,
       },
       Object {
@@ -5134,7 +5134,7 @@ Array [
         "initialY0": null,
         "initialY1": 482,
         "x": 482,
-        "y0": 0,
+        "y0": null,
         "y1": 482,
       },
       Object {
@@ -5142,7 +5142,7 @@ Array [
         "initialY0": null,
         "initialY1": 483,
         "x": 483,
-        "y0": 0,
+        "y0": null,
         "y1": 483,
       },
       Object {
@@ -5150,7 +5150,7 @@ Array [
         "initialY0": null,
         "initialY1": 484,
         "x": 484,
-        "y0": 0,
+        "y0": null,
         "y1": 484,
       },
       Object {
@@ -5158,7 +5158,7 @@ Array [
         "initialY0": null,
         "initialY1": 485,
         "x": 485,
-        "y0": 0,
+        "y0": null,
         "y1": 485,
       },
       Object {
@@ -5166,7 +5166,7 @@ Array [
         "initialY0": null,
         "initialY1": 486,
         "x": 486,
-        "y0": 0,
+        "y0": null,
         "y1": 486,
       },
       Object {
@@ -5174,7 +5174,7 @@ Array [
         "initialY0": null,
         "initialY1": 487,
         "x": 487,
-        "y0": 0,
+        "y0": null,
         "y1": 487,
       },
       Object {
@@ -5182,7 +5182,7 @@ Array [
         "initialY0": null,
         "initialY1": 488,
         "x": 488,
-        "y0": 0,
+        "y0": null,
         "y1": 488,
       },
       Object {
@@ -5190,7 +5190,7 @@ Array [
         "initialY0": null,
         "initialY1": 489,
         "x": 489,
-        "y0": 0,
+        "y0": null,
         "y1": 489,
       },
       Object {
@@ -5198,7 +5198,7 @@ Array [
         "initialY0": null,
         "initialY1": 490,
         "x": 490,
-        "y0": 0,
+        "y0": null,
         "y1": 490,
       },
       Object {
@@ -5206,7 +5206,7 @@ Array [
         "initialY0": null,
         "initialY1": 491,
         "x": 491,
-        "y0": 0,
+        "y0": null,
         "y1": 491,
       },
       Object {
@@ -5214,7 +5214,7 @@ Array [
         "initialY0": null,
         "initialY1": 492,
         "x": 492,
-        "y0": 0,
+        "y0": null,
         "y1": 492,
       },
       Object {
@@ -5222,7 +5222,7 @@ Array [
         "initialY0": null,
         "initialY1": 493,
         "x": 493,
-        "y0": 0,
+        "y0": null,
         "y1": 493,
       },
       Object {
@@ -5230,7 +5230,7 @@ Array [
         "initialY0": null,
         "initialY1": 494,
         "x": 494,
-        "y0": 0,
+        "y0": null,
         "y1": 494,
       },
       Object {
@@ -5238,7 +5238,7 @@ Array [
         "initialY0": null,
         "initialY1": 495,
         "x": 495,
-        "y0": 0,
+        "y0": null,
         "y1": 495,
       },
       Object {
@@ -5246,7 +5246,7 @@ Array [
         "initialY0": null,
         "initialY1": 496,
         "x": 496,
-        "y0": 0,
+        "y0": null,
         "y1": 496,
       },
       Object {
@@ -5254,7 +5254,7 @@ Array [
         "initialY0": null,
         "initialY1": 497,
         "x": 497,
-        "y0": 0,
+        "y0": null,
         "y1": 497,
       },
       Object {
@@ -5262,7 +5262,7 @@ Array [
         "initialY0": null,
         "initialY1": 498,
         "x": 498,
-        "y0": 0,
+        "y0": null,
         "y1": 498,
       },
       Object {
@@ -5270,7 +5270,7 @@ Array [
         "initialY0": null,
         "initialY1": 499,
         "x": 499,
-        "y0": 0,
+        "y0": null,
         "y1": 499,
       },
       Object {
@@ -5278,7 +5278,7 @@ Array [
         "initialY0": null,
         "initialY1": 500,
         "x": 500,
-        "y0": 0,
+        "y0": null,
         "y1": 500,
       },
       Object {
@@ -5286,7 +5286,7 @@ Array [
         "initialY0": null,
         "initialY1": 501,
         "x": 501,
-        "y0": 0,
+        "y0": null,
         "y1": 501,
       },
       Object {
@@ -5294,7 +5294,7 @@ Array [
         "initialY0": null,
         "initialY1": 502,
         "x": 502,
-        "y0": 0,
+        "y0": null,
         "y1": 502,
       },
       Object {
@@ -5302,7 +5302,7 @@ Array [
         "initialY0": null,
         "initialY1": 503,
         "x": 503,
-        "y0": 0,
+        "y0": null,
         "y1": 503,
       },
       Object {
@@ -5310,7 +5310,7 @@ Array [
         "initialY0": null,
         "initialY1": 504,
         "x": 504,
-        "y0": 0,
+        "y0": null,
         "y1": 504,
       },
       Object {
@@ -5318,7 +5318,7 @@ Array [
         "initialY0": null,
         "initialY1": 505,
         "x": 505,
-        "y0": 0,
+        "y0": null,
         "y1": 505,
       },
       Object {
@@ -5326,7 +5326,7 @@ Array [
         "initialY0": null,
         "initialY1": 506,
         "x": 506,
-        "y0": 0,
+        "y0": null,
         "y1": 506,
       },
       Object {
@@ -5334,7 +5334,7 @@ Array [
         "initialY0": null,
         "initialY1": 507,
         "x": 507,
-        "y0": 0,
+        "y0": null,
         "y1": 507,
       },
       Object {
@@ -5342,7 +5342,7 @@ Array [
         "initialY0": null,
         "initialY1": 508,
         "x": 508,
-        "y0": 0,
+        "y0": null,
         "y1": 508,
       },
       Object {
@@ -5350,7 +5350,7 @@ Array [
         "initialY0": null,
         "initialY1": 509,
         "x": 509,
-        "y0": 0,
+        "y0": null,
         "y1": 509,
       },
       Object {
@@ -5358,7 +5358,7 @@ Array [
         "initialY0": null,
         "initialY1": 510,
         "x": 510,
-        "y0": 0,
+        "y0": null,
         "y1": 510,
       },
       Object {
@@ -5366,7 +5366,7 @@ Array [
         "initialY0": null,
         "initialY1": 511,
         "x": 511,
-        "y0": 0,
+        "y0": null,
         "y1": 511,
       },
       Object {
@@ -5374,7 +5374,7 @@ Array [
         "initialY0": null,
         "initialY1": 512,
         "x": 512,
-        "y0": 0,
+        "y0": null,
         "y1": 512,
       },
       Object {
@@ -5382,7 +5382,7 @@ Array [
         "initialY0": null,
         "initialY1": 513,
         "x": 513,
-        "y0": 0,
+        "y0": null,
         "y1": 513,
       },
       Object {
@@ -5390,7 +5390,7 @@ Array [
         "initialY0": null,
         "initialY1": 514,
         "x": 514,
-        "y0": 0,
+        "y0": null,
         "y1": 514,
       },
       Object {
@@ -5398,7 +5398,7 @@ Array [
         "initialY0": null,
         "initialY1": 515,
         "x": 515,
-        "y0": 0,
+        "y0": null,
         "y1": 515,
       },
       Object {
@@ -5406,7 +5406,7 @@ Array [
         "initialY0": null,
         "initialY1": 516,
         "x": 516,
-        "y0": 0,
+        "y0": null,
         "y1": 516,
       },
       Object {
@@ -5414,7 +5414,7 @@ Array [
         "initialY0": null,
         "initialY1": 517,
         "x": 517,
-        "y0": 0,
+        "y0": null,
         "y1": 517,
       },
       Object {
@@ -5422,7 +5422,7 @@ Array [
         "initialY0": null,
         "initialY1": 518,
         "x": 518,
-        "y0": 0,
+        "y0": null,
         "y1": 518,
       },
       Object {
@@ -5430,7 +5430,7 @@ Array [
         "initialY0": null,
         "initialY1": 519,
         "x": 519,
-        "y0": 0,
+        "y0": null,
         "y1": 519,
       },
       Object {
@@ -5438,7 +5438,7 @@ Array [
         "initialY0": null,
         "initialY1": 520,
         "x": 520,
-        "y0": 0,
+        "y0": null,
         "y1": 520,
       },
       Object {
@@ -5446,7 +5446,7 @@ Array [
         "initialY0": null,
         "initialY1": 521,
         "x": 521,
-        "y0": 0,
+        "y0": null,
         "y1": 521,
       },
       Object {
@@ -5454,7 +5454,7 @@ Array [
         "initialY0": null,
         "initialY1": 522,
         "x": 522,
-        "y0": 0,
+        "y0": null,
         "y1": 522,
       },
       Object {
@@ -5462,7 +5462,7 @@ Array [
         "initialY0": null,
         "initialY1": 523,
         "x": 523,
-        "y0": 0,
+        "y0": null,
         "y1": 523,
       },
       Object {
@@ -5470,7 +5470,7 @@ Array [
         "initialY0": null,
         "initialY1": 524,
         "x": 524,
-        "y0": 0,
+        "y0": null,
         "y1": 524,
       },
       Object {
@@ -5478,7 +5478,7 @@ Array [
         "initialY0": null,
         "initialY1": 525,
         "x": 525,
-        "y0": 0,
+        "y0": null,
         "y1": 525,
       },
       Object {
@@ -5486,7 +5486,7 @@ Array [
         "initialY0": null,
         "initialY1": 526,
         "x": 526,
-        "y0": 0,
+        "y0": null,
         "y1": 526,
       },
       Object {
@@ -5494,7 +5494,7 @@ Array [
         "initialY0": null,
         "initialY1": 527,
         "x": 527,
-        "y0": 0,
+        "y0": null,
         "y1": 527,
       },
       Object {
@@ -5502,7 +5502,7 @@ Array [
         "initialY0": null,
         "initialY1": 528,
         "x": 528,
-        "y0": 0,
+        "y0": null,
         "y1": 528,
       },
       Object {
@@ -5510,7 +5510,7 @@ Array [
         "initialY0": null,
         "initialY1": 529,
         "x": 529,
-        "y0": 0,
+        "y0": null,
         "y1": 529,
       },
       Object {
@@ -5518,7 +5518,7 @@ Array [
         "initialY0": null,
         "initialY1": 530,
         "x": 530,
-        "y0": 0,
+        "y0": null,
         "y1": 530,
       },
       Object {
@@ -5526,7 +5526,7 @@ Array [
         "initialY0": null,
         "initialY1": 531,
         "x": 531,
-        "y0": 0,
+        "y0": null,
         "y1": 531,
       },
       Object {
@@ -5534,7 +5534,7 @@ Array [
         "initialY0": null,
         "initialY1": 532,
         "x": 532,
-        "y0": 0,
+        "y0": null,
         "y1": 532,
       },
       Object {
@@ -5542,7 +5542,7 @@ Array [
         "initialY0": null,
         "initialY1": 533,
         "x": 533,
-        "y0": 0,
+        "y0": null,
         "y1": 533,
       },
       Object {
@@ -5550,7 +5550,7 @@ Array [
         "initialY0": null,
         "initialY1": 534,
         "x": 534,
-        "y0": 0,
+        "y0": null,
         "y1": 534,
       },
       Object {
@@ -5558,7 +5558,7 @@ Array [
         "initialY0": null,
         "initialY1": 535,
         "x": 535,
-        "y0": 0,
+        "y0": null,
         "y1": 535,
       },
       Object {
@@ -5566,7 +5566,7 @@ Array [
         "initialY0": null,
         "initialY1": 536,
         "x": 536,
-        "y0": 0,
+        "y0": null,
         "y1": 536,
       },
       Object {
@@ -5574,7 +5574,7 @@ Array [
         "initialY0": null,
         "initialY1": 537,
         "x": 537,
-        "y0": 0,
+        "y0": null,
         "y1": 537,
       },
       Object {
@@ -5582,7 +5582,7 @@ Array [
         "initialY0": null,
         "initialY1": 538,
         "x": 538,
-        "y0": 0,
+        "y0": null,
         "y1": 538,
       },
       Object {
@@ -5590,7 +5590,7 @@ Array [
         "initialY0": null,
         "initialY1": 539,
         "x": 539,
-        "y0": 0,
+        "y0": null,
         "y1": 539,
       },
       Object {
@@ -5598,7 +5598,7 @@ Array [
         "initialY0": null,
         "initialY1": 540,
         "x": 540,
-        "y0": 0,
+        "y0": null,
         "y1": 540,
       },
       Object {
@@ -5606,7 +5606,7 @@ Array [
         "initialY0": null,
         "initialY1": 541,
         "x": 541,
-        "y0": 0,
+        "y0": null,
         "y1": 541,
       },
       Object {
@@ -5614,7 +5614,7 @@ Array [
         "initialY0": null,
         "initialY1": 542,
         "x": 542,
-        "y0": 0,
+        "y0": null,
         "y1": 542,
       },
       Object {
@@ -5622,7 +5622,7 @@ Array [
         "initialY0": null,
         "initialY1": 543,
         "x": 543,
-        "y0": 0,
+        "y0": null,
         "y1": 543,
       },
       Object {
@@ -5630,7 +5630,7 @@ Array [
         "initialY0": null,
         "initialY1": 544,
         "x": 544,
-        "y0": 0,
+        "y0": null,
         "y1": 544,
       },
       Object {
@@ -5638,7 +5638,7 @@ Array [
         "initialY0": null,
         "initialY1": 545,
         "x": 545,
-        "y0": 0,
+        "y0": null,
         "y1": 545,
       },
       Object {
@@ -5646,7 +5646,7 @@ Array [
         "initialY0": null,
         "initialY1": 546,
         "x": 546,
-        "y0": 0,
+        "y0": null,
         "y1": 546,
       },
       Object {
@@ -5654,7 +5654,7 @@ Array [
         "initialY0": null,
         "initialY1": 547,
         "x": 547,
-        "y0": 0,
+        "y0": null,
         "y1": 547,
       },
       Object {
@@ -5662,7 +5662,7 @@ Array [
         "initialY0": null,
         "initialY1": 548,
         "x": 548,
-        "y0": 0,
+        "y0": null,
         "y1": 548,
       },
       Object {
@@ -5670,7 +5670,7 @@ Array [
         "initialY0": null,
         "initialY1": 549,
         "x": 549,
-        "y0": 0,
+        "y0": null,
         "y1": 549,
       },
       Object {
@@ -5678,7 +5678,7 @@ Array [
         "initialY0": null,
         "initialY1": 550,
         "x": 550,
-        "y0": 0,
+        "y0": null,
         "y1": 550,
       },
       Object {
@@ -5686,7 +5686,7 @@ Array [
         "initialY0": null,
         "initialY1": 551,
         "x": 551,
-        "y0": 0,
+        "y0": null,
         "y1": 551,
       },
       Object {
@@ -5694,7 +5694,7 @@ Array [
         "initialY0": null,
         "initialY1": 552,
         "x": 552,
-        "y0": 0,
+        "y0": null,
         "y1": 552,
       },
       Object {
@@ -5702,7 +5702,7 @@ Array [
         "initialY0": null,
         "initialY1": 553,
         "x": 553,
-        "y0": 0,
+        "y0": null,
         "y1": 553,
       },
       Object {
@@ -5710,7 +5710,7 @@ Array [
         "initialY0": null,
         "initialY1": 554,
         "x": 554,
-        "y0": 0,
+        "y0": null,
         "y1": 554,
       },
       Object {
@@ -5718,7 +5718,7 @@ Array [
         "initialY0": null,
         "initialY1": 555,
         "x": 555,
-        "y0": 0,
+        "y0": null,
         "y1": 555,
       },
       Object {
@@ -5726,7 +5726,7 @@ Array [
         "initialY0": null,
         "initialY1": 556,
         "x": 556,
-        "y0": 0,
+        "y0": null,
         "y1": 556,
       },
       Object {
@@ -5734,7 +5734,7 @@ Array [
         "initialY0": null,
         "initialY1": 557,
         "x": 557,
-        "y0": 0,
+        "y0": null,
         "y1": 557,
       },
       Object {
@@ -5742,7 +5742,7 @@ Array [
         "initialY0": null,
         "initialY1": 558,
         "x": 558,
-        "y0": 0,
+        "y0": null,
         "y1": 558,
       },
       Object {
@@ -5750,7 +5750,7 @@ Array [
         "initialY0": null,
         "initialY1": 559,
         "x": 559,
-        "y0": 0,
+        "y0": null,
         "y1": 559,
       },
       Object {
@@ -5758,7 +5758,7 @@ Array [
         "initialY0": null,
         "initialY1": 560,
         "x": 560,
-        "y0": 0,
+        "y0": null,
         "y1": 560,
       },
       Object {
@@ -5766,7 +5766,7 @@ Array [
         "initialY0": null,
         "initialY1": 561,
         "x": 561,
-        "y0": 0,
+        "y0": null,
         "y1": 561,
       },
       Object {
@@ -5774,7 +5774,7 @@ Array [
         "initialY0": null,
         "initialY1": 562,
         "x": 562,
-        "y0": 0,
+        "y0": null,
         "y1": 562,
       },
       Object {
@@ -5782,7 +5782,7 @@ Array [
         "initialY0": null,
         "initialY1": 563,
         "x": 563,
-        "y0": 0,
+        "y0": null,
         "y1": 563,
       },
       Object {
@@ -5790,7 +5790,7 @@ Array [
         "initialY0": null,
         "initialY1": 564,
         "x": 564,
-        "y0": 0,
+        "y0": null,
         "y1": 564,
       },
       Object {
@@ -5798,7 +5798,7 @@ Array [
         "initialY0": null,
         "initialY1": 565,
         "x": 565,
-        "y0": 0,
+        "y0": null,
         "y1": 565,
       },
       Object {
@@ -5806,7 +5806,7 @@ Array [
         "initialY0": null,
         "initialY1": 566,
         "x": 566,
-        "y0": 0,
+        "y0": null,
         "y1": 566,
       },
       Object {
@@ -5814,7 +5814,7 @@ Array [
         "initialY0": null,
         "initialY1": 567,
         "x": 567,
-        "y0": 0,
+        "y0": null,
         "y1": 567,
       },
       Object {
@@ -5822,7 +5822,7 @@ Array [
         "initialY0": null,
         "initialY1": 568,
         "x": 568,
-        "y0": 0,
+        "y0": null,
         "y1": 568,
       },
       Object {
@@ -5830,7 +5830,7 @@ Array [
         "initialY0": null,
         "initialY1": 569,
         "x": 569,
-        "y0": 0,
+        "y0": null,
         "y1": 569,
       },
       Object {
@@ -5838,7 +5838,7 @@ Array [
         "initialY0": null,
         "initialY1": 570,
         "x": 570,
-        "y0": 0,
+        "y0": null,
         "y1": 570,
       },
       Object {
@@ -5846,7 +5846,7 @@ Array [
         "initialY0": null,
         "initialY1": 571,
         "x": 571,
-        "y0": 0,
+        "y0": null,
         "y1": 571,
       },
       Object {
@@ -5854,7 +5854,7 @@ Array [
         "initialY0": null,
         "initialY1": 572,
         "x": 572,
-        "y0": 0,
+        "y0": null,
         "y1": 572,
       },
       Object {
@@ -5862,7 +5862,7 @@ Array [
         "initialY0": null,
         "initialY1": 573,
         "x": 573,
-        "y0": 0,
+        "y0": null,
         "y1": 573,
       },
       Object {
@@ -5870,7 +5870,7 @@ Array [
         "initialY0": null,
         "initialY1": 574,
         "x": 574,
-        "y0": 0,
+        "y0": null,
         "y1": 574,
       },
       Object {
@@ -5878,7 +5878,7 @@ Array [
         "initialY0": null,
         "initialY1": 575,
         "x": 575,
-        "y0": 0,
+        "y0": null,
         "y1": 575,
       },
       Object {
@@ -5886,7 +5886,7 @@ Array [
         "initialY0": null,
         "initialY1": 576,
         "x": 576,
-        "y0": 0,
+        "y0": null,
         "y1": 576,
       },
       Object {
@@ -5894,7 +5894,7 @@ Array [
         "initialY0": null,
         "initialY1": 577,
         "x": 577,
-        "y0": 0,
+        "y0": null,
         "y1": 577,
       },
       Object {
@@ -5902,7 +5902,7 @@ Array [
         "initialY0": null,
         "initialY1": 578,
         "x": 578,
-        "y0": 0,
+        "y0": null,
         "y1": 578,
       },
       Object {
@@ -5910,7 +5910,7 @@ Array [
         "initialY0": null,
         "initialY1": 579,
         "x": 579,
-        "y0": 0,
+        "y0": null,
         "y1": 579,
       },
       Object {
@@ -5918,7 +5918,7 @@ Array [
         "initialY0": null,
         "initialY1": 580,
         "x": 580,
-        "y0": 0,
+        "y0": null,
         "y1": 580,
       },
       Object {
@@ -5926,7 +5926,7 @@ Array [
         "initialY0": null,
         "initialY1": 581,
         "x": 581,
-        "y0": 0,
+        "y0": null,
         "y1": 581,
       },
       Object {
@@ -5934,7 +5934,7 @@ Array [
         "initialY0": null,
         "initialY1": 582,
         "x": 582,
-        "y0": 0,
+        "y0": null,
         "y1": 582,
       },
       Object {
@@ -5942,7 +5942,7 @@ Array [
         "initialY0": null,
         "initialY1": 583,
         "x": 583,
-        "y0": 0,
+        "y0": null,
         "y1": 583,
       },
       Object {
@@ -5950,7 +5950,7 @@ Array [
         "initialY0": null,
         "initialY1": 584,
         "x": 584,
-        "y0": 0,
+        "y0": null,
         "y1": 584,
       },
       Object {
@@ -5958,7 +5958,7 @@ Array [
         "initialY0": null,
         "initialY1": 585,
         "x": 585,
-        "y0": 0,
+        "y0": null,
         "y1": 585,
       },
       Object {
@@ -5966,7 +5966,7 @@ Array [
         "initialY0": null,
         "initialY1": 586,
         "x": 586,
-        "y0": 0,
+        "y0": null,
         "y1": 586,
       },
       Object {
@@ -5974,7 +5974,7 @@ Array [
         "initialY0": null,
         "initialY1": 587,
         "x": 587,
-        "y0": 0,
+        "y0": null,
         "y1": 587,
       },
       Object {
@@ -5982,7 +5982,7 @@ Array [
         "initialY0": null,
         "initialY1": 588,
         "x": 588,
-        "y0": 0,
+        "y0": null,
         "y1": 588,
       },
       Object {
@@ -5990,7 +5990,7 @@ Array [
         "initialY0": null,
         "initialY1": 589,
         "x": 589,
-        "y0": 0,
+        "y0": null,
         "y1": 589,
       },
       Object {
@@ -5998,7 +5998,7 @@ Array [
         "initialY0": null,
         "initialY1": 590,
         "x": 590,
-        "y0": 0,
+        "y0": null,
         "y1": 590,
       },
       Object {
@@ -6006,7 +6006,7 @@ Array [
         "initialY0": null,
         "initialY1": 591,
         "x": 591,
-        "y0": 0,
+        "y0": null,
         "y1": 591,
       },
       Object {
@@ -6014,7 +6014,7 @@ Array [
         "initialY0": null,
         "initialY1": 592,
         "x": 592,
-        "y0": 0,
+        "y0": null,
         "y1": 592,
       },
       Object {
@@ -6022,7 +6022,7 @@ Array [
         "initialY0": null,
         "initialY1": 593,
         "x": 593,
-        "y0": 0,
+        "y0": null,
         "y1": 593,
       },
       Object {
@@ -6030,7 +6030,7 @@ Array [
         "initialY0": null,
         "initialY1": 594,
         "x": 594,
-        "y0": 0,
+        "y0": null,
         "y1": 594,
       },
       Object {
@@ -6038,7 +6038,7 @@ Array [
         "initialY0": null,
         "initialY1": 595,
         "x": 595,
-        "y0": 0,
+        "y0": null,
         "y1": 595,
       },
       Object {
@@ -6046,7 +6046,7 @@ Array [
         "initialY0": null,
         "initialY1": 596,
         "x": 596,
-        "y0": 0,
+        "y0": null,
         "y1": 596,
       },
       Object {
@@ -6054,7 +6054,7 @@ Array [
         "initialY0": null,
         "initialY1": 597,
         "x": 597,
-        "y0": 0,
+        "y0": null,
         "y1": 597,
       },
       Object {
@@ -6062,7 +6062,7 @@ Array [
         "initialY0": null,
         "initialY1": 598,
         "x": 598,
-        "y0": 0,
+        "y0": null,
         "y1": 598,
       },
       Object {
@@ -6070,7 +6070,7 @@ Array [
         "initialY0": null,
         "initialY1": 599,
         "x": 599,
-        "y0": 0,
+        "y0": null,
         "y1": 599,
       },
       Object {
@@ -6078,7 +6078,7 @@ Array [
         "initialY0": null,
         "initialY1": 600,
         "x": 600,
-        "y0": 0,
+        "y0": null,
         "y1": 600,
       },
       Object {
@@ -6086,7 +6086,7 @@ Array [
         "initialY0": null,
         "initialY1": 601,
         "x": 601,
-        "y0": 0,
+        "y0": null,
         "y1": 601,
       },
       Object {
@@ -6094,7 +6094,7 @@ Array [
         "initialY0": null,
         "initialY1": 602,
         "x": 602,
-        "y0": 0,
+        "y0": null,
         "y1": 602,
       },
       Object {
@@ -6102,7 +6102,7 @@ Array [
         "initialY0": null,
         "initialY1": 603,
         "x": 603,
-        "y0": 0,
+        "y0": null,
         "y1": 603,
       },
       Object {
@@ -6110,7 +6110,7 @@ Array [
         "initialY0": null,
         "initialY1": 604,
         "x": 604,
-        "y0": 0,
+        "y0": null,
         "y1": 604,
       },
       Object {
@@ -6118,7 +6118,7 @@ Array [
         "initialY0": null,
         "initialY1": 605,
         "x": 605,
-        "y0": 0,
+        "y0": null,
         "y1": 605,
       },
       Object {
@@ -6126,7 +6126,7 @@ Array [
         "initialY0": null,
         "initialY1": 606,
         "x": 606,
-        "y0": 0,
+        "y0": null,
         "y1": 606,
       },
       Object {
@@ -6134,7 +6134,7 @@ Array [
         "initialY0": null,
         "initialY1": 607,
         "x": 607,
-        "y0": 0,
+        "y0": null,
         "y1": 607,
       },
       Object {
@@ -6142,7 +6142,7 @@ Array [
         "initialY0": null,
         "initialY1": 608,
         "x": 608,
-        "y0": 0,
+        "y0": null,
         "y1": 608,
       },
       Object {
@@ -6150,7 +6150,7 @@ Array [
         "initialY0": null,
         "initialY1": 609,
         "x": 609,
-        "y0": 0,
+        "y0": null,
         "y1": 609,
       },
       Object {
@@ -6158,7 +6158,7 @@ Array [
         "initialY0": null,
         "initialY1": 610,
         "x": 610,
-        "y0": 0,
+        "y0": null,
         "y1": 610,
       },
       Object {
@@ -6166,7 +6166,7 @@ Array [
         "initialY0": null,
         "initialY1": 611,
         "x": 611,
-        "y0": 0,
+        "y0": null,
         "y1": 611,
       },
       Object {
@@ -6174,7 +6174,7 @@ Array [
         "initialY0": null,
         "initialY1": 612,
         "x": 612,
-        "y0": 0,
+        "y0": null,
         "y1": 612,
       },
       Object {
@@ -6182,7 +6182,7 @@ Array [
         "initialY0": null,
         "initialY1": 613,
         "x": 613,
-        "y0": 0,
+        "y0": null,
         "y1": 613,
       },
       Object {
@@ -6190,7 +6190,7 @@ Array [
         "initialY0": null,
         "initialY1": 614,
         "x": 614,
-        "y0": 0,
+        "y0": null,
         "y1": 614,
       },
       Object {
@@ -6198,7 +6198,7 @@ Array [
         "initialY0": null,
         "initialY1": 615,
         "x": 615,
-        "y0": 0,
+        "y0": null,
         "y1": 615,
       },
       Object {
@@ -6206,7 +6206,7 @@ Array [
         "initialY0": null,
         "initialY1": 616,
         "x": 616,
-        "y0": 0,
+        "y0": null,
         "y1": 616,
       },
       Object {
@@ -6214,7 +6214,7 @@ Array [
         "initialY0": null,
         "initialY1": 617,
         "x": 617,
-        "y0": 0,
+        "y0": null,
         "y1": 617,
       },
       Object {
@@ -6222,7 +6222,7 @@ Array [
         "initialY0": null,
         "initialY1": 618,
         "x": 618,
-        "y0": 0,
+        "y0": null,
         "y1": 618,
       },
       Object {
@@ -6230,7 +6230,7 @@ Array [
         "initialY0": null,
         "initialY1": 619,
         "x": 619,
-        "y0": 0,
+        "y0": null,
         "y1": 619,
       },
       Object {
@@ -6238,7 +6238,7 @@ Array [
         "initialY0": null,
         "initialY1": 620,
         "x": 620,
-        "y0": 0,
+        "y0": null,
         "y1": 620,
       },
       Object {
@@ -6246,7 +6246,7 @@ Array [
         "initialY0": null,
         "initialY1": 621,
         "x": 621,
-        "y0": 0,
+        "y0": null,
         "y1": 621,
       },
       Object {
@@ -6254,7 +6254,7 @@ Array [
         "initialY0": null,
         "initialY1": 622,
         "x": 622,
-        "y0": 0,
+        "y0": null,
         "y1": 622,
       },
       Object {
@@ -6262,7 +6262,7 @@ Array [
         "initialY0": null,
         "initialY1": 623,
         "x": 623,
-        "y0": 0,
+        "y0": null,
         "y1": 623,
       },
       Object {
@@ -6270,7 +6270,7 @@ Array [
         "initialY0": null,
         "initialY1": 624,
         "x": 624,
-        "y0": 0,
+        "y0": null,
         "y1": 624,
       },
       Object {
@@ -6278,7 +6278,7 @@ Array [
         "initialY0": null,
         "initialY1": 625,
         "x": 625,
-        "y0": 0,
+        "y0": null,
         "y1": 625,
       },
       Object {
@@ -6286,7 +6286,7 @@ Array [
         "initialY0": null,
         "initialY1": 626,
         "x": 626,
-        "y0": 0,
+        "y0": null,
         "y1": 626,
       },
       Object {
@@ -6294,7 +6294,7 @@ Array [
         "initialY0": null,
         "initialY1": 627,
         "x": 627,
-        "y0": 0,
+        "y0": null,
         "y1": 627,
       },
       Object {
@@ -6302,7 +6302,7 @@ Array [
         "initialY0": null,
         "initialY1": 628,
         "x": 628,
-        "y0": 0,
+        "y0": null,
         "y1": 628,
       },
       Object {
@@ -6310,7 +6310,7 @@ Array [
         "initialY0": null,
         "initialY1": 629,
         "x": 629,
-        "y0": 0,
+        "y0": null,
         "y1": 629,
       },
       Object {
@@ -6318,7 +6318,7 @@ Array [
         "initialY0": null,
         "initialY1": 630,
         "x": 630,
-        "y0": 0,
+        "y0": null,
         "y1": 630,
       },
       Object {
@@ -6326,7 +6326,7 @@ Array [
         "initialY0": null,
         "initialY1": 631,
         "x": 631,
-        "y0": 0,
+        "y0": null,
         "y1": 631,
       },
       Object {
@@ -6334,7 +6334,7 @@ Array [
         "initialY0": null,
         "initialY1": 632,
         "x": 632,
-        "y0": 0,
+        "y0": null,
         "y1": 632,
       },
       Object {
@@ -6342,7 +6342,7 @@ Array [
         "initialY0": null,
         "initialY1": 633,
         "x": 633,
-        "y0": 0,
+        "y0": null,
         "y1": 633,
       },
       Object {
@@ -6350,7 +6350,7 @@ Array [
         "initialY0": null,
         "initialY1": 634,
         "x": 634,
-        "y0": 0,
+        "y0": null,
         "y1": 634,
       },
       Object {
@@ -6358,7 +6358,7 @@ Array [
         "initialY0": null,
         "initialY1": 635,
         "x": 635,
-        "y0": 0,
+        "y0": null,
         "y1": 635,
       },
       Object {
@@ -6366,7 +6366,7 @@ Array [
         "initialY0": null,
         "initialY1": 636,
         "x": 636,
-        "y0": 0,
+        "y0": null,
         "y1": 636,
       },
       Object {
@@ -6374,7 +6374,7 @@ Array [
         "initialY0": null,
         "initialY1": 637,
         "x": 637,
-        "y0": 0,
+        "y0": null,
         "y1": 637,
       },
       Object {
@@ -6382,7 +6382,7 @@ Array [
         "initialY0": null,
         "initialY1": 638,
         "x": 638,
-        "y0": 0,
+        "y0": null,
         "y1": 638,
       },
       Object {
@@ -6390,7 +6390,7 @@ Array [
         "initialY0": null,
         "initialY1": 639,
         "x": 639,
-        "y0": 0,
+        "y0": null,
         "y1": 639,
       },
       Object {
@@ -6398,7 +6398,7 @@ Array [
         "initialY0": null,
         "initialY1": 640,
         "x": 640,
-        "y0": 0,
+        "y0": null,
         "y1": 640,
       },
       Object {
@@ -6406,7 +6406,7 @@ Array [
         "initialY0": null,
         "initialY1": 641,
         "x": 641,
-        "y0": 0,
+        "y0": null,
         "y1": 641,
       },
       Object {
@@ -6414,7 +6414,7 @@ Array [
         "initialY0": null,
         "initialY1": 642,
         "x": 642,
-        "y0": 0,
+        "y0": null,
         "y1": 642,
       },
       Object {
@@ -6422,7 +6422,7 @@ Array [
         "initialY0": null,
         "initialY1": 643,
         "x": 643,
-        "y0": 0,
+        "y0": null,
         "y1": 643,
       },
       Object {
@@ -6430,7 +6430,7 @@ Array [
         "initialY0": null,
         "initialY1": 644,
         "x": 644,
-        "y0": 0,
+        "y0": null,
         "y1": 644,
       },
       Object {
@@ -6438,7 +6438,7 @@ Array [
         "initialY0": null,
         "initialY1": 645,
         "x": 645,
-        "y0": 0,
+        "y0": null,
         "y1": 645,
       },
       Object {
@@ -6446,7 +6446,7 @@ Array [
         "initialY0": null,
         "initialY1": 646,
         "x": 646,
-        "y0": 0,
+        "y0": null,
         "y1": 646,
       },
       Object {
@@ -6454,7 +6454,7 @@ Array [
         "initialY0": null,
         "initialY1": 647,
         "x": 647,
-        "y0": 0,
+        "y0": null,
         "y1": 647,
       },
       Object {
@@ -6462,7 +6462,7 @@ Array [
         "initialY0": null,
         "initialY1": 648,
         "x": 648,
-        "y0": 0,
+        "y0": null,
         "y1": 648,
       },
       Object {
@@ -6470,7 +6470,7 @@ Array [
         "initialY0": null,
         "initialY1": 649,
         "x": 649,
-        "y0": 0,
+        "y0": null,
         "y1": 649,
       },
       Object {
@@ -6478,7 +6478,7 @@ Array [
         "initialY0": null,
         "initialY1": 650,
         "x": 650,
-        "y0": 0,
+        "y0": null,
         "y1": 650,
       },
       Object {
@@ -6486,7 +6486,7 @@ Array [
         "initialY0": null,
         "initialY1": 651,
         "x": 651,
-        "y0": 0,
+        "y0": null,
         "y1": 651,
       },
       Object {
@@ -6494,7 +6494,7 @@ Array [
         "initialY0": null,
         "initialY1": 652,
         "x": 652,
-        "y0": 0,
+        "y0": null,
         "y1": 652,
       },
       Object {
@@ -6502,7 +6502,7 @@ Array [
         "initialY0": null,
         "initialY1": 653,
         "x": 653,
-        "y0": 0,
+        "y0": null,
         "y1": 653,
       },
       Object {
@@ -6510,7 +6510,7 @@ Array [
         "initialY0": null,
         "initialY1": 654,
         "x": 654,
-        "y0": 0,
+        "y0": null,
         "y1": 654,
       },
       Object {
@@ -6518,7 +6518,7 @@ Array [
         "initialY0": null,
         "initialY1": 655,
         "x": 655,
-        "y0": 0,
+        "y0": null,
         "y1": 655,
       },
       Object {
@@ -6526,7 +6526,7 @@ Array [
         "initialY0": null,
         "initialY1": 656,
         "x": 656,
-        "y0": 0,
+        "y0": null,
         "y1": 656,
       },
       Object {
@@ -6534,7 +6534,7 @@ Array [
         "initialY0": null,
         "initialY1": 657,
         "x": 657,
-        "y0": 0,
+        "y0": null,
         "y1": 657,
       },
       Object {
@@ -6542,7 +6542,7 @@ Array [
         "initialY0": null,
         "initialY1": 658,
         "x": 658,
-        "y0": 0,
+        "y0": null,
         "y1": 658,
       },
       Object {
@@ -6550,7 +6550,7 @@ Array [
         "initialY0": null,
         "initialY1": 659,
         "x": 659,
-        "y0": 0,
+        "y0": null,
         "y1": 659,
       },
       Object {
@@ -6558,7 +6558,7 @@ Array [
         "initialY0": null,
         "initialY1": 660,
         "x": 660,
-        "y0": 0,
+        "y0": null,
         "y1": 660,
       },
       Object {
@@ -6566,7 +6566,7 @@ Array [
         "initialY0": null,
         "initialY1": 661,
         "x": 661,
-        "y0": 0,
+        "y0": null,
         "y1": 661,
       },
       Object {
@@ -6574,7 +6574,7 @@ Array [
         "initialY0": null,
         "initialY1": 662,
         "x": 662,
-        "y0": 0,
+        "y0": null,
         "y1": 662,
       },
       Object {
@@ -6582,7 +6582,7 @@ Array [
         "initialY0": null,
         "initialY1": 663,
         "x": 663,
-        "y0": 0,
+        "y0": null,
         "y1": 663,
       },
       Object {
@@ -6590,7 +6590,7 @@ Array [
         "initialY0": null,
         "initialY1": 664,
         "x": 664,
-        "y0": 0,
+        "y0": null,
         "y1": 664,
       },
       Object {
@@ -6598,7 +6598,7 @@ Array [
         "initialY0": null,
         "initialY1": 665,
         "x": 665,
-        "y0": 0,
+        "y0": null,
         "y1": 665,
       },
       Object {
@@ -6606,7 +6606,7 @@ Array [
         "initialY0": null,
         "initialY1": 666,
         "x": 666,
-        "y0": 0,
+        "y0": null,
         "y1": 666,
       },
       Object {
@@ -6614,7 +6614,7 @@ Array [
         "initialY0": null,
         "initialY1": 667,
         "x": 667,
-        "y0": 0,
+        "y0": null,
         "y1": 667,
       },
       Object {
@@ -6622,7 +6622,7 @@ Array [
         "initialY0": null,
         "initialY1": 668,
         "x": 668,
-        "y0": 0,
+        "y0": null,
         "y1": 668,
       },
       Object {
@@ -6630,7 +6630,7 @@ Array [
         "initialY0": null,
         "initialY1": 669,
         "x": 669,
-        "y0": 0,
+        "y0": null,
         "y1": 669,
       },
       Object {
@@ -6638,7 +6638,7 @@ Array [
         "initialY0": null,
         "initialY1": 670,
         "x": 670,
-        "y0": 0,
+        "y0": null,
         "y1": 670,
       },
       Object {
@@ -6646,7 +6646,7 @@ Array [
         "initialY0": null,
         "initialY1": 671,
         "x": 671,
-        "y0": 0,
+        "y0": null,
         "y1": 671,
       },
       Object {
@@ -6654,7 +6654,7 @@ Array [
         "initialY0": null,
         "initialY1": 672,
         "x": 672,
-        "y0": 0,
+        "y0": null,
         "y1": 672,
       },
       Object {
@@ -6662,7 +6662,7 @@ Array [
         "initialY0": null,
         "initialY1": 673,
         "x": 673,
-        "y0": 0,
+        "y0": null,
         "y1": 673,
       },
       Object {
@@ -6670,7 +6670,7 @@ Array [
         "initialY0": null,
         "initialY1": 674,
         "x": 674,
-        "y0": 0,
+        "y0": null,
         "y1": 674,
       },
       Object {
@@ -6678,7 +6678,7 @@ Array [
         "initialY0": null,
         "initialY1": 675,
         "x": 675,
-        "y0": 0,
+        "y0": null,
         "y1": 675,
       },
       Object {
@@ -6686,7 +6686,7 @@ Array [
         "initialY0": null,
         "initialY1": 676,
         "x": 676,
-        "y0": 0,
+        "y0": null,
         "y1": 676,
       },
       Object {
@@ -6694,7 +6694,7 @@ Array [
         "initialY0": null,
         "initialY1": 677,
         "x": 677,
-        "y0": 0,
+        "y0": null,
         "y1": 677,
       },
       Object {
@@ -6702,7 +6702,7 @@ Array [
         "initialY0": null,
         "initialY1": 678,
         "x": 678,
-        "y0": 0,
+        "y0": null,
         "y1": 678,
       },
       Object {
@@ -6710,7 +6710,7 @@ Array [
         "initialY0": null,
         "initialY1": 679,
         "x": 679,
-        "y0": 0,
+        "y0": null,
         "y1": 679,
       },
       Object {
@@ -6718,7 +6718,7 @@ Array [
         "initialY0": null,
         "initialY1": 680,
         "x": 680,
-        "y0": 0,
+        "y0": null,
         "y1": 680,
       },
       Object {
@@ -6726,7 +6726,7 @@ Array [
         "initialY0": null,
         "initialY1": 681,
         "x": 681,
-        "y0": 0,
+        "y0": null,
         "y1": 681,
       },
       Object {
@@ -6734,7 +6734,7 @@ Array [
         "initialY0": null,
         "initialY1": 682,
         "x": 682,
-        "y0": 0,
+        "y0": null,
         "y1": 682,
       },
       Object {
@@ -6742,7 +6742,7 @@ Array [
         "initialY0": null,
         "initialY1": 683,
         "x": 683,
-        "y0": 0,
+        "y0": null,
         "y1": 683,
       },
       Object {
@@ -6750,7 +6750,7 @@ Array [
         "initialY0": null,
         "initialY1": 684,
         "x": 684,
-        "y0": 0,
+        "y0": null,
         "y1": 684,
       },
       Object {
@@ -6758,7 +6758,7 @@ Array [
         "initialY0": null,
         "initialY1": 685,
         "x": 685,
-        "y0": 0,
+        "y0": null,
         "y1": 685,
       },
       Object {
@@ -6766,7 +6766,7 @@ Array [
         "initialY0": null,
         "initialY1": 686,
         "x": 686,
-        "y0": 0,
+        "y0": null,
         "y1": 686,
       },
       Object {
@@ -6774,7 +6774,7 @@ Array [
         "initialY0": null,
         "initialY1": 687,
         "x": 687,
-        "y0": 0,
+        "y0": null,
         "y1": 687,
       },
       Object {
@@ -6782,7 +6782,7 @@ Array [
         "initialY0": null,
         "initialY1": 688,
         "x": 688,
-        "y0": 0,
+        "y0": null,
         "y1": 688,
       },
       Object {
@@ -6790,7 +6790,7 @@ Array [
         "initialY0": null,
         "initialY1": 689,
         "x": 689,
-        "y0": 0,
+        "y0": null,
         "y1": 689,
       },
       Object {
@@ -6798,7 +6798,7 @@ Array [
         "initialY0": null,
         "initialY1": 690,
         "x": 690,
-        "y0": 0,
+        "y0": null,
         "y1": 690,
       },
       Object {
@@ -6806,7 +6806,7 @@ Array [
         "initialY0": null,
         "initialY1": 691,
         "x": 691,
-        "y0": 0,
+        "y0": null,
         "y1": 691,
       },
       Object {
@@ -6814,7 +6814,7 @@ Array [
         "initialY0": null,
         "initialY1": 692,
         "x": 692,
-        "y0": 0,
+        "y0": null,
         "y1": 692,
       },
       Object {
@@ -6822,7 +6822,7 @@ Array [
         "initialY0": null,
         "initialY1": 693,
         "x": 693,
-        "y0": 0,
+        "y0": null,
         "y1": 693,
       },
       Object {
@@ -6830,7 +6830,7 @@ Array [
         "initialY0": null,
         "initialY1": 694,
         "x": 694,
-        "y0": 0,
+        "y0": null,
         "y1": 694,
       },
       Object {
@@ -6838,7 +6838,7 @@ Array [
         "initialY0": null,
         "initialY1": 695,
         "x": 695,
-        "y0": 0,
+        "y0": null,
         "y1": 695,
       },
       Object {
@@ -6846,7 +6846,7 @@ Array [
         "initialY0": null,
         "initialY1": 696,
         "x": 696,
-        "y0": 0,
+        "y0": null,
         "y1": 696,
       },
       Object {
@@ -6854,7 +6854,7 @@ Array [
         "initialY0": null,
         "initialY1": 697,
         "x": 697,
-        "y0": 0,
+        "y0": null,
         "y1": 697,
       },
       Object {
@@ -6862,7 +6862,7 @@ Array [
         "initialY0": null,
         "initialY1": 698,
         "x": 698,
-        "y0": 0,
+        "y0": null,
         "y1": 698,
       },
       Object {
@@ -6870,7 +6870,7 @@ Array [
         "initialY0": null,
         "initialY1": 699,
         "x": 699,
-        "y0": 0,
+        "y0": null,
         "y1": 699,
       },
       Object {
@@ -6878,7 +6878,7 @@ Array [
         "initialY0": null,
         "initialY1": 700,
         "x": 700,
-        "y0": 0,
+        "y0": null,
         "y1": 700,
       },
       Object {
@@ -6886,7 +6886,7 @@ Array [
         "initialY0": null,
         "initialY1": 701,
         "x": 701,
-        "y0": 0,
+        "y0": null,
         "y1": 701,
       },
       Object {
@@ -6894,7 +6894,7 @@ Array [
         "initialY0": null,
         "initialY1": 702,
         "x": 702,
-        "y0": 0,
+        "y0": null,
         "y1": 702,
       },
       Object {
@@ -6902,7 +6902,7 @@ Array [
         "initialY0": null,
         "initialY1": 703,
         "x": 703,
-        "y0": 0,
+        "y0": null,
         "y1": 703,
       },
       Object {
@@ -6910,7 +6910,7 @@ Array [
         "initialY0": null,
         "initialY1": 704,
         "x": 704,
-        "y0": 0,
+        "y0": null,
         "y1": 704,
       },
       Object {
@@ -6918,7 +6918,7 @@ Array [
         "initialY0": null,
         "initialY1": 705,
         "x": 705,
-        "y0": 0,
+        "y0": null,
         "y1": 705,
       },
       Object {
@@ -6926,7 +6926,7 @@ Array [
         "initialY0": null,
         "initialY1": 706,
         "x": 706,
-        "y0": 0,
+        "y0": null,
         "y1": 706,
       },
       Object {
@@ -6934,7 +6934,7 @@ Array [
         "initialY0": null,
         "initialY1": 707,
         "x": 707,
-        "y0": 0,
+        "y0": null,
         "y1": 707,
       },
       Object {
@@ -6942,7 +6942,7 @@ Array [
         "initialY0": null,
         "initialY1": 708,
         "x": 708,
-        "y0": 0,
+        "y0": null,
         "y1": 708,
       },
       Object {
@@ -6950,7 +6950,7 @@ Array [
         "initialY0": null,
         "initialY1": 709,
         "x": 709,
-        "y0": 0,
+        "y0": null,
         "y1": 709,
       },
       Object {
@@ -6958,7 +6958,7 @@ Array [
         "initialY0": null,
         "initialY1": 710,
         "x": 710,
-        "y0": 0,
+        "y0": null,
         "y1": 710,
       },
       Object {
@@ -6966,7 +6966,7 @@ Array [
         "initialY0": null,
         "initialY1": 711,
         "x": 711,
-        "y0": 0,
+        "y0": null,
         "y1": 711,
       },
       Object {
@@ -6974,7 +6974,7 @@ Array [
         "initialY0": null,
         "initialY1": 712,
         "x": 712,
-        "y0": 0,
+        "y0": null,
         "y1": 712,
       },
       Object {
@@ -6982,7 +6982,7 @@ Array [
         "initialY0": null,
         "initialY1": 713,
         "x": 713,
-        "y0": 0,
+        "y0": null,
         "y1": 713,
       },
       Object {
@@ -6990,7 +6990,7 @@ Array [
         "initialY0": null,
         "initialY1": 714,
         "x": 714,
-        "y0": 0,
+        "y0": null,
         "y1": 714,
       },
       Object {
@@ -6998,7 +6998,7 @@ Array [
         "initialY0": null,
         "initialY1": 715,
         "x": 715,
-        "y0": 0,
+        "y0": null,
         "y1": 715,
       },
       Object {
@@ -7006,7 +7006,7 @@ Array [
         "initialY0": null,
         "initialY1": 716,
         "x": 716,
-        "y0": 0,
+        "y0": null,
         "y1": 716,
       },
       Object {
@@ -7014,7 +7014,7 @@ Array [
         "initialY0": null,
         "initialY1": 717,
         "x": 717,
-        "y0": 0,
+        "y0": null,
         "y1": 717,
       },
       Object {
@@ -7022,7 +7022,7 @@ Array [
         "initialY0": null,
         "initialY1": 718,
         "x": 718,
-        "y0": 0,
+        "y0": null,
         "y1": 718,
       },
       Object {
@@ -7030,7 +7030,7 @@ Array [
         "initialY0": null,
         "initialY1": 719,
         "x": 719,
-        "y0": 0,
+        "y0": null,
         "y1": 719,
       },
       Object {
@@ -7038,7 +7038,7 @@ Array [
         "initialY0": null,
         "initialY1": 720,
         "x": 720,
-        "y0": 0,
+        "y0": null,
         "y1": 720,
       },
       Object {
@@ -7046,7 +7046,7 @@ Array [
         "initialY0": null,
         "initialY1": 721,
         "x": 721,
-        "y0": 0,
+        "y0": null,
         "y1": 721,
       },
       Object {
@@ -7054,7 +7054,7 @@ Array [
         "initialY0": null,
         "initialY1": 722,
         "x": 722,
-        "y0": 0,
+        "y0": null,
         "y1": 722,
       },
       Object {
@@ -7062,7 +7062,7 @@ Array [
         "initialY0": null,
         "initialY1": 723,
         "x": 723,
-        "y0": 0,
+        "y0": null,
         "y1": 723,
       },
       Object {
@@ -7070,7 +7070,7 @@ Array [
         "initialY0": null,
         "initialY1": 724,
         "x": 724,
-        "y0": 0,
+        "y0": null,
         "y1": 724,
       },
       Object {
@@ -7078,7 +7078,7 @@ Array [
         "initialY0": null,
         "initialY1": 725,
         "x": 725,
-        "y0": 0,
+        "y0": null,
         "y1": 725,
       },
       Object {
@@ -7086,7 +7086,7 @@ Array [
         "initialY0": null,
         "initialY1": 726,
         "x": 726,
-        "y0": 0,
+        "y0": null,
         "y1": 726,
       },
       Object {
@@ -7094,7 +7094,7 @@ Array [
         "initialY0": null,
         "initialY1": 727,
         "x": 727,
-        "y0": 0,
+        "y0": null,
         "y1": 727,
       },
       Object {
@@ -7102,7 +7102,7 @@ Array [
         "initialY0": null,
         "initialY1": 728,
         "x": 728,
-        "y0": 0,
+        "y0": null,
         "y1": 728,
       },
       Object {
@@ -7110,7 +7110,7 @@ Array [
         "initialY0": null,
         "initialY1": 729,
         "x": 729,
-        "y0": 0,
+        "y0": null,
         "y1": 729,
       },
       Object {
@@ -7118,7 +7118,7 @@ Array [
         "initialY0": null,
         "initialY1": 730,
         "x": 730,
-        "y0": 0,
+        "y0": null,
         "y1": 730,
       },
       Object {
@@ -7126,7 +7126,7 @@ Array [
         "initialY0": null,
         "initialY1": 731,
         "x": 731,
-        "y0": 0,
+        "y0": null,
         "y1": 731,
       },
       Object {
@@ -7134,7 +7134,7 @@ Array [
         "initialY0": null,
         "initialY1": 732,
         "x": 732,
-        "y0": 0,
+        "y0": null,
         "y1": 732,
       },
       Object {
@@ -7142,7 +7142,7 @@ Array [
         "initialY0": null,
         "initialY1": 733,
         "x": 733,
-        "y0": 0,
+        "y0": null,
         "y1": 733,
       },
       Object {
@@ -7150,7 +7150,7 @@ Array [
         "initialY0": null,
         "initialY1": 734,
         "x": 734,
-        "y0": 0,
+        "y0": null,
         "y1": 734,
       },
       Object {
@@ -7158,7 +7158,7 @@ Array [
         "initialY0": null,
         "initialY1": 735,
         "x": 735,
-        "y0": 0,
+        "y0": null,
         "y1": 735,
       },
       Object {
@@ -7166,7 +7166,7 @@ Array [
         "initialY0": null,
         "initialY1": 736,
         "x": 736,
-        "y0": 0,
+        "y0": null,
         "y1": 736,
       },
       Object {
@@ -7174,7 +7174,7 @@ Array [
         "initialY0": null,
         "initialY1": 737,
         "x": 737,
-        "y0": 0,
+        "y0": null,
         "y1": 737,
       },
       Object {
@@ -7182,7 +7182,7 @@ Array [
         "initialY0": null,
         "initialY1": 738,
         "x": 738,
-        "y0": 0,
+        "y0": null,
         "y1": 738,
       },
       Object {
@@ -7190,7 +7190,7 @@ Array [
         "initialY0": null,
         "initialY1": 739,
         "x": 739,
-        "y0": 0,
+        "y0": null,
         "y1": 739,
       },
       Object {
@@ -7198,7 +7198,7 @@ Array [
         "initialY0": null,
         "initialY1": 740,
         "x": 740,
-        "y0": 0,
+        "y0": null,
         "y1": 740,
       },
       Object {
@@ -7206,7 +7206,7 @@ Array [
         "initialY0": null,
         "initialY1": 741,
         "x": 741,
-        "y0": 0,
+        "y0": null,
         "y1": 741,
       },
       Object {
@@ -7214,7 +7214,7 @@ Array [
         "initialY0": null,
         "initialY1": 742,
         "x": 742,
-        "y0": 0,
+        "y0": null,
         "y1": 742,
       },
       Object {
@@ -7222,7 +7222,7 @@ Array [
         "initialY0": null,
         "initialY1": 743,
         "x": 743,
-        "y0": 0,
+        "y0": null,
         "y1": 743,
       },
       Object {
@@ -7230,7 +7230,7 @@ Array [
         "initialY0": null,
         "initialY1": 744,
         "x": 744,
-        "y0": 0,
+        "y0": null,
         "y1": 744,
       },
       Object {
@@ -7238,7 +7238,7 @@ Array [
         "initialY0": null,
         "initialY1": 745,
         "x": 745,
-        "y0": 0,
+        "y0": null,
         "y1": 745,
       },
       Object {
@@ -7246,7 +7246,7 @@ Array [
         "initialY0": null,
         "initialY1": 746,
         "x": 746,
-        "y0": 0,
+        "y0": null,
         "y1": 746,
       },
       Object {
@@ -7254,7 +7254,7 @@ Array [
         "initialY0": null,
         "initialY1": 747,
         "x": 747,
-        "y0": 0,
+        "y0": null,
         "y1": 747,
       },
       Object {
@@ -7262,7 +7262,7 @@ Array [
         "initialY0": null,
         "initialY1": 748,
         "x": 748,
-        "y0": 0,
+        "y0": null,
         "y1": 748,
       },
       Object {
@@ -7270,7 +7270,7 @@ Array [
         "initialY0": null,
         "initialY1": 749,
         "x": 749,
-        "y0": 0,
+        "y0": null,
         "y1": 749,
       },
       Object {
@@ -7278,7 +7278,7 @@ Array [
         "initialY0": null,
         "initialY1": 750,
         "x": 750,
-        "y0": 0,
+        "y0": null,
         "y1": 750,
       },
       Object {
@@ -7286,7 +7286,7 @@ Array [
         "initialY0": null,
         "initialY1": 751,
         "x": 751,
-        "y0": 0,
+        "y0": null,
         "y1": 751,
       },
       Object {
@@ -7294,7 +7294,7 @@ Array [
         "initialY0": null,
         "initialY1": 752,
         "x": 752,
-        "y0": 0,
+        "y0": null,
         "y1": 752,
       },
       Object {
@@ -7302,7 +7302,7 @@ Array [
         "initialY0": null,
         "initialY1": 753,
         "x": 753,
-        "y0": 0,
+        "y0": null,
         "y1": 753,
       },
       Object {
@@ -7310,7 +7310,7 @@ Array [
         "initialY0": null,
         "initialY1": 754,
         "x": 754,
-        "y0": 0,
+        "y0": null,
         "y1": 754,
       },
       Object {
@@ -7318,7 +7318,7 @@ Array [
         "initialY0": null,
         "initialY1": 755,
         "x": 755,
-        "y0": 0,
+        "y0": null,
         "y1": 755,
       },
       Object {
@@ -7326,7 +7326,7 @@ Array [
         "initialY0": null,
         "initialY1": 756,
         "x": 756,
-        "y0": 0,
+        "y0": null,
         "y1": 756,
       },
       Object {
@@ -7334,7 +7334,7 @@ Array [
         "initialY0": null,
         "initialY1": 757,
         "x": 757,
-        "y0": 0,
+        "y0": null,
         "y1": 757,
       },
       Object {
@@ -7342,7 +7342,7 @@ Array [
         "initialY0": null,
         "initialY1": 758,
         "x": 758,
-        "y0": 0,
+        "y0": null,
         "y1": 758,
       },
       Object {
@@ -7350,7 +7350,7 @@ Array [
         "initialY0": null,
         "initialY1": 759,
         "x": 759,
-        "y0": 0,
+        "y0": null,
         "y1": 759,
       },
       Object {
@@ -7358,7 +7358,7 @@ Array [
         "initialY0": null,
         "initialY1": 760,
         "x": 760,
-        "y0": 0,
+        "y0": null,
         "y1": 760,
       },
       Object {
@@ -7366,7 +7366,7 @@ Array [
         "initialY0": null,
         "initialY1": 761,
         "x": 761,
-        "y0": 0,
+        "y0": null,
         "y1": 761,
       },
       Object {
@@ -7374,7 +7374,7 @@ Array [
         "initialY0": null,
         "initialY1": 762,
         "x": 762,
-        "y0": 0,
+        "y0": null,
         "y1": 762,
       },
       Object {
@@ -7382,7 +7382,7 @@ Array [
         "initialY0": null,
         "initialY1": 763,
         "x": 763,
-        "y0": 0,
+        "y0": null,
         "y1": 763,
       },
       Object {
@@ -7390,7 +7390,7 @@ Array [
         "initialY0": null,
         "initialY1": 764,
         "x": 764,
-        "y0": 0,
+        "y0": null,
         "y1": 764,
       },
       Object {
@@ -7398,7 +7398,7 @@ Array [
         "initialY0": null,
         "initialY1": 765,
         "x": 765,
-        "y0": 0,
+        "y0": null,
         "y1": 765,
       },
       Object {
@@ -7406,7 +7406,7 @@ Array [
         "initialY0": null,
         "initialY1": 766,
         "x": 766,
-        "y0": 0,
+        "y0": null,
         "y1": 766,
       },
       Object {
@@ -7414,7 +7414,7 @@ Array [
         "initialY0": null,
         "initialY1": 767,
         "x": 767,
-        "y0": 0,
+        "y0": null,
         "y1": 767,
       },
       Object {
@@ -7422,7 +7422,7 @@ Array [
         "initialY0": null,
         "initialY1": 768,
         "x": 768,
-        "y0": 0,
+        "y0": null,
         "y1": 768,
       },
       Object {
@@ -7430,7 +7430,7 @@ Array [
         "initialY0": null,
         "initialY1": 769,
         "x": 769,
-        "y0": 0,
+        "y0": null,
         "y1": 769,
       },
       Object {
@@ -7438,7 +7438,7 @@ Array [
         "initialY0": null,
         "initialY1": 770,
         "x": 770,
-        "y0": 0,
+        "y0": null,
         "y1": 770,
       },
       Object {
@@ -7446,7 +7446,7 @@ Array [
         "initialY0": null,
         "initialY1": 771,
         "x": 771,
-        "y0": 0,
+        "y0": null,
         "y1": 771,
       },
       Object {
@@ -7454,7 +7454,7 @@ Array [
         "initialY0": null,
         "initialY1": 772,
         "x": 772,
-        "y0": 0,
+        "y0": null,
         "y1": 772,
       },
       Object {
@@ -7462,7 +7462,7 @@ Array [
         "initialY0": null,
         "initialY1": 773,
         "x": 773,
-        "y0": 0,
+        "y0": null,
         "y1": 773,
       },
       Object {
@@ -7470,7 +7470,7 @@ Array [
         "initialY0": null,
         "initialY1": 774,
         "x": 774,
-        "y0": 0,
+        "y0": null,
         "y1": 774,
       },
       Object {
@@ -7478,7 +7478,7 @@ Array [
         "initialY0": null,
         "initialY1": 775,
         "x": 775,
-        "y0": 0,
+        "y0": null,
         "y1": 775,
       },
       Object {
@@ -7486,7 +7486,7 @@ Array [
         "initialY0": null,
         "initialY1": 776,
         "x": 776,
-        "y0": 0,
+        "y0": null,
         "y1": 776,
       },
       Object {
@@ -7494,7 +7494,7 @@ Array [
         "initialY0": null,
         "initialY1": 777,
         "x": 777,
-        "y0": 0,
+        "y0": null,
         "y1": 777,
       },
       Object {
@@ -7502,7 +7502,7 @@ Array [
         "initialY0": null,
         "initialY1": 778,
         "x": 778,
-        "y0": 0,
+        "y0": null,
         "y1": 778,
       },
       Object {
@@ -7510,7 +7510,7 @@ Array [
         "initialY0": null,
         "initialY1": 779,
         "x": 779,
-        "y0": 0,
+        "y0": null,
         "y1": 779,
       },
       Object {
@@ -7518,7 +7518,7 @@ Array [
         "initialY0": null,
         "initialY1": 780,
         "x": 780,
-        "y0": 0,
+        "y0": null,
         "y1": 780,
       },
       Object {
@@ -7526,7 +7526,7 @@ Array [
         "initialY0": null,
         "initialY1": 781,
         "x": 781,
-        "y0": 0,
+        "y0": null,
         "y1": 781,
       },
       Object {
@@ -7534,7 +7534,7 @@ Array [
         "initialY0": null,
         "initialY1": 782,
         "x": 782,
-        "y0": 0,
+        "y0": null,
         "y1": 782,
       },
       Object {
@@ -7542,7 +7542,7 @@ Array [
         "initialY0": null,
         "initialY1": 783,
         "x": 783,
-        "y0": 0,
+        "y0": null,
         "y1": 783,
       },
       Object {
@@ -7550,7 +7550,7 @@ Array [
         "initialY0": null,
         "initialY1": 784,
         "x": 784,
-        "y0": 0,
+        "y0": null,
         "y1": 784,
       },
       Object {
@@ -7558,7 +7558,7 @@ Array [
         "initialY0": null,
         "initialY1": 785,
         "x": 785,
-        "y0": 0,
+        "y0": null,
         "y1": 785,
       },
       Object {
@@ -7566,7 +7566,7 @@ Array [
         "initialY0": null,
         "initialY1": 786,
         "x": 786,
-        "y0": 0,
+        "y0": null,
         "y1": 786,
       },
       Object {
@@ -7574,7 +7574,7 @@ Array [
         "initialY0": null,
         "initialY1": 787,
         "x": 787,
-        "y0": 0,
+        "y0": null,
         "y1": 787,
       },
       Object {
@@ -7582,7 +7582,7 @@ Array [
         "initialY0": null,
         "initialY1": 788,
         "x": 788,
-        "y0": 0,
+        "y0": null,
         "y1": 788,
       },
       Object {
@@ -7590,7 +7590,7 @@ Array [
         "initialY0": null,
         "initialY1": 789,
         "x": 789,
-        "y0": 0,
+        "y0": null,
         "y1": 789,
       },
       Object {
@@ -7598,7 +7598,7 @@ Array [
         "initialY0": null,
         "initialY1": 790,
         "x": 790,
-        "y0": 0,
+        "y0": null,
         "y1": 790,
       },
       Object {
@@ -7606,7 +7606,7 @@ Array [
         "initialY0": null,
         "initialY1": 791,
         "x": 791,
-        "y0": 0,
+        "y0": null,
         "y1": 791,
       },
       Object {
@@ -7614,7 +7614,7 @@ Array [
         "initialY0": null,
         "initialY1": 792,
         "x": 792,
-        "y0": 0,
+        "y0": null,
         "y1": 792,
       },
       Object {
@@ -7622,7 +7622,7 @@ Array [
         "initialY0": null,
         "initialY1": 793,
         "x": 793,
-        "y0": 0,
+        "y0": null,
         "y1": 793,
       },
       Object {
@@ -7630,7 +7630,7 @@ Array [
         "initialY0": null,
         "initialY1": 794,
         "x": 794,
-        "y0": 0,
+        "y0": null,
         "y1": 794,
       },
       Object {
@@ -7638,7 +7638,7 @@ Array [
         "initialY0": null,
         "initialY1": 795,
         "x": 795,
-        "y0": 0,
+        "y0": null,
         "y1": 795,
       },
       Object {
@@ -7646,7 +7646,7 @@ Array [
         "initialY0": null,
         "initialY1": 796,
         "x": 796,
-        "y0": 0,
+        "y0": null,
         "y1": 796,
       },
       Object {
@@ -7654,7 +7654,7 @@ Array [
         "initialY0": null,
         "initialY1": 797,
         "x": 797,
-        "y0": 0,
+        "y0": null,
         "y1": 797,
       },
       Object {
@@ -7662,7 +7662,7 @@ Array [
         "initialY0": null,
         "initialY1": 798,
         "x": 798,
-        "y0": 0,
+        "y0": null,
         "y1": 798,
       },
       Object {
@@ -7670,7 +7670,7 @@ Array [
         "initialY0": null,
         "initialY1": 799,
         "x": 799,
-        "y0": 0,
+        "y0": null,
         "y1": 799,
       },
       Object {
@@ -7678,7 +7678,7 @@ Array [
         "initialY0": null,
         "initialY1": 800,
         "x": 800,
-        "y0": 0,
+        "y0": null,
         "y1": 800,
       },
       Object {
@@ -7686,7 +7686,7 @@ Array [
         "initialY0": null,
         "initialY1": 801,
         "x": 801,
-        "y0": 0,
+        "y0": null,
         "y1": 801,
       },
       Object {
@@ -7694,7 +7694,7 @@ Array [
         "initialY0": null,
         "initialY1": 802,
         "x": 802,
-        "y0": 0,
+        "y0": null,
         "y1": 802,
       },
       Object {
@@ -7702,7 +7702,7 @@ Array [
         "initialY0": null,
         "initialY1": 803,
         "x": 803,
-        "y0": 0,
+        "y0": null,
         "y1": 803,
       },
       Object {
@@ -7710,7 +7710,7 @@ Array [
         "initialY0": null,
         "initialY1": 804,
         "x": 804,
-        "y0": 0,
+        "y0": null,
         "y1": 804,
       },
       Object {
@@ -7718,7 +7718,7 @@ Array [
         "initialY0": null,
         "initialY1": 805,
         "x": 805,
-        "y0": 0,
+        "y0": null,
         "y1": 805,
       },
       Object {
@@ -7726,7 +7726,7 @@ Array [
         "initialY0": null,
         "initialY1": 806,
         "x": 806,
-        "y0": 0,
+        "y0": null,
         "y1": 806,
       },
       Object {
@@ -7734,7 +7734,7 @@ Array [
         "initialY0": null,
         "initialY1": 807,
         "x": 807,
-        "y0": 0,
+        "y0": null,
         "y1": 807,
       },
       Object {
@@ -7742,7 +7742,7 @@ Array [
         "initialY0": null,
         "initialY1": 808,
         "x": 808,
-        "y0": 0,
+        "y0": null,
         "y1": 808,
       },
       Object {
@@ -7750,7 +7750,7 @@ Array [
         "initialY0": null,
         "initialY1": 809,
         "x": 809,
-        "y0": 0,
+        "y0": null,
         "y1": 809,
       },
       Object {
@@ -7758,7 +7758,7 @@ Array [
         "initialY0": null,
         "initialY1": 810,
         "x": 810,
-        "y0": 0,
+        "y0": null,
         "y1": 810,
       },
       Object {
@@ -7766,7 +7766,7 @@ Array [
         "initialY0": null,
         "initialY1": 811,
         "x": 811,
-        "y0": 0,
+        "y0": null,
         "y1": 811,
       },
       Object {
@@ -7774,7 +7774,7 @@ Array [
         "initialY0": null,
         "initialY1": 812,
         "x": 812,
-        "y0": 0,
+        "y0": null,
         "y1": 812,
       },
       Object {
@@ -7782,7 +7782,7 @@ Array [
         "initialY0": null,
         "initialY1": 813,
         "x": 813,
-        "y0": 0,
+        "y0": null,
         "y1": 813,
       },
       Object {
@@ -7790,7 +7790,7 @@ Array [
         "initialY0": null,
         "initialY1": 814,
         "x": 814,
-        "y0": 0,
+        "y0": null,
         "y1": 814,
       },
       Object {
@@ -7798,7 +7798,7 @@ Array [
         "initialY0": null,
         "initialY1": 815,
         "x": 815,
-        "y0": 0,
+        "y0": null,
         "y1": 815,
       },
       Object {
@@ -7806,7 +7806,7 @@ Array [
         "initialY0": null,
         "initialY1": 816,
         "x": 816,
-        "y0": 0,
+        "y0": null,
         "y1": 816,
       },
       Object {
@@ -7814,7 +7814,7 @@ Array [
         "initialY0": null,
         "initialY1": 817,
         "x": 817,
-        "y0": 0,
+        "y0": null,
         "y1": 817,
       },
       Object {
@@ -7822,7 +7822,7 @@ Array [
         "initialY0": null,
         "initialY1": 818,
         "x": 818,
-        "y0": 0,
+        "y0": null,
         "y1": 818,
       },
       Object {
@@ -7830,7 +7830,7 @@ Array [
         "initialY0": null,
         "initialY1": 819,
         "x": 819,
-        "y0": 0,
+        "y0": null,
         "y1": 819,
       },
       Object {
@@ -7838,7 +7838,7 @@ Array [
         "initialY0": null,
         "initialY1": 820,
         "x": 820,
-        "y0": 0,
+        "y0": null,
         "y1": 820,
       },
       Object {
@@ -7846,7 +7846,7 @@ Array [
         "initialY0": null,
         "initialY1": 821,
         "x": 821,
-        "y0": 0,
+        "y0": null,
         "y1": 821,
       },
       Object {
@@ -7854,7 +7854,7 @@ Array [
         "initialY0": null,
         "initialY1": 822,
         "x": 822,
-        "y0": 0,
+        "y0": null,
         "y1": 822,
       },
       Object {
@@ -7862,7 +7862,7 @@ Array [
         "initialY0": null,
         "initialY1": 823,
         "x": 823,
-        "y0": 0,
+        "y0": null,
         "y1": 823,
       },
       Object {
@@ -7870,7 +7870,7 @@ Array [
         "initialY0": null,
         "initialY1": 824,
         "x": 824,
-        "y0": 0,
+        "y0": null,
         "y1": 824,
       },
       Object {
@@ -7878,7 +7878,7 @@ Array [
         "initialY0": null,
         "initialY1": 825,
         "x": 825,
-        "y0": 0,
+        "y0": null,
         "y1": 825,
       },
       Object {
@@ -7886,7 +7886,7 @@ Array [
         "initialY0": null,
         "initialY1": 826,
         "x": 826,
-        "y0": 0,
+        "y0": null,
         "y1": 826,
       },
       Object {
@@ -7894,7 +7894,7 @@ Array [
         "initialY0": null,
         "initialY1": 827,
         "x": 827,
-        "y0": 0,
+        "y0": null,
         "y1": 827,
       },
       Object {
@@ -7902,7 +7902,7 @@ Array [
         "initialY0": null,
         "initialY1": 828,
         "x": 828,
-        "y0": 0,
+        "y0": null,
         "y1": 828,
       },
       Object {
@@ -7910,7 +7910,7 @@ Array [
         "initialY0": null,
         "initialY1": 829,
         "x": 829,
-        "y0": 0,
+        "y0": null,
         "y1": 829,
       },
       Object {
@@ -7918,7 +7918,7 @@ Array [
         "initialY0": null,
         "initialY1": 830,
         "x": 830,
-        "y0": 0,
+        "y0": null,
         "y1": 830,
       },
       Object {
@@ -7926,7 +7926,7 @@ Array [
         "initialY0": null,
         "initialY1": 831,
         "x": 831,
-        "y0": 0,
+        "y0": null,
         "y1": 831,
       },
       Object {
@@ -7934,7 +7934,7 @@ Array [
         "initialY0": null,
         "initialY1": 832,
         "x": 832,
-        "y0": 0,
+        "y0": null,
         "y1": 832,
       },
       Object {
@@ -7942,7 +7942,7 @@ Array [
         "initialY0": null,
         "initialY1": 833,
         "x": 833,
-        "y0": 0,
+        "y0": null,
         "y1": 833,
       },
       Object {
@@ -7950,7 +7950,7 @@ Array [
         "initialY0": null,
         "initialY1": 834,
         "x": 834,
-        "y0": 0,
+        "y0": null,
         "y1": 834,
       },
       Object {
@@ -7958,7 +7958,7 @@ Array [
         "initialY0": null,
         "initialY1": 835,
         "x": 835,
-        "y0": 0,
+        "y0": null,
         "y1": 835,
       },
       Object {
@@ -7966,7 +7966,7 @@ Array [
         "initialY0": null,
         "initialY1": 836,
         "x": 836,
-        "y0": 0,
+        "y0": null,
         "y1": 836,
       },
       Object {
@@ -7974,7 +7974,7 @@ Array [
         "initialY0": null,
         "initialY1": 837,
         "x": 837,
-        "y0": 0,
+        "y0": null,
         "y1": 837,
       },
       Object {
@@ -7982,7 +7982,7 @@ Array [
         "initialY0": null,
         "initialY1": 838,
         "x": 838,
-        "y0": 0,
+        "y0": null,
         "y1": 838,
       },
       Object {
@@ -7990,7 +7990,7 @@ Array [
         "initialY0": null,
         "initialY1": 839,
         "x": 839,
-        "y0": 0,
+        "y0": null,
         "y1": 839,
       },
       Object {
@@ -7998,7 +7998,7 @@ Array [
         "initialY0": null,
         "initialY1": 840,
         "x": 840,
-        "y0": 0,
+        "y0": null,
         "y1": 840,
       },
       Object {
@@ -8006,7 +8006,7 @@ Array [
         "initialY0": null,
         "initialY1": 841,
         "x": 841,
-        "y0": 0,
+        "y0": null,
         "y1": 841,
       },
       Object {
@@ -8014,7 +8014,7 @@ Array [
         "initialY0": null,
         "initialY1": 842,
         "x": 842,
-        "y0": 0,
+        "y0": null,
         "y1": 842,
       },
       Object {
@@ -8022,7 +8022,7 @@ Array [
         "initialY0": null,
         "initialY1": 843,
         "x": 843,
-        "y0": 0,
+        "y0": null,
         "y1": 843,
       },
       Object {
@@ -8030,7 +8030,7 @@ Array [
         "initialY0": null,
         "initialY1": 844,
         "x": 844,
-        "y0": 0,
+        "y0": null,
         "y1": 844,
       },
       Object {
@@ -8038,7 +8038,7 @@ Array [
         "initialY0": null,
         "initialY1": 845,
         "x": 845,
-        "y0": 0,
+        "y0": null,
         "y1": 845,
       },
       Object {
@@ -8046,7 +8046,7 @@ Array [
         "initialY0": null,
         "initialY1": 846,
         "x": 846,
-        "y0": 0,
+        "y0": null,
         "y1": 846,
       },
       Object {
@@ -8054,7 +8054,7 @@ Array [
         "initialY0": null,
         "initialY1": 847,
         "x": 847,
-        "y0": 0,
+        "y0": null,
         "y1": 847,
       },
       Object {
@@ -8062,7 +8062,7 @@ Array [
         "initialY0": null,
         "initialY1": 848,
         "x": 848,
-        "y0": 0,
+        "y0": null,
         "y1": 848,
       },
       Object {
@@ -8070,7 +8070,7 @@ Array [
         "initialY0": null,
         "initialY1": 849,
         "x": 849,
-        "y0": 0,
+        "y0": null,
         "y1": 849,
       },
       Object {
@@ -8078,7 +8078,7 @@ Array [
         "initialY0": null,
         "initialY1": 850,
         "x": 850,
-        "y0": 0,
+        "y0": null,
         "y1": 850,
       },
       Object {
@@ -8086,7 +8086,7 @@ Array [
         "initialY0": null,
         "initialY1": 851,
         "x": 851,
-        "y0": 0,
+        "y0": null,
         "y1": 851,
       },
       Object {
@@ -8094,7 +8094,7 @@ Array [
         "initialY0": null,
         "initialY1": 852,
         "x": 852,
-        "y0": 0,
+        "y0": null,
         "y1": 852,
       },
       Object {
@@ -8102,7 +8102,7 @@ Array [
         "initialY0": null,
         "initialY1": 853,
         "x": 853,
-        "y0": 0,
+        "y0": null,
         "y1": 853,
       },
       Object {
@@ -8110,7 +8110,7 @@ Array [
         "initialY0": null,
         "initialY1": 854,
         "x": 854,
-        "y0": 0,
+        "y0": null,
         "y1": 854,
       },
       Object {
@@ -8118,7 +8118,7 @@ Array [
         "initialY0": null,
         "initialY1": 855,
         "x": 855,
-        "y0": 0,
+        "y0": null,
         "y1": 855,
       },
       Object {
@@ -8126,7 +8126,7 @@ Array [
         "initialY0": null,
         "initialY1": 856,
         "x": 856,
-        "y0": 0,
+        "y0": null,
         "y1": 856,
       },
       Object {
@@ -8134,7 +8134,7 @@ Array [
         "initialY0": null,
         "initialY1": 857,
         "x": 857,
-        "y0": 0,
+        "y0": null,
         "y1": 857,
       },
       Object {
@@ -8142,7 +8142,7 @@ Array [
         "initialY0": null,
         "initialY1": 858,
         "x": 858,
-        "y0": 0,
+        "y0": null,
         "y1": 858,
       },
       Object {
@@ -8150,7 +8150,7 @@ Array [
         "initialY0": null,
         "initialY1": 859,
         "x": 859,
-        "y0": 0,
+        "y0": null,
         "y1": 859,
       },
       Object {
@@ -8158,7 +8158,7 @@ Array [
         "initialY0": null,
         "initialY1": 860,
         "x": 860,
-        "y0": 0,
+        "y0": null,
         "y1": 860,
       },
       Object {
@@ -8166,7 +8166,7 @@ Array [
         "initialY0": null,
         "initialY1": 861,
         "x": 861,
-        "y0": 0,
+        "y0": null,
         "y1": 861,
       },
       Object {
@@ -8174,7 +8174,7 @@ Array [
         "initialY0": null,
         "initialY1": 862,
         "x": 862,
-        "y0": 0,
+        "y0": null,
         "y1": 862,
       },
       Object {
@@ -8182,7 +8182,7 @@ Array [
         "initialY0": null,
         "initialY1": 863,
         "x": 863,
-        "y0": 0,
+        "y0": null,
         "y1": 863,
       },
       Object {
@@ -8190,7 +8190,7 @@ Array [
         "initialY0": null,
         "initialY1": 864,
         "x": 864,
-        "y0": 0,
+        "y0": null,
         "y1": 864,
       },
       Object {
@@ -8198,7 +8198,7 @@ Array [
         "initialY0": null,
         "initialY1": 865,
         "x": 865,
-        "y0": 0,
+        "y0": null,
         "y1": 865,
       },
       Object {
@@ -8206,7 +8206,7 @@ Array [
         "initialY0": null,
         "initialY1": 866,
         "x": 866,
-        "y0": 0,
+        "y0": null,
         "y1": 866,
       },
       Object {
@@ -8214,7 +8214,7 @@ Array [
         "initialY0": null,
         "initialY1": 867,
         "x": 867,
-        "y0": 0,
+        "y0": null,
         "y1": 867,
       },
       Object {
@@ -8222,7 +8222,7 @@ Array [
         "initialY0": null,
         "initialY1": 868,
         "x": 868,
-        "y0": 0,
+        "y0": null,
         "y1": 868,
       },
       Object {
@@ -8230,7 +8230,7 @@ Array [
         "initialY0": null,
         "initialY1": 869,
         "x": 869,
-        "y0": 0,
+        "y0": null,
         "y1": 869,
       },
       Object {
@@ -8238,7 +8238,7 @@ Array [
         "initialY0": null,
         "initialY1": 870,
         "x": 870,
-        "y0": 0,
+        "y0": null,
         "y1": 870,
       },
       Object {
@@ -8246,7 +8246,7 @@ Array [
         "initialY0": null,
         "initialY1": 871,
         "x": 871,
-        "y0": 0,
+        "y0": null,
         "y1": 871,
       },
       Object {
@@ -8254,7 +8254,7 @@ Array [
         "initialY0": null,
         "initialY1": 872,
         "x": 872,
-        "y0": 0,
+        "y0": null,
         "y1": 872,
       },
       Object {
@@ -8262,7 +8262,7 @@ Array [
         "initialY0": null,
         "initialY1": 873,
         "x": 873,
-        "y0": 0,
+        "y0": null,
         "y1": 873,
       },
       Object {
@@ -8270,7 +8270,7 @@ Array [
         "initialY0": null,
         "initialY1": 874,
         "x": 874,
-        "y0": 0,
+        "y0": null,
         "y1": 874,
       },
       Object {
@@ -8278,7 +8278,7 @@ Array [
         "initialY0": null,
         "initialY1": 875,
         "x": 875,
-        "y0": 0,
+        "y0": null,
         "y1": 875,
       },
       Object {
@@ -8286,7 +8286,7 @@ Array [
         "initialY0": null,
         "initialY1": 876,
         "x": 876,
-        "y0": 0,
+        "y0": null,
         "y1": 876,
       },
       Object {
@@ -8294,7 +8294,7 @@ Array [
         "initialY0": null,
         "initialY1": 877,
         "x": 877,
-        "y0": 0,
+        "y0": null,
         "y1": 877,
       },
       Object {
@@ -8302,7 +8302,7 @@ Array [
         "initialY0": null,
         "initialY1": 878,
         "x": 878,
-        "y0": 0,
+        "y0": null,
         "y1": 878,
       },
       Object {
@@ -8310,7 +8310,7 @@ Array [
         "initialY0": null,
         "initialY1": 879,
         "x": 879,
-        "y0": 0,
+        "y0": null,
         "y1": 879,
       },
       Object {
@@ -8318,7 +8318,7 @@ Array [
         "initialY0": null,
         "initialY1": 880,
         "x": 880,
-        "y0": 0,
+        "y0": null,
         "y1": 880,
       },
       Object {
@@ -8326,7 +8326,7 @@ Array [
         "initialY0": null,
         "initialY1": 881,
         "x": 881,
-        "y0": 0,
+        "y0": null,
         "y1": 881,
       },
       Object {
@@ -8334,7 +8334,7 @@ Array [
         "initialY0": null,
         "initialY1": 882,
         "x": 882,
-        "y0": 0,
+        "y0": null,
         "y1": 882,
       },
       Object {
@@ -8342,7 +8342,7 @@ Array [
         "initialY0": null,
         "initialY1": 883,
         "x": 883,
-        "y0": 0,
+        "y0": null,
         "y1": 883,
       },
       Object {
@@ -8350,7 +8350,7 @@ Array [
         "initialY0": null,
         "initialY1": 884,
         "x": 884,
-        "y0": 0,
+        "y0": null,
         "y1": 884,
       },
       Object {
@@ -8358,7 +8358,7 @@ Array [
         "initialY0": null,
         "initialY1": 885,
         "x": 885,
-        "y0": 0,
+        "y0": null,
         "y1": 885,
       },
       Object {
@@ -8366,7 +8366,7 @@ Array [
         "initialY0": null,
         "initialY1": 886,
         "x": 886,
-        "y0": 0,
+        "y0": null,
         "y1": 886,
       },
       Object {
@@ -8374,7 +8374,7 @@ Array [
         "initialY0": null,
         "initialY1": 887,
         "x": 887,
-        "y0": 0,
+        "y0": null,
         "y1": 887,
       },
       Object {
@@ -8382,7 +8382,7 @@ Array [
         "initialY0": null,
         "initialY1": 888,
         "x": 888,
-        "y0": 0,
+        "y0": null,
         "y1": 888,
       },
       Object {
@@ -8390,7 +8390,7 @@ Array [
         "initialY0": null,
         "initialY1": 889,
         "x": 889,
-        "y0": 0,
+        "y0": null,
         "y1": 889,
       },
       Object {
@@ -8398,7 +8398,7 @@ Array [
         "initialY0": null,
         "initialY1": 890,
         "x": 890,
-        "y0": 0,
+        "y0": null,
         "y1": 890,
       },
       Object {
@@ -8406,7 +8406,7 @@ Array [
         "initialY0": null,
         "initialY1": 891,
         "x": 891,
-        "y0": 0,
+        "y0": null,
         "y1": 891,
       },
       Object {
@@ -8414,7 +8414,7 @@ Array [
         "initialY0": null,
         "initialY1": 892,
         "x": 892,
-        "y0": 0,
+        "y0": null,
         "y1": 892,
       },
       Object {
@@ -8422,7 +8422,7 @@ Array [
         "initialY0": null,
         "initialY1": 893,
         "x": 893,
-        "y0": 0,
+        "y0": null,
         "y1": 893,
       },
       Object {
@@ -8430,7 +8430,7 @@ Array [
         "initialY0": null,
         "initialY1": 894,
         "x": 894,
-        "y0": 0,
+        "y0": null,
         "y1": 894,
       },
       Object {
@@ -8438,7 +8438,7 @@ Array [
         "initialY0": null,
         "initialY1": 895,
         "x": 895,
-        "y0": 0,
+        "y0": null,
         "y1": 895,
       },
       Object {
@@ -8446,7 +8446,7 @@ Array [
         "initialY0": null,
         "initialY1": 896,
         "x": 896,
-        "y0": 0,
+        "y0": null,
         "y1": 896,
       },
       Object {
@@ -8454,7 +8454,7 @@ Array [
         "initialY0": null,
         "initialY1": 897,
         "x": 897,
-        "y0": 0,
+        "y0": null,
         "y1": 897,
       },
       Object {
@@ -8462,7 +8462,7 @@ Array [
         "initialY0": null,
         "initialY1": 898,
         "x": 898,
-        "y0": 0,
+        "y0": null,
         "y1": 898,
       },
       Object {
@@ -8470,7 +8470,7 @@ Array [
         "initialY0": null,
         "initialY1": 899,
         "x": 899,
-        "y0": 0,
+        "y0": null,
         "y1": 899,
       },
       Object {
@@ -8478,7 +8478,7 @@ Array [
         "initialY0": null,
         "initialY1": 900,
         "x": 900,
-        "y0": 0,
+        "y0": null,
         "y1": 900,
       },
       Object {
@@ -8486,7 +8486,7 @@ Array [
         "initialY0": null,
         "initialY1": 901,
         "x": 901,
-        "y0": 0,
+        "y0": null,
         "y1": 901,
       },
       Object {
@@ -8494,7 +8494,7 @@ Array [
         "initialY0": null,
         "initialY1": 902,
         "x": 902,
-        "y0": 0,
+        "y0": null,
         "y1": 902,
       },
       Object {
@@ -8502,7 +8502,7 @@ Array [
         "initialY0": null,
         "initialY1": 903,
         "x": 903,
-        "y0": 0,
+        "y0": null,
         "y1": 903,
       },
       Object {
@@ -8510,7 +8510,7 @@ Array [
         "initialY0": null,
         "initialY1": 904,
         "x": 904,
-        "y0": 0,
+        "y0": null,
         "y1": 904,
       },
       Object {
@@ -8518,7 +8518,7 @@ Array [
         "initialY0": null,
         "initialY1": 905,
         "x": 905,
-        "y0": 0,
+        "y0": null,
         "y1": 905,
       },
       Object {
@@ -8526,7 +8526,7 @@ Array [
         "initialY0": null,
         "initialY1": 906,
         "x": 906,
-        "y0": 0,
+        "y0": null,
         "y1": 906,
       },
       Object {
@@ -8534,7 +8534,7 @@ Array [
         "initialY0": null,
         "initialY1": 907,
         "x": 907,
-        "y0": 0,
+        "y0": null,
         "y1": 907,
       },
       Object {
@@ -8542,7 +8542,7 @@ Array [
         "initialY0": null,
         "initialY1": 908,
         "x": 908,
-        "y0": 0,
+        "y0": null,
         "y1": 908,
       },
       Object {
@@ -8550,7 +8550,7 @@ Array [
         "initialY0": null,
         "initialY1": 909,
         "x": 909,
-        "y0": 0,
+        "y0": null,
         "y1": 909,
       },
       Object {
@@ -8558,7 +8558,7 @@ Array [
         "initialY0": null,
         "initialY1": 910,
         "x": 910,
-        "y0": 0,
+        "y0": null,
         "y1": 910,
       },
       Object {
@@ -8566,7 +8566,7 @@ Array [
         "initialY0": null,
         "initialY1": 911,
         "x": 911,
-        "y0": 0,
+        "y0": null,
         "y1": 911,
       },
       Object {
@@ -8574,7 +8574,7 @@ Array [
         "initialY0": null,
         "initialY1": 912,
         "x": 912,
-        "y0": 0,
+        "y0": null,
         "y1": 912,
       },
       Object {
@@ -8582,7 +8582,7 @@ Array [
         "initialY0": null,
         "initialY1": 913,
         "x": 913,
-        "y0": 0,
+        "y0": null,
         "y1": 913,
       },
       Object {
@@ -8590,7 +8590,7 @@ Array [
         "initialY0": null,
         "initialY1": 914,
         "x": 914,
-        "y0": 0,
+        "y0": null,
         "y1": 914,
       },
       Object {
@@ -8598,7 +8598,7 @@ Array [
         "initialY0": null,
         "initialY1": 915,
         "x": 915,
-        "y0": 0,
+        "y0": null,
         "y1": 915,
       },
       Object {
@@ -8606,7 +8606,7 @@ Array [
         "initialY0": null,
         "initialY1": 916,
         "x": 916,
-        "y0": 0,
+        "y0": null,
         "y1": 916,
       },
       Object {
@@ -8614,7 +8614,7 @@ Array [
         "initialY0": null,
         "initialY1": 917,
         "x": 917,
-        "y0": 0,
+        "y0": null,
         "y1": 917,
       },
       Object {
@@ -8622,7 +8622,7 @@ Array [
         "initialY0": null,
         "initialY1": 918,
         "x": 918,
-        "y0": 0,
+        "y0": null,
         "y1": 918,
       },
       Object {
@@ -8630,7 +8630,7 @@ Array [
         "initialY0": null,
         "initialY1": 919,
         "x": 919,
-        "y0": 0,
+        "y0": null,
         "y1": 919,
       },
       Object {
@@ -8638,7 +8638,7 @@ Array [
         "initialY0": null,
         "initialY1": 920,
         "x": 920,
-        "y0": 0,
+        "y0": null,
         "y1": 920,
       },
       Object {
@@ -8646,7 +8646,7 @@ Array [
         "initialY0": null,
         "initialY1": 921,
         "x": 921,
-        "y0": 0,
+        "y0": null,
         "y1": 921,
       },
       Object {
@@ -8654,7 +8654,7 @@ Array [
         "initialY0": null,
         "initialY1": 922,
         "x": 922,
-        "y0": 0,
+        "y0": null,
         "y1": 922,
       },
       Object {
@@ -8662,7 +8662,7 @@ Array [
         "initialY0": null,
         "initialY1": 923,
         "x": 923,
-        "y0": 0,
+        "y0": null,
         "y1": 923,
       },
       Object {
@@ -8670,7 +8670,7 @@ Array [
         "initialY0": null,
         "initialY1": 924,
         "x": 924,
-        "y0": 0,
+        "y0": null,
         "y1": 924,
       },
       Object {
@@ -8678,7 +8678,7 @@ Array [
         "initialY0": null,
         "initialY1": 925,
         "x": 925,
-        "y0": 0,
+        "y0": null,
         "y1": 925,
       },
       Object {
@@ -8686,7 +8686,7 @@ Array [
         "initialY0": null,
         "initialY1": 926,
         "x": 926,
-        "y0": 0,
+        "y0": null,
         "y1": 926,
       },
       Object {
@@ -8694,7 +8694,7 @@ Array [
         "initialY0": null,
         "initialY1": 927,
         "x": 927,
-        "y0": 0,
+        "y0": null,
         "y1": 927,
       },
       Object {
@@ -8702,7 +8702,7 @@ Array [
         "initialY0": null,
         "initialY1": 928,
         "x": 928,
-        "y0": 0,
+        "y0": null,
         "y1": 928,
       },
       Object {
@@ -8710,7 +8710,7 @@ Array [
         "initialY0": null,
         "initialY1": 929,
         "x": 929,
-        "y0": 0,
+        "y0": null,
         "y1": 929,
       },
       Object {
@@ -8718,7 +8718,7 @@ Array [
         "initialY0": null,
         "initialY1": 930,
         "x": 930,
-        "y0": 0,
+        "y0": null,
         "y1": 930,
       },
       Object {
@@ -8726,7 +8726,7 @@ Array [
         "initialY0": null,
         "initialY1": 931,
         "x": 931,
-        "y0": 0,
+        "y0": null,
         "y1": 931,
       },
       Object {
@@ -8734,7 +8734,7 @@ Array [
         "initialY0": null,
         "initialY1": 932,
         "x": 932,
-        "y0": 0,
+        "y0": null,
         "y1": 932,
       },
       Object {
@@ -8742,7 +8742,7 @@ Array [
         "initialY0": null,
         "initialY1": 933,
         "x": 933,
-        "y0": 0,
+        "y0": null,
         "y1": 933,
       },
       Object {
@@ -8750,7 +8750,7 @@ Array [
         "initialY0": null,
         "initialY1": 934,
         "x": 934,
-        "y0": 0,
+        "y0": null,
         "y1": 934,
       },
       Object {
@@ -8758,7 +8758,7 @@ Array [
         "initialY0": null,
         "initialY1": 935,
         "x": 935,
-        "y0": 0,
+        "y0": null,
         "y1": 935,
       },
       Object {
@@ -8766,7 +8766,7 @@ Array [
         "initialY0": null,
         "initialY1": 936,
         "x": 936,
-        "y0": 0,
+        "y0": null,
         "y1": 936,
       },
       Object {
@@ -8774,7 +8774,7 @@ Array [
         "initialY0": null,
         "initialY1": 937,
         "x": 937,
-        "y0": 0,
+        "y0": null,
         "y1": 937,
       },
       Object {
@@ -8782,7 +8782,7 @@ Array [
         "initialY0": null,
         "initialY1": 938,
         "x": 938,
-        "y0": 0,
+        "y0": null,
         "y1": 938,
       },
       Object {
@@ -8790,7 +8790,7 @@ Array [
         "initialY0": null,
         "initialY1": 939,
         "x": 939,
-        "y0": 0,
+        "y0": null,
         "y1": 939,
       },
       Object {
@@ -8798,7 +8798,7 @@ Array [
         "initialY0": null,
         "initialY1": 940,
         "x": 940,
-        "y0": 0,
+        "y0": null,
         "y1": 940,
       },
       Object {
@@ -8806,7 +8806,7 @@ Array [
         "initialY0": null,
         "initialY1": 941,
         "x": 941,
-        "y0": 0,
+        "y0": null,
         "y1": 941,
       },
       Object {
@@ -8814,7 +8814,7 @@ Array [
         "initialY0": null,
         "initialY1": 942,
         "x": 942,
-        "y0": 0,
+        "y0": null,
         "y1": 942,
       },
       Object {
@@ -8822,7 +8822,7 @@ Array [
         "initialY0": null,
         "initialY1": 943,
         "x": 943,
-        "y0": 0,
+        "y0": null,
         "y1": 943,
       },
       Object {
@@ -8830,7 +8830,7 @@ Array [
         "initialY0": null,
         "initialY1": 944,
         "x": 944,
-        "y0": 0,
+        "y0": null,
         "y1": 944,
       },
       Object {
@@ -8838,7 +8838,7 @@ Array [
         "initialY0": null,
         "initialY1": 945,
         "x": 945,
-        "y0": 0,
+        "y0": null,
         "y1": 945,
       },
       Object {
@@ -8846,7 +8846,7 @@ Array [
         "initialY0": null,
         "initialY1": 946,
         "x": 946,
-        "y0": 0,
+        "y0": null,
         "y1": 946,
       },
       Object {
@@ -8854,7 +8854,7 @@ Array [
         "initialY0": null,
         "initialY1": 947,
         "x": 947,
-        "y0": 0,
+        "y0": null,
         "y1": 947,
       },
       Object {
@@ -8862,7 +8862,7 @@ Array [
         "initialY0": null,
         "initialY1": 948,
         "x": 948,
-        "y0": 0,
+        "y0": null,
         "y1": 948,
       },
       Object {
@@ -8870,7 +8870,7 @@ Array [
         "initialY0": null,
         "initialY1": 949,
         "x": 949,
-        "y0": 0,
+        "y0": null,
         "y1": 949,
       },
       Object {
@@ -8878,7 +8878,7 @@ Array [
         "initialY0": null,
         "initialY1": 950,
         "x": 950,
-        "y0": 0,
+        "y0": null,
         "y1": 950,
       },
       Object {
@@ -8886,7 +8886,7 @@ Array [
         "initialY0": null,
         "initialY1": 951,
         "x": 951,
-        "y0": 0,
+        "y0": null,
         "y1": 951,
       },
       Object {
@@ -8894,7 +8894,7 @@ Array [
         "initialY0": null,
         "initialY1": 952,
         "x": 952,
-        "y0": 0,
+        "y0": null,
         "y1": 952,
       },
       Object {
@@ -8902,7 +8902,7 @@ Array [
         "initialY0": null,
         "initialY1": 953,
         "x": 953,
-        "y0": 0,
+        "y0": null,
         "y1": 953,
       },
       Object {
@@ -8910,7 +8910,7 @@ Array [
         "initialY0": null,
         "initialY1": 954,
         "x": 954,
-        "y0": 0,
+        "y0": null,
         "y1": 954,
       },
       Object {
@@ -8918,7 +8918,7 @@ Array [
         "initialY0": null,
         "initialY1": 955,
         "x": 955,
-        "y0": 0,
+        "y0": null,
         "y1": 955,
       },
       Object {
@@ -8926,7 +8926,7 @@ Array [
         "initialY0": null,
         "initialY1": 956,
         "x": 956,
-        "y0": 0,
+        "y0": null,
         "y1": 956,
       },
       Object {
@@ -8934,7 +8934,7 @@ Array [
         "initialY0": null,
         "initialY1": 957,
         "x": 957,
-        "y0": 0,
+        "y0": null,
         "y1": 957,
       },
       Object {
@@ -8942,7 +8942,7 @@ Array [
         "initialY0": null,
         "initialY1": 958,
         "x": 958,
-        "y0": 0,
+        "y0": null,
         "y1": 958,
       },
       Object {
@@ -8950,7 +8950,7 @@ Array [
         "initialY0": null,
         "initialY1": 959,
         "x": 959,
-        "y0": 0,
+        "y0": null,
         "y1": 959,
       },
       Object {
@@ -8958,7 +8958,7 @@ Array [
         "initialY0": null,
         "initialY1": 960,
         "x": 960,
-        "y0": 0,
+        "y0": null,
         "y1": 960,
       },
       Object {
@@ -8966,7 +8966,7 @@ Array [
         "initialY0": null,
         "initialY1": 961,
         "x": 961,
-        "y0": 0,
+        "y0": null,
         "y1": 961,
       },
       Object {
@@ -8974,7 +8974,7 @@ Array [
         "initialY0": null,
         "initialY1": 962,
         "x": 962,
-        "y0": 0,
+        "y0": null,
         "y1": 962,
       },
       Object {
@@ -8982,7 +8982,7 @@ Array [
         "initialY0": null,
         "initialY1": 963,
         "x": 963,
-        "y0": 0,
+        "y0": null,
         "y1": 963,
       },
       Object {
@@ -8990,7 +8990,7 @@ Array [
         "initialY0": null,
         "initialY1": 964,
         "x": 964,
-        "y0": 0,
+        "y0": null,
         "y1": 964,
       },
       Object {
@@ -8998,7 +8998,7 @@ Array [
         "initialY0": null,
         "initialY1": 965,
         "x": 965,
-        "y0": 0,
+        "y0": null,
         "y1": 965,
       },
       Object {
@@ -9006,7 +9006,7 @@ Array [
         "initialY0": null,
         "initialY1": 966,
         "x": 966,
-        "y0": 0,
+        "y0": null,
         "y1": 966,
       },
       Object {
@@ -9014,7 +9014,7 @@ Array [
         "initialY0": null,
         "initialY1": 967,
         "x": 967,
-        "y0": 0,
+        "y0": null,
         "y1": 967,
       },
       Object {
@@ -9022,7 +9022,7 @@ Array [
         "initialY0": null,
         "initialY1": 968,
         "x": 968,
-        "y0": 0,
+        "y0": null,
         "y1": 968,
       },
       Object {
@@ -9030,7 +9030,7 @@ Array [
         "initialY0": null,
         "initialY1": 969,
         "x": 969,
-        "y0": 0,
+        "y0": null,
         "y1": 969,
       },
       Object {
@@ -9038,7 +9038,7 @@ Array [
         "initialY0": null,
         "initialY1": 970,
         "x": 970,
-        "y0": 0,
+        "y0": null,
         "y1": 970,
       },
       Object {
@@ -9046,7 +9046,7 @@ Array [
         "initialY0": null,
         "initialY1": 971,
         "x": 971,
-        "y0": 0,
+        "y0": null,
         "y1": 971,
       },
       Object {
@@ -9054,7 +9054,7 @@ Array [
         "initialY0": null,
         "initialY1": 972,
         "x": 972,
-        "y0": 0,
+        "y0": null,
         "y1": 972,
       },
       Object {
@@ -9062,7 +9062,7 @@ Array [
         "initialY0": null,
         "initialY1": 973,
         "x": 973,
-        "y0": 0,
+        "y0": null,
         "y1": 973,
       },
       Object {
@@ -9070,7 +9070,7 @@ Array [
         "initialY0": null,
         "initialY1": 974,
         "x": 974,
-        "y0": 0,
+        "y0": null,
         "y1": 974,
       },
       Object {
@@ -9078,7 +9078,7 @@ Array [
         "initialY0": null,
         "initialY1": 975,
         "x": 975,
-        "y0": 0,
+        "y0": null,
         "y1": 975,
       },
       Object {
@@ -9086,7 +9086,7 @@ Array [
         "initialY0": null,
         "initialY1": 976,
         "x": 976,
-        "y0": 0,
+        "y0": null,
         "y1": 976,
       },
       Object {
@@ -9094,7 +9094,7 @@ Array [
         "initialY0": null,
         "initialY1": 977,
         "x": 977,
-        "y0": 0,
+        "y0": null,
         "y1": 977,
       },
       Object {
@@ -9102,7 +9102,7 @@ Array [
         "initialY0": null,
         "initialY1": 978,
         "x": 978,
-        "y0": 0,
+        "y0": null,
         "y1": 978,
       },
       Object {
@@ -9110,7 +9110,7 @@ Array [
         "initialY0": null,
         "initialY1": 979,
         "x": 979,
-        "y0": 0,
+        "y0": null,
         "y1": 979,
       },
       Object {
@@ -9118,7 +9118,7 @@ Array [
         "initialY0": null,
         "initialY1": 980,
         "x": 980,
-        "y0": 0,
+        "y0": null,
         "y1": 980,
       },
       Object {
@@ -9126,7 +9126,7 @@ Array [
         "initialY0": null,
         "initialY1": 981,
         "x": 981,
-        "y0": 0,
+        "y0": null,
         "y1": 981,
       },
       Object {
@@ -9134,7 +9134,7 @@ Array [
         "initialY0": null,
         "initialY1": 982,
         "x": 982,
-        "y0": 0,
+        "y0": null,
         "y1": 982,
       },
       Object {
@@ -9142,7 +9142,7 @@ Array [
         "initialY0": null,
         "initialY1": 983,
         "x": 983,
-        "y0": 0,
+        "y0": null,
         "y1": 983,
       },
       Object {
@@ -9150,7 +9150,7 @@ Array [
         "initialY0": null,
         "initialY1": 984,
         "x": 984,
-        "y0": 0,
+        "y0": null,
         "y1": 984,
       },
       Object {
@@ -9158,7 +9158,7 @@ Array [
         "initialY0": null,
         "initialY1": 985,
         "x": 985,
-        "y0": 0,
+        "y0": null,
         "y1": 985,
       },
       Object {
@@ -9166,7 +9166,7 @@ Array [
         "initialY0": null,
         "initialY1": 986,
         "x": 986,
-        "y0": 0,
+        "y0": null,
         "y1": 986,
       },
       Object {
@@ -9174,7 +9174,7 @@ Array [
         "initialY0": null,
         "initialY1": 987,
         "x": 987,
-        "y0": 0,
+        "y0": null,
         "y1": 987,
       },
       Object {
@@ -9182,7 +9182,7 @@ Array [
         "initialY0": null,
         "initialY1": 988,
         "x": 988,
-        "y0": 0,
+        "y0": null,
         "y1": 988,
       },
       Object {
@@ -9190,7 +9190,7 @@ Array [
         "initialY0": null,
         "initialY1": 989,
         "x": 989,
-        "y0": 0,
+        "y0": null,
         "y1": 989,
       },
       Object {
@@ -9198,7 +9198,7 @@ Array [
         "initialY0": null,
         "initialY1": 990,
         "x": 990,
-        "y0": 0,
+        "y0": null,
         "y1": 990,
       },
       Object {
@@ -9206,7 +9206,7 @@ Array [
         "initialY0": null,
         "initialY1": 991,
         "x": 991,
-        "y0": 0,
+        "y0": null,
         "y1": 991,
       },
       Object {
@@ -9214,7 +9214,7 @@ Array [
         "initialY0": null,
         "initialY1": 992,
         "x": 992,
-        "y0": 0,
+        "y0": null,
         "y1": 992,
       },
       Object {
@@ -9222,7 +9222,7 @@ Array [
         "initialY0": null,
         "initialY1": 993,
         "x": 993,
-        "y0": 0,
+        "y0": null,
         "y1": 993,
       },
       Object {
@@ -9230,7 +9230,7 @@ Array [
         "initialY0": null,
         "initialY1": 994,
         "x": 994,
-        "y0": 0,
+        "y0": null,
         "y1": 994,
       },
       Object {
@@ -9238,7 +9238,7 @@ Array [
         "initialY0": null,
         "initialY1": 995,
         "x": 995,
-        "y0": 0,
+        "y0": null,
         "y1": 995,
       },
       Object {
@@ -9246,7 +9246,7 @@ Array [
         "initialY0": null,
         "initialY1": 996,
         "x": 996,
-        "y0": 0,
+        "y0": null,
         "y1": 996,
       },
       Object {
@@ -9254,7 +9254,7 @@ Array [
         "initialY0": null,
         "initialY1": 997,
         "x": 997,
-        "y0": 0,
+        "y0": null,
         "y1": 997,
       },
       Object {
@@ -9262,7 +9262,7 @@ Array [
         "initialY0": null,
         "initialY1": 998,
         "x": 998,
-        "y0": 0,
+        "y0": null,
         "y1": 998,
       },
       Object {
@@ -9270,7 +9270,7 @@ Array [
         "initialY0": null,
         "initialY1": 999,
         "x": 999,
-        "y0": 0,
+        "y0": null,
         "y1": 999,
       },
     ],
@@ -17301,7 +17301,7 @@ Array [
         "initialY0": null,
         "initialY1": 1,
         "x": 1,
-        "y0": 0,
+        "y0": null,
         "y1": 1,
       },
       Object {
@@ -17309,7 +17309,7 @@ Array [
         "initialY0": null,
         "initialY1": 2,
         "x": 2,
-        "y0": 0,
+        "y0": null,
         "y1": 2,
       },
       Object {
@@ -17317,7 +17317,7 @@ Array [
         "initialY0": null,
         "initialY1": 3,
         "x": 3,
-        "y0": 0,
+        "y0": null,
         "y1": 3,
       },
       Object {
@@ -17325,7 +17325,7 @@ Array [
         "initialY0": null,
         "initialY1": 4,
         "x": 4,
-        "y0": 0,
+        "y0": null,
         "y1": 4,
       },
     ],
@@ -17639,7 +17639,7 @@ Array [
         "initialY0": null,
         "initialY1": 1,
         "x": 1,
-        "y0": 0,
+        "y0": null,
         "y1": 1,
       },
       Object {
@@ -17647,7 +17647,7 @@ Array [
         "initialY0": null,
         "initialY1": 2,
         "x": 2,
-        "y0": 0,
+        "y0": null,
         "y1": 2,
       },
       Object {
@@ -17655,7 +17655,7 @@ Array [
         "initialY0": null,
         "initialY1": 4,
         "x": 4,
-        "y0": 0,
+        "y0": null,
         "y1": 4,
       },
     ],
@@ -17923,7 +17923,7 @@ Array [
         "initialY0": null,
         "initialY1": 1,
         "x": 1,
-        "y0": 0,
+        "y0": null,
         "y1": 1,
       },
       Object {
@@ -17931,7 +17931,7 @@ Array [
         "initialY0": null,
         "initialY1": 4,
         "x": 4,
-        "y0": 0,
+        "y0": null,
         "y1": 4,
       },
       Object {
@@ -17939,7 +17939,7 @@ Array [
         "initialY0": null,
         "initialY1": 2,
         "x": 2,
-        "y0": 0,
+        "y0": null,
         "y1": 2,
       },
     ],
@@ -17997,7 +17997,7 @@ Array [
             "initialY0": null,
             "initialY1": 1,
             "x": 0,
-            "y0": 0,
+            "y0": null,
             "y1": 1,
           },
           Object {
@@ -18009,7 +18009,7 @@ Array [
             "initialY0": null,
             "initialY1": 2,
             "x": 1,
-            "y0": 0,
+            "y0": null,
             "y1": 2,
           },
           Object {
@@ -18021,7 +18021,7 @@ Array [
             "initialY0": null,
             "initialY1": 1,
             "x": 2,
-            "y0": 0,
+            "y0": null,
             "y1": 1,
           },
           Object {
@@ -18033,7 +18033,7 @@ Array [
             "initialY0": null,
             "initialY1": 6,
             "x": 3,
-            "y0": 0,
+            "y0": null,
             "y1": 6,
           },
         ],

--- a/src/chart_types/xy_chart/utils/series.ts
+++ b/src/chart_types/xy_chart/utils/series.ts
@@ -6,6 +6,7 @@ import { formatNonStackedDataSeriesValues } from './nonstacked_series_utils';
 import { isEqualSeriesKey } from './series_utils';
 import { BasicSeriesSpec, Datum, SeriesAccessors } from './specs';
 import { formatStackedDataSeriesValues } from './stacked_series_utils';
+import { LastValues } from '../store/utils';
 
 export interface RawDataSeriesDatum {
   /** the x value */
@@ -59,8 +60,9 @@ export interface DataSeriesCounts {
 
 export interface DataSeriesColorsValues {
   specId: SpecId;
+  banded?: boolean;
   colorValues: any[];
-  lastValue?: any;
+  lastValue?: LastValues;
   specSortIndex?: number;
 }
 
@@ -315,10 +317,13 @@ export function getSplittedSeries(
 
     splittedSeries.set(specId, currentRawDataSeries);
 
+    const banded = spec.y0Accessors && spec.y0Accessors.length > 0;
+
     dataSeries.colorsValues.forEach((colorValues, key) => {
       seriesColors.set(key, {
         specId,
         specSortIndex: spec.sortIndex,
+        banded,
         colorValues,
       });
     });
@@ -334,18 +339,16 @@ export function getSplittedSeries(
   };
 }
 
+export function getSortIndex({ specSortIndex }: DataSeriesColorsValues, total: number): number {
+  return specSortIndex != null ? specSortIndex : total;
+}
+
 export function getSortedDataSeriesColorsValuesMap(
   colorValuesMap: Map<string, DataSeriesColorsValues>,
 ): Map<string, DataSeriesColorsValues> {
   const seriesColorsArray = [...colorValuesMap];
-  seriesColorsArray.sort((seriesA, seriesB) => {
-    const [, colorValuesA] = seriesA;
-    const [, colorValuesB] = seriesB;
-
-    const specAIndex = colorValuesA.specSortIndex != null ? colorValuesA.specSortIndex : colorValuesMap.size;
-    const specBIndex = colorValuesB.specSortIndex != null ? colorValuesB.specSortIndex : colorValuesMap.size;
-
-    return specAIndex - specBIndex;
+  seriesColorsArray.sort(([, specA], [, specB]) => {
+    return getSortIndex(specA, colorValuesMap.size) - getSortIndex(specB, colorValuesMap.size);
   });
 
   return new Map([...seriesColorsArray]);
@@ -359,11 +362,11 @@ export function getSeriesColorMap(
   const seriesColorMap = new Map<string, string>();
   let counter = 0;
 
-  seriesColors.forEach((value: DataSeriesColorsValues, seriesColorKey: string) => {
-    const customSeriesColor: string | undefined = customColors.get(seriesColorKey);
+  seriesColors.forEach((_, key) => {
+    const customSeriesColor: string | undefined = customColors.get(key);
     const color = customSeriesColor || chartColors.vizColors[counter % chartColors.vizColors.length];
 
-    seriesColorMap.set(seriesColorKey, color);
+    seriesColorMap.set(key, color);
     counter++;
   });
   return seriesColorMap;

--- a/src/chart_types/xy_chart/utils/specs.ts
+++ b/src/chart_types/xy_chart/utils/specs.ts
@@ -109,17 +109,32 @@ export interface SeriesSpec {
   sortIndex?: number;
   displayValueSettings?: DisplayValueSpec;
   /**
-   * Postfix string or accessor function for y1 accesor when using `y0Accessors`
+   * Postfix string or accessor function for y1 accessor when using `y0Accessors`
    *
    * @default ' - upper'
    */
   y0AccessorFormat?: AccessorFormat;
   /**
-   * Postfix string or accessor function for y1 accesor when using `y0Accessors`
+   * Postfix string or accessor function for y1 accessor when using `y0Accessors`
    *
    * @default ' - lower'
    */
   y1AccessorFormat?: AccessorFormat;
+}
+
+export interface Postfixes {
+  /**
+   * Postfix for y1 accessor when using `y0Accessors`
+   *
+   * @default 'upper'
+   */
+  y0AccessorFormat?: string;
+  /**
+   * Postfix for y1 accessor when using `y0Accessors`
+   *
+   * @default 'lower'
+   */
+  y1AccessorFormat?: string;
 }
 
 export type CustomSeriesColorsMap = Map<DataSeriesColorsValues, string>;
@@ -167,21 +182,22 @@ export type BasicSeriesSpec = SeriesSpec & SeriesAccessors & SeriesScales;
 /**
  * This spec describe the dataset configuration used to display a bar series.
  */
-export type BarSeriesSpec = BasicSeriesSpec & {
-  /** @default bar */
-  seriesType: 'bar';
-  /** If true, will stack all BarSeries and align bars to ticks (instead of centered on ticks) */
-  enableHistogramMode?: boolean;
-  barSeriesStyle?: RecursivePartial<BarSeriesStyle>;
-  /**
-   * Stack each series in percentage for each point.
-   */
-  stackAsPercentage?: boolean;
-  /**
-   * An optional functional accessor to return custom color or style for bar datum
-   */
-  styleAccessor?: BarStyleAccessor;
-};
+export type BarSeriesSpec = BasicSeriesSpec &
+  Postfixes & {
+    /** @default bar */
+    seriesType: 'bar';
+    /** If true, will stack all BarSeries and align bars to ticks (instead of centered on ticks) */
+    enableHistogramMode?: boolean;
+    barSeriesStyle?: RecursivePartial<BarSeriesStyle>;
+    /**
+     * Stack each series in percentage for each point.
+     */
+    stackAsPercentage?: boolean;
+    /**
+     * An optional functional accessor to return custom color or style for bar datum
+     */
+    styleAccessor?: BarStyleAccessor;
+  };
 
 /**
  * This spec describe the dataset configuration used to display a histogram bar series.
@@ -210,7 +226,8 @@ export type LineSeriesSpec = BasicSeriesSpec &
  * This spec describe the dataset configuration used to display an area series.
  */
 export type AreaSeriesSpec = BasicSeriesSpec &
-  HistogramConfig & {
+  HistogramConfig &
+  Postfixes & {
     /** @default area */
     seriesType: 'area';
     /** The type of interpolator to be used to interpolate values between points */

--- a/src/chart_types/xy_chart/utils/stacked_percent_series_utils.test.ts
+++ b/src/chart_types/xy_chart/utils/stacked_percent_series_utils.test.ts
@@ -168,7 +168,7 @@ describe('Stacked Series Utils', () => {
       const formattedData = formatStackedDataSeriesValues(STANDARD_DATA_SET, false, true);
       const data0 = formattedData[0].data[0];
       expect(data0.initialY1).toBe(0.1);
-      expect(data0.y0).toBe(0);
+      expect(data0.y0).toBeNull();
       expect(data0.y1).toBe(0.1);
 
       const data1 = formattedData[1].data[0];
@@ -185,7 +185,7 @@ describe('Stacked Series Utils', () => {
       const formattedData = formatStackedDataSeriesValues(WITH_NULL_DATASET, false, true);
       const data0 = formattedData[0].data[0];
       expect(data0.initialY1).toBe(0.25);
-      expect(data0.y0).toBe(0);
+      expect(data0.y0).toBeNull();
       expect(data0.y1).toBe(0.25);
 
       expect(formattedData[1].data[0]).toEqual({
@@ -253,7 +253,7 @@ describe('Stacked Series Utils', () => {
         initialY0: null,
         initialY1: 0.1,
         x: 1,
-        y0: 0,
+        y0: null,
         y1: 0.1,
       });
       expect(formattedData[0].data[1]).toEqual({
@@ -261,7 +261,7 @@ describe('Stacked Series Utils', () => {
         initialY0: null,
         initialY1: 1,
         x: 2,
-        y0: 0,
+        y0: null,
         y1: 1,
       });
       expect(formattedData[0].data[2]).toEqual({
@@ -269,7 +269,7 @@ describe('Stacked Series Utils', () => {
         initialY0: null,
         initialY1: 1,
         x: 4,
-        y0: 0,
+        y0: null,
         y1: 1,
       });
       expect(formattedData[1].data[0]).toEqual({

--- a/src/chart_types/xy_chart/utils/stacked_series_utils.test.ts
+++ b/src/chart_types/xy_chart/utils/stacked_series_utils.test.ts
@@ -230,7 +230,7 @@ describe('Stacked Series Utils', () => {
         initialY0: null,
         initialY1: 10,
         x: 0,
-        y0: 0,
+        y0: null,
         y1: 10,
       });
       expect(formattedData[1].data[0]).toEqual({
@@ -326,7 +326,7 @@ describe('Stacked Series Utils', () => {
         initialY0: null,
         initialY1: 1,
         x: 1,
-        y0: 0,
+        y0: null,
         y1: 1,
       });
       expect(formattedData[0].data[1]).toEqual({
@@ -334,7 +334,7 @@ describe('Stacked Series Utils', () => {
         initialY0: null,
         initialY1: 2,
         x: 2,
-        y0: 0,
+        y0: null,
         y1: 2,
       });
       expect(formattedData[0].data[2]).toEqual({
@@ -342,7 +342,7 @@ describe('Stacked Series Utils', () => {
         initialY0: null,
         initialY1: 4,
         x: 4,
-        y0: 0,
+        y0: null,
         y1: 4,
       });
       expect(formattedData[1].data[0]).toEqual({

--- a/src/chart_types/xy_chart/utils/stacked_series_utils.ts
+++ b/src/chart_types/xy_chart/utils/stacked_series_utils.ts
@@ -100,9 +100,10 @@ export function formatStackedDataSeriesValues(
       if (scaleToExtent) {
         computedY0 = y0 ? y0 : y1;
       } else {
-        computedY0 = y0 ? y0 : 0;
+        computedY0 = y0 ? y0 : null;
       }
       const initialY0 = y0 == null ? null : y0;
+
       if (seriesIndex === 0) {
         newData.push({
           x,
@@ -128,6 +129,7 @@ export function formatStackedDataSeriesValues(
             stackedY0 = null;
           }
         }
+
         newData.push({
           x,
           y1: stackedY1,

--- a/stories/area_chart.tsx
+++ b/stories/area_chart.tsx
@@ -477,12 +477,12 @@ storiesOf('Area Chart', module)
   })
   .add('stacked band area chart', () => {
     const data = KIBANA_METRICS.metrics.kibana_os_load[0].data;
-    const data2 = KIBANA_METRICS.metrics.kibana_os_load[0].data.map((d) => {
-      return [d[0], 20, 10];
-    });
+    const data2 = KIBANA_METRICS.metrics.kibana_os_load[0].data.map((d) => [d[0], 20, 10]);
     const scaleToDataExtent = boolean('scale to extent', false);
+
     return (
       <Chart className={'story-chart'}>
+        <Settings showLegend />
         <Axis
           id={getAxisId('bottom')}
           title={'timestamp per 1 minute'}


### PR DESCRIPTION
## Summary

- Allow user to set postfix for upper and lower bound of banded series to distinguish between values sets
- Update `displayValue` type changes, fix defaulting point values from 0 to null.

Hard naming fix for #398 

closes #162

### Checklist

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
