### PR TITLE
chore: preparation for spec rendering order

### DIFF
--- a/src/chart_types/xy_chart/state/chart_state.interactions.test.ts
+++ b/src/chart_types/xy_chart/state/chart_state.interactions.test.ts
@@ -222,7 +222,7 @@ describe('Chart state pointer interactions', () => {
     store.dispatch(onPointerMove({ x: 10, y: 10 + 70 }, 0));
     const tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
     // no tooltip values exist if we have a TooltipType === None
-    expect(tooltipData.tooltipValues.length).toBe(0);
+    expect(tooltipData.tooltip.values.length).toBe(0);
     let isTooltipVisible = isTooltipVisibleSelector(store.getState());
     expect(isTooltipVisible).toBe(false);
 
@@ -284,7 +284,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
       onPointerMoveCaller(state);
     });
     const tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
-    expect(tooltipData.tooltipValues).toEqual([]);
+    expect(tooltipData.tooltip.values).toEqual([]);
   });
 
   test('store is correctly configured', () => {
@@ -299,13 +299,13 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     expect(onPointerUpdateListener).toBeCalledTimes(1);
 
     const tooltipData1 = getTooltipValuesAndGeometriesSelector(store.getState());
-    expect(tooltipData1.tooltipValues.length).toBe(2);
+    expect(tooltipData1.tooltip.values.length).toBe(1);
     // avoid calls
     store.dispatch(onPointerMove({ x: chartLeft + 12, y: chartTop + 12 }, 1));
     expect(onPointerUpdateListener).toBeCalledTimes(1);
 
     const tooltipData2 = getTooltipValuesAndGeometriesSelector(store.getState());
-    expect(tooltipData2.tooltipValues.length).toBe(2);
+    expect(tooltipData2.tooltip.values.length).toBe(1);
     expect(tooltipData1).toEqual(tooltipData2);
   });
 
