### PR TITLE
fix(highlighter): hide it when tooltip type is None

### DIFF
--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -1,19 +1,5 @@
 import React from 'react';
-import {
-  Axis,
-  Chart,
-  getAxisId,
-  getSpecId,
-  Position,
-  ScaleType,
-  Settings,
-  LIGHT_THEME,
-  niceTimeFormatter,
-  LineAnnotation,
-  AnnotationDomainTypes,
-  BarSeries,
-  RectAnnotation,
-} from '../src';
+import { Chart, Settings, TooltipType, LineSeries } from '../src';
 import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
 export class Playground extends React.Component {
   chartRef: React.RefObject<Chart> = React.createRef();
@@ -42,50 +28,17 @@ export class Playground extends React.Component {
     }
   };
   render() {
-    const data = KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 7);
-
     return (
       <>
         <button onClick={this.onSnapshot}>Snapshot</button>
         <div className="chart">
-          <Chart ref={this.chartRef}>
-            <Settings theme={LIGHT_THEME} showLegend={true} />
-            <Axis
-              id={getAxisId('time')}
-              position={Position.Bottom}
-              tickFormat={niceTimeFormatter([data[0][0], data[data.length - 1][0]])}
-            />
-            <Axis id={getAxisId('count')} position={Position.Left} />
-            <LineAnnotation
-              id="line annotation"
-              dataValues={[
-                {
-                  dataValue: data[5][0],
-                  details: 'hello tooltip',
-                },
-              ]}
-              domainType={AnnotationDomainTypes.XDomain}
-              marker={<div style={{ width: 10, height: 10, background: 'red' }} />}
-            />
-            <RectAnnotation
-              id="rect annotation"
-              dataValues={[
-                {
-                  coordinates: {
-                    x1: data[3][0],
-                  },
-                  details: 'hello',
-                },
-              ]}
-            />
-            <BarSeries
-              id={getSpecId('series bars chart')}
-              xScaleType={ScaleType.Linear}
-              yScaleType={ScaleType.Linear}
+          <Chart>
+            <Settings tooltip={{ type: TooltipType.Follow }} showLegend />
+            <LineSeries
+              id="lines"
               xAccessor={0}
               yAccessors={[1]}
-              data={data}
-              yScaleToDataExtent={true}
+              data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
             />
           </Chart>
         </div>

--- a/src/chart_types/xy_chart/state/chart_state.interactions.test.ts
+++ b/src/chart_types/xy_chart/state/chart_state.interactions.test.ts
@@ -212,10 +212,8 @@ describe('Chart state pointer interactions', () => {
     store.dispatch(specParsed());
     store.dispatch(onPointerMove({ x: 10, y: 10 + 70 }, 0));
     const tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
-    expect(tooltipData.tooltipValues.length).toBe(2);
-    expect(tooltipData.tooltipValues[0].isXValue).toBe(true);
-    expect(tooltipData.tooltipValues[1].isXValue).toBe(false);
-    expect(tooltipData.tooltipValues[1].isHighlighted).toBe(true);
+    // no tooltip values exist if we have a TooltipType === None
+    expect(tooltipData.tooltipValues.length).toBe(0);
     let isTooltipVisible = isTooltipVisibleSelector(store.getState());
     expect(isTooltipVisible).toBe(false);
 

--- a/src/chart_types/xy_chart/state/chart_state.tooltip.test.ts
+++ b/src/chart_types/xy_chart/state/chart_state.tooltip.test.ts
@@ -1,0 +1,45 @@
+import { GlobalChartState, chartStoreReducer } from '../../../state/chart_state';
+import { createStore, Store } from 'redux';
+import { upsertSpec, specParsed } from '../../../state/actions/specs';
+import { MockSeriesSpec, MockGlobalSpec } from '../../../mocks/specs';
+import { updateParentDimensions } from '../../../state/actions/chart_settings';
+import { getTooltipValuesAndGeometriesSelector } from './selectors/get_tooltip_values_highlighted_geoms';
+import { onPointerMove } from '../../../state/actions/mouse';
+import { TooltipType } from '../utils/interactions';
+
+describe('XYChart - State tooltips', () => {
+  let store: Store<GlobalChartState>;
+  beforeEach(() => {
+    const storeReducer = chartStoreReducer('chartId');
+    store = createStore(storeReducer);
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ data: [{ x: 1, y: 10 }, { x: 2, y: 5 }] })));
+    store.dispatch(upsertSpec(MockGlobalSpec.settings()));
+    store.dispatch(specParsed());
+    store.dispatch(updateParentDimensions({ width: 100, height: 100, top: 0, left: 0 }));
+  });
+
+  describe('should compute tooltip values depending on tooltip type', () => {
+    it.each<[TooltipType, number, number]>([
+      [TooltipType.None, 0, 0],
+      [TooltipType.Follow, 1, 2],
+      [TooltipType.VerticalCursor, 1, 2],
+      [TooltipType.Crosshairs, 1, 2],
+    ])('tooltip type %s', (tooltipType, expectedHgeomsLength, expectedTooltipValuesLength) => {
+      store.dispatch(onPointerMove({ x: 25, y: 50 }, 0));
+      store.dispatch(
+        upsertSpec(
+          MockGlobalSpec.settings({
+            tooltip: {
+              type: tooltipType,
+            },
+          }),
+        ),
+      );
+      store.dispatch(specParsed());
+      const state = store.getState();
+      const tooltipValues = getTooltipValuesAndGeometriesSelector(state);
+      expect(tooltipValues.tooltipValues).toHaveLength(expectedTooltipValuesLength);
+      expect(tooltipValues.highlightedGeometries).toHaveLength(expectedHgeomsLength);
+    });
+  });
+});

