### PR TITLE
fix(tickformatter): add timeZone to tickFormatter

### DIFF
--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
-import { Axis, Chart, getAxisId, getSpecId, Position, ScaleType, BarSeries, Settings } from '../src';
+import { Axis, Chart, getAxisId, getSpecId, Position, ScaleType, BarSeries, Settings, niceTimeFormatter } from '../src';
+import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
 
 export class Playground extends React.Component<{}, { dataLimit: boolean }> {
   state = {
@@ -13,21 +14,7 @@ export class Playground extends React.Component<{}, { dataLimit: boolean }> {
     });
   };
   render() {
-    const data = [
-      {
-        g: null,
-        i: 'aa',
-        x: 1571212800000,
-        y: 16,
-        y1: 2,
-      },
-      // {
-      //   x: 1571290200000,
-      //   y: 1,
-      //   y1: 5,
-      //   // g: 'authentication_success',
-      // },
-    ];
+    const { data } = KIBANA_METRICS.metrics.kibana_os_load[0];
     return (
       <Fragment>
         <div>
@@ -36,23 +23,22 @@ export class Playground extends React.Component<{}, { dataLimit: boolean }> {
         <div className="chart">
           <Chart>
             <Settings showLegend />
-            <Axis id={getAxisId('top')} position={Position.Bottom} title={'Top axis'} />
             <Axis
-              id={getAxisId('left2')}
-              title={'Left axis'}
-              position={Position.Left}
-              tickFormat={(d: any) => Number(d).toFixed(2)}
+              id={getAxisId('top')}
+              position={Position.Bottom}
+              title={'Top axis'}
+              tickFormat={niceTimeFormatter([data[0][0], data[data.length - 1][0]])}
             />
+            <Axis id={getAxisId('left2')} title={'Left axis'} position={Position.Left} />
 
             <BarSeries
               id={getSpecId('bars1')}
-              xScaleType={ScaleType.Linear}
+              xScaleType={ScaleType.Time}
               yScaleType={ScaleType.Linear}
-              xAccessor="x"
-              yAccessors={['y']}
-              splitSeriesAccessors={['g']}
-              stackAccessors={['x']}
-              data={data.slice(0, this.state.dataLimit ? 1 : 2)}
+              xAccessor={0}
+              yAccessors={[1]}
+              data={data}
+              timeZone={'utc+8'}
             />
           </Chart>
         </div>

--- a/src/chart_types/xy_chart/tooltip/tooltip.ts
+++ b/src/chart_types/xy_chart/tooltip/tooltip.ts
@@ -1,7 +1,15 @@
 import { TooltipValue, isFollowTooltipType, TooltipType, TooltipValueFormatter } from '../utils/interactions';
 import { IndexedGeometry, isPointOnGeometry, AccessorType } from '../rendering/rendering';
 import { getColorValuesAsString } from '../utils/series';
-import { AxisSpec, BasicSeriesSpec, Rotation, isAreaSeriesSpec, isBandedSpec, isBarSeriesSpec } from '../utils/specs';
+import {
+  AxisSpec,
+  BasicSeriesSpec,
+  Rotation,
+  isAreaSeriesSpec,
+  isBandedSpec,
+  isBarSeriesSpec,
+  TickFormatterOptions,
+} from '../utils/specs';
 import { SpecId, AxisId, GroupId } from '../../../utils/ids';
 import { getAxesSpecForSpecId } from '../store/utils';
 import { Scale } from '../../../utils/scales/scales';
@@ -65,10 +73,11 @@ export function formatTooltip(
   }
 
   const value = isXValue ? x : y;
+  const tickFormatOptions: TickFormatterOptions | undefined = spec.timeZone ? { timeZone: spec.timeZone } : undefined;
   return {
     seriesKey: seriesKeyAsString,
     name: displayName,
-    value: axisSpec ? axisSpec.tickFormat(value) : emptyFormatter(value),
+    value: axisSpec ? axisSpec.tickFormat(value, tickFormatOptions) : emptyFormatter(value),
     color,
     isHighlighted: isXValue ? false : isHighlighted,
     isXValue,

--- a/src/chart_types/xy_chart/utils/specs.ts
+++ b/src/chart_types/xy_chart/utils/specs.ts
@@ -300,9 +300,9 @@ export interface AxisSpec {
   integersOnly?: boolean;
 }
 
-export type TickFormatterOptions = Partial<{
-  timeZone: string;
-}>;
+export type TickFormatterOptions = {
+  timeZone?: string;
+};
 export type TickFormatter = (value: any, options?: TickFormatterOptions) => string;
 
 export interface AxisStyle {

--- a/src/chart_types/xy_chart/utils/specs.ts
+++ b/src/chart_types/xy_chart/utils/specs.ts
@@ -300,7 +300,10 @@ export interface AxisSpec {
   integersOnly?: boolean;
 }
 
-export type TickFormatter = (value: any) => string;
+export type TickFormatterOptions = Partial<{
+  timeZone: string;
+}>;
+export type TickFormatter = (value: any, options?: TickFormatterOptions) => string;
 
 export interface AxisStyle {
   /** Specifies the amount of padding on the tick label bounding box */

--- a/src/utils/data/formatters.ts
+++ b/src/utils/data/formatters.ts
@@ -2,7 +2,7 @@ import { DateTime, Interval } from 'luxon';
 import { TickFormatter, TickFormatterOptions } from '../../chart_types/xy_chart/utils/specs';
 
 export function timeFormatter(format: string): TickFormatter {
-  return (value: number, options?: Partial<TickFormatterOptions>): string => {
+  return (value: number, options?: TickFormatterOptions): string => {
     const dateTimeOptions = options && options.timeZone ? { zone: options.timeZone } : undefined;
     return DateTime.fromMillis(value, dateTimeOptions).toFormat(format);
   };

--- a/src/utils/data/formatters.ts
+++ b/src/utils/data/formatters.ts
@@ -1,14 +1,14 @@
 import { DateTime, Interval } from 'luxon';
+import { TickFormatter, TickFormatterOptions } from '../../chart_types/xy_chart/utils/specs';
 
-type TimeFormatter = (value: number) => string;
-
-export function timeFormatter(format: string): TimeFormatter {
-  return (value: number): string => {
-    return DateTime.fromMillis(value).toFormat(format);
+export function timeFormatter(format: string): TickFormatter {
+  return (value: number, options?: Partial<TickFormatterOptions>): string => {
+    const dateTimeOptions = options && options.timeZone ? { zone: options.timeZone } : undefined;
+    return DateTime.fromMillis(value, dateTimeOptions).toFormat(format);
   };
 }
 
-export function niceTimeFormatter(domain: [number, number]): TimeFormatter {
+export function niceTimeFormatter(domain: [number, number]): TickFormatter {
   const minDate = DateTime.fromMillis(domain[0]);
   const maxDate = DateTime.fromMillis(domain[1]);
   const diff = Interval.fromDateTimes(minDate, maxDate);


### PR DESCRIPTION
## Summary

to correctly handle a the tick formatting on time based series, we need to share the timeZone
parameter to the tickFormatter. When the tickFormatter is an external function, the user can
manually configure that parameter, but for the niceTimeFormatter we don't have that option already.
Instead of adding a breaking change I've added an optional parameter to the tickFormat props to
share the configured timeZone parameter

fix #427

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