@@ -385,7 +385,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
 
   test('can hover top-left corner of the first bar', () => {
     let tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
-    expect(tooltipData.tooltipValues).toEqual([]);
+    expect(tooltipData.tooltip.values).toEqual([]);
     store.dispatch(onPointerMove({ x: chartLeft + 0, y: chartTop + 0 }, 0));
     let projectedPointerPosition = getProjectedPointerPositionSelector(store.getState());
     expect(projectedPointerPosition).toEqual({ x: 0, y: 0 });
@@ -396,7 +396,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     let isTooltipVisible = isTooltipVisibleSelector(store.getState());
     expect(isTooltipVisible).toBe(true);
     tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
-    expect(tooltipData.tooltipValues.length).toBe(2); // x value + 1 y value
+    expect(tooltipData.tooltip.values.length).toBe(1);
     expect(tooltipData.highlightedGeometries.length).toBe(1);
     expect(onOverListener).toBeCalledTimes(1);
     expect(onOutListener).toBeCalledTimes(0);
@@ -423,7 +423,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     isTooltipVisible = isTooltipVisibleSelector(store.getState());
     expect(isTooltipVisible).toBe(false);
     tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
-    expect(tooltipData.tooltipValues.length).toBe(0);
+    expect(tooltipData.tooltip.values.length).toBe(0);
     expect(tooltipData.highlightedGeometries.length).toBe(0);
     expect(onOverListener).toBeCalledTimes(1);
     expect(onOutListener).toBeCalledTimes(1);
@@ -441,7 +441,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     expect(isTooltipVisible).toBe(true);
     let tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
     expect(tooltipData.highlightedGeometries.length).toBe(1);
-    expect(tooltipData.tooltipValues.length).toBe(2); // x value + 1 y value
+    expect(tooltipData.tooltip.values.length).toBe(1);
     expect(onOverListener).toBeCalledTimes(1);
     expect(onOutListener).toBeCalledTimes(0);
     expect(onOverListener.mock.calls[0][0]).toEqual([
@@ -466,7 +466,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     isTooltipVisible = isTooltipVisibleSelector(store.getState());
     expect(isTooltipVisible).toBe(false);
     tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
-    expect(tooltipData.tooltipValues.length).toBe(0);
+    expect(tooltipData.tooltip.values.length).toBe(0);
     expect(tooltipData.highlightedGeometries.length).toBe(0);
     expect(onOverListener).toBeCalledTimes(1);
     expect(onOutListener).toBeCalledTimes(1);
@@ -488,7 +488,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     expect(isTooltipVisible).toBe(true);
     let tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
     expect(tooltipData.highlightedGeometries.length).toBe(1);
-    expect(tooltipData.tooltipValues.length).toBe(2);
+    expect(tooltipData.tooltip.values.length).toBe(1);
     expect(onOverListener).toBeCalledTimes(1);
     expect(onOutListener).toBeCalledTimes(0);
     expect(onOverListener.mock.calls[0][0]).toEqual([
@@ -518,7 +518,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     isTooltipVisible = isTooltipVisibleSelector(store.getState());
     expect(isTooltipVisible).toBe(true);
     tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
-    expect(tooltipData.tooltipValues.length).toBe(2);
+    expect(tooltipData.tooltip.values.length).toBe(1);
     expect(tooltipData.highlightedGeometries.length).toBe(0);
     expect(onOverListener).toBeCalledTimes(1);
     expect(onOutListener).toBeCalledTimes(1);
@@ -540,7 +540,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     expect(isTooltipVisible).toBe(true);
     let tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
     expect(tooltipData.highlightedGeometries.length).toBe(1);
-    expect(tooltipData.tooltipValues.length).toBe(2);
+    expect(tooltipData.tooltip.values.length).toBe(1);
     expect(onOverListener).toBeCalledTimes(1);
     expect(onOutListener).toBeCalledTimes(0);
     expect(onOverListener.mock.calls[0][0]).toEqual([
@@ -570,7 +570,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     isTooltipVisible = isTooltipVisibleSelector(store.getState());
     expect(isTooltipVisible).toBe(true);
     tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
-    expect(tooltipData.tooltipValues.length).toBe(2);
+    expect(tooltipData.tooltip.values.length).toBe(1);
     // we are over the second bar here
     expect(tooltipData.highlightedGeometries.length).toBe(1);
     expect(onOverListener).toBeCalledTimes(2);
@@ -601,7 +601,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     expect(onOutListener).toBeCalledTimes(0);
     let tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
     expect(tooltipData.highlightedGeometries.length).toBe(0);
-    expect(tooltipData.tooltipValues.length).toBe(0);
+    expect(tooltipData.tooltip.values.length).toBe(0);
 
     store.dispatch(onPointerMove({ x: chartLeft + 89, y: chartTop + 0 }, 0));
     const projectedPointerPosition = getProjectedPointerPositionSelector(store.getState());
@@ -615,7 +615,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     expect(isTooltipVisible).toBe(true);
     tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
     expect(tooltipData.highlightedGeometries.length).toBe(0);
-    expect(tooltipData.tooltipValues.length).toBe(2);
+    expect(tooltipData.tooltip.values.length).toBe(1);
     expect(onOverListener).toBeCalledTimes(0);
     expect(onOutListener).toBeCalledTimes(0);
   });
@@ -667,7 +667,7 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     expect(isTooltipVisible).toBe(true);
     const tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
     expect(tooltipData.highlightedGeometries.length).toBe(1);
-    expect(tooltipData.tooltipValues.length).toBe(2);
+    expect(tooltipData.tooltip.values.length).toBe(1);
     expect(onOverListener).toBeCalledTimes(1);
     expect(onOverListener.mock.calls[0][0]).toEqual([
       [
@@ -744,8 +744,8 @@ function mouseOverTestSuite(scaleType: ScaleType) {
     test('chart 0 rotation', () => {
       store.dispatch(onPointerMove({ x: chartLeft + 0, y: chartTop + 89 }, 0));
       const tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
-      expect(tooltipData.tooltipValues[0].value).toBe('bottom 0');
-      expect(tooltipData.tooltipValues[1].value).toBe('left 10');
+      expect(tooltipData.tooltip.header?.value).toBe('bottom 0');
+      expect(tooltipData.tooltip.values[0].value).toBe('left 10');
     });
 
     test('chart 90 deg rotated', () => {
@@ -758,8 +758,8 @@ function mouseOverTestSuite(scaleType: ScaleType) {
       store.dispatch(specParsed());
       store.dispatch(onPointerMove({ x: chartLeft + 0, y: chartTop + 89 }, 0));
       const tooltipData = getTooltipValuesAndGeometriesSelector(store.getState());
-      expect(tooltipData.tooltipValues[0].value).toBe('left 1');
-      expect(tooltipData.tooltipValues[1].value).toBe('bottom 5');
+      expect(tooltipData.tooltip.header?.value).toBe('left 1');
+      expect(tooltipData.tooltip.values[0].value).toBe('bottom 5');
     });
   });
   describe('brush', () => {

--- a/src/chart_types/xy_chart/state/chart_state.specs.test.ts
+++ b/src/chart_types/xy_chart/state/chart_state.specs.test.ts
@@ -1,0 +1,83 @@
+import { GlobalChartState, chartStoreReducer } from '../../../state/chart_state';
+import { createStore, Store } from 'redux';
+import { upsertSpec, specParsed, specParsing } from '../../../state/actions/specs';
+import { MockSeriesSpec } from '../../../mocks/specs';
+import { getLegendItemsSelector } from '../../../state/selectors/get_legend_items';
+
+const data = [
+  { x: 0, y: 10 },
+  { x: 1, y: 10 },
+];
+
+describe('XYChart - specs ordering', () => {
+  let store: Store<GlobalChartState>;
+  beforeEach(() => {
+    const storeReducer = chartStoreReducer('chartId');
+    store = createStore(storeReducer);
+    store.dispatch(specParsing());
+  });
+
+  it('the legend respect the insert [A, B, C] order', () => {
+    store.dispatch(specParsing());
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'A', data })));
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'B', data })));
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'C', data })));
+    store.dispatch(specParsed());
+
+    const legendItems = getLegendItemsSelector(store.getState());
+    const labels = [...legendItems.values()].map((item) => item.label);
+    expect(labels).toEqual(['A', 'B', 'C']);
+  });
+  it('the legend respect the insert order [B, A, C]', () => {
+    store.dispatch(specParsing());
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'B', data })));
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'A', data })));
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'C', data })));
+    store.dispatch(specParsed());
+    const legendItems = getLegendItemsSelector(store.getState());
+    const labels = [...legendItems.values()].map((item) => item.label);
+    expect(labels).toEqual(['B', 'A', 'C']);
+  });
+  it('the legend respect the order when changing properties of existing specs', () => {
+    store.dispatch(specParsing());
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'A', data })));
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'B', data })));
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'C', data })));
+    store.dispatch(specParsed());
+
+    let legendItems = getLegendItemsSelector(store.getState());
+    let labels = [...legendItems.values()].map((item) => item.label);
+    expect(labels).toEqual(['A', 'B', 'C']);
+
+    store.dispatch(specParsing());
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'A', data })));
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'B', name: 'B updated', data })));
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'C', data })));
+    store.dispatch(specParsed());
+
+    legendItems = getLegendItemsSelector(store.getState());
+    labels = [...legendItems.values()].map((item) => item.label);
+    expect(labels).toEqual(['A', 'B updated', 'C']);
+  });
+  it('the legend respect the order when changing the order of the specs', () => {
+    store.dispatch(specParsing());
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'A', data })));
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'B', data })));
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'C', data })));
+    store.dispatch(specParsed());
+
+    let legendItems = getLegendItemsSelector(store.getState());
+    let labels = [...legendItems.values()].map((item) => item.label);
+    expect(labels).toEqual(['A', 'B', 'C']);
+
+    store.dispatch(specParsing());
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'B', data })));
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'A', data })));
+    store.dispatch(upsertSpec(MockSeriesSpec.bar({ id: 'C', data })));
+    store.dispatch(specParsed());
+
+    legendItems = getLegendItemsSelector(store.getState());
+    labels = [...legendItems.values()].map((item) => item.label);
+    expect(labels).toEqual(['B', 'A', 'C']);
+  });
+});

