### PR TITLE
build(deps): move react as peer dependency, upgrade Konva

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,7 +67,8 @@ module.exports = {
   settings: {
     'import/resolver': {
       node: {
-        extensions: ['.mjs', '.js', '.json', '.ts', '.tsx'],
+        extensions: ['.mjs', '.js', '.json', '.ts', '.d.ts', '.tsx'],
+        moduleDirectory: ['node_modules', 'src/'],
       },
     },
     react: {

--- a/integration/jest-env-setup.ts
+++ b/integration/jest-env-setup.ts
@@ -8,3 +8,6 @@ export const toMatchImageSnapshot = configureToMatchImageSnapshot({
 });
 
 expect.extend({ toMatchImageSnapshot });
+
+export const JEST_TIMEOUT = 10000;
+jest.setTimeout(JEST_TIMEOUT);

--- a/integration/page_objects/common.ts
+++ b/integration/page_objects/common.ts
@@ -1,6 +1,6 @@
 import Url from 'url';
 
-import { toMatchImageSnapshot } from '../jest-env-setup';
+import { JEST_TIMEOUT, toMatchImageSnapshot } from '../jest-env-setup';
 // @ts-ignore
 import defaults from '../defaults';
 
@@ -114,7 +114,7 @@ class CommonPage {
    * @param {string} [selector] the DOM selector to wait for, default to '.echChartStatus[data-ech-render-complete=true]'
    * @param {number} [timeout] - the timeout for the operation, default to 10000ms
    */
-  async waitForElement(selector = '.echChartStatus[data-ech-render-complete=true]', timeout = 10000) {
+  async waitForElement(selector = '.echChartStatus[data-ech-render-complete=true]', timeout = JEST_TIMEOUT) {
     await page.waitForSelector(selector, { timeout });
   }
 }

--- a/package.json
+++ b/package.json
@@ -162,8 +162,8 @@
   },
   "peerDependencies": {
     "moment-timezone": "^0.5.27",
-    "react": "^16.8.3",
-    "react-dom": "^16.8.3"
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -120,8 +120,10 @@
     "prettier": "1.16.4",
     "pretty-quick": "^2.0.0",
     "puppeteer": "^1.20.0",
+    "react": "^16.12.0",
     "react-docgen-typescript-loader": "^3.0.1",
     "react-docgen-typescript-webpack-plugin": "^1.1.0",
+    "react-dom": "^16.12.0",
     "redux-devtools-extension": "^2.13.8",
     "sass-graph": "^3.0.4",
     "sass-loader": "^7.1.0",
@@ -145,13 +147,11 @@
     "d3-collection": "^1.0.7",
     "d3-scale": "^1.0.7",
     "d3-shape": "^1.3.4",
-    "konva": "^2.6.0",
+    "konva": "^4.0.18",
     "newtype-ts": "^0.2.4",
     "prop-types": "^15.7.2",
     "re-reselect": "^3.4.0",
-    "react": "^16.8.3",
-    "react-dom": "^16.8.3",
-    "react-konva": "16.8.3",
+    "react-konva": "16.10.1-0",
     "react-redux": "^7.1.0",
     "react-spring": "^8.0.8",
     "redux": "^4.0.4",
@@ -161,7 +161,9 @@
     "uuid": "^3.3.2"
   },
   "peerDependencies": {
-    "moment-timezone": "^0.5.27"
+    "moment-timezone": "^0.5.27",
+    "react": "^16.8.3",
+    "react-dom": "^16.8.3"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@storybook/addon-info": "5.1.9",
     "@storybook/addon-knobs": "5.1.9",
     "@storybook/react": "5.1.9",
+    "@storybook/theming": "5.1.9",
     "@types/classnames": "^2.2.7",
     "@types/d3-array": "^1.2.6",
     "@types/d3-collection": "^1.0.8",

--- a/src/chart_types/xy_chart/renderer/canvas/area_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/area_geometries.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Group as KonvaGroup, PathConfig } from 'konva';
+import { Group as KonvaGroup } from 'konva/types/Group';
+import { PathConfig } from 'konva/types/shapes/Path';
 import { Circle, Group, Path } from 'react-konva';
 import {
   buildAreaRenderProps,

--- a/src/chart_types/xy_chart/renderer/canvas/bar_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/bar_geometries.tsx
@@ -1,4 +1,4 @@
-import { Group as KonvaGroup } from 'konva';
+import { Group as KonvaGroup } from 'konva/types/Group';
 import React from 'react';
 import { Group, Rect } from 'react-konva';
 import { animated, Spring } from 'react-spring/renderprops-konva.cjs';

--- a/src/chart_types/xy_chart/renderer/canvas/bar_values_utils.ts
+++ b/src/chart_types/xy_chart/renderer/canvas/bar_values_utils.ts
@@ -2,7 +2,7 @@ import { Required } from 'utility-types';
 import { Rotation } from '../../utils/specs';
 import { Dimensions } from '../../../../utils/dimensions';
 import { DisplayValueStyle } from '../../../../utils/themes/theme';
-import { ContainerConfig } from 'konva';
+import { ContainerConfig } from 'konva/types/Container';
 import { ClippedRanges } from '../../../../utils/geometry';
 
 export interface PointStyleProps {

--- a/src/chart_types/xy_chart/renderer/canvas/line_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/line_geometries.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Group as KonvaGroup } from 'konva';
+import { Group as KonvaGroup } from 'konva/types/Group';
 import { Circle, Group, Path } from 'react-konva';
 import {
   buildLineRenderProps,

--- a/src/chart_types/xy_chart/renderer/canvas/utils/rendering_props_utils.ts
+++ b/src/chart_types/xy_chart/renderer/canvas/utils/rendering_props_utils.ts
@@ -1,4 +1,6 @@
-import { RectConfig, PathConfig, CircleConfig } from 'konva';
+import { RectConfig } from 'konva/types/shapes/Rect';
+import { PathConfig } from 'konva/types/shapes/Path';
+import { CircleConfig } from 'konva/types/shapes/Circle';
 import {
   AreaStyle,
   LineStyle,

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -118,7 +118,7 @@ export class Chart extends React.Component<ChartProps, ChartState> {
     if (!this.chartStageRef.current) {
       return null;
     }
-    const stage = this.chartStageRef.current.getStage().clone();
+    const stage = this.chartStageRef.current.getStage().clone(null);
     const width = stage.getWidth();
     const height = stage.getHeight();
     const backgroundLayer = new Konva.Layer();

--- a/src/components/react_canvas/globals.ts
+++ b/src/components/react_canvas/globals.ts
@@ -1,4 +1,4 @@
-import { ShapeConfig } from 'konva';
+import { ShapeConfig } from 'konva/types/Shape';
 
 export const GlobalKonvaElementProps: ShapeConfig = {
   strokeHitEnabled: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9470,10 +9470,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-konva@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/konva/-/konva-2.6.0.tgz#43165b95e32a4378ce532d9113c914f4998409c3"
-  integrity sha512-LCOoavICTD9PYoAqtWo8sbxYtCiXdgEeY7vj/Sq8b2bwFmrQr9Ak0RkD4/jxAf5fcUQRL5e1zPLyfRpVndp20A==
+konva@^4.0.18:
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/konva/-/konva-4.0.18.tgz#43e614c9b22827183506d4a6b3b474f90187b469"
+  integrity sha512-Tlq0v7QHr8q73xr1cKjHdQl41oHC06IOldPO+ukjt99G74NgoU0TVouvPIFpW2whA9t3xNk/+/VJcc3XPcboOw==
 
 latest-version@^3.0.0:
   version "3.1.0"
@@ -12666,6 +12666,16 @@ react-docgen@^4.1.0:
     node-dir "^0.1.10"
     recast "^0.17.3"
 
+react-dom@^16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
+  integrity sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.18.0"
+
 react-dom@^16.8.3:
   version "16.10.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.10.2.tgz#4840bce5409176bc3a1f2bd8cb10b92db452fda6"
@@ -12756,13 +12766,13 @@ react-is@~16.3.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
   integrity sha512-ybEM7YOr4yBgFd6w8dJqwxegqZGJNBZl6U27HnGKuTZmDvVrD5quWOK/wAnMywiZzW+Qsk+l4X2c70+thp/A8Q==
 
-react-konva@16.8.3:
-  version "16.8.3"
-  resolved "https://registry.yarnpkg.com/react-konva/-/react-konva-16.8.3.tgz#e55390040ea54675a0ef0d40b4fa93731e6d7b03"
-  integrity sha512-gU36TBxcPZANQOV5prAFnpRSNp2ikAT7zCICHTBJvOzAfa8Yhcyaey6EIrD+NTT/4y0PyGFBIkmWq6zdrlNrQg==
+react-konva@16.10.1-0:
+  version "16.10.1-0"
+  resolved "https://registry.yarnpkg.com/react-konva/-/react-konva-16.10.1-0.tgz#f8cc2c95374933069e891a6c714c70d0fdc77e68"
+  integrity sha512-N0Zi3TcWmUxb2d7y1DUDQhRA+WIcqk54DQmmUmJSadj+fS0bg6iZDebQSEQC8dMbjnLHc/338xRT4a4718PEiw==
   dependencies:
-    react-reconciler "^0.20.1"
-    scheduler "^0.13.3"
+    react-reconciler "^0.22.1"
+    scheduler "^0.16.1"
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -12789,15 +12799,15 @@ react-popper@^1.3.4:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-reconciler@^0.20.1:
-  version "0.20.4"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.20.4.tgz#3da6a95841592f849cb4edd3d38676c86fd920b2"
-  integrity sha512-kxERc4H32zV2lXMg/iMiwQHOtyqf15qojvkcZ5Ja2CPkjVohHw9k70pdDBwrnQhLVetUJBSYyqU3yqrlVTOajA==
+react-reconciler@^0.22.1:
+  version "0.22.2"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.22.2.tgz#e8a10374fec8fee7c5cd0cf3cd05626f1b134d3e"
+  integrity sha512-MLX5Y2pNLsdXzWz/GLNhhYkdLOvxEtw2IGqVCzkiRdSFSHRjujI9gfTOQ3rV5z8toTBxSZ2qrRkRUo97mmEdhA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.6"
+    scheduler "^0.16.2"
 
 react-redux@^5.0.7:
   version "5.1.2"
@@ -12906,6 +12916,15 @@ react-virtualized@^9.21.2:
     loose-envify "^1.3.0"
     prop-types "^15.6.0"
     react-lifecycles-compat "^3.0.4"
+
+react@^16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
+  integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 react@^16.8.3:
   version "16.10.2"
@@ -13746,18 +13765,18 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scheduler@^0.13.3, scheduler@^0.13.6:
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
-  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+scheduler@^0.16.1, scheduler@^0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.16.2.tgz#f74cd9d33eff6fc554edfb79864868e4819132c1"
+  integrity sha512-BqYVWqwz6s1wZMhjFvLfVR5WXP7ZY32M/wYPo04CcuPM7XZEbV2TBNW7Z0UkguPTl0dWMA59VbNXxK6q+pHItg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-scheduler@^0.16.2:
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.16.2.tgz#f74cd9d33eff6fc554edfb79864868e4819132c1"
-  integrity sha512-BqYVWqwz6s1wZMhjFvLfVR5WXP7ZY32M/wYPo04CcuPM7XZEbV2TBNW7Z0UkguPTl0dWMA59VbNXxK6q+pHItg==
+scheduler@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.18.0.tgz#5901ad6659bc1d8f3fdaf36eb7a67b0d6746b1c4"
+  integrity sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
## Summary

Moving `react` and `react-dom` as peer dependency.
Upgrading `react` and `react-dom` to 16.12
Upgrading `konva` to the latest 4.x version

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- ~[ ] Unit tests were updated or added to match the most common scenarios~
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
