### PR TITLE
fix(external pointer): avoid recursive-loops on pointer events

### DIFF
--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Chart, Settings, TooltipType, BarSeries } from '../src';
+import { Chart, Settings, TooltipType, AreaSeries, PointerEvent } from '../src';
 import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
 export class Playground extends React.Component {
   chartRef: React.RefObject<Chart> = React.createRef();
+  chartRef2: React.RefObject<Chart> = React.createRef();
   onSnapshot = () => {
     if (!this.chartRef.current) {
       return;
@@ -27,39 +28,43 @@ export class Playground extends React.Component {
         document.body.removeChild(link);
     }
   };
+  onPointerUpdate = (event: PointerEvent) => {
+    if (this.chartRef && this.chartRef.current) {
+      this.chartRef.current.dispatchExternalPointerEvent(event);
+    }
+    if (this.chartRef2 && this.chartRef2.current) {
+      this.chartRef2.current.dispatchExternalPointerEvent(event);
+    }
+  };
   render() {
     return (
       <>
         <button onClick={this.onSnapshot}>Snapshot</button>
         <div className="chart">
-          <Chart size={[200, 100]}>
-            <Settings tooltip={{ type: TooltipType.Crosshairs }} showLegend />
-            <BarSeries
-              id="lines"
-              xAccessor={0}
-              yAccessors={[1]}
-              data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 5)}
+          <Chart ref={this.chartRef}>
+            <Settings
+              tooltip={{ type: TooltipType.VerticalCursor }}
+              showLegend
+              onPointerUpdate={this.onPointerUpdate}
             />
-            <BarSeries
-              id="lines2"
-              xAccessor={0}
-              yAccessors={[1]}
-              data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 5)}
-            />
-          </Chart>
-        </div>
-        <div className="chart">
-          <Chart>
-            <Settings tooltip={{ type: TooltipType.Crosshairs }} showLegend />
-            <BarSeries
+            <AreaSeries
               id="lines"
               xAccessor={0}
               yAccessors={[1]}
               stackAccessors={[0]}
               data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 5)}
             />
-            <BarSeries
-              id="lines2"
+          </Chart>
+        </div>
+        <div className="chart">
+          <Chart ref={this.chartRef2}>
+            <Settings
+              tooltip={{ type: TooltipType.VerticalCursor }}
+              showLegend
+              onPointerUpdate={this.onPointerUpdate}
+            />
+            <AreaSeries
+              id="lines"
               xAccessor={0}
               yAccessors={[1]}
               stackAccessors={[0]}

--- a/src/chart_types/xy_chart/state/selectors/get_cursor_band.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_cursor_band.ts
@@ -4,7 +4,7 @@ import { Point } from '../../../../utils/point';
 import { Scale } from '../../../../utils/scales/scales';
 import { isLineAreaOnlyChart } from '../utils';
 import { getCursorBandPosition } from '../../crosshair/crosshair_utils';
-import { SettingsSpec, CursorEvent } from '../../../../specs/settings';
+import { SettingsSpec, PointerEvent, isPointerOverEvent } from '../../../../specs/settings';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
 import { BasicSeriesSpec } from '../../utils/specs';
@@ -15,7 +15,7 @@ import { getOrientedProjectedPointerPositionSelector } from './get_oriented_proj
 import { isTooltipSnapEnableSelector } from './is_tooltip_snap_enabled';
 import { getGeometriesIndexKeysSelector } from './get_geometries_index_keys';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { isValidExternalPointerEvent } from '../../../../utils/events';
+import { isValidPointerOverEvent } from '../../../../utils/events';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 
 const getExternalPointerEventStateSelector = (state: GlobalChartState) => state.externalEvents.pointer;