--- a/src/chart_types/xy_chart/state/chart_state.timescales.test.ts
+++ b/src/chart_types/xy_chart/state/chart_state.timescales.test.ts
@@ -69,20 +69,20 @@ describe('Render chart', () => {
     });
     test('check mouse position correctly return inverted value', () => {
       store.dispatch(onPointerMove({ x: 15, y: 10 }, 0)); // check first valid tooltip
-      let tooltipData = getTooltipValuesSelector(store.getState());
-      expect(tooltipData.length).toBe(2); // x value + y value
-      expect(tooltipData[0].value).toBe(day1); // x value
-      expect(tooltipData[1].value).toBe(10); // y value
+      let tooltip = getTooltipValuesSelector(store.getState());
+      expect(tooltip.values.length).toBe(1);
+      expect(tooltip.header?.value).toBe(day1);
+      expect(tooltip.values[0].value).toBe(10);
       store.dispatch(onPointerMove({ x: 35, y: 10 }, 1)); // check second valid tooltip
-      tooltipData = getTooltipValuesSelector(store.getState());
-      expect(tooltipData.length).toBe(2); // x value + y value
-      expect(tooltipData[0].value).toBe(day2); // x value
-      expect(tooltipData[1].value).toBe(22); // y value
+      tooltip = getTooltipValuesSelector(store.getState());
+      expect(tooltip.values.length).toBe(1);
+      expect(tooltip.header?.value).toBe(day2);
+      expect(tooltip.values[0].value).toBe(22);
       store.dispatch(onPointerMove({ x: 76, y: 10 }, 2)); // check third valid tooltip
-      tooltipData = getTooltipValuesSelector(store.getState());
-      expect(tooltipData.length).toBe(2); // x value + y value
-      expect(tooltipData[0].value).toBe(day3); // x value
-      expect(tooltipData[1].value).toBe(6); // y value
+      tooltip = getTooltipValuesSelector(store.getState());
+      expect(tooltip.values.length).toBe(1);
+      expect(tooltip.header?.value).toBe(day3);
+      expect(tooltip.values[0].value).toBe(6);
     });
   });
   describe('line, utc-time, 5m interval', () => {
@@ -138,20 +138,20 @@ describe('Render chart', () => {
     });
     test('check mouse position correctly return inverted value', () => {
       store.dispatch(onPointerMove({ x: 15, y: 10 }, 0)); // check first valid tooltip
-      let tooltipData = getTooltipValuesSelector(store.getState());
-      expect(tooltipData.length).toBe(2); // x value + y value
-      expect(tooltipData[0].value).toBe(date1); // x value
-      expect(tooltipData[1].value).toBe(10); // y value
+      let tooltip = getTooltipValuesSelector(store.getState());
+      expect(tooltip.values.length).toBe(1);
+      expect(tooltip.header?.value).toBe(date1);
+      expect(tooltip.values[0].value).toBe(10);
       store.dispatch(onPointerMove({ x: 35, y: 10 }, 1)); // check second valid tooltip
-      tooltipData = getTooltipValuesSelector(store.getState());
-      expect(tooltipData.length).toBe(2); // x value + y value
-      expect(tooltipData[0].value).toBe(date2); // x value
-      expect(tooltipData[1].value).toBe(22); // y value
+      tooltip = getTooltipValuesSelector(store.getState());
+      expect(tooltip.values.length).toBe(1);
+      expect(tooltip.header?.value).toBe(date2);
+      expect(tooltip.values[0].value).toBe(22);
       store.dispatch(onPointerMove({ x: 76, y: 10 }, 2)); // check third valid tooltip
-      tooltipData = getTooltipValuesSelector(store.getState());
-      expect(tooltipData.length).toBe(2); // x value + y value
-      expect(tooltipData[0].value).toBe(date3); // x value
-      expect(tooltipData[1].value).toBe(6); // y value
+      tooltip = getTooltipValuesSelector(store.getState());
+      expect(tooltip.values.length).toBe(1);
+      expect(tooltip.header?.value).toBe(date3);
+      expect(tooltip.values[0].value).toBe(6);
     });
   });
   describe('line, non utc-time, 5m + 1s interval', () => {
@@ -225,20 +225,20 @@ describe('Render chart', () => {
     });
     test('check mouse position correctly return inverted value', () => {
       store.dispatch(onPointerMove({ x: 15, y: 10 }, 0)); // check first valid tooltip
-      let tooltipData = getTooltipValuesSelector(store.getState());
-      expect(tooltipData.length).toBe(2); // x value + y value
-      expect(tooltipData[0].value).toBe(date1); // x value
-      expect(tooltipData[1].value).toBe(10); // y value
+      let tooltip = getTooltipValuesSelector(store.getState());
+      expect(tooltip.values.length).toBe(1);
+      expect(tooltip.header?.value).toBe(date1);
+      expect(tooltip.values[0].value).toBe(10);
       store.dispatch(onPointerMove({ x: 35, y: 10 }, 1)); // check second valid tooltip
-      tooltipData = getTooltipValuesSelector(store.getState());
-      expect(tooltipData.length).toBe(2); // x value + y value
-      expect(tooltipData[0].value).toBe(date2); // x value
-      expect(tooltipData[1].value).toBe(22); // y value
+      tooltip = getTooltipValuesSelector(store.getState());
+      expect(tooltip.values.length).toBe(1);
+      expect(tooltip.header?.value).toBe(date2);
+      expect(tooltip.values[0].value).toBe(22);
       store.dispatch(onPointerMove({ x: 76, y: 10 }, 2)); // check third valid tooltip
-      tooltipData = getTooltipValuesSelector(store.getState());
-      expect(tooltipData.length).toBe(2); // x value + y value
-      expect(tooltipData[0].value).toBe(date3); // x value
-      expect(tooltipData[1].value).toBe(6); // y value
+      tooltip = getTooltipValuesSelector(store.getState());
+      expect(tooltip.values.length).toBe(1);
+      expect(tooltip.header?.value).toBe(date3);
+      expect(tooltip.values[0].value).toBe(6);
     });
   });
 });

