### PR TITLE
fix: legend sizing issue with no initial legend

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "concat:sass": "node scripts/concat_sass.js",
     "autoprefix:css": "yarn postcss dist/*.css --no-map --use autoprefixer -d dist",
     "build": "yarn build:clean && yarn build:ts && yarn build:sass && yarn autoprefix:css && yarn concat:sass",
+    "build:watch": "yarn build:clean && yarn build:sass && yarn autoprefix:css && yarn concat:sass && yarn build:ts -w ",
     "start": "yarn storybook",
     "storybook": "start-storybook -p 9001 -c .storybook --ci",
     "storybook:build": "rm -rf .out && build-storybook -c .storybook -o .out",

--- a/src/components/legend/legend.tsx
+++ b/src/components/legend/legend.tsx
@@ -1,7 +1,6 @@
 import React, { createRef } from 'react';
 import { inject, observer } from 'mobx-react';
 import classNames from 'classnames';
-import { debounce } from 'ts-debounce';
 
 import { isVerticalAxis, isHorizontalAxis } from '../../chart_types/xy_chart/utils/axis_utils';
 import { LegendItem as SeriesLegendItem } from '../../chart_types/xy_chart/legend/legend';
@@ -82,17 +81,19 @@ class LegendComponent extends React.Component<LegendProps, LegendState> {
     );
   }
 
-  tryLegendResize = debounce(() => {
-    const { chartTheme, legendPosition, legendItems } = this.props.chartStore!;
+  tryLegendResize = () => {
+    const { chartInitialized, chartTheme, legendPosition, legendItems } = this.props.chartStore!;
     const { width } = this.state;
 
     if (
       this.echLegend.current &&
       isVerticalAxis(legendPosition.get()) &&
+      !chartInitialized.get() &&
       width === undefined &&
       this.echLegend.current.offsetWidth > 0
     ) {
       const buffer = chartTheme.legend.spacingBuffer;
+      this.legendItemCount = legendItems.size;
 
       this.setState({
         width: this.echLegend.current.offsetWidth + buffer,
@@ -102,11 +103,12 @@ class LegendComponent extends React.Component<LegendProps, LegendState> {
     // Need to reset width to enable downsizing of width
     if (width !== undefined && legendItems.size !== this.legendItemCount) {
       this.legendItemCount = legendItems.size;
+
       this.setState({
         width: undefined,
       });
     }
-  }, 200);
+  };
 
   getLegendListStyle = (position: Position, { chartMargins, legend }: Theme): LegendListStyle => {
     const { top: paddingTop, bottom: paddingBottom, left: paddingLeft, right: paddingRight } = chartMargins;

--- a/src/components/legend/legend.tsx
+++ b/src/components/legend/legend.tsx
@@ -95,7 +95,7 @@ class LegendComponent extends React.Component<LegendProps, LegendState> {
       const buffer = chartTheme.legend.spacingBuffer;
       this.legendItemCount = legendItems.size;
 
-      this.setState({
+      return this.setState({
         width: this.echLegend.current.offsetWidth + buffer,
       });
     }

--- a/src/components/legend/legend.tsx
+++ b/src/components/legend/legend.tsx
@@ -47,7 +47,8 @@ class LegendComponent extends React.Component<LegendProps, LegendState> {
       this.echLegend.current &&
       isVerticalAxis(legendPosition.get()) &&
       this.state.width === undefined &&
-      !chartInitialized.get()
+      !chartInitialized.get() &&
+      this.echLegend.current.offsetWidth > 0
     ) {
       const buffer = chartTheme.legend.spacingBuffer;
 


### PR DESCRIPTION
## Summary

Prevent setting legend width when element width is `0`.

### Fix `0` width legends in lens

#### Before
![Screen Recording 2019-10-24 at 03 33 PM](https://user-images.githubusercontent.com/19007109/67523253-ec70d400-f673-11e9-9df2-d26cefa5ea5b.gif)


#### After
![Screen Recording 2019-10-24 at 03 22 PM](https://user-images.githubusercontent.com/19007109/67522966-550b8100-f673-11e9-9b09-5254cbecc9da.gif)


### Trigger legend to resize (grow/shrink) when legend item count changes

Dynamic charts such as TSBV create dynamic legend content which leaves legends squished when resize is only on initialization.

![Screen Recording 2019-10-24 at 04 07 PM](https://user-images.githubusercontent.com/19007109/67528248-a0775c80-f67e-11e9-85b3-ab2c32c6a2ee.gif)


fixes #367

Adds `build:watch` script to run elastic-charts in watch mode when symlinked to kibana.

### Checklist

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

Verified in Chrome, Firefox, safari and IE. All look good, though IE seems to not be fully supported rn.

![image](https://user-images.githubusercontent.com/19007109/67523842-17a7f300-f675-11e9-93f4-e932c6a3e975.png)


- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