@@ -59,7 +59,7 @@ export const getCursorBandPositionSelector = createCachedSelector(
 
 function getCursorBand(
   orientedProjectedPoinerPosition: Point,
-  externalPointerEvent: CursorEvent | null,
+  externalPointerEvent: PointerEvent | null,
   chartDimensions: Dimensions,
   settingsSpec: SettingsSpec,
   xScale: Scale | undefined,
@@ -75,7 +75,11 @@ function getCursorBand(
   }
   let pointerPosition = orientedProjectedPoinerPosition;
   let xValue;
-  if (externalPointerEvent && isValidExternalPointerEvent(externalPointerEvent, xScale)) {
+  if (
+    externalPointerEvent &&
+    isPointerOverEvent(externalPointerEvent) &&
+    isValidPointerOverEvent(externalPointerEvent, xScale)
+  ) {
     const x = xScale.pureScale(externalPointerEvent.value);
 
     if (x == null || x > chartDimensions.width + chartDimensions.left) {

--- a/src/chart_types/xy_chart/state/selectors/get_cursor_band.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_cursor_band.ts
@@ -4,7 +4,7 @@ import { Point } from '../../../../utils/point';
 import { Scale } from '../../../../utils/scales/scales';
 import { isLineAreaOnlyChart } from '../utils';
 import { getCursorBandPosition } from '../../crosshair/crosshair_utils';
-import { SettingsSpec, PointerEvent, isPointerOverEvent } from '../../../../specs/settings';
+import { SettingsSpec, PointerEvent } from '../../../../specs/settings';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
 import { BasicSeriesSpec } from '../../utils/specs';
@@ -75,11 +75,7 @@ function getCursorBand(
   }
   let pointerPosition = orientedProjectedPoinerPosition;
   let xValue;
-  if (
-    externalPointerEvent &&
-    isPointerOverEvent(externalPointerEvent) &&
-    isValidPointerOverEvent(externalPointerEvent, xScale)
-  ) {
+  if (isValidPointerOverEvent(xScale, externalPointerEvent)) {
     const x = xScale.pureScale(externalPointerEvent.value);
 
     if (x == null || x > chartDimensions.width + chartDimensions.left) {

--- a/src/chart_types/xy_chart/state/selectors/get_elements_at_cursor_pos.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_elements_at_cursor_pos.ts
@@ -6,11 +6,11 @@ import { getComputedScalesSelector } from './get_computed_scales';
 import { getGeometriesIndexKeysSelector } from './get_geometries_index_keys';
 import { getGeometriesIndexSelector } from './get_geometries_index';
 import { IndexedGeometry } from '../../../../utils/geometry';
-import { CursorEvent } from '../../../../specs';
+import { PointerEvent, isPointerOverEvent } from '../../../../specs';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
 import { Dimensions } from '../../../../utils/dimensions';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { isValidExternalPointerEvent } from '../../../../utils/events';
+import { isValidPointerOverEvent } from '../../../../utils/events';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 
 const getExternalPointerEventStateSelector = (state: GlobalChartState) => state.externalEvents.pointer;
@@ -32,14 +32,18 @@ function getElementAtCursorPosition(
   scales: ComputedScales,
   geometriesIndexKeys: any,
   geometriesIndex: Map<any, IndexedGeometry[]>,
-  externalPointerEvent: CursorEvent | null,
+  externalPointerEvent: PointerEvent | null,
   {
     chartDimensions,
   }: {
     chartDimensions: Dimensions;
   },
 ): IndexedGeometry[] {
-  if (externalPointerEvent && isValidExternalPointerEvent(externalPointerEvent, scales.xScale)) {
+  if (
+    externalPointerEvent &&
+    isPointerOverEvent(externalPointerEvent) &&
+    isValidPointerOverEvent(externalPointerEvent, scales.xScale)
+  ) {
     const x = scales.xScale.pureScale(externalPointerEvent.value);
 
     if (x == null || x > chartDimensions.width + chartDimensions.left) {

--- a/src/chart_types/xy_chart/state/selectors/get_elements_at_cursor_pos.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_elements_at_cursor_pos.ts
@@ -6,7 +6,7 @@ import { getComputedScalesSelector } from './get_computed_scales';
 import { getGeometriesIndexKeysSelector } from './get_geometries_index_keys';
 import { getGeometriesIndexSelector } from './get_geometries_index';
 import { IndexedGeometry } from '../../../../utils/geometry';
-import { PointerEvent, isPointerOverEvent } from '../../../../specs';
+import { PointerEvent } from '../../../../specs';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
 import { Dimensions } from '../../../../utils/dimensions';
 import { GlobalChartState } from '../../../../state/chart_state';
@@ -39,11 +39,7 @@ function getElementAtCursorPosition(
     chartDimensions: Dimensions;
   },
 ): IndexedGeometry[] {
-  if (
-    externalPointerEvent &&
-    isPointerOverEvent(externalPointerEvent) &&
-    isValidPointerOverEvent(externalPointerEvent, scales.xScale)
-  ) {
+  if (isValidPointerOverEvent(scales.xScale, externalPointerEvent)) {
     const x = scales.xScale.pureScale(externalPointerEvent.value);
 
     if (x == null || x > chartDimensions.width + chartDimensions.left) {

--- a/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
@@ -14,7 +14,7 @@ import { formatTooltip } from '../../tooltip/tooltip';
 import { getTooltipHeaderFormatterSelector } from './get_tooltip_header_formatter';
 import { isPointOnGeometry } from '../../rendering/rendering';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { PointerEvent, isPointerOverEvent, isPointerOutEvent } from '../../../../specs';
+import { PointerEvent, isPointerOutEvent } from '../../../../specs';
 import { isValidPointerOverEvent } from '../../../../utils/events';
 import { getChartRotationSelector } from '../../../../state/selectors/get_chart_rotation';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
@@ -72,11 +72,7 @@ function getTooltipAndHighlightFromXValue(
   }
   let x = orientedProjectedPointerPosition.x;
   let y = orientedProjectedPointerPosition.y;
-  if (
-    externalPointerEvent &&
-    isPointerOverEvent(externalPointerEvent) &&
-    isValidPointerOverEvent(externalPointerEvent, scales.xScale)
-  ) {
+  if (isValidPointerOverEvent(scales.xScale, externalPointerEvent)) {
     x = scales.xScale.pureScale(externalPointerEvent.value);
     y = 0;
   } else if (projectedPointerPosition.x === -1 || projectedPointerPosition.y === -1) {

--- a/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
@@ -14,8 +14,8 @@ import { formatTooltip } from '../../tooltip/tooltip';
 import { getTooltipHeaderFormatterSelector } from './get_tooltip_header_formatter';
 import { isPointOnGeometry } from '../../rendering/rendering';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { CursorEvent } from '../../../../specs';
-import { isValidExternalPointerEvent } from '../../../../utils/events';
+import { PointerEvent, isPointerOverEvent, isPointerOutEvent } from '../../../../specs';
+import { isValidPointerOverEvent } from '../../../../utils/events';
 import { getChartRotationSelector } from '../../../../state/selectors/get_chart_rotation';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { hasSingleSeriesSelector } from './has_single_series';
@@ -61,7 +61,7 @@ function getTooltipAndHighlightFromXValue(
   scales: ComputedScales,
   xMatchingGeoms: IndexedGeometry[],
   tooltipType: TooltipType,
-  externalPointerEvent: CursorEvent | null,
+  externalPointerEvent: PointerEvent | null,
   tooltipHeaderFormatter?: TooltipValueFormatter,
 ): TooltipAndHighlightedGeoms {
   if (!scales.xScale || !scales.yScales) {
@@ -72,7 +72,11 @@ function getTooltipAndHighlightFromXValue(
   }
   let x = orientedProjectedPointerPosition.x;
   let y = orientedProjectedPointerPosition.y;
-  if (externalPointerEvent && isValidExternalPointerEvent(externalPointerEvent, scales.xScale)) {
+  if (
+    externalPointerEvent &&
+    isPointerOverEvent(externalPointerEvent) &&
+    isValidPointerOverEvent(externalPointerEvent, scales.xScale)
+  ) {
     x = scales.xScale.pureScale(externalPointerEvent.value);
     y = 0;
   } else if (projectedPointerPosition.x === -1 || projectedPointerPosition.y === -1) {
@@ -108,7 +112,10 @@ function getTooltipAndHighlightFromXValue(
 
       // check if the pointer is on the geometry (avoid checking if using external pointer event)
       let isHighlighted = false;
-      if (!externalPointerEvent && isPointOnGeometry(x, y, indexedGeometry)) {
+      if (
+        (!externalPointerEvent || isPointerOutEvent(externalPointerEvent)) &&
+        isPointOnGeometry(x, y, indexedGeometry)
+      ) {
         isHighlighted = true;
         highlightedGeometries.push(indexedGeometry);
       }

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -23,7 +23,7 @@ import { ChartTypes } from '../chart_types/index';
 import { getSettingsSpecSelector } from '../state/selectors/get_settings_specs';
 import { createOnBrushEndCaller } from '../chart_types/xy_chart/state/selectors/on_brush_end_caller';
 import { onExternalPointerEvent } from '../state/actions/events';
-import { CursorEvent } from '../specs';
+import { PointerEvent } from '../specs';
 import { createOnPointerMoveCaller } from '../chart_types/xy_chart/state/selectors/on_pointer_move_caller';
 
 interface ChartProps {
@@ -102,7 +102,7 @@ export class Chart extends React.Component<ChartProps, ChartState> {
     });
   }
 
-  dispatchExternalCursorEvent(event?: CursorEvent) {
+  dispatchExternalPointerEvent(event: PointerEvent) {
     this.chartStore.dispatch(onExternalPointerEvent(event));
   }
 

--- a/src/specs/settings.test.tsx
+++ b/src/specs/settings.test.tsx
@@ -116,7 +116,7 @@ describe('Settings spec component', () => {
     const onLegendEvent = (): void => {
       return;
     };
-    const onCursorUpdateEvent = (): void => {
+    const onPointerUpdateEvent = (): void => {
       return;
     };
     const onRenderChangeEvent = (): void => {
@@ -133,7 +133,7 @@ describe('Settings spec component', () => {
       onLegendItemClick: onLegendEvent,
       onLegendItemPlusClick: onLegendEvent,
       onLegendItemMinusClick: onLegendEvent,
-      onCursorUpdate: onCursorUpdateEvent,
+      onPointerUpdate: onPointerUpdateEvent,
       onRenderChange: onRenderChangeEvent,
     };
 
@@ -149,7 +149,7 @@ describe('Settings spec component', () => {
     expect(settingSpec.onLegendItemClick).toEqual(onLegendEvent);
     expect(settingSpec.onLegendItemPlusClick).toEqual(onLegendEvent);
     expect(settingSpec.onLegendItemMinusClick).toEqual(onLegendEvent);
-    expect(settingSpec.onCursorUpdate).toEqual(onCursorUpdateEvent);
+    expect(settingSpec.onPointerUpdate).toEqual(onPointerUpdateEvent);
     expect(settingSpec.onRenderChange).toEqual(onRenderChangeEvent);
   });
 

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -1,3 +1,4 @@
+import { $Values } from 'utility-types';
 import { DomainRange, Position, Rendering, Rotation, SpecTypes } from '../chart_types/xy_chart/utils/specs';
 import { PartialTheme, Theme } from '../utils/themes/theme';
 import { Domain } from '../utils/domain';
@@ -14,7 +15,7 @@ export type ElementClickListener = (values: GeometryValue[]) => void;
 export type ElementOverListener = (values: GeometryValue[]) => void;
 export type BrushEndListener = (min: number, max: number) => void;
 export type LegendItemListener = (series: SeriesIdentifier | null) => void;
-export type CursorUpdateListener = (event?: CursorEvent) => void;
+export type PointerUpdateListener = (event: PointerEvent) => void;
 /**
  * Listener to be called when chart render state changes
  *
@@ -22,21 +23,38 @@ export type CursorUpdateListener = (event?: CursorEvent) => void;
  */
 export type RenderChangeListener = (isRendered: boolean) => void;
 export type BasicListener = () => undefined | void;
-/**
- * Event used to syncronize cursors between Charts.
- *
- * fired as callback argument for `CursorUpdateListener`
- */
-export interface CursorEvent {
+
+export const PointerEventType = Object.freeze({
+  Over: 'Over' as 'Over',
+  Out: 'Out' as 'Out',
+});
+
+export type PointerEventType = $Values<typeof PointerEventType>;
+
+export interface BasePointerEvent {
   chartId: string;
+  type: PointerEventType;
+}
+/**
+ * Event used to syncronize pointers/mouse positions between Charts.
+ *
+ * fired as callback argument for `PointerUpdateListener`
+ */
+export interface PointerOverEvent extends BasePointerEvent {
+  type: typeof PointerEventType.Over;
   scale: ScaleTypes;
   /**
    * @todo
    * unit for event (i.e. `time`, `feet`, `count`, etc.)
    */
   unit?: string;
-  value: number | string;
+  value: number | string | null;
 }
+export interface PointerOutEvent extends BasePointerEvent {
+  type: typeof PointerEventType.Out;
+}
+
+export type PointerEvent = PointerOverEvent | PointerOutEvent;
 
 interface TooltipProps {
   type?: TooltipType;
@@ -87,7 +105,7 @@ export interface SettingsSpec extends Spec {
   onLegendItemClick?: LegendItemListener;
   onLegendItemPlusClick?: LegendItemListener;
   onLegendItemMinusClick?: LegendItemListener;
-  onCursorUpdate?: CursorUpdateListener;
+  onPointerUpdate?: PointerUpdateListener;
   onRenderChange?: RenderChangeListener;
   xDomain?: Domain | DomainRange;
   resizeDebounce?: number;
@@ -137,3 +155,11 @@ export type SettingsSpecProps = Partial<Omit<SettingsSpec, 'chartType' | 'specTy
 export const Settings: React.FunctionComponent<SettingsSpecProps> = getConnect()(
   specComponentFactory<SettingsSpec, DefaultSettingsProps>(DEFAULT_SETTINGS_SPEC),
 );
+
+export function isPointerOutEvent(event: PointerEvent): event is PointerOutEvent {
+  return event.type === PointerEventType.Out;
+}
+
+export function isPointerOverEvent(event: PointerEvent): event is PointerOverEvent {
+  return event.type === PointerEventType.Over;
+}

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -156,10 +156,10 @@ export const Settings: React.FunctionComponent<SettingsSpecProps> = getConnect()
   specComponentFactory<SettingsSpec, DefaultSettingsProps>(DEFAULT_SETTINGS_SPEC),
 );
 
-export function isPointerOutEvent(event: PointerEvent): event is PointerOutEvent {
-  return event.type === PointerEventType.Out;
+export function isPointerOutEvent(event: PointerEvent | null | undefined): event is PointerOutEvent {
+  return event !== null && event !== undefined && event.type === PointerEventType.Out;
 }
 
-export function isPointerOverEvent(event: PointerEvent): event is PointerOverEvent {
-  return event.type === PointerEventType.Over;
+export function isPointerOverEvent(event: PointerEvent | null | undefined): event is PointerOverEvent {
+  return event !== null && event !== undefined && event.type === PointerEventType.Over;
 }

--- a/src/state/actions/events.ts
+++ b/src/state/actions/events.ts
@@ -1,13 +1,13 @@
-import { CursorEvent } from '../../specs/settings';
+import { PointerEvent } from '../../specs/settings';
 
 export const EXTERNAL_POINTER_EVENT = 'EXTERNAL_POINTER_EVENT';
 
 interface ExternalPointerEvent {
   type: typeof EXTERNAL_POINTER_EVENT;
-  event?: CursorEvent;
+  event: PointerEvent;
 }
 
-export function onExternalPointerEvent(event?: CursorEvent): ExternalPointerEvent {
+export function onExternalPointerEvent(event: PointerEvent): ExternalPointerEvent {
   return { type: EXTERNAL_POINTER_EVENT, event };
 }
 

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -3,8 +3,8 @@ import { interactionsReducer } from './reducers/interactions';
 import { ChartTypes } from '../chart_types';
 import { XYAxisChartState } from '../chart_types/xy_chart/state/chart_state';
 import { SeriesIdentifier } from '../chart_types/xy_chart/utils/series';
-import { Spec } from '../specs';
-import { DEFAULT_SETTINGS_SPEC, CursorEvent } from '../specs/settings';
+import { Spec, PointerEvent } from '../specs';
+import { DEFAULT_SETTINGS_SPEC } from '../specs/settings';
 import { Dimensions } from '../utils/dimensions';
 import { Point } from '../utils/point';
 import { LegendItem } from '../chart_types/xy_chart/legend/legend';
@@ -69,7 +69,7 @@ export interface InteractionsState {
 }
 
 export interface ExternalEventsState {
-  pointer: CursorEvent | null;
+  pointer: PointerEvent | null;
 }
 
 export interface GlobalChartState {
@@ -202,7 +202,7 @@ export const chartStoreReducer = (chartId: string) => {
         };
       case EXTERNAL_POINTER_EVENT:
         // discard events from self if any
-        if (!action.event || action.event.chartId === state.chartId) {
+        if (action.event.chartId === chartId) {
           return {
             ...state,
             externalEvents: {

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,6 +1,6 @@
-import { CursorEvent } from '../specs';
+import { PointerOverEvent } from '../specs';
 import { Scale } from './scales/scales';
 
-export function isValidExternalPointerEvent(event: CursorEvent, mainScale: Scale): boolean {
+export function isValidPointerOverEvent(event: PointerOverEvent, mainScale: Scale): boolean {
   return event.unit === undefined || event.unit === mainScale.unit;
 }

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,6 +1,9 @@
-import { PointerOverEvent } from '../specs';
+import { PointerEvent, isPointerOverEvent, PointerOverEvent } from '../specs';
 import { Scale } from './scales/scales';
 
-export function isValidPointerOverEvent(event: PointerOverEvent, mainScale: Scale): boolean {
-  return event.unit === undefined || event.unit === mainScale.unit;
+export function isValidPointerOverEvent(
+  mainScale: Scale,
+  event: PointerEvent | null | undefined,
+): event is PointerOverEvent {
+  return isPointerOverEvent(event) && (event.unit === undefined || event.unit === mainScale.unit);
 }

--- a/stories/interactions.tsx
+++ b/stories/interactions.tsx
@@ -46,7 +46,7 @@ const onLegendItemListeners = {
 };
 
 const onRenderChange = action('onRenderChange');
-const onCursorUpdate = action('onCursorUpdate');
+const onPointerUpdate = action('onPointerUpdate');
 
 storiesOf('Interactions', module)
   .add('bar clicks and hovers', () => {
@@ -671,7 +671,7 @@ storiesOf('Interactions', module)
     () => {
       return (
         <Chart className={'story-chart'}>
-          <Settings showLegend={true} legendPosition={Position.Right} onCursorUpdate={onCursorUpdate} />
+          <Settings showLegend={true} legendPosition={Position.Right} onPointerUpdate={onPointerUpdate} />
           <Axis id={getAxisId('bottom')} position={Position.Bottom} title={'Bottom axis'} showOverlappingTicks={true} />
           <Axis
             id={getAxisId('left2')}


### PR DESCRIPTION
## Summary
If the consumer code doesn't take care of correctly distribute the pointer events avoiding feeding a chart with its own cursor position, it will end up with a recursive loop that ultimately throw a max stack trace. This provide the fix for such case.

**BREAKING CHANGE**: The `onCursorUpdate` Settings property is changed to a more generic
`onPointerUpdate`. The same apply for the event type `CursorEvent` that is now `PointerEvent` and can assume a `PointerOverEvent` or `PointOutEvent` shape (see TS types)



To test on previous version:
```tsx
import React from 'react';
import { Chart, Settings, TooltipType, AreaSeries, PointerEvent } from '../src';
import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
export class Playground extends React.Component {
  chartRef: React.RefObject<Chart> = React.createRef();
  chartRef2: React.RefObject<Chart> = React.createRef();
  onPointerUpdate = (event: PointerEvent) => {
    if (this.chartRef && this.chartRef.current) {
      this.chartRef.current.dispatchExternalPointerEvent(event);
    }
    if (this.chartRef2 && this.chartRef2.current) {
      this.chartRef2.current.dispatchExternalPointerEvent(event);
    }
  };
  render() {
    return (
      <>
        <button onClick={this.onSnapshot}>Snapshot</button>
        <div className="chart">
          <Chart ref={this.chartRef}>
            <Settings
              tooltip={{ type: TooltipType.VerticalCursor }}
              showLegend
              onPointerUpdate={this.onPointerUpdate}
            />
            <AreaSeries
              id="lines"
              xAccessor={0}
              yAccessors={[1]}
              stackAccessors={[0]}
              data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 5)}
            />
          </Chart>
        </div>
        <div className="chart">
          <Chart ref={this.chartRef2}>
            <Settings
              tooltip={{ type: TooltipType.VerticalCursor }}
              showLegend
              onPointerUpdate={this.onPointerUpdate}
            />
            <AreaSeries
              id="lines"
              xAccessor={0}
              yAccessors={[1]}
              stackAccessors={[0]}
              data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 5)}
            />
          </Chart>
        </div>
      </>
    );
  }
}
```

fix #504

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- ~[ ] Proper documentation or storybook story was added for features that require explanation or tutorials~
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