--- a/src/chart_types/xy_chart/state/chart_state.tooltip.test.ts
+++ b/src/chart_types/xy_chart/state/chart_state.tooltip.test.ts
@@ -28,12 +28,12 @@ describe('XYChart - State tooltips', () => {
   });
 
   describe('should compute tooltip values depending on tooltip type', () => {
-    it.each<[TooltipType, number, number]>([
-      [TooltipType.None, 0, 0],
-      [TooltipType.Follow, 1, 2],
-      [TooltipType.VerticalCursor, 1, 2],
-      [TooltipType.Crosshairs, 1, 2],
-    ])('tooltip type %s', (tooltipType, expectedHgeomsLength, expectedTooltipValuesLength) => {
+    it.each<[TooltipType, number, boolean, number]>([
+      [TooltipType.None, 0, true, 0],
+      [TooltipType.Follow, 1, false, 1],
+      [TooltipType.VerticalCursor, 1, false, 1],
+      [TooltipType.Crosshairs, 1, false, 1],
+    ])('tooltip type %s', (tooltipType, expectedHgeomsLength, expectHeader, expectedTooltipValuesLength) => {
       store.dispatch(onPointerMove({ x: 25, y: 50 }, 0));
       store.dispatch(
         upsertSpec(
@@ -47,7 +47,8 @@ describe('XYChart - State tooltips', () => {
       store.dispatch(specParsed());
       const state = store.getState();
       const tooltipValues = getTooltipValuesAndGeometriesSelector(state);
-      expect(tooltipValues.tooltipValues).toHaveLength(expectedTooltipValuesLength);
+      expect(tooltipValues.tooltip.values).toHaveLength(expectedTooltipValuesLength);
+      expect(tooltipValues.tooltip.header === null).toBe(expectHeader);
       expect(tooltipValues.highlightedGeometries).toHaveLength(expectedHgeomsLength);
     });
   });

--- a/src/chart_types/xy_chart/state/selectors/get_annotation_tooltip_state.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_annotation_tooltip_state.ts
@@ -1,7 +1,6 @@
 import createCachedSelector from 're-reselect';
 import { Dimensions } from '../../../../utils/dimensions';
 import { Point } from '../../../../utils/point';
-import { TooltipValue } from '../../utils/interactions';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
 import { getAxisSpecsSelector, getAnnotationSpecsSelector } from './get_specs';
 import { AxisSpec, AnnotationSpec, Rotation, AnnotationTypes } from '../../utils/specs';
@@ -15,7 +14,7 @@ import { getChartRotationSelector } from '../../../../state/selectors/get_chart_
 import { AnnotationId } from '../../../../utils/ids';
 import { computeSeriesGeometriesSelector } from './compute_series_geometries';
 import { ComputedGeometries } from '../utils';
-import { getTooltipValuesSelector } from './get_tooltip_values_highlighted_geoms';
+import { getTooltipValuesSelector, TooltipData } from './get_tooltip_values_highlighted_geoms';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { GlobalChartState } from '../../../../state/chart_state';
 
@@ -47,7 +46,7 @@ function getAnnotationTooltipState(
   annotationSpecs: AnnotationSpec[],
   axesSpecs: AxisSpec[],
   annotationDimensions: Map<AnnotationId, AnnotationDimensions>,
-  tooltipValues: TooltipValue[],
+  tooltip: TooltipData,
 ): AnnotationTooltipState | null {
   // get positions relative to chart
   if (x < 0 || y < 0) {
@@ -70,7 +69,7 @@ function getAnnotationTooltipState(
   );
 
   // If there's a highlighted chart element tooltip value, don't show annotation tooltip
-  const isChartTooltipDisplayed = tooltipValues.some(({ isHighlighted }) => isHighlighted);
+  const isChartTooltipDisplayed = tooltip.values.some(({ isHighlighted }) => isHighlighted);
   if (
     tooltipState &&
     tooltipState.isVisible &&

--- a/src/chart_types/xy_chart/state/selectors/get_legend_tooltip_values.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_legend_tooltip_values.ts
@@ -5,7 +5,7 @@ import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 
 export const getLegendTooltipValuesSelector = createCachedSelector(
   [getTooltipValuesSelector],
-  (tooltipData): Map<string, TooltipLegendValue> => {
-    return getSeriesTooltipValues(tooltipData);
+  ({ values }): Map<string, TooltipLegendValue> => {
+    return getSeriesTooltipValues(values);
   },
 )(getChartIdSelector);

--- a/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
@@ -21,12 +21,19 @@ import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { hasSingleSeriesSelector } from './has_single_series';
 
 const EMPTY_VALUES = Object.freeze({
-  tooltipValues: [],
+  tooltip: {
+    header: null,
+    values: [],
+  },
   highlightedGeometries: [],
 });
 
+export interface TooltipData {
+  header: TooltipValue | null;
+  values: TooltipValue[];
+}
 export interface TooltipAndHighlightedGeoms {
-  tooltipValues: TooltipValue[];
+  tooltip: TooltipData;
   highlightedGeometries: IndexedGeometry[];
 }
 
@@ -84,7 +91,7 @@ function getTooltipAndHighlightFromXValue(
   }
 
   // build the tooltip value list
-  let xValueInfo: TooltipValue | null = null;
+  let tooltipHeader: TooltipValue | null = null;
   const highlightedGeometries: IndexedGeometry[] = [];
   const tooltipValues = xMatchingGeoms
     .filter(({ value: { y } }) => y !== null)
@@ -134,27 +141,29 @@ function getTooltipAndHighlightFromXValue(
       );
 
       // format only one time the x value
-      if (!xValueInfo) {
+      if (!tooltipHeader) {
         // if we have a tooltipHeaderFormatter, then don't pass in the xAxis as the user will define a formatter
         const xAxisFormatSpec = [0, 180].includes(chartRotation) ? xAxis : yAxis;
         const formatterAxis = tooltipHeaderFormatter ? undefined : xAxisFormatSpec;
-        xValueInfo = formatTooltip(indexedGeometry, spec, true, false, hasSingleSeries, formatterAxis);
-        return [xValueInfo, ...acc, formattedTooltip];
+        tooltipHeader = formatTooltip(indexedGeometry, spec, true, false, hasSingleSeries, formatterAxis);
       }
 
       return [...acc, formattedTooltip];
     }, []);
 
   return {
-    tooltipValues,
+    tooltip: {
+      header: tooltipHeader,
+      values: tooltipValues,
+    },
     highlightedGeometries,
   };
 }
 
 export const getTooltipValuesSelector = createCachedSelector(
   [getTooltipValuesAndGeometriesSelector],
-  (values): TooltipValue[] => {
-    return values.tooltipValues;
+  ({ tooltip }): TooltipData => {
+    return tooltip;
   },
 )(getChartIdSelector);
 

--- a/src/chart_types/xy_chart/state/selectors/is_tooltip_visible.ts
+++ b/src/chart_types/xy_chart/state/selectors/is_tooltip_visible.ts
@@ -1,10 +1,10 @@
 import createCachedSelector from 're-reselect';
-import { TooltipType, TooltipValue, isTooltipType, isTooltipProps } from '../../utils/interactions';
+import { TooltipType, isTooltipType, isTooltipProps } from '../../utils/interactions';
 import { Point } from '../../../../utils/point';
 import { GlobalChartState, PointerStates } from '../../../../state/chart_state';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getProjectedPointerPositionSelector } from './get_projected_pointer_position';
-import { getTooltipValuesSelector } from './get_tooltip_values_highlighted_geoms';
+import { getTooltipValuesSelector, TooltipData } from './get_tooltip_values_highlighted_geoms';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 
 const getTooltipType = (state: GlobalChartState): TooltipType | undefined => {
@@ -30,13 +30,13 @@ function isTooltipVisible(
   tooltipType: TooltipType | undefined,
   pointer: PointerStates,
   projectedPointerPosition: Point,
-  tooltipValues: TooltipValue[],
+  tooltip: TooltipData,
 ) {
   return (
     tooltipType !== TooltipType.None &&
     pointer.down === null &&
     projectedPointerPosition.x > -1 &&
     projectedPointerPosition.y > -1 &&
-    tooltipValues.length > 0
+    tooltip.values.length > 0
   );
 }

--- a/src/chart_types/xy_chart/tooltip/tooltip.ts
+++ b/src/chart_types/xy_chart/tooltip/tooltip.ts
@@ -26,12 +26,7 @@ export function getSeriesTooltipValues(
   // map from seriesKey to TooltipLegendValue
   const seriesTooltipValues = new Map<string, TooltipLegendValue>();
 
-  // First TooltipLegendValue is the header
-  if (tooltipValues.length <= 1) {
-    return seriesTooltipValues;
-  }
-
-  tooltipValues.slice(1).forEach(({ seriesKey, value, yAccessor }) => {
+  tooltipValues.forEach(({ seriesKey, value, yAccessor }) => {
     const seriesValue = defaultValue ? defaultValue : value;
     const current = seriesTooltipValues.get(seriesKey) || {};
 

--- a/src/specs/specs_parser.tsx
+++ b/src/specs/specs_parser.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect } from 'react';
 import { bindActionCreators, Dispatch } from 'redux';
 import { connect } from 'react-redux';
-import { specParsed, specUnmounted } from '../state/actions/specs';
+import { specParsing, specParsed, specUnmounted } from '../state/actions/specs';
 
 export const SpecsParserComponent: React.FunctionComponent<{}> = (props) => {
   const injected = props as DispatchProps;
+  injected.specParsing();
   useEffect(() => {
     injected.specParsed();
   });
@@ -18,6 +19,7 @@ export const SpecsParserComponent: React.FunctionComponent<{}> = (props) => {
 };
 
 interface DispatchProps {
+  specParsing: () => void;
   specParsed: () => void;
   specUnmounted: () => void;
 }
@@ -25,6 +27,7 @@ interface DispatchProps {
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps =>
   bindActionCreators(
     {
+      specParsing,
       specParsed,
       specUnmounted,
     },

--- a/src/state/actions/specs.ts
+++ b/src/state/actions/specs.ts
@@ -3,7 +3,12 @@ import { Spec } from '../../specs';
 export const UPSERT_SPEC = 'UPSERT_SPEC';
 export const REMOVE_SPEC = 'REMOVE_SPEC';
 export const SPEC_PARSED = 'SPEC_PARSED';
+export const SPEC_PARSING = 'SPEC_PARSING';
 export const SPEC_UNMOUNTED = 'SPEC_UNMOUNTED';
+
+interface SpecParsingAction {
+  type: typeof SPEC_PARSING;
+}
 
 interface SpecParsedAction {
   type: typeof SPEC_PARSED;
@@ -35,8 +40,17 @@ export function specParsed(): SpecParsedAction {
   return { type: SPEC_PARSED };
 }
 
+export function specParsing(): SpecParsingAction {
+  return { type: SPEC_PARSING };
+}
+
 export function specUnmounted(): SpecUnmountedAction {
   return { type: SPEC_UNMOUNTED };
 }
 
-export type SpecActions = SpecParsedAction | SpecUnmountedAction | UpsertSpecAction | RemoveSpecAction;
+export type SpecActions =
+  | SpecParsingAction
+  | SpecParsedAction
+  | SpecUnmountedAction
+  | UpsertSpecAction
+  | RemoveSpecAction;

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -1,4 +1,4 @@
-import { SPEC_PARSED, SPEC_UNMOUNTED, UPSERT_SPEC, REMOVE_SPEC } from './actions/specs';
+import { SPEC_PARSED, SPEC_UNMOUNTED, UPSERT_SPEC, REMOVE_SPEC, SPEC_PARSING } from './actions/specs';
 import { interactionsReducer } from './reducers/interactions';
 import { ChartTypes } from '../chart_types';
 import { XYAxisChartState } from '../chart_types/xy_chart/state/chart_state';
@@ -142,6 +142,15 @@ export const chartStoreReducer = (chartId: string) => {
   const initialState = getInitialState(chartId);
   return (state = initialState, action: StateActions): GlobalChartState => {
     switch (action.type) {
+      case SPEC_PARSING:
+        return {
+          ...state,
+          specsInitialized: false,
+          chartRendered: false,
+          specs: {
+            [DEFAULT_SETTINGS_SPEC.id]: DEFAULT_SETTINGS_SPEC,
+          },
+        };
       case SPEC_PARSED:
         const chartType = findMainChartType(state.specs);
 
@@ -150,7 +159,6 @@ export const chartStoreReducer = (chartId: string) => {
           return {
             ...state,
             specsInitialized: true,
-            chartRendered: false,
             chartType,
             internalChartState,
           };
@@ -158,7 +166,6 @@ export const chartStoreReducer = (chartId: string) => {
           return {
             ...state,
             specsInitialized: true,
-            chartRendered: false,
             chartType,
           };
         }
@@ -171,8 +178,6 @@ export const chartStoreReducer = (chartId: string) => {
       case UPSERT_SPEC:
         return {
           ...state,
-          specsInitialized: false,
-          chartRendered: false,
           specs: {
             ...state.specs,
             [action.spec.id]: action.spec,
@@ -182,8 +187,6 @@ export const chartStoreReducer = (chartId: string) => {
         const { [action.id]: specToRemove, ...rest } = state.specs;
         return {
           ...state,
-          specsInitialized: false,
-          chartRendered: false,
           specs: {
             ...rest,
           },


### PR DESCRIPTION
## Summary

This PR is the first one to that allow us to implement a valid and clear method to sort the splitted series and allow custom rendering order of bars/area/lines in either chart, legend and tooltips.

This PR in particular clean up few small items:

- include the parsing action that that is useful to distinguish in which state we are when updating a spec. This will also ensure that the default setting component is always part of the specs array
- split the `tooltipValues` array into an header and an array with only the metric values.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [x] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
