### PR TITLE
fix: mixing bars with line or area series breaks legend toggle

### DIFF
--- a/src/chart_types/xy_chart/utils/scales.test.ts
+++ b/src/chart_types/xy_chart/utils/scales.test.ts
@@ -162,4 +162,36 @@ describe('Series scales', () => {
     expect(stackedBarsInCluster).toBe(2);
     expect(totalBarsInCluster).toBe(14);
   });
+  describe('bandwidth when totalBarsInCluster is greater than 0 or less than 0', () => {
+    const xDomainLinear: XDomain = {
+      type: 'xDomain',
+      isBandScale: true,
+      domain: [0, 3],
+      minInterval: 1,
+      scaleType: ScaleType.Linear,
+    };
+    const maxRange = 120;
+    const scaleOver0 = computeXScale({
+      xDomain: xDomainLinear,
+      totalBarsInCluster: 2,
+      range: [0, maxRange],
+      barsPadding: 0,
+      enableHistogramMode: false,
+    });
+
+    test('totalBarsInCluster greater than 0', () => {
+      expect(scaleOver0.bandwidth).toBe(maxRange / 4 / 2);
+    });
+
+    const scaleUnder0 = computeXScale({
+      xDomain: xDomainLinear,
+      totalBarsInCluster: 0,
+      range: [0, maxRange],
+      barsPadding: 0,
+      enableHistogramMode: false,
+    });
+    test('totalBarsInCluster less than 0', () => {
+      expect(scaleUnder0.bandwidth).toBe(maxRange / 4);
+    });
+  });
 });

--- a/src/chart_types/xy_chart/utils/scales.ts
+++ b/src/chart_types/xy_chart/utils/scales.ts
@@ -51,7 +51,6 @@ function getBandScaleRange(
   const rangeEndOffset = isSingleValueHistogram ? 0 : bandwidth;
   const start = isInverse ? minRange - rangeEndOffset : minRange;
   const end = isInverse ? maxRange : maxRange - rangeEndOffset;
-
   return { start, end };
 }
 
@@ -100,7 +99,7 @@ export function computeXScale(options: XScaleOptions): Scale {
           range: [start, end],
         },
         {
-          bandwidth: totalBarsInCluster > 0 ? bandwidth / totalBarsInCluster : 0,
+          bandwidth: totalBarsInCluster > 0 ? bandwidth / totalBarsInCluster : bandwidth / 1,
           minInterval,
           timeZone,
           totalBarsInCluster,

--- a/src/chart_types/xy_chart/utils/scales.ts
+++ b/src/chart_types/xy_chart/utils/scales.ts
@@ -100,7 +100,7 @@ export function computeXScale(options: XScaleOptions): Scale {
           range: [start, end],
         },
         {
-          bandwidth: bandwidth / totalBarsInCluster,
+          bandwidth: totalBarsInCluster > 0 ? bandwidth / totalBarsInCluster : 0,
           minInterval,
           timeZone,
           totalBarsInCluster,

--- a/src/chart_types/xy_chart/utils/scales.ts
+++ b/src/chart_types/xy_chart/utils/scales.ts
@@ -99,7 +99,7 @@ export function computeXScale(options: XScaleOptions): Scale {
           range: [start, end],
         },
         {
-          bandwidth: totalBarsInCluster > 0 ? bandwidth / totalBarsInCluster : bandwidth / 1,
+          bandwidth: totalBarsInCluster > 0 ? bandwidth / totalBarsInCluster : bandwidth,
           minInterval,
           timeZone,
           totalBarsInCluster,


### PR DESCRIPTION
## Summary

Fixes #399 

![PR410](https://user-images.githubusercontent.com/20343860/66429415-3a7bab80-e9d5-11e9-87e1-c16ebc739e24.gif)

The initial commit 4f2346e cast bandwidth in `scales.ts` in ` function computeXScale` to 0 instead of the original issue where bandwidth was being divided by 0.

Commit 209560a changed bandwidth to be `bandwidth/1` (instead of 0) which seems to be working as expected. My initial pass at this was to resolve the bug and get the x axis sizing appropriately based on the series that is visible. I plan to write or add to any unit tests but was hoping to get an initial first review to gather some feedback. Thanks!

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
~~- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials~~
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
