### PR TITLE
fix: align series names on splitted series configuration

### DIFF
--- a/.playground/index.html
+++ b/.playground/index.html
@@ -18,14 +18,12 @@
         position: absolute;
         top: 10px;
         left: 10px;
-        bottom: 10px;
-        right: 10px;
       }
       .chart {
         background: white;
         position: relative;
-        width: 800px;
-        height: 450px;
+        width: 600px;
+        height: 350px;
         margin: 10px;
       }
     </style>

--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -1,13 +1,41 @@
 import React, { Fragment } from 'react';
-import { Axis, Chart, getAxisId, getSpecId, Position, ScaleType, BarSeries } from '../src';
+import { Axis, Chart, getAxisId, getSpecId, Position, ScaleType, BarSeries, Settings } from '../src';
 
-export class Playground extends React.Component {
+export class Playground extends React.Component<{}, { dataLimit: boolean }> {
+  state = {
+    dataLimit: false,
+  };
+  changeData = () => {
+    this.setState((prevState) => {
+      return {
+        dataLimit: !prevState.dataLimit,
+      };
+    });
+  };
   render() {
-    const data = [{ x: 0, y: -4 }, { x: 1, y: -3 }, { x: 2, y: 2 }, { x: 3, y: 1 }];
+    const data = [
+      {
+        g: null,
+        i: 'aa',
+        x: 1571212800000,
+        y: 16,
+        y1: 2,
+      },
+      // {
+      //   x: 1571290200000,
+      //   y: 1,
+      //   y1: 5,
+      //   // g: 'authentication_success',
+      // },
+    ];
     return (
       <Fragment>
+        <div>
+          <button onClick={this.changeData}>Reduce data</button>
+        </div>
         <div className="chart">
           <Chart>
+            <Settings showLegend />
             <Axis id={getAxisId('top')} position={Position.Bottom} title={'Top axis'} />
             <Axis
               id={getAxisId('left2')}
@@ -17,15 +45,14 @@ export class Playground extends React.Component {
             />
 
             <BarSeries
-              id={getSpecId('bars')}
+              id={getSpecId('bars1')}
               xScaleType={ScaleType.Linear}
               yScaleType={ScaleType.Linear}
               xAccessor="x"
               yAccessors={['y']}
               splitSeriesAccessors={['g']}
               stackAccessors={['x']}
-              data={data}
-              yScaleToDataExtent={true}
+              data={data.slice(0, this.state.dataLimit ? 1 : 2)}
             />
           </Chart>
         </div>

--- a/src/chart_types/xy_chart/legend/legend.test.ts
+++ b/src/chart_types/xy_chart/legend/legend.test.ts
@@ -263,4 +263,27 @@ describe('Legends', () => {
     label = getSeriesColorLabel([0], false, spec1);
     expect(label).toBe('0');
   });
+  it('use the splitted value as label if has a single series and splitSeries is used', () => {
+    const specWithSplit: BasicSeriesSpec = {
+      ...spec1,
+      splitSeriesAccessors: ['g'],
+    };
+    let label = getSeriesColorLabel([], true, specWithSplit);
+    expect(label).toBe('Spec 1 title');
+
+    label = getSeriesColorLabel(['a'], true, specWithSplit);
+    expect(label).toBe('a');
+
+    // happens when we have multiple values in splitSeriesAccessor
+    // or we have also multiple yAccessors
+    label = getSeriesColorLabel(['a', 'b'], true, specWithSplit);
+    expect(label).toBe('a - b');
+
+    // happens when the value of a splitSeriesAccessor is null
+    label = getSeriesColorLabel([null], true, specWithSplit);
+    expect(label).toBe('Spec 1 title');
+
+    label = getSeriesColorLabel([], false, specWithSplit);
+    expect(label).toBe('Spec 1 title');
+  });
 });

--- a/src/chart_types/xy_chart/legend/legend.ts
+++ b/src/chart_types/xy_chart/legend/legend.ts
@@ -95,7 +95,7 @@ export function computeLegend(
 }
 
 export function getSeriesColorLabel(
-  colorValues: any[],
+  colorValues: Array<string | number | null | undefined>,
   hasSingleSeries: boolean,
   spec?: BasicSeriesSpec,
 ): string | undefined {
@@ -104,7 +104,11 @@ export function getSeriesColorLabel(
     if (!spec) {
       return;
     }
-    label = spec.name || `${spec.id}`;
+    if (spec.splitSeriesAccessors && colorValues.length > 0 && colorValues[0] !== null) {
+      label = colorValues.join(' - ');
+    } else {
+      label = spec.name || `${spec.id}`;
+    }
   } else {
     label = colorValues.join(' - ');
   }


### PR DESCRIPTION
## Summary

This PR align the series name when using a splitted series accessor. The names of the series now
uses the value coming from the splitted series accessor, independently on how many series are
computed

fix #420

**Before the fix:**
![Oct-17-2019 12-30-12](https://user-images.githubusercontent.com/1421091/67012141-23357000-f0f1-11e9-84ef-f1051847ff7e.gif)


**After the fix:**

![Oct-17-2019 12-30-03](https://user-images.githubusercontent.com/1421091/67012102-144ebd80-f0f1-11e9-8b87-dac8109c6e84.gif)


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
