### PR TITLE
fix(tooltip): fix spec naming

### DIFF
--- a/src/chart_types/xy_chart/tooltip/tooltip.test.ts
+++ b/src/chart_types/xy_chart/tooltip/tooltip.test.ts
@@ -95,6 +95,15 @@ describe('Tooltip formatting', () => {
     expect(tooltipValue.color).toBe('blue');
     expect(tooltipValue.value).toBe('10');
   });
+  it('should set name as spec name when provided', () => {
+    const name = 'test - spec';
+    const tooltipValue = formatTooltip(indexedBandedGeometry, { ...SPEC_1, name }, false, false, YAXIS_SPEC);
+    expect(tooltipValue.name).toBe(name);
+  });
+  it('should set name as spec id when name is not provided', () => {
+    const tooltipValue = formatTooltip(indexedBandedGeometry, SPEC_1, false, false, YAXIS_SPEC);
+    expect(tooltipValue.name).toBe(SPEC_1.id);
+  });
   test('format banded tooltip - upper', () => {
     const tooltipValue = formatTooltip(indexedBandedGeometry, bandedSpec, false, false, YAXIS_SPEC);
     expect(tooltipValue.name).toBe('bar_1 - upper');

--- a/src/chart_types/xy_chart/tooltip/tooltip.ts
+++ b/src/chart_types/xy_chart/tooltip/tooltip.ts
@@ -55,7 +55,7 @@ export function formatTooltip(
   if (seriesKey.length > 0) {
     displayName = seriesKey.join(' - ');
   } else {
-    displayName = name || `${spec.id}`;
+    displayName = spec.name || `${spec.id}`;
   }
 
   if (isBandedSpec(spec.y0Accessors) && (isAreaSeriesSpec(spec) || isBarSeriesSpec(spec))) {


### PR DESCRIPTION
## Summary

set name to spec name then spec id

name is a global variable in ts and thus was not caught in the typecheck

closes #411

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
