### PR TITLE
feat: fill multi-series with missing x values data points

### DIFF
--- a/.playground/index.html
+++ b/.playground/index.html
@@ -25,7 +25,7 @@
         background: white;
         position: relative;
         width: 800px;
-        height: 150px;
+        height: 450px;
         margin: 10px;
       }
     </style>

--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -6,125 +6,64 @@ export class Playground extends React.Component {
     return (
       <Fragment>
         <div className="chart">
-          <Chart className="story-chart">
-            <Settings
-              theme={{
-                areaSeriesStyle: {
-                  point: {
-                    visible: true,
-                  },
-                },
-              }}
-            />
+          <Chart>
+            <Settings showLegend theme={{ areaSeriesStyle: { point: { visible: true } } }} />
             <Axis
               id={getAxisId('bottom')}
               position={Position.Bottom}
               title={'Bottom axis'}
               showOverlappingTicks={true}
             />
-            <Axis id={getAxisId('left')} title={'Left axis'} position={Position.Left} />
-            {/* <AreaSeries
-              id={getSpecId(`machine-3`)}
-              xScaleType={ScaleType.Linear}
-              yScaleType={ScaleType.Linear}
-              xAccessor={0}
-              yAccessors={[1]}
-              stackAccessors={[0]}
-              data={[
-                [0, 100],
-                [1, null],
-                [2, 300],
-                [3, null],
-                [3.5, 200],
-                [4, 200],
-                [5, null],
-                [6, 231],
-                [7, null],
-                [8, 100],
-                [9, 110],
-                [10, null],
-                [11, 100],
-                [12, 140],
-                [13, 180],
-                [14, 200],
-                [15, 230],
-                [16, 260],
-                [17, null],
-                [18, null],
-                [19, 100],
-                [20, 100],
-                [21, 100],
-              ]}
-            /> */}
-            <AreaSeries
-              id={getSpecId(`machine-1`)}
-              xScaleType={ScaleType.Linear}
-              yScaleType={ScaleType.Linear}
-              xAccessor={'x'}
-              yAccessors={['y1']}
-              stackAccessors={['x']}
-              stackAsPercentage
-              data={[{ x: 1, y1: 90 }, { x: 3, y1: 30 }]}
-              // data={[
-              //   [0, 100],
-              //   [1, null],
-              //   [2, 300],
-              //   [3, null],
-              //   [3.5, 200],
-              //   [4, 200],
-              //   [5, null],
-              //   [6, 231],
-              //   [7, null],
-              //   [8, 100],
-              //   [8.5, 40],
-              //   [9, 110],
-              //   [10, null],
-              //   [11, 100],
-              //   [12, 140],
-              //   [13, 180],
-              //   [14, 200],
-              //   [15, 230],
-              //   [16, 260],
-              //   [17, null],
-              //   [18, null],
-              //   [19, 100],
-              //   [20, 100],
-              //   [21, 100],
-              // ]}
+            <Axis
+              id={getAxisId('left2')}
+              title={'Left axis'}
+              position={Position.Left}
+              tickFormat={(d: any) => Number(d).toFixed(2)}
             />
             <AreaSeries
-              id={getSpecId(`machine-2`)}
+              id={getSpecId('bars1')}
               xScaleType={ScaleType.Linear}
               yScaleType={ScaleType.Linear}
-              xAccessor={'x'}
-              yAccessors={['y1']}
+              xAccessor="x"
+              yAccessors={['y']}
               stackAccessors={['x']}
-              data={
-                [{ x: 1, y1: 10 }, { x: 2, y1: 20 }, { x: 4, y1: 40 }]
-                // [[0, 100],
-                // [1, null],
-                // [2, 300],
-                // [3, null],
-                // [3.5, 200],
-                // [4, 200],
-                // [5, null],
-                // [6, 231],
-                // [7, null],
-                // [8, 100],
-                // [9, 110],
-                // [10, null],
-                // [11, 100],
-                // [12, 140],
-                // [13, 180],
-                // [14, 200],
-                // [15, 230],
-                // [16, 260],
-                // [17, null],
-                // [18, null],
-                // [19, 100],
-                // [20, 100],
-                // [21, 100],]
-              }
+              splitSeriesAccessors={['g']}
+              // curve={CurveType.CURVE_MONOTONE_X}
+              data={[
+                { x: 0, y: 2, g: 'a' },
+                { x: 1, y: 7, g: 'a' },
+                { x: 2, y: 3, g: 'a' },
+                { x: 3, y: 6, g: 'a' },
+                { x: 0, y: 4, g: 'b' },
+                { x: 1, y: 5, g: 'b' },
+                { x: 2, y: 8, g: 'b' },
+                { x: 3, y: 2, g: 'b' },
+                { x: 4, y: 6, g: 'b' },
+                { x: 5, y: 7, g: 'a' },
+                { x: 5, y: 7, g: 'b' },
+                { x: 6, y: 7, g: 'a' },
+                { x: 6, y: 7, g: 'b' },
+              ]}
+            />
+            <AreaSeries
+              id={getSpecId('area2')}
+              xScaleType={ScaleType.Linear}
+              yScaleType={ScaleType.Linear}
+              xAccessor="x"
+              yAccessors={['y']}
+              stackAccessors={['x']}
+              splitSeriesAccessors={['g']}
+              // curve={CurveType.CURVE_MONOTONE_X}
+              data={[
+                { x: 1, y: 7, g: 'a' },
+                { x: 2, y: 3, g: 'a' },
+                { x: 3, y: 6, g: 'a' },
+                { x: 0, y: 4, g: 'b' },
+                { x: 1, y: 5, g: 'b' },
+                { x: 2, y: 8, g: 'b' },
+                { x: 3, y: 2, g: 'b' },
+                { x: 4, y: 6, g: 'b' },
+              ]}
             />
           </Chart>
         </div>

--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -1,16 +1,5 @@
 import React, { Fragment } from 'react';
-import {
-  Axis,
-  Chart,
-  getAxisId,
-  getSpecId,
-  Position,
-  ScaleType,
-  Settings,
-  BarSeries,
-  LineSeries,
-  AreaSeries,
-} from '../src';
+import { Axis, Chart, getAxisId, getSpecId, Position, ScaleType, Settings, AreaSeries } from '../src';
 
 export class Playground extends React.Component {
   render() {
@@ -26,9 +15,6 @@ export class Playground extends React.Component {
                   },
                 },
               }}
-              xDomain={{
-                max: 3.8,
-              }}
             />
             <Axis
               id={getAxisId('bottom')}
@@ -36,40 +22,109 @@ export class Playground extends React.Component {
               title={'Bottom axis'}
               showOverlappingTicks={true}
             />
-            <Axis
-              id={getAxisId('left')}
-              title={'Left axis'}
-              position={Position.Left}
-              domain={{
-                max: 5,
-              }}
-            />
-
-            <BarSeries
-              id={getSpecId('bar')}
+            <Axis id={getAxisId('left')} title={'Left axis'} position={Position.Left} />
+            {/* <AreaSeries
+              id={getSpecId(`machine-3`)}
               xScaleType={ScaleType.Linear}
               yScaleType={ScaleType.Linear}
               xAccessor={0}
               yAccessors={[1]}
-              data={[[0, 1], [1, 2], [2, 10], [3, 4], [4, 5]]}
-            />
-
-            <LineSeries
-              id={getSpecId('line')}
-              xScaleType={ScaleType.Linear}
-              yScaleType={ScaleType.Linear}
-              xAccessor={0}
-              yAccessors={[1]}
-              data={[[0, 1], [1, 2], [2, 10], [3, 4], [4, 5]]}
-            />
-
+              stackAccessors={[0]}
+              data={[
+                [0, 100],
+                [1, null],
+                [2, 300],
+                [3, null],
+                [3.5, 200],
+                [4, 200],
+                [5, null],
+                [6, 231],
+                [7, null],
+                [8, 100],
+                [9, 110],
+                [10, null],
+                [11, 100],
+                [12, 140],
+                [13, 180],
+                [14, 200],
+                [15, 230],
+                [16, 260],
+                [17, null],
+                [18, null],
+                [19, 100],
+                [20, 100],
+                [21, 100],
+              ]}
+            /> */}
             <AreaSeries
-              id={getSpecId('area')}
+              id={getSpecId(`machine-1`)}
               xScaleType={ScaleType.Linear}
               yScaleType={ScaleType.Linear}
-              xAccessor={0}
-              yAccessors={[1]}
-              data={[[0, 1], [1, 2], [2, 10], [3, 4], [4, 5]]}
+              xAccessor={'x'}
+              yAccessors={['y1']}
+              stackAccessors={['x']}
+              stackAsPercentage
+              data={[{ x: 1, y1: 90 }, { x: 3, y1: 30 }]}
+              // data={[
+              //   [0, 100],
+              //   [1, null],
+              //   [2, 300],
+              //   [3, null],
+              //   [3.5, 200],
+              //   [4, 200],
+              //   [5, null],
+              //   [6, 231],
+              //   [7, null],
+              //   [8, 100],
+              //   [8.5, 40],
+              //   [9, 110],
+              //   [10, null],
+              //   [11, 100],
+              //   [12, 140],
+              //   [13, 180],
+              //   [14, 200],
+              //   [15, 230],
+              //   [16, 260],
+              //   [17, null],
+              //   [18, null],
+              //   [19, 100],
+              //   [20, 100],
+              //   [21, 100],
+              // ]}
+            />
+            <AreaSeries
+              id={getSpecId(`machine-2`)}
+              xScaleType={ScaleType.Linear}
+              yScaleType={ScaleType.Linear}
+              xAccessor={'x'}
+              yAccessors={['y1']}
+              stackAccessors={['x']}
+              data={
+                [{ x: 1, y1: 10 }, { x: 2, y1: 20 }, { x: 4, y1: 40 }]
+                // [[0, 100],
+                // [1, null],
+                // [2, 300],
+                // [3, null],
+                // [3.5, 200],
+                // [4, 200],
+                // [5, null],
+                // [6, 231],
+                // [7, null],
+                // [8, 100],
+                // [9, 110],
+                // [10, null],
+                // [11, 100],
+                // [12, 140],
+                // [13, 180],
+                // [14, 200],
+                // [15, 230],
+                // [16, 260],
+                // [17, null],
+                // [18, null],
+                // [19, 100],
+                // [20, 100],
+                // [21, 100],]
+              }
             />
           </Chart>
         </div>

--- a/src/chart_types/xy_chart/domains/x_domain.ts
+++ b/src/chart_types/xy_chart/domains/x_domain.ts
@@ -1,5 +1,5 @@
 import { isCompleteBound, isLowerBound, isUpperBound } from '../utils/axis_utils';
-import { compareByValueAsc, identity } from '../../../utils/commons';
+import { compareByValueAsc, identity, isNumberArray } from '../../../utils/commons';
 import { computeContinuousDataDomain, computeOrdinalDataDomain, Domain } from '../../../utils/domain';
 import { ScaleType } from '../../../utils/scales/scales';
 import { BasicSeriesSpec, DomainRange } from '../utils/specs';
@@ -22,7 +22,7 @@ export type XDomain = BaseDomain & {
  */
 export function mergeXDomain(
   specs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType'>[],
-  xValues: Set<any>,
+  xValues: Set<string | number>,
   customXDomain?: DomainRange | Domain,
 ): XDomain {
   const mainXScaleType = convertXScaleTypes(specs);
@@ -46,7 +46,11 @@ export function mergeXDomain(
   } else {
     seriesXComputedDomains = computeContinuousDataDomain(values, identity, true);
     let customMinInterval: undefined | number;
-
+    if (!isNumberArray(values)) {
+      throw new Error(
+        `Each X value in a ${mainXScaleType.scaleType} x scale needs be be a number. String or objects are not allowed`,
+      );
+    }
     if (customXDomain) {
       if (Array.isArray(customXDomain)) {
         throw new Error('xDomain for continuous scale should be a DomainRange object, not an array');
@@ -78,7 +82,6 @@ export function mergeXDomain(
         }
       }
     }
-
     const computedMinInterval = findMinInterval(values);
     if (customMinInterval != null) {
       // Allow greater custom min iff xValues has 1 member.

--- a/src/chart_types/xy_chart/rendering/rendering.ts
+++ b/src/chart_types/xy_chart/rendering/rendering.ts
@@ -197,9 +197,9 @@ export function renderPoints(
   const isLogScale = isLogarithmicScale(yScale);
   const pointGeometries = dataset.reduce(
     (acc, datum) => {
-      const { x: xValue, y0, y1, initialY0, initialY1 } = datum;
-      // don't create the point if not within the xScale domain
-      if (!xScale.isValueInDomain(xValue)) {
+      const { x: xValue, y0, y1, initialY0, initialY1, filled } = datum;
+      // don't create the point if not within the xScale domain or it that point was filled
+      if (!xScale.isValueInDomain(xValue) || (filled && filled.y1 !== undefined)) {
         return acc;
       }
       const x = xScale.scale(xValue);
@@ -286,9 +286,9 @@ export function renderBars(
   const fontFamily = sharedSeriesStyle.displayValue.fontFamily;
 
   dataset.forEach((datum) => {
-    const { y0, y1, initialY1 } = datum;
+    const { y0, y1, initialY1, filled } = datum;
     // don't create a bar if the initialY1 value is null.
-    if (initialY1 === null) {
+    if (initialY1 === null || (filled && filled.y1 !== undefined)) {
       return;
     }
     // don't create a bar if not within the xScale domain

--- a/src/chart_types/xy_chart/store/utils.ts
+++ b/src/chart_types/xy_chart/store/utils.ts
@@ -165,7 +165,7 @@ export function computeSeriesDomains(
   const xDomain = mergeXDomain(specsArray, xValues, customXDomain);
   const yDomain = mergeYDomain(splittedSeries, specsArray, customYDomainsByGroupId);
 
-  const formattedDataSeries = getFormattedDataseries(specsArray, splittedSeries);
+  const formattedDataSeries = getFormattedDataseries(specsArray, splittedSeries, xValues, xDomain.scaleType);
 
   // we need to get the last values from the formatted dataseries
   // because we change the format if we are on percentage mode

--- a/src/chart_types/xy_chart/store/utils.ts
+++ b/src/chart_types/xy_chart/store/utils.ts
@@ -118,7 +118,7 @@ export function getLastValues(formattedDataSeries: {
         if (last !== null) {
           const { initialY1: y1, initialY0: y0 } = last;
 
-          if (y1 !== null || y0 !== null) {
+          if (!last.filled && (y1 !== null || y0 !== null)) {
             lastValues.set(series.seriesColorKey, { y0, y1 });
           }
         }

--- a/src/chart_types/xy_chart/utils/__snapshots__/series.test.ts.snap
+++ b/src/chart_types/xy_chart/utils/__snapshots__/series.test.ts.snap
@@ -17652,10 +17652,14 @@ Array [
       },
       Object {
         "datum": undefined,
+        "filled": Object {
+          "x": 3,
+          "y1": 0,
+        },
         "initialY0": null,
         "initialY1": 0,
         "x": 3,
-        "y0": 0,
+        "y0": null,
         "y1": 0,
       },
       Object {
@@ -17685,6 +17689,10 @@ Array [
       },
       Object {
         "datum": undefined,
+        "filled": Object {
+          "x": 2,
+          "y1": 0,
+        },
         "initialY0": null,
         "initialY1": 0,
         "x": 2,
@@ -17701,6 +17709,10 @@ Array [
       },
       Object {
         "datum": undefined,
+        "filled": Object {
+          "x": 4,
+          "y1": 0,
+        },
         "initialY0": null,
         "initialY1": 0,
         "x": 4,
@@ -17739,6 +17751,10 @@ Array [
       },
       Object {
         "datum": undefined,
+        "filled": Object {
+          "x": 3,
+          "y1": 0,
+        },
         "initialY0": null,
         "initialY1": 0,
         "x": 3,
@@ -17772,6 +17788,10 @@ Array [
       },
       Object {
         "datum": undefined,
+        "filled": Object {
+          "x": 2,
+          "y1": 0,
+        },
         "initialY0": null,
         "initialY1": 0,
         "x": 2,
@@ -17788,6 +17808,10 @@ Array [
       },
       Object {
         "datum": undefined,
+        "filled": Object {
+          "x": 4,
+          "y1": 0,
+        },
         "initialY0": null,
         "initialY1": 0,
         "x": 4,
@@ -17826,6 +17850,10 @@ Array [
       },
       Object {
         "datum": undefined,
+        "filled": Object {
+          "x": 3,
+          "y1": 0,
+        },
         "initialY0": null,
         "initialY1": 0,
         "x": 3,
@@ -17913,6 +17941,10 @@ Array [
       },
       Object {
         "datum": undefined,
+        "filled": Object {
+          "x": 3,
+          "y1": 0,
+        },
         "initialY0": null,
         "initialY1": 0,
         "x": 3,
@@ -17993,30 +18025,21 @@ Array [
       Object {
         "datum": undefined,
         "initialY0": null,
-<<<<<<< HEAD
-        "initialY1": 4,
-        "x": 4,
-        "y0": null,
-        "y1": 4,
-=======
         "initialY1": 2,
         "x": 2,
-        "y0": 0,
+        "y0": null,
         "y1": 2,
->>>>>>> feat: fill multi-series with missing x values data points
       },
       Object {
         "datum": undefined,
+        "filled": Object {
+          "x": 3,
+          "y1": 0,
+        },
         "initialY0": null,
-<<<<<<< HEAD
-        "initialY1": 2,
-        "x": 2,
-        "y0": null,
-        "y1": 2,
-=======
         "initialY1": 0,
         "x": 3,
-        "y0": 0,
+        "y0": null,
         "y1": 0,
       },
       Object {
@@ -18024,9 +18047,8 @@ Array [
         "initialY0": null,
         "initialY1": 4,
         "x": 4,
-        "y0": 0,
+        "y0": null,
         "y1": 4,
->>>>>>> feat: fill multi-series with missing x values data points
       },
     ],
     "key": Array [
@@ -18047,6 +18069,10 @@ Array [
       },
       Object {
         "datum": undefined,
+        "filled": Object {
+          "x": 2,
+          "y1": 0,
+        },
         "initialY0": null,
         "initialY1": 0,
         "x": 2,
@@ -18063,6 +18089,10 @@ Array [
       },
       Object {
         "datum": undefined,
+        "filled": Object {
+          "x": 4,
+          "y1": 0,
+        },
         "initialY0": null,
         "initialY1": 0,
         "x": 4,

--- a/src/chart_types/xy_chart/utils/__snapshots__/series.test.ts.snap
+++ b/src/chart_types/xy_chart/utils/__snapshots__/series.test.ts.snap
@@ -17653,6 +17653,14 @@ Array [
       Object {
         "datum": undefined,
         "initialY0": null,
+        "initialY1": 0,
+        "x": 3,
+        "y0": 0,
+        "y1": 0,
+      },
+      Object {
+        "datum": undefined,
+        "initialY0": null,
         "initialY1": 4,
         "x": 4,
         "y0": null,
@@ -17678,10 +17686,26 @@ Array [
       Object {
         "datum": undefined,
         "initialY0": null,
+        "initialY1": 0,
+        "x": 2,
+        "y0": 2,
+        "y1": 2,
+      },
+      Object {
+        "datum": undefined,
+        "initialY0": null,
         "initialY1": 23,
         "x": 3,
         "y0": 0,
         "y1": 23,
+      },
+      Object {
+        "datum": undefined,
+        "initialY0": null,
+        "initialY1": 0,
+        "x": 4,
+        "y0": 4,
+        "y1": 4,
       },
     ],
     "key": Array [
@@ -17716,6 +17740,14 @@ Array [
       Object {
         "datum": undefined,
         "initialY0": null,
+        "initialY1": 0,
+        "x": 3,
+        "y0": 0,
+        "y1": 0,
+      },
+      Object {
+        "datum": undefined,
+        "initialY0": null,
         "initialY1": 4,
         "x": 4,
         "y0": 4,
@@ -17741,10 +17773,26 @@ Array [
       Object {
         "datum": undefined,
         "initialY0": null,
+        "initialY1": 0,
+        "x": 2,
+        "y0": 2,
+        "y1": 2,
+      },
+      Object {
+        "datum": undefined,
+        "initialY0": null,
         "initialY1": 23,
         "x": 3,
         "y0": 0,
         "y1": 23,
+      },
+      Object {
+        "datum": undefined,
+        "initialY0": null,
+        "initialY1": 0,
+        "x": 4,
+        "y0": 4,
+        "y1": 4,
       },
     ],
     "key": Array [
@@ -17775,6 +17823,14 @@ Array [
         "x": 2,
         "y0": 2,
         "y1": 3,
+      },
+      Object {
+        "datum": undefined,
+        "initialY0": null,
+        "initialY1": 0,
+        "x": 3,
+        "y0": 0,
+        "y1": 0,
       },
       Object {
         "datum": undefined,
@@ -17857,6 +17913,14 @@ Array [
       },
       Object {
         "datum": undefined,
+        "initialY0": null,
+        "initialY1": 0,
+        "x": 3,
+        "y0": 0,
+        "y1": 0,
+      },
+      Object {
+        "datum": undefined,
         "initialY0": 3,
         "initialY1": 4,
         "x": 4,
@@ -17929,18 +17993,40 @@ Array [
       Object {
         "datum": undefined,
         "initialY0": null,
+<<<<<<< HEAD
         "initialY1": 4,
         "x": 4,
         "y0": null,
         "y1": 4,
+=======
+        "initialY1": 2,
+        "x": 2,
+        "y0": 0,
+        "y1": 2,
+>>>>>>> feat: fill multi-series with missing x values data points
       },
       Object {
         "datum": undefined,
         "initialY0": null,
+<<<<<<< HEAD
         "initialY1": 2,
         "x": 2,
         "y0": null,
         "y1": 2,
+=======
+        "initialY1": 0,
+        "x": 3,
+        "y0": 0,
+        "y1": 0,
+      },
+      Object {
+        "datum": undefined,
+        "initialY0": null,
+        "initialY1": 4,
+        "x": 4,
+        "y0": 0,
+        "y1": 4,
+>>>>>>> feat: fill multi-series with missing x values data points
       },
     ],
     "key": Array [
@@ -17954,6 +18040,22 @@ Array [
       Object {
         "datum": undefined,
         "initialY0": null,
+        "initialY1": 21,
+        "x": 1,
+        "y0": 1,
+        "y1": 22,
+      },
+      Object {
+        "datum": undefined,
+        "initialY0": null,
+        "initialY1": 0,
+        "x": 2,
+        "y0": 2,
+        "y1": 2,
+      },
+      Object {
+        "datum": undefined,
+        "initialY0": null,
         "initialY1": 23,
         "x": 3,
         "y0": 0,
@@ -17962,10 +18064,10 @@ Array [
       Object {
         "datum": undefined,
         "initialY0": null,
-        "initialY1": 21,
-        "x": 1,
-        "y0": 1,
-        "y1": 22,
+        "initialY1": 0,
+        "x": 4,
+        "y0": 4,
+        "y1": 4,
       },
     ],
     "key": Array [

--- a/src/chart_types/xy_chart/utils/series.test.ts
+++ b/src/chart_types/xy_chart/utils/series.test.ts
@@ -100,7 +100,8 @@ describe('Series', () => {
         data: [{ x: 1, y1: 21 }, { x: 3, y1: 23 }],
       },
     ];
-    const stackedValues = formatStackedDataSeriesValues(dataSeries, false);
+    const xValues = new Set([1, 2, 3, 4]);
+    const stackedValues = formatStackedDataSeriesValues(dataSeries, false, false, xValues, ScaleType.Linear);
     expect(stackedValues).toMatchSnapshot();
   });
   test('Can stack multiple dataseries', () => {
@@ -130,7 +131,8 @@ describe('Series', () => {
         data: [{ x: 1, y1: 1 }, { x: 2, y1: 2 }, { x: 3, y1: 3 }, { x: 4, y1: 4 }],
       },
     ];
-    const stackedValues = formatStackedDataSeriesValues(dataSeries, false);
+    const xValues = new Set([1, 2, 3, 4]);
+    const stackedValues = formatStackedDataSeriesValues(dataSeries, false, false, xValues, ScaleType.Linear);
     expect(stackedValues).toMatchSnapshot();
   });
   test('Can stack unsorted dataseries', () => {
@@ -148,7 +150,8 @@ describe('Series', () => {
         data: [{ x: 3, y1: 23 }, { x: 1, y1: 21 }],
       },
     ];
-    const stackedValues = formatStackedDataSeriesValues(dataSeries, false);
+    const xValues = new Set([1, 2, 3, 4]);
+    const stackedValues = formatStackedDataSeriesValues(dataSeries, false, false, xValues, ScaleType.Linear);
     expect(stackedValues).toMatchSnapshot();
   });
   test('Can stack high volume of dataseries', () => {
@@ -167,7 +170,8 @@ describe('Series', () => {
         data: new Array(maxArrayItems).fill(0).map((d, i) => ({ x: i, y1: i })),
       },
     ];
-    const stackedValues = formatStackedDataSeriesValues(dataSeries, false);
+    const xValues = new Set(new Array(maxArrayItems).fill(0).map((d, i) => i));
+    const stackedValues = formatStackedDataSeriesValues(dataSeries, false, false, xValues, ScaleType.Linear);
     expect(stackedValues).toMatchSnapshot();
   });
   test('Can stack simple dataseries with scale to extent', () => {
@@ -185,7 +189,8 @@ describe('Series', () => {
         data: [{ x: 1, y1: 21 }, { x: 3, y1: 23 }],
       },
     ];
-    const stackedValues = formatStackedDataSeriesValues(dataSeries, true);
+    const xValues = new Set([1, 2, 3, 4]);
+    const stackedValues = formatStackedDataSeriesValues(dataSeries, true, false, xValues, ScaleType.Linear);
     // the datum on the snapshots is undefined because we are not adding it to
     // the test raw dataseries
     expect(stackedValues).toMatchSnapshot();
@@ -217,7 +222,8 @@ describe('Series', () => {
         data: [{ x: 1, y1: 1 }, { x: 2, y1: 2 }, { x: 3, y1: 3 }, { x: 4, y1: 4 }],
       },
     ];
-    const stackedValues = formatStackedDataSeriesValues(dataSeries, true);
+    const xValues = new Set([1, 2, 3, 4]);
+    const stackedValues = formatStackedDataSeriesValues(dataSeries, true, false, xValues, ScaleType.Linear);
     // the datum on the snapshots is undefined because we are not adding it to
     // the test raw dataseries
     expect(stackedValues).toMatchSnapshot();
@@ -237,7 +243,8 @@ describe('Series', () => {
         data: [{ x: 1, y1: 2, y0: 1 }, { x: 2, y1: 3, y0: 1 }, { x: 3, y1: 23, y0: 4 }, { x: 4, y1: 4, y0: 1 }],
       },
     ];
-    const stackedValues = formatStackedDataSeriesValues(dataSeries, true);
+    const xValues = new Set([1, 2, 3, 4]);
+    const stackedValues = formatStackedDataSeriesValues(dataSeries, true, false, xValues, ScaleType.Linear);
     // the datum on the snapshots is undefined because we are not adding it to
     // the test raw dataseries
 
@@ -268,7 +275,8 @@ describe('Series', () => {
         data: [{ x: 1, y1: 2, y0: 1 }, { x: 2, y1: 3, y0: 1 }, { x: 3, y1: 23, y0: 4 }, { x: 4, y1: 4, y0: 1 }],
       },
     ];
-    const stackedValues = formatStackedDataSeriesValues(dataSeries, true);
+    const xValues = new Set([1, 2, 3, 4]);
+    const stackedValues = formatStackedDataSeriesValues(dataSeries, true, false, xValues, ScaleType.Linear);
     // the datum on the snapshots is undefined because we are not adding it to
     // the test raw dataseries
     expect(stackedValues[0].data[0].y0).toBe(1);
@@ -343,10 +351,16 @@ describe('Series', () => {
       data: TestDataset.BARCHART_2Y0G,
       hideInLegend: false,
     };
+    const xValues = new Set([0, 1, 2, 3]);
     seriesSpecs.set(spec1.id, spec1);
     seriesSpecs.set(spec2.id, spec2);
     const splittedDataSeries = getSplittedSeries(seriesSpecs);
-    const stackedDataSeries = getFormattedDataseries([spec1, spec2], splittedDataSeries.splittedSeries);
+    const stackedDataSeries = getFormattedDataseries(
+      [spec1, spec2],
+      splittedDataSeries.splittedSeries,
+      xValues,
+      ScaleType.Linear,
+    );
     expect(stackedDataSeries.stacked).toMatchSnapshot();
   });
   test('should get series color map', () => {

--- a/src/chart_types/xy_chart/utils/series.ts
+++ b/src/chart_types/xy_chart/utils/series.ts
@@ -9,6 +9,15 @@ import { formatStackedDataSeriesValues } from './stacked_series_utils';
 import { LastValues } from '../store/utils';
 import { ScaleType } from '../../../utils/scales/scales';
 
+export interface FilledValues {
+  /** the x value */
+  x: number | string;
+  /** the max y value */
+  y1: number | null;
+  /** the minimum y value */
+  y0: number | null;
+}
+
 export interface RawDataSeriesDatum {
   /** the x value */
   x: number | string;
@@ -21,6 +30,7 @@ export interface RawDataSeriesDatum {
 }
 
 export interface DataSeriesDatum {
+  /** the x value */
   x: number | string;
   /** the max y value */
   y1: number | null;
@@ -32,6 +42,8 @@ export interface DataSeriesDatum {
   initialY0: number | null;
   /** the datum */
   datum?: any;
+  /** the list of filled values because missing or nulls */
+  filled?: Partial<FilledValues>;
 }
 
 export interface DataSeries {
@@ -341,6 +353,7 @@ export function getSplittedSeries(
       xValues.add(xValue);
     }
   }
+  // keep the user order for ordinal scales
   if (!isOrdinalScale) {
     xValues = new Set([...xValues].sort());
   }

--- a/src/chart_types/xy_chart/utils/stacked_percent_series_utils.test.ts
+++ b/src/chart_types/xy_chart/utils/stacked_percent_series_utils.test.ts
@@ -307,6 +307,10 @@ describe('Stacked Series Utils', () => {
         x: 2,
         y0: 1,
         y1: 1,
+        filled: {
+          x: 2,
+          y1: 0,
+        },
       });
       expect(formattedData[1].data[2]).toEqual({
         datum: undefined,

--- a/src/chart_types/xy_chart/utils/stacked_percent_series_utils.test.ts
+++ b/src/chart_types/xy_chart/utils/stacked_percent_series_utils.test.ts
@@ -1,6 +1,7 @@
 import { getSpecId } from '../../../utils/ids';
 import { RawDataSeries } from './series';
 import { formatStackedDataSeriesValues } from './stacked_series_utils';
+import { ScaleType } from '../../../utils/scales/scales';
 
 describe('Stacked Series Utils', () => {
   const STANDARD_DATA_SET: RawDataSeries[] = [
@@ -162,10 +163,12 @@ describe('Stacked Series Utils', () => {
       data: [{ x: 1, y1: 90 }, { x: 3, y1: 30 }],
     },
   ];
+  const xValues = new Set([0]);
+  const with2NullsXValues = new Set([1, 2, 3, 4]);
 
   describe('Format stacked dataset', () => {
     test('format data without nulls', () => {
-      const formattedData = formatStackedDataSeriesValues(STANDARD_DATA_SET, false, true);
+      const formattedData = formatStackedDataSeriesValues(STANDARD_DATA_SET, false, true, xValues, ScaleType.Linear);
       const data0 = formattedData[0].data[0];
       expect(data0.initialY1).toBe(0.1);
       expect(data0.y0).toBeNull();
@@ -182,7 +185,7 @@ describe('Stacked Series Utils', () => {
       expect(data2.y1).toBe(1);
     });
     test('format data with nulls', () => {
-      const formattedData = formatStackedDataSeriesValues(WITH_NULL_DATASET, false, true);
+      const formattedData = formatStackedDataSeriesValues(WITH_NULL_DATASET, false, true, xValues, ScaleType.Linear);
       const data0 = formattedData[0].data[0];
       expect(data0.initialY1).toBe(0.25);
       expect(data0.y0).toBeNull();
@@ -203,7 +206,13 @@ describe('Stacked Series Utils', () => {
       expect(data2.y1).toBe(1);
     });
     test('format data without nulls with y0 values', () => {
-      const formattedData = formatStackedDataSeriesValues(STANDARD_DATA_SET_WY0, false, true);
+      const formattedData = formatStackedDataSeriesValues(
+        STANDARD_DATA_SET_WY0,
+        false,
+        true,
+        xValues,
+        ScaleType.Linear,
+      );
       const data0 = formattedData[0].data[0];
       expect(data0.initialY0).toBe(0.02);
       expect(data0.initialY1).toBe(0.1);
@@ -223,7 +232,13 @@ describe('Stacked Series Utils', () => {
       expect(data2.y1).toBe(1);
     });
     test('format data with nulls', () => {
-      const formattedData = formatStackedDataSeriesValues(WITH_NULL_DATASET_WY0, false, true);
+      const formattedData = formatStackedDataSeriesValues(
+        WITH_NULL_DATASET_WY0,
+        false,
+        true,
+        xValues,
+        ScaleType.Linear,
+      );
       const data0 = formattedData[0].data[0];
       expect(data0.initialY0).toBe(0.02);
       expect(data0.initialY1).toBe(0.1);
@@ -243,11 +258,16 @@ describe('Stacked Series Utils', () => {
       expect(data2.y1).toBe(1);
     });
     test('format data without nulls on second series', () => {
-      const formattedData = formatStackedDataSeriesValues(DATA_SET_WITH_NULL_2, false, true);
+      const formattedData = formatStackedDataSeriesValues(
+        DATA_SET_WITH_NULL_2,
+        false,
+        true,
+        with2NullsXValues,
+        ScaleType.Linear,
+      );
       expect(formattedData.length).toBe(2);
-      expect(formattedData[0].data.length).toBe(3);
-      expect(formattedData[1].data.length).toBe(2);
-
+      expect(formattedData[0].data.length).toBe(4);
+      expect(formattedData[1].data.length).toBe(4);
       expect(formattedData[0].data[0]).toEqual({
         datum: undefined,
         initialY0: null,
@@ -264,7 +284,7 @@ describe('Stacked Series Utils', () => {
         y0: null,
         y1: 1,
       });
-      expect(formattedData[0].data[2]).toEqual({
+      expect(formattedData[0].data[3]).toEqual({
         datum: undefined,
         initialY0: null,
         initialY1: 1,
@@ -281,6 +301,14 @@ describe('Stacked Series Utils', () => {
         y1: 1,
       });
       expect(formattedData[1].data[1]).toEqual({
+        datum: undefined,
+        initialY0: null,
+        initialY1: 0,
+        x: 2,
+        y0: 1,
+        y1: 1,
+      });
+      expect(formattedData[1].data[2]).toEqual({
         datum: undefined,
         initialY0: null,
         initialY1: 1,

--- a/src/chart_types/xy_chart/utils/stacked_series_utils.test.ts
+++ b/src/chart_types/xy_chart/utils/stacked_series_utils.test.ts
@@ -1,6 +1,7 @@
 import { getSpecId } from '../../../utils/ids';
 import { RawDataSeries } from './series';
 import { computeYStackedMapValues, formatStackedDataSeriesValues, getYValueStackMap } from './stacked_series_utils';
+import { ScaleType } from '../../../utils/scales/scales';
 
 describe('Stacked Series Utils', () => {
   const EMPTY_DATA_SET: RawDataSeries[] = [
@@ -170,13 +171,16 @@ describe('Stacked Series Utils', () => {
       data: [{ x: 1, y1: 21 }, { x: 3, y1: 23 }],
     },
   ];
+  const xValues = new Set([0]);
+  const emptyXValues: Set<number> = new Set();
+  const with2NullsXValues = new Set([1, 2, 3, 4]);
   describe('create stacked maps', () => {
     test('with empty values', () => {
-      const stackedMap = getYValueStackMap(EMPTY_DATA_SET);
+      const stackedMap = getYValueStackMap(EMPTY_DATA_SET, emptyXValues);
       expect(stackedMap.size).toBe(0);
     });
     test('with basic values', () => {
-      const stackedMap = getYValueStackMap(STANDARD_DATA_SET);
+      const stackedMap = getYValueStackMap(STANDARD_DATA_SET, xValues);
       expect(stackedMap.size).toBe(1);
       const x0StackArray = stackedMap.get(0)!;
       expect(x0StackArray).toBeDefined();
@@ -185,7 +189,7 @@ describe('Stacked Series Utils', () => {
       // expect(x0StackArray).toEqual([10, 20, 30]);
     });
     test('with values with nulls', () => {
-      const stackedMap = getYValueStackMap(WITH_NULL_DATASET);
+      const stackedMap = getYValueStackMap(WITH_NULL_DATASET, xValues);
       expect(stackedMap.size).toBe(1);
       const x0StackArray = stackedMap.get(0)!;
       expect(x0StackArray).toBeDefined();
@@ -195,14 +199,14 @@ describe('Stacked Series Utils', () => {
   });
   describe('compute stacked arrays', () => {
     test('with empty values', () => {
-      const stackedMap = getYValueStackMap(EMPTY_DATA_SET);
+      const stackedMap = getYValueStackMap(EMPTY_DATA_SET, emptyXValues);
       let computedStackedMap = computeYStackedMapValues(stackedMap, false);
       expect(computedStackedMap.size).toBe(0);
       computedStackedMap = computeYStackedMapValues(stackedMap, true);
       expect(computedStackedMap.size).toBe(0);
     });
     test('with basic values', () => {
-      const stackedMap = getYValueStackMap(STANDARD_DATA_SET);
+      const stackedMap = getYValueStackMap(STANDARD_DATA_SET, xValues);
       const computedStackedMap = computeYStackedMapValues(stackedMap, false);
       expect(computedStackedMap.size).toBe(1);
       const x0Array = computedStackedMap.get(0)!;
@@ -212,7 +216,7 @@ describe('Stacked Series Utils', () => {
       expect(x0Array.total).toBe(60);
     });
     test('with null values', () => {
-      const stackedMap = getYValueStackMap(WITH_NULL_DATASET);
+      const stackedMap = getYValueStackMap(WITH_NULL_DATASET, xValues);
       const computedStackedMap = computeYStackedMapValues(stackedMap, false);
       expect(computedStackedMap.size).toBe(1);
       const x0Array = computedStackedMap.get(0)!;
@@ -224,7 +228,7 @@ describe('Stacked Series Utils', () => {
   });
   describe('Format stacked dataset', () => {
     test('format data without nulls', () => {
-      const formattedData = formatStackedDataSeriesValues(STANDARD_DATA_SET, false);
+      const formattedData = formatStackedDataSeriesValues(STANDARD_DATA_SET, false, false, xValues, ScaleType.Linear);
       expect(formattedData[0].data[0]).toEqual({
         datum: undefined,
         initialY0: null,
@@ -251,7 +255,7 @@ describe('Stacked Series Utils', () => {
       });
     });
     test('format data with nulls', () => {
-      const formattedData = formatStackedDataSeriesValues(WITH_NULL_DATASET, false);
+      const formattedData = formatStackedDataSeriesValues(WITH_NULL_DATASET, false, false, xValues, ScaleType.Linear);
       expect(formattedData[1].data[0]).toEqual({
         datum: undefined,
         initialY0: null,
@@ -262,7 +266,13 @@ describe('Stacked Series Utils', () => {
       });
     });
     test('format data without nulls with y0 values', () => {
-      const formattedData = formatStackedDataSeriesValues(STANDARD_DATA_SET_WY0, false);
+      const formattedData = formatStackedDataSeriesValues(
+        STANDARD_DATA_SET_WY0,
+        false,
+        false,
+        xValues,
+        ScaleType.Linear,
+      );
       expect(formattedData[0].data[0]).toEqual({
         datum: undefined,
         initialY0: 2,
@@ -289,7 +299,13 @@ describe('Stacked Series Utils', () => {
       });
     });
     test('format data with nulls', () => {
-      const formattedData = formatStackedDataSeriesValues(WITH_NULL_DATASET_WY0, false);
+      const formattedData = formatStackedDataSeriesValues(
+        WITH_NULL_DATASET_WY0,
+        false,
+        false,
+        xValues,
+        ScaleType.Linear,
+      );
       expect(formattedData[0].data[0]).toEqual({
         datum: undefined,
         initialY0: 2,
@@ -316,10 +332,16 @@ describe('Stacked Series Utils', () => {
       });
     });
     test('format data without nulls on second series', () => {
-      const formattedData = formatStackedDataSeriesValues(DATA_SET_WITH_NULL_2, false);
+      const formattedData = formatStackedDataSeriesValues(
+        DATA_SET_WITH_NULL_2,
+        false,
+        false,
+        with2NullsXValues,
+        ScaleType.Linear,
+      );
       expect(formattedData.length).toBe(2);
-      expect(formattedData[0].data.length).toBe(3);
-      expect(formattedData[1].data.length).toBe(2);
+      expect(formattedData[0].data.length).toBe(4);
+      expect(formattedData[1].data.length).toBe(4);
 
       expect(formattedData[0].data[0]).toEqual({
         datum: undefined,
@@ -337,7 +359,7 @@ describe('Stacked Series Utils', () => {
         y0: null,
         y1: 2,
       });
-      expect(formattedData[0].data[2]).toEqual({
+      expect(formattedData[0].data[3]).toEqual({
         datum: undefined,
         initialY0: null,
         initialY1: 4,
@@ -353,7 +375,7 @@ describe('Stacked Series Utils', () => {
         y0: 1,
         y1: 22,
       });
-      expect(formattedData[1].data[1]).toEqual({
+      expect(formattedData[1].data[2]).toEqual({
         datum: undefined,
         initialY0: null,
         initialY1: 23,

--- a/src/components/legend/legend.tsx
+++ b/src/components/legend/legend.tsx
@@ -169,25 +169,21 @@ class LegendComponent extends React.Component<LegendProps, LegendState> {
     const tooltipValues = legendItemTooltipValues.get();
     const legendValues = this.getLegendValues(tooltipValues, key, banded);
 
-    return (
-      <>
-        {legendValues.map((value, index) => {
-          const yAccessor: AccessorType = index === 0 ? AccessorType.Y1 : AccessorType.Y0;
-          return (
-            <LegendItem
-              {...item}
-              label={this.getItemLabel(item, yAccessor)}
-              key={`${key}-${yAccessor}`}
-              legendItemKey={key}
-              legendPosition={legendPosition.get()}
-              displayValue={isCursorOnChart.get() ? value : displayValue.formatted[yAccessor]}
-              onMouseEnter={this.onLegendItemMouseover(key)}
-              onMouseLeave={this.onLegendItemMouseout}
-            />
-          );
-        })}
-      </>
-    );
+    return legendValues.map((value, index) => {
+      const yAccessor: AccessorType = index === 0 ? AccessorType.Y1 : AccessorType.Y0;
+      return (
+        <LegendItem
+          {...item}
+          label={this.getItemLabel(item, yAccessor)}
+          key={`${key}-${yAccessor}`}
+          legendItemKey={key}
+          legendPosition={legendPosition.get()}
+          displayValue={isCursorOnChart.get() ? value : displayValue.formatted[yAccessor]}
+          onMouseEnter={this.onLegendItemMouseover(key)}
+          onMouseLeave={this.onLegendItemMouseout}
+        />
+      );
+    });
   };
 }
 

--- a/src/components/react_canvas/reactive_chart.tsx
+++ b/src/components/react_canvas/reactive_chart.tsx
@@ -355,10 +355,10 @@ class Chart extends React.Component<ReactiveChartProps, ReactiveChartState> {
   sortAndRenderElements() {
     const { chartRotation, chartDimensions } = this.props.chartStore!;
     const clippings = {
-      clipX: 0,
-      clipY: 0,
-      clipWidth: [90, -90].includes(chartRotation) ? chartDimensions.height : chartDimensions.width,
-      clipHeight: [90, -90].includes(chartRotation) ? chartDimensions.width : chartDimensions.height,
+      clipX: -1,
+      clipY: -1,
+      clipWidth: ([90, -90].includes(chartRotation) ? chartDimensions.height : chartDimensions.width) + 1,
+      clipHeight: ([90, -90].includes(chartRotation) ? chartDimensions.width : chartDimensions.height) + 1,
     };
 
     const bars = this.renderBarSeries(clippings);

--- a/src/utils/commons.ts
+++ b/src/utils/commons.ts
@@ -123,3 +123,7 @@ export function mergePartial<T>(
 
   return getPartialValue<T>(base, partial, additionalPartials);
 }
+
+export function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((element) => typeof element === 'number');
+}

--- a/stories/bar_chart.tsx
+++ b/stories/bar_chart.tsx
@@ -88,7 +88,7 @@ storiesOf('Bar Chart', module)
       hideClippedValue,
     };
 
-    const debug = boolean('debug', true);
+    const debug = boolean('debug', false);
     const chartRotation = select<Rotation>(
       'chartRotation',
       {
@@ -133,7 +133,7 @@ storiesOf('Bar Chart', module)
 
     return (
       <Chart renderer="canvas" className={'story-chart'}>
-        <Settings theme={theme} debug={debug} rotation={chartRotation} />
+        <Settings theme={theme} debug={debug} rotation={chartRotation} showLegend />
         <Axis id={getAxisId('bottom')} position={Position.Bottom} title={'Bottom axis'} showOverlappingTicks={true} />
         <Axis
           id={getAxisId('left2')}
@@ -141,7 +141,7 @@ storiesOf('Bar Chart', module)
           position={Position.Left}
           tickFormat={(d: any) => Number(d).toFixed(2)}
         />
-        <BarSeries
+        <LineSeries
           id={getSpecId('bars')}
           displayValueSettings={displayValueSettings}
           xScaleType={ScaleType.Linear}
@@ -153,7 +153,7 @@ storiesOf('Bar Chart', module)
           data={data}
           yScaleToDataExtent={false}
         />
-        <BarSeries
+        <LineSeries
           id={getSpecId('bars2')}
           displayValueSettings={displayValueSettings}
           xScaleType={ScaleType.Linear}


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/elastic-charts/issues/388

Before the fix

<img width="827" alt="Screenshot 2019-10-07 at 22 36 10" src="https://user-images.githubusercontent.com/666475/65450652-a4a82400-de0b-11e9-82e0-fa7d1b8bde52.png">


After the fix:

<img width="827" alt="Screenshot 2019-10-07 at 22 36 10" src="https://user-images.githubusercontent.com/1421091/66346665-eaf49b80-e952-11e9-9624-0228ccacfe5c.png">


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
