### PR TITLE
fix: try to get canvas post mounting

### DIFF
--- a/src/chart_types/partition_chart/renderer/canvas/partition.tsx
+++ b/src/chart_types/partition_chart/renderer/canvas/partition.tsx
@@ -44,7 +44,15 @@ class PartitionComponent extends React.Component<PartitionProps> {
     }
   }
 
+  private tryCanvasContext() {
+    const canvas = this.canvasRef.current;
+    this.ctx = canvas && canvas.getContext('2d');
+  }
+
   componentDidUpdate() {
+    if (!this.ctx) {
+      this.tryCanvasContext();
+    }
     if (this.props.initialized) {
       this.drawCanvas();
       this.props.onChartRendered();
@@ -54,8 +62,7 @@ class PartitionComponent extends React.Component<PartitionProps> {
   componentDidMount() {
     // the DOM element has just been appended, and getContext('2d') is always non-null,
     // so we could use a couple of ! non-null assertions but no big plus
-    const canvas = this.canvasRef.current;
-    this.ctx = canvas && canvas.getContext('2d');
+    this.tryCanvasContext();
     this.drawCanvas();
   }
 


### PR DESCRIPTION
## Summary

While treemap / pie charts render in Storybook and Kibana Lens, Dashboard initially mounts the chart component with incomplete settings, so the Canvas2d context is not assigned upon mounting. The fix checks for `this.ctx` in component update, and attempts to get the proper value if still falsey. Thanks @wylieconlon for reporting and @markov00 for triaging.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] ~~Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)~~
- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [ ] ~~Proper documentation or storybook story was added for features that require explanation or tutorials~~
- [ ] ~~Unit tests were updated or added to match the most common scenarios~~
- [X] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