--- a/src/chart_types/xy_chart/state/selectors/get_specs.test.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_specs.test.ts
@@ -1,23 +1,12 @@
 import { getSeriesSpecsSelector } from './get_specs';
 import { getInitialState } from '../../../../state/chart_state';
-import { ChartTypes } from '../../..';
-import { SpecTypes } from '../../utils/specs';
+import { MockSeriesSpec } from '../../../../mocks/specs';
 
 describe('selector - get_specs', () => {
   const state = getInitialState('chartId1');
-  const barSpec1 = {
-    id: 'bars1',
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
-  };
-  const barSpec2 = {
-    id: 'bars2',
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
-  };
   beforeEach(() => {
-    state.specs['bars1'] = barSpec1;
-    state.specs['bars2'] = barSpec2;
+    state.specs['bars1'] = MockSeriesSpec.bar({ id: 'bars1' });
+    state.specs['bars2'] = MockSeriesSpec.bar({ id: 'bars2' });
   });
   it('shall return the same ref objects', () => {
     const series = getSeriesSpecsSelector(state);

--- a/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
@@ -67,6 +67,9 @@ function getTooltipAndHighlightFromXValue(
   if (!scales.xScale || !scales.yScales) {
     return EMPTY_VALUES;
   }
+  if (tooltipType === TooltipType.None) {
+    return EMPTY_VALUES;
+  }
   let x = orientedProjectedPointerPosition.x;
   let y = orientedProjectedPointerPosition.y;
   if (externalPointerEvent && isValidExternalPointerEvent(externalPointerEvent, scales.xScale)) {

--- a/src/mocks/specs/specs.ts
+++ b/src/mocks/specs/specs.ts
@@ -10,10 +10,14 @@ import {
   BasicSeriesSpec,
   SpecTypes,
   SeriesTypes,
+  Position,
 } from '../../chart_types/xy_chart/utils/specs';
 import { getSpecId, getGroupId } from '../../utils/ids';
 import { ScaleType } from '../../utils/scales/scales';
 import { ChartTypes } from '../../chart_types';
+import { SettingsSpec } from '../../specs';
+import { TooltipType } from '../../chart_types/xy_chart/utils/interactions';
+import { LIGHT_THEME } from '../../utils/themes/light_theme';
 
 export class MockSeriesSpec {
   private static readonly barBase: BarSeriesSpec = {
@@ -104,13 +108,10 @@ export class MockSeriesSpec {
     switch (type) {
       case 'line':
         return MockSeriesSpec.lineBase;
-        break;
       case 'bar':
         return MockSeriesSpec.barBase;
-        break;
       case 'area':
         return MockSeriesSpec.areaBase;
-        break;
       default:
         return MockSeriesSpec.barBase;
     }
@@ -131,5 +132,31 @@ export class MockSeriesSpecs {
 
   static empty(): SeriesSpecs {
     return [];
+  }
+}
+
+export class MockGlobalSpec {
+  private static readonly settingsBase: SettingsSpec = {
+    id: '__global__settings___',
+    chartType: ChartTypes.Global,
+    specType: SpecTypes.Settings,
+    rendering: 'canvas' as 'canvas',
+    rotation: 0 as 0,
+    animateData: true,
+    showLegend: false,
+    resizeDebounce: 10,
+    debug: false,
+    tooltip: {
+      type: TooltipType.VerticalCursor,
+      snap: true,
+    },
+    legendPosition: Position.Right,
+    showLegendDisplayValue: true,
+    hideDuplicateAxes: false,
+    theme: LIGHT_THEME,
+  };
+
+  static settings(partial?: Partial<SettingsSpec>): SettingsSpec {
+    return mergePartial<SettingsSpec>(MockGlobalSpec.settingsBase, partial, { mergeOptionalPartialValues: true });
   }
 }

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -112,7 +112,7 @@ export type DefaultSettingsProps =
 export const DEFAULT_TOOLTIP_TYPE = TooltipType.VerticalCursor;
 export const DEFAULT_TOOLTIP_SNAP = true;
 
-export const DEFAULT_SETTINGS_SPEC = {
+export const DEFAULT_SETTINGS_SPEC: SettingsSpec = {
   id: '__global__settings___',
   chartType: ChartTypes.Global,
   specType: SpecTypes.Settings,
@@ -125,7 +125,6 @@ export const DEFAULT_SETTINGS_SPEC = {
   tooltip: {
     type: DEFAULT_TOOLTIP_TYPE,
     snap: DEFAULT_TOOLTIP_SNAP,
-    value: '',
   },
   legendPosition: Position.Right,
   showLegendDisplayValue: true,

--- a/src/utils/commons.test.ts
+++ b/src/utils/commons.test.ts
@@ -7,7 +7,7 @@ import {
   RecursivePartial,
   getPartialValue,
   getAllKeys,
-  simpleClone,
+  shallowClone,
 } from './commons';
 
 describe('commons utilities', () => {
@@ -129,34 +129,34 @@ describe('commons utilities', () => {
     });
   });
 
-  describe('simpleClone', () => {
+  describe('shallowClone', () => {
     const obj = { value: 'test' };
     const arr = ['test'];
 
     it('should clone object', () => {
-      const result = simpleClone(obj);
+      const result = shallowClone(obj);
 
       expect(result).toEqual(obj);
       expect(result).not.toBe(obj);
     });
 
     it('should clone array', () => {
-      const result = simpleClone(arr);
+      const result = shallowClone(arr);
 
       expect(result).toEqual(arr);
       expect(result).not.toBe(arr);
     });
 
     it('should return simple values', () => {
-      expect(simpleClone(false)).toBe(false);
-      expect(simpleClone(true)).toBe(true);
-      expect(simpleClone('string')).toBe('string');
-      expect(simpleClone(10)).toBe(10);
-      expect(simpleClone(undefined)).toBeUndefined();
+      expect(shallowClone(false)).toBe(false);
+      expect(shallowClone(true)).toBe(true);
+      expect(shallowClone('string')).toBe('string');
+      expect(shallowClone(10)).toBe(10);
+      expect(shallowClone(undefined)).toBeUndefined();
     });
 
     it('should return null', () => {
-      expect(simpleClone(null)).toBeNull();
+      expect(shallowClone(null)).toBeNull();
     });
   });
 

--- a/src/utils/commons.test.ts
+++ b/src/utils/commons.test.ts
@@ -157,6 +157,36 @@ describe('commons utilities', () => {
     beforeAll(() => {
       baseClone = JSON.parse(JSON.stringify(base)) as TestType;
     });
+    // skipped until we fix https://github.com/elastic/elastic-charts/issues/479
+    test.skip('should override union types', () => {
+      type TestObject = { string1?: string; string2?: string };
+      interface TestUnionType {
+        union: 'val1' | 'val2' | TestObject;
+      }
+      expect(
+        mergePartial<TestUnionType>(
+          { union: 'val2' },
+          { union: { string1: 'other' } },
+          { mergeOptionalPartialValues: true },
+        ),
+      ).toEqual({
+        union: { string1: 'other' },
+      });
+    });
+    // skipped until we fix https://github.com/elastic/elastic-charts/issues/479
+    test.skip('should override union types', () => {
+      type TestObject = { string1?: string; string2?: string };
+      interface TestUnionType {
+        union: 'val1' | 'val2' | TestObject;
+      }
+      expect(
+        mergePartial<TestUnionType>(
+          { union: { string1: 'other' } },
+          { union: 'val2' },
+          { mergeOptionalPartialValues: true },
+        ),
+      ).toEqual({ union: 'val2' });
+    });
 
     test('should allow partial to be undefined', () => {
       expect(mergePartial('test')).toBe('test');

--- a/src/utils/commons.test.ts
+++ b/src/utils/commons.test.ts
@@ -2,10 +2,12 @@ import {
   clamp,
   compareByValueAsc,
   identity,
+  hasPartialObjectToMerge,
   mergePartial,
   RecursivePartial,
   getPartialValue,
   getAllKeys,
+  simpleClone,
 } from './commons';
 
 describe('commons utilities', () => {
@@ -127,6 +129,69 @@ describe('commons utilities', () => {
     });
   });
 
+  describe('simpleClone', () => {
+    const obj = { value: 'test' };
+    const arr = ['test'];
+
+    it('should clone object', () => {
+      const result = simpleClone(obj);
+
+      expect(result).toEqual(obj);
+      expect(result).not.toBe(obj);
+    });
+
+    it('should clone array', () => {
+      const result = simpleClone(arr);
+
+      expect(result).toEqual(arr);
+      expect(result).not.toBe(arr);
+    });
+
+    it('should return simple values', () => {
+      expect(simpleClone(false)).toBe(false);
+      expect(simpleClone(true)).toBe(true);
+      expect(simpleClone('string')).toBe('string');
+      expect(simpleClone(10)).toBe(10);
+      expect(simpleClone(undefined)).toBeUndefined();
+    });
+
+    it('should return null', () => {
+      expect(simpleClone(null)).toBeNull();
+    });
+  });
+
+  describe('hasPartialObjectToMerge', () => {
+    it('should return false if base is an array', () => {
+      const result = hasPartialObjectToMerge([]);
+      expect(result).toBe(false);
+    });
+
+    it('should return true if base and partial are objects', () => {
+      const result = hasPartialObjectToMerge({}, {});
+      expect(result).toBe(true);
+    });
+
+    it('should return true if base and any additionalPartials are objects', () => {
+      const result = hasPartialObjectToMerge({}, undefined, ['string', [], {}]);
+      expect(result).toBe(true);
+    });
+
+    it('should return true if base and any additionalPartials are objects even if partial is an array', () => {
+      const result = hasPartialObjectToMerge({}, [], ['string', [], {}]);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if base is an object but not the partial nor any additionalPartials are not objects', () => {
+      const result = hasPartialObjectToMerge({}, undefined, ['string', []]);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if base is an object but not the partial nor any additionalPartials are not objects even if partial is an array', () => {
+      const result = hasPartialObjectToMerge({}, [], ['string', []]);
+      expect(result).toBe(false);
+    });
+  });
+
   describe('mergePartial', () => {
     let baseClone: TestType;
     interface TestType {
@@ -157,35 +222,126 @@ describe('commons utilities', () => {
     beforeAll(() => {
       baseClone = JSON.parse(JSON.stringify(base)) as TestType;
     });
-    // skipped until we fix https://github.com/elastic/elastic-charts/issues/479
-    test.skip('should override union types', () => {
+
+    describe('Union types', () => {
       type TestObject = { string1?: string; string2?: string };
       interface TestUnionType {
-        union: 'val1' | 'val2' | TestObject;
+        union: 'val1' | 'val2' | TestObject | string[];
       }
-      expect(
-        mergePartial<TestUnionType>(
+
+      test('should override simple union type with object', () => {
+        const result = mergePartial<TestUnionType>(
           { union: 'val2' },
           { union: { string1: 'other' } },
           { mergeOptionalPartialValues: true },
-        ),
-      ).toEqual({
-        union: { string1: 'other' },
+        );
+        expect(result).toEqual({
+          union: { string1: 'other' },
+        });
       });
-    });
-    // skipped until we fix https://github.com/elastic/elastic-charts/issues/479
-    test.skip('should override union types', () => {
-      type TestObject = { string1?: string; string2?: string };
-      interface TestUnionType {
-        union: 'val1' | 'val2' | TestObject;
-      }
-      expect(
-        mergePartial<TestUnionType>(
+
+      test('should override simple union type with array', () => {
+        const result = mergePartial<TestUnionType>(
+          { union: 'val2' },
+          { union: ['string'] },
+          { mergeOptionalPartialValues: true },
+        );
+        expect(result).toEqual({
+          union: ['string'],
+        });
+      });
+
+      test('should override simple union type with object from additionalPartials', () => {
+        const result = mergePartial<TestUnionType>({ union: 'val2' }, {}, { mergeOptionalPartialValues: true }, [
+          {},
+          { union: { string1: 'other' } },
+        ]);
+        expect(result).toEqual({
+          union: { string1: 'other' },
+        });
+      });
+
+      test('should override simple union type with array from additionalPartials', () => {
+        const result = mergePartial<TestUnionType>({ union: 'val2' }, {}, { mergeOptionalPartialValues: true }, [
+          {},
+          { union: ['string'] },
+        ]);
+        expect(result).toEqual({
+          union: ['string'],
+        });
+      });
+
+      test('should override object union type with simple', () => {
+        const result = mergePartial<TestUnionType>(
           { union: { string1: 'other' } },
           { union: 'val2' },
           { mergeOptionalPartialValues: true },
-        ),
-      ).toEqual({ union: 'val2' });
+        );
+        expect(result).toEqual({ union: 'val2' });
+      });
+
+      test('should override object union type with array', () => {
+        const result = mergePartial<TestUnionType>(
+          { union: { string1: 'other' } },
+          { union: ['string'] },
+          { mergeOptionalPartialValues: true },
+        );
+        expect(result).toEqual({ union: ['string'] });
+      });
+
+      test('should override object union type with simple from additionalPartials', () => {
+        const result = mergePartial<TestUnionType>(
+          { union: { string1: 'other' } },
+          {},
+          { mergeOptionalPartialValues: true },
+          [{}, { union: 'val2' }],
+        );
+        expect(result).toEqual({ union: 'val2' });
+      });
+
+      test('should override object union type with array from additionalPartials', () => {
+        const result = mergePartial<TestUnionType>(
+          { union: { string1: 'other' } },
+          {},
+          { mergeOptionalPartialValues: true },
+          [{}, { union: ['string'] }],
+        );
+        expect(result).toEqual({ union: ['string'] });
+      });
+
+      test('should override array union type with simple', () => {
+        const result = mergePartial<TestUnionType>(
+          { union: ['string'] },
+          { union: 'val2' },
+          { mergeOptionalPartialValues: true },
+        );
+        expect(result).toEqual({ union: 'val2' });
+      });
+
+      test('should override array union type with object', () => {
+        const result = mergePartial<TestUnionType>(
+          { union: ['string'] },
+          { union: { string1: 'other' } },
+          { mergeOptionalPartialValues: true },
+        );
+        expect(result).toEqual({ union: { string1: 'other' } });
+      });
+
+      test('should override array union type with simple from additionalPartials', () => {
+        const result = mergePartial<TestUnionType>({ union: ['string'] }, {}, { mergeOptionalPartialValues: true }, [
+          {},
+          { union: 'val2' },
+        ]);
+        expect(result).toEqual({ union: 'val2' });
+      });
+
+      test('should override array union type with object from additionalPartials', () => {
+        const result = mergePartial<TestUnionType>({ union: ['string'] }, {}, { mergeOptionalPartialValues: true }, [
+          {},
+          { union: { string1: 'other' } },
+        ]);
+        expect(result).toEqual({ union: { string1: 'other' } });
+      });
     });
 
     test('should allow partial to be undefined', () => {

--- a/src/utils/commons.ts
+++ b/src/utils/commons.ts
@@ -77,6 +77,38 @@ export function getAllKeys(object: any, objects: any[] = []): string[] {
   }, Object.keys(object));
 }
 
+export function hasPartialObjectToMerge<T>(
+  base: T,
+  partial?: RecursivePartial<T>,
+  additionalPartials: RecursivePartial<T>[] = [],
+): boolean {
+  if (Array.isArray(base)) {
+    return false;
+  }
+
+  if (typeof base === 'object') {
+    if (typeof partial === 'object' && !Array.isArray(partial)) {
+      return true;
+    }
+
+    return additionalPartials.some((p) => typeof p === 'object' && !Array.isArray(p));
+  }
+
+  return false;
+}
+
+export function simpleClone(value: any) {
+  if (Array.isArray(value)) {
+    return [...value];
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    return { ...value };
+  }
+
+  return value;
+}
+
 /**
  * Merges values of a partial structure with a base structure.
  *
@@ -93,9 +125,9 @@ export function mergePartial<T>(
   options: MergeOptions = {},
   additionalPartials: RecursivePartial<T>[] = [],
 ): T {
-  if (!Array.isArray(base) && typeof base === 'object') {
-    const baseClone = { ...base };
+  const baseClone = simpleClone(base);
 
+  if (hasPartialObjectToMerge(base, partial, additionalPartials)) {
     if (partial !== undefined && options.mergeOptionalPartialValues) {
       getAllKeys(partial, additionalPartials).forEach((key) => {
         if (!(key in baseClone)) {
@@ -118,7 +150,7 @@ export function mergePartial<T>(
     }, baseClone);
   }
 
-  return getPartialValue<T>(base, partial, additionalPartials);
+  return getPartialValue<T>(baseClone, partial, additionalPartials);
 }
 
 export function isNumberArray(value: unknown): value is number[] {

--- a/src/utils/commons.ts
+++ b/src/utils/commons.ts
@@ -97,7 +97,7 @@ export function hasPartialObjectToMerge<T>(
   return false;
 }
 
-export function simpleClone(value: any) {
+export function shallowClone(value: any) {
   if (Array.isArray(value)) {
     return [...value];
   }
@@ -125,7 +125,7 @@ export function mergePartial<T>(
   options: MergeOptions = {},
   additionalPartials: RecursivePartial<T>[] = [],
 ): T {
-  const baseClone = simpleClone(base);
+  const baseClone = shallowClone(base);
 
   if (hasPartialObjectToMerge(base, partial, additionalPartials)) {
     if (partial !== undefined && options.mergeOptionalPartialValues) {


### PR DESCRIPTION
## Summary

If the tooltip type is hidden (TooltipType.None) then the tooltip should not be shown. This add the
check in the selector and includes also a smoke test for all tooltips.

*side notes*
there was already a test checking if the tooltip was visible or not, but it doesn't include a check if the highlighter was visible or not.

fix #478

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
