### PR TITLE
fix: move seedrandom to dependency list

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "react-docgen-typescript-webpack-plugin": "^1.1.0",
     "sass-graph": "^3.0.4",
     "sass-loader": "^7.1.0",
-    "seedrandom": "^3.0.5",
     "semantic-release": "^15.13.19",
     "semantic-release-slack-bot": "^1.2.0",
     "style-loader": "^0.23.1",
@@ -145,6 +144,7 @@
     "react-konva": "16.8.3",
     "react-spring": "^8.0.8",
     "resize-observer-polyfill": "^1.5.1",
+    "seedrandom": "^3.0.5",
     "ts-debounce": "^1.0.0",
     "uuid": "^3.3.2"
   },


### PR DESCRIPTION
## Summary

We are shipping the project with `seedrandom` as devDependency.
Since this is used in `DataGenerator` that is exposed as public module we should move the `seedrandom` devDependency to the dependency list.

see Jenkins errors in Kibana: https://kibana-ci.elastic.co/job/elastic+kibana+pipeline-pull-request/5354/console and the updating PR: https://github.com/elastic/kibana/pull/47939

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- ~[ ] Unit tests were updated or added to match the most common scenarios~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
