### PR TITLE
feat(piechart): add piechart spec and basic rendering 

### DIFF
--- a/.playground/index.html
+++ b/.playground/index.html
@@ -20,13 +20,14 @@
         top: 0px;
         left: 0px;
         width: 100%;
+        height: 100%;
       }
       .chart {
         background: white;
         display: inline-block;
         position: relative;
-        width: 1000px;
-        height: 350px;
+        width: 50%;
+        height: 50%;
         margin: 0px;
       }
     </style>

--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -1,22 +1,12 @@
 import React from 'react';
-import {
-  Axis,
-  Chart,
-  getAxisId,
-  getSpecId,
-  Position,
-  ScaleType,
-  Settings,
-  LIGHT_THEME,
-  niceTimeFormatter,
-  LineAnnotation,
-  AnnotationDomainTypes,
-  BarSeries,
-  RectAnnotation,
-} from '../src';
-import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
-export class Playground extends React.Component {
+import { Chart, BarSeries } from '../src';
+
+import { Pie } from '../src/chart_types/pie_chart/specs/pie';
+export class Playground extends React.Component<{}, { isPieShown: boolean }> {
   chartRef: React.RefObject<Chart> = React.createRef();
+  state = {
+    isPieShown: false,
+  };
   onSnapshot = () => {
     if (!this.chartRef.current) {
       return;
@@ -41,51 +31,38 @@ export class Playground extends React.Component {
         document.body.removeChild(link);
     }
   };
-  render() {
-    const data = KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 7);
+  switchSpec = () => {
+    this.setState((prevState) => {
+      return {
+        isPieShown: !prevState.isPieShown,
+      };
+    });
+  };
 
+  render() {
+    const Spec = this.state.isPieShown ? Pie : BarSeries;
     return (
       <>
         <button onClick={this.onSnapshot}>Snapshot</button>
+        <button onClick={this.switchSpec}>Switch Pie - Bar </button>
         <div className="chart">
           <Chart ref={this.chartRef}>
-            <Settings theme={LIGHT_THEME} showLegend={true} />
-            <Axis
-              id={getAxisId('time')}
-              position={Position.Bottom}
-              tickFormat={niceTimeFormatter([data[0][0], data[data.length - 1][0]])}
-            />
-            <Axis id={getAxisId('count')} position={Position.Left} />
-            <LineAnnotation
-              id="line annotation"
-              dataValues={[
+            <Spec
+              id={'test'}
+              data={[
                 {
-                  dataValue: data[5][0],
-                  details: 'hello tooltip',
+                  x: 1,
+                  y: 10,
+                },
+                {
+                  x: 2,
+                  y: 20,
+                },
+                {
+                  x: 3,
+                  y: 30,
                 },
               ]}
-              domainType={AnnotationDomainTypes.XDomain}
-              marker={<div style={{ width: 10, height: 10, background: 'red' }} />}
-            />
-            <RectAnnotation
-              id="rect annotation"
-              dataValues={[
-                {
-                  coordinates: {
-                    x1: data[3][0],
-                  },
-                  details: 'hello',
-                },
-              ]}
-            />
-            <BarSeries
-              id={getSpecId('series bars chart')}
-              xScaleType={ScaleType.Linear}
-              yScaleType={ScaleType.Linear}
-              xAccessor={0}
-              yAccessors={[1]}
-              data={data}
-              yScaleToDataExtent={true}
             />
           </Chart>
         </div>

--- a/src/chart_types/pie_chart/renderer/canvas/pie_chart.tsx
+++ b/src/chart_types/pie_chart/renderer/canvas/pie_chart.tsx
@@ -1,0 +1,118 @@
+import React, { RefObject } from 'react';
+import { bindActionCreators, Dispatch } from 'redux';
+import { connect } from 'react-redux';
+import { Layer, Stage, Path, Group } from 'react-konva';
+import { onChartRendered } from '../../../../state/actions/chart';
+import { isInitialized } from '../../../../state/selectors/is_initialized';
+import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
+import { GlobalChartState } from '../../../../state/chart_state';
+import { Dimensions } from '../../../../utils/dimensions';
+import { Theme } from '../../../../utils/themes/theme';
+import { LIGHT_THEME } from '../../../../utils/themes/light_theme';
+import { ArcGeometry } from '../../../../utils/geometry';
+import { computeGeometriesSelector } from '../../state/selectors/compute_geometries';
+
+interface ReactiveChartStateProps {
+  initialized: boolean;
+  geometries: { arcs?: ArcGeometry[] };
+  chartContainerDimensions: Dimensions;
+  theme: Theme;
+}
+interface ReactiveChartDispatchProps {
+  onChartRendered: typeof onChartRendered;
+}
+interface ReactiveChartOwnProps {
+  forwardStageRef: RefObject<Stage>;
+}
+interface ReactiveChartElementIndex {
+  element: JSX.Element;
+  zIndex: number;
+}
+
+type PieChartProps = ReactiveChartOwnProps & ReactiveChartStateProps & ReactiveChartDispatchProps;
+class PieChartComponent extends React.Component<PieChartProps> {
+  static displayName = 'PieChart';
+  firstRender = true;
+
+  componentDidUpdate() {
+    if (this.props.initialized) {
+      this.props.onChartRendered();
+    }
+  }
+  renderPie = () => {
+    const { geometries } = this.props;
+    if (!geometries.arcs) {
+      return null;
+    }
+
+    return (
+      <Group>
+        {geometries.arcs.map((arc, i) => {
+          return <Path key={i} data={arc.arc} fill={arc.color} x={arc.transform.x} y={arc.transform.y} />;
+        })}
+      </Group>
+    );
+  };
+
+  render() {
+    const { initialized, chartContainerDimensions } = this.props;
+    if (!initialized || chartContainerDimensions.width === 0 || chartContainerDimensions.height === 0) {
+      return null;
+    }
+
+    return (
+      <Stage
+        width={chartContainerDimensions.width}
+        height={chartContainerDimensions.height}
+        ref={this.props.forwardStageRef}
+        style={{
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        <Layer hitGraphEnabled={false} listening={false}>
+          {this.renderPie()}
+        </Layer>
+      </Stage>
+    );
+  }
+}
+
+const mapDispatchToProps = (dispatch: Dispatch): ReactiveChartDispatchProps =>
+  bindActionCreators(
+    {
+      onChartRendered,
+    },
+    dispatch,
+  );
+
+const DEFAULT_PROPS: ReactiveChartStateProps = {
+  initialized: false,
+  theme: LIGHT_THEME,
+  geometries: {
+    arcs: [],
+  },
+  chartContainerDimensions: {
+    width: 0,
+    height: 0,
+    left: 0,
+    top: 0,
+  },
+};
+
+const mapStateToProps = (state: GlobalChartState): ReactiveChartStateProps => {
+  if (!isInitialized(state)) {
+    return DEFAULT_PROPS;
+  }
+  return {
+    initialized: true,
+    theme: getChartThemeSelector(state),
+    geometries: computeGeometriesSelector(state),
+    chartContainerDimensions: state.parentDimensions,
+  };
+};
+
+export const PieChart = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PieChartComponent);

--- a/src/chart_types/pie_chart/specs/pie.tsx
+++ b/src/chart_types/pie_chart/specs/pie.tsx
@@ -1,0 +1,18 @@
+import { PieSpec } from './pie_spec';
+import { ChartTypes } from '../../../chart_types';
+import { specComponentFactory, getConnect } from '../../../state/spec_factory';
+import { SpecTypes } from '../../xy_chart/utils/specs';
+
+const defaultProps = {
+  chartType: ChartTypes.Pie,
+  specType: SpecTypes.Series,
+  yAccessor: 'y',
+  donut: false,
+};
+
+type SpecRequiredProps = Pick<PieSpec, 'id' | 'data'>;
+type SpecOptionalProps = Partial<Omit<PieSpec, 'chartType' | 'specType' | 'id' | 'data'>>;
+
+export const Pie: React.FunctionComponent<SpecRequiredProps & SpecOptionalProps> = getConnect()(
+  specComponentFactory<PieSpec, 'yAccessor' | 'donut'>(defaultProps),
+);

--- a/src/chart_types/pie_chart/specs/pie_spec.ts
+++ b/src/chart_types/pie_chart/specs/pie_spec.ts
@@ -1,0 +1,12 @@
+import { Spec } from '../../../specs';
+import { ChartTypes } from '../..';
+import { SpecTypes, Datum } from '../../xy_chart/utils/specs';
+import { Accessor } from '../../../utils/accessor';
+
+export interface PieSpec extends Spec {
+  specType: typeof SpecTypes.Series;
+  chartType: typeof ChartTypes.Pie;
+  yAccessor: Accessor;
+  data: Datum[];
+  donut: boolean;
+}

--- a/src/chart_types/pie_chart/state/chart_state.tsx
+++ b/src/chart_types/pie_chart/state/chart_state.tsx
@@ -1,0 +1,35 @@
+import React, { RefObject } from 'react';
+import { InternalChartState, BackwardRef } from '../../../state/chart_state';
+import { ChartTypes } from '../..';
+import { Stage } from 'react-konva';
+import { PieChart } from '../renderer/canvas/pie_chart';
+
+const EMPTY_MAP = new Map();
+export class PieChartState implements InternalChartState {
+  chartType = ChartTypes.Pie;
+  isBrushAvailable() {
+    return false;
+  }
+  isBrushing() {
+    return false;
+  }
+  isChartEmpty() {
+    return false;
+  }
+  getLegendItems() {
+    return EMPTY_MAP;
+  }
+  getLegendItemsValues() {
+    return EMPTY_MAP;
+  }
+  chartRenderer(containerRef: BackwardRef, forwardStageRef: RefObject<Stage>) {
+    return (
+      <React.Fragment>
+        <PieChart forwardStageRef={forwardStageRef} />
+      </React.Fragment>
+    );
+  }
+  getPointerCursor() {
+    return 'default';
+  }
+}

--- a/src/chart_types/pie_chart/state/selectors/compute_geometries.ts
+++ b/src/chart_types/pie_chart/state/selectors/compute_geometries.ts
@@ -1,0 +1,56 @@
+import { arc, pie } from 'd3-shape';
+import createCachedSelector from 're-reselect';
+import { GlobalChartState } from '../../../../state/chart_state';
+import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
+import { Theme } from '../../../../utils/themes/theme';
+import { ArcGeometry } from '../../../../utils/geometry';
+import { Dimensions } from '../../../../utils/dimensions';
+import { PieSpec } from '../../specs/pie_spec';
+import { getSpecsFromStore } from '../../../../state/utils';
+import { ChartTypes } from '../../..';
+import { SpecTypes } from '../../../xy_chart/utils/specs';
+
+const getSpecs = (state: GlobalChartState) => state.specs;
+const getParentDimensionsSelector = (state: GlobalChartState) => state.parentDimensions;
+
+function render(pieSpec: PieSpec, parentDimensions: Dimensions, theme: Theme) {
+  const paths = pie().value((d: any) => {
+    return d[pieSpec.yAccessor];
+  })(pieSpec.data);
+  const { width, height } = parentDimensions;
+  const outerRadius = width < height ? width / 2 : height / 2;
+  const innerRadius = pieSpec.donut ? outerRadius / 2 : 0;
+  const arcGenerator = arc();
+  const arcs = paths.map((path, i) => {
+    const arc = arcGenerator({
+      ...path,
+      innerRadius: innerRadius,
+      outerRadius: outerRadius,
+    });
+    return {
+      arc: arc === null ? '' : arc,
+      color: theme.colors.vizColors[i % theme.colors.vizColors.length],
+      transform: {
+        x: width / 2,
+        y: height / 2,
+      },
+      geometryId: {
+        specId: pieSpec.id,
+        seriesKey: [],
+      },
+      seriesArcStyle: theme.arcSeriesStyle.arc,
+    };
+  });
+  return { arcs };
+}
+
+export const computeGeometriesSelector = createCachedSelector(
+  [getSpecs, getParentDimensionsSelector, getChartThemeSelector],
+  (specs, parentDimensions, theme): { arcs?: ArcGeometry[] } => {
+    const pieSpecs = getSpecsFromStore<PieSpec>(specs, ChartTypes.Pie, SpecTypes.Series);
+    if (pieSpecs.length !== 1) {
+      return {};
+    }
+    return render(pieSpecs[0], parentDimensions, theme);
+  },
+)((state) => state.chartId);

--- a/src/chart_types/xy_chart/renderer/canvas/axis.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/axis.tsx
@@ -24,6 +24,7 @@ import { computeChartDimensionsSelector } from '../../state/selectors/compute_ch
 import { LIGHT_THEME } from '../../../../utils/themes/light_theme';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getSpecsById } from '../../state/utils';
+import { ChartTypes } from '../../..';
 
 interface AxisProps {
   theme: Theme;
@@ -286,7 +287,9 @@ class AxesComponent extends React.PureComponent<AxesProps> {
 }
 
 const mapStateToProps = (state: GlobalChartState): AxesProps => {
-  if (!state.specsInitialized) {
+  // check for correct chartType required because <Axis /> live in a different
+  // redux context (see ReactiveChart render method)
+  if (!state.specsInitialized || state.chartType !== ChartTypes.XYAxis) {
     return {
       theme: LIGHT_THEME,
       chartDimensions: {

--- a/src/chart_types/xy_chart/renderer/canvas/bar_values.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/bar_values.tsx
@@ -13,6 +13,7 @@ import { getChartRotationSelector } from '../../../../state/selectors/get_chart_
 import { computeSeriesGeometriesSelector } from '../../state/selectors/compute_series_geometries';
 import { LIGHT_THEME } from '../../../../utils/themes/light_theme';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
+import { ChartTypes } from '../../..';
 
 interface BarValuesProps {
   theme: Theme;
@@ -76,7 +77,9 @@ export class BarValuesComponent extends React.PureComponent<BarValuesProps> {
 }
 
 const mapStateToProps = (state: GlobalChartState): BarValuesProps => {
-  if (!state.specsInitialized) {
+  // check for correct chartType required because <BarValues /> live in a different
+  // redux context (see ReactiveChart render method)
+  if (!state.specsInitialized || state.chartType !== ChartTypes.XYAxis) {
     return {
       theme: LIGHT_THEME,
       chartDimensions: {

--- a/src/chart_types/xy_chart/renderer/canvas/grid.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/grid.tsx
@@ -13,6 +13,7 @@ import { computeAxisVisibleTicksSelector } from '../../state/selectors/compute_a
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { LIGHT_THEME } from '../../../../utils/themes/light_theme';
 import { getSpecsById } from '../../state/utils';
+import { ChartTypes } from '../../..';
 
 interface GridProps {
   chartTheme: Theme;
@@ -54,7 +55,9 @@ class GridComponent extends React.PureComponent<GridProps> {
 }
 
 const mapStateToProps = (state: GlobalChartState): GridProps => {
-  if (!state.specsInitialized) {
+  // check for correct chartType required because <Grid /> leave in a different
+  // redux context (see ReactiveChart render method)
+  if (!state.specsInitialized || state.chartType !== ChartTypes.XYAxis) {
     return {
       chartTheme: LIGHT_THEME,
       chartDimensions: {

--- a/src/chart_types/xy_chart/renderer/canvas/reactive_chart.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/reactive_chart.tsx
@@ -37,6 +37,7 @@ import { getSettingsSpecSelector } from '../../../../state/selectors/get_setting
 import { computeChartDimensionsSelector } from '../../state/selectors/compute_chart_dimensions';
 import { getChartContainerDimensionsSelector } from '../../../../state/selectors/get_chart_container_dimensions';
 import { Clippings } from './bar_values_utils';
+import { ChartTypes } from '../../..';
 
 interface ReactiveChartStateProps {
   initialized: boolean;
@@ -332,7 +333,7 @@ const DEFAULT_PROPS: ReactiveChartStateProps = {
 };
 
 const mapStateToProps = (state: GlobalChartState): ReactiveChartStateProps => {
-  if (!isInitialized(state)) {
+  if (!isInitialized(state) || state.chartType !== ChartTypes.XYAxis) {
     return DEFAULT_PROPS;
   }
   return {

--- a/src/chart_types/xy_chart/state/chart_state.tsx
+++ b/src/chart_types/xy_chart/state/chart_state.tsx
@@ -15,12 +15,16 @@ import { getLegendTooltipValuesSelector } from './selectors/get_legend_tooltip_v
 import { TooltipLegendValue } from '../tooltip/tooltip';
 import { getPointerCursorSelector } from './selectors/get_cursor_pointer';
 import { Stage } from 'react-konva';
+import { isBrushingSelector } from './selectors/is_brushing';
 
 export class XYAxisChartState implements InternalChartState {
   chartType = ChartTypes.XYAxis;
   legendId: string = htmlIdGenerator()('legend');
   isBrushAvailable(globalState: GlobalChartState) {
     return isBrushAvailableSelector(globalState);
+  }
+  isBrushing(globalState: GlobalChartState) {
+    return isBrushingSelector(globalState);
   }
   isChartEmpty(globalState: GlobalChartState) {
     return isChartEmptySelector(globalState);

--- a/src/components/chart_container.tsx
+++ b/src/components/chart_container.tsx
@@ -10,8 +10,8 @@ import { isInternalChartEmptySelector } from '../state/selectors/is_chart_empty'
 import { isInitialized } from '../state/selectors/is_initialized';
 import { getSettingsSpecSelector } from '../state/selectors/get_settings_specs';
 import { SettingsSpec } from '../specs';
-import { isBrushingSelector } from '../chart_types/xy_chart/state/selectors/is_brushing';
 import { Stage } from 'react-konva';
+import { getInternalIsBrushingSelector } from '../state/selectors/get_internal_is_brushing';
 
 interface ReactiveChartStateProps {
   initialized: boolean;
@@ -161,7 +161,7 @@ const mapStateToProps = (state: GlobalChartState): ReactiveChartStateProps => {
     isChartEmpty: isInternalChartEmptySelector(state),
     pointerCursor: getInternalPointerCursor(state),
     isBrushingAvailable: getInternalIsBrushingAvailableSelector(state),
-    isBrushing: isBrushingSelector(state),
+    isBrushing: getInternalIsBrushingSelector(state),
     internalChartRenderer: getInternalChartRendererSelector(state),
     settings: getSettingsSpecSelector(state),
   };

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -15,6 +15,7 @@ import { UPDATE_PARENT_DIMENSION } from './actions/chart_settings';
 import { EXTERNAL_POINTER_EVENT } from './actions/events';
 import { RefObject } from 'react';
 import { Stage } from 'react-konva';
+import { PieChartState } from '../chart_types/pie_chart/state/chart_state';
 
 export type BackwardRef = () => React.RefObject<HTMLDivElement>;
 
@@ -29,6 +30,8 @@ export interface InternalChartState {
   chartRenderer(containerRef: BackwardRef, forwardStageRef: RefObject<Stage>): JSX.Element | null;
   // true if the brush is available for this chart type
   isBrushAvailable(globalState: GlobalChartState): boolean;
+  // true if the brush is available for this chart type
+  isBrushing(globalState: GlobalChartState): boolean;
   // true if the chart is empty (no data displayed)
   isChartEmpty(globalState: GlobalChartState): boolean;
   // return the list of legend items
@@ -258,7 +261,7 @@ function findMainChartType(specs: SpecList): ChartTypes | null {
 function initInternalChartState(chartType: ChartTypes | null): InternalChartState | null {
   switch (chartType) {
     case ChartTypes.Pie:
-      return null; // TODO add pie chart state
+      return new PieChartState();
     case ChartTypes.XYAxis:
       return new XYAxisChartState();
     default:

--- a/src/state/selectors/get_internal_is_brushing.ts
+++ b/src/state/selectors/get_internal_is_brushing.ts
@@ -1,0 +1,9 @@
+import { GlobalChartState } from '../chart_state';
+
+export const getInternalIsBrushingSelector = (state: GlobalChartState): boolean => {
+  if (state.internalChartState) {
+    return state.internalChartState.isBrushing(state);
+  } else {
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary

This PR implement a basic rendering for a Pie chart with a simplified spec configuration.

To Do:
- [ ] handle switching specs between bar and pie on the chart configuration (seems that we have to terminate the created selectors)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
- [ ] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
