### PR TITLE
fix: replace PureComponent with shouldComponentUpdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "d3-color": "^1.4.0",
     "d3-scale": "^1.0.7",
     "d3-shape": "^1.3.4",
+    "fast-deep-equal": "^3.1.1",
     "konva": "^4.0.18",
     "newtype-ts": "^0.2.4",
     "prop-types": "^15.7.2",

--- a/src/chart_types/xy_chart/renderer/canvas/area_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/area_geometries.tsx
@@ -25,10 +25,8 @@ interface AreaGeometriesDataProps {
   highlightedLegendItem: LegendItem | null;
   clippings: Clippings;
 }
-interface AreaGeometriesDataState {
-  overPoint?: PointGeometry;
-}
-export class AreaGeometries extends React.Component<AreaGeometriesDataProps, AreaGeometriesDataState> {
+
+export class AreaGeometries extends React.Component<AreaGeometriesDataProps> {
   static defaultProps: Partial<AreaGeometriesDataProps> = {
     animated: false,
   };
@@ -36,13 +34,10 @@ export class AreaGeometries extends React.Component<AreaGeometriesDataProps, Are
   constructor(props: AreaGeometriesDataProps) {
     super(props);
     this.barSeriesRef = React.createRef();
-    this.state = {
-      overPoint: undefined,
-    };
   }
 
-  shouldComponentUpdate(nextProps: AreaGeometriesDataProps, nextState: AreaGeometriesDataState) {
-    return !deepEqual(this.props, nextProps) || !deepEqual(this.state, nextState);
+  shouldComponentUpdate(nextProps: AreaGeometriesDataProps) {
+    return !deepEqual(this.props, nextProps);
   }
 
   render() {

--- a/src/chart_types/xy_chart/renderer/canvas/area_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/area_geometries.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Group as KonvaGroup } from 'konva/types/Group';
 import { PathConfig } from 'konva/types/shapes/Path';
 import { Circle, Group, Path } from 'react-konva';
+import deepEqual from 'fast-deep-equal/es6/react';
 import {
   buildAreaRenderProps,
   buildPointStyleProps,
@@ -27,7 +28,7 @@ interface AreaGeometriesDataProps {
 interface AreaGeometriesDataState {
   overPoint?: PointGeometry;
 }
-export class AreaGeometries extends React.PureComponent<AreaGeometriesDataProps, AreaGeometriesDataState> {
+export class AreaGeometries extends React.Component<AreaGeometriesDataProps, AreaGeometriesDataState> {
   static defaultProps: Partial<AreaGeometriesDataProps> = {
     animated: false,
   };
@@ -39,6 +40,11 @@ export class AreaGeometries extends React.PureComponent<AreaGeometriesDataProps,
       overPoint: undefined,
     };
   }
+
+  shouldComponentUpdate(nextProps: AreaGeometriesDataProps, nextState: AreaGeometriesDataState) {
+    return !deepEqual(this.props, nextProps) || !deepEqual(this.state, nextState);
+  }
+
   render() {
     return (
       <Group ref={this.barSeriesRef} key={'bar_series'}>

--- a/src/chart_types/xy_chart/renderer/canvas/axis.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/axis.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Group, Line, Rect, Text } from 'react-konva';
+import deepEqual from 'fast-deep-equal/es6/react';
 import {
   AxisTick,
   AxisTicksDimensions,
@@ -36,7 +37,11 @@ interface AxisProps {
   chartDimensions: Dimensions;
 }
 
-export class Axis extends React.PureComponent<AxisProps> {
+export class Axis extends React.Component<AxisProps> {
+  shouldComponentUpdate(nextProps: AxisProps) {
+    return !deepEqual(this.props, nextProps);
+  }
+
   private renderTickLabel = (tick: AxisTick, i: number) => {
     /**
      * padding is already computed through width
@@ -249,7 +254,11 @@ interface AxesProps {
   debug: boolean;
   chartDimensions: Dimensions;
 }
-class AxesComponent extends React.PureComponent<AxesProps> {
+class AxesComponent extends React.Component<AxesProps> {
+  shouldComponentUpdate(nextProps: AxesProps) {
+    return !deepEqual(this.props, nextProps);
+  }
+
   render() {
     const {
       axesVisibleTicks,

--- a/src/chart_types/xy_chart/renderer/canvas/bar_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/bar_geometries.tsx
@@ -2,6 +2,7 @@ import { Group as KonvaGroup } from 'konva/types/Group';
 import React from 'react';
 import { Group, Rect } from 'react-konva';
 import { animated, Spring } from 'react-spring/renderprops-konva.cjs';
+import deepEqual from 'fast-deep-equal/es6/react';
 import { buildBarRenderProps, buildBarBorderRenderProps } from './utils/rendering_props_utils';
 import { BarGeometry } from '../../../../utils/geometry';
 import { LegendItem } from '../../../../chart_types/xy_chart/legend/legend';
@@ -19,7 +20,7 @@ interface BarGeometriesDataProps {
 interface BarGeometriesDataState {
   overBar?: BarGeometry;
 }
-export class BarGeometries extends React.PureComponent<BarGeometriesDataProps, BarGeometriesDataState> {
+export class BarGeometries extends React.Component<BarGeometriesDataProps, BarGeometriesDataState> {
   static defaultProps: Partial<BarGeometriesDataProps> = {
     animated: false,
   };
@@ -31,6 +32,11 @@ export class BarGeometries extends React.PureComponent<BarGeometriesDataProps, B
       overBar: undefined,
     };
   }
+
+  shouldComponentUpdate(nextProps: BarGeometriesDataProps, nextState: BarGeometriesDataState) {
+    return !deepEqual(this.props, nextProps) || !deepEqual(this.state, nextState);
+  }
+
   render() {
     const { bars, clippings } = this.props;
     return (

--- a/src/chart_types/xy_chart/renderer/canvas/bar_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/bar_geometries.tsx
@@ -17,8 +17,10 @@ interface BarGeometriesDataProps {
   highlightedLegendItem: LegendItem | null;
   clippings: Clippings;
 }
-
-export class BarGeometries extends React.Component<BarGeometriesDataProps> {
+interface BarGeometriesDataState {
+  overBar?: BarGeometry;
+}
+export class BarGeometries extends React.Component<BarGeometriesDataProps, BarGeometriesDataState> {
   static defaultProps: Partial<BarGeometriesDataProps> = {
     animated: false,
   };
@@ -26,10 +28,13 @@ export class BarGeometries extends React.Component<BarGeometriesDataProps> {
   constructor(props: BarGeometriesDataProps) {
     super(props);
     this.barSeriesRef = React.createRef();
+    this.state = {
+      overBar: undefined,
+    };
   }
 
-  shouldComponentUpdate(nextProps: BarGeometriesDataProps) {
-    return !deepEqual(this.props, nextProps);
+  shouldComponentUpdate(nextProps: BarGeometriesDataProps, nextState: BarGeometriesDataState) {
+    return !deepEqual(this.props, nextProps) || !deepEqual(this.state, nextState);
   }
 
   render() {
@@ -42,11 +47,25 @@ export class BarGeometries extends React.Component<BarGeometriesDataProps> {
   }
 
   private renderBarGeoms = (bars: BarGeometry[]): JSX.Element[] => {
+    const { overBar } = this.state;
     const { sharedStyle } = this.props;
     return bars.map((bar, index) => {
       const { x, y, width, height, color, seriesStyle } = bar;
 
-      const geometryStyle = getGeometryStateStyle(bar.seriesIdentifier, this.props.highlightedLegendItem, sharedStyle);
+      // Properties to determine if we need to highlight individual bars depending on hover state
+      const hasGeometryHover = overBar != null;
+      const hasHighlight = overBar === bar;
+      const individualHighlight = {
+        hasGeometryHover,
+        hasHighlight,
+      };
+
+      const geometryStyle = getGeometryStateStyle(
+        bar.seriesIdentifier,
+        this.props.highlightedLegendItem,
+        sharedStyle,
+        individualHighlight,
+      );
       const key = `bar-${index}`;
 
       if (this.props.animated) {

--- a/src/chart_types/xy_chart/renderer/canvas/bar_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/bar_geometries.tsx
@@ -17,10 +17,8 @@ interface BarGeometriesDataProps {
   highlightedLegendItem: LegendItem | null;
   clippings: Clippings;
 }
-interface BarGeometriesDataState {
-  overBar?: BarGeometry;
-}
-export class BarGeometries extends React.Component<BarGeometriesDataProps, BarGeometriesDataState> {
+
+export class BarGeometries extends React.Component<BarGeometriesDataProps> {
   static defaultProps: Partial<BarGeometriesDataProps> = {
     animated: false,
   };
@@ -28,13 +26,10 @@ export class BarGeometries extends React.Component<BarGeometriesDataProps, BarGe
   constructor(props: BarGeometriesDataProps) {
     super(props);
     this.barSeriesRef = React.createRef();
-    this.state = {
-      overBar: undefined,
-    };
   }
 
-  shouldComponentUpdate(nextProps: BarGeometriesDataProps, nextState: BarGeometriesDataState) {
-    return !deepEqual(this.props, nextProps) || !deepEqual(this.state, nextState);
+  shouldComponentUpdate(nextProps: BarGeometriesDataProps) {
+    return !deepEqual(this.props, nextProps);
   }
 
   render() {
@@ -47,25 +42,11 @@ export class BarGeometries extends React.Component<BarGeometriesDataProps, BarGe
   }
 
   private renderBarGeoms = (bars: BarGeometry[]): JSX.Element[] => {
-    const { overBar } = this.state;
     const { sharedStyle } = this.props;
     return bars.map((bar, index) => {
       const { x, y, width, height, color, seriesStyle } = bar;
 
-      // Properties to determine if we need to highlight individual bars depending on hover state
-      const hasGeometryHover = overBar != null;
-      const hasHighlight = overBar === bar;
-      const individualHighlight = {
-        hasGeometryHover,
-        hasHighlight,
-      };
-
-      const geometryStyle = getGeometryStateStyle(
-        bar.seriesIdentifier,
-        this.props.highlightedLegendItem,
-        sharedStyle,
-        individualHighlight,
-      );
+      const geometryStyle = getGeometryStateStyle(bar.seriesIdentifier, this.props.highlightedLegendItem, sharedStyle);
       const key = `bar-${index}`;
 
       if (this.props.animated) {

--- a/src/chart_types/xy_chart/renderer/canvas/bar_values.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/bar_values.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Group, Rect, Text } from 'react-konva';
+import deepEqual from 'fast-deep-equal/es6/react';
 import { Rotation } from '../../utils/specs';
 import { Theme } from '../../../../utils/themes/theme';
 import { Dimensions } from '../../../../utils/dimensions';
@@ -23,7 +24,11 @@ interface BarValuesProps {
   bars: BarGeometry[];
 }
 
-export class BarValuesComponent extends React.PureComponent<BarValuesProps> {
+export class BarValuesComponent extends React.Component<BarValuesProps> {
+  shouldComponentUpdate(nextProps: BarValuesProps) {
+    return !deepEqual(this.props, nextProps);
+  }
+
   render() {
     const { chartDimensions, bars } = this.props;
     if (!bars) {

--- a/src/chart_types/xy_chart/renderer/canvas/grid.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/grid.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Group, Line } from 'react-konva';
 import { connect } from 'react-redux';
+import deepEqual from 'fast-deep-equal/es6/react';
 import { AxisLinePosition, isVerticalGrid } from '../../utils/axis_utils';
 import { GridLineConfig, mergeGridLineConfigs, Theme } from '../../../../utils/themes/theme';
 import { Dimensions } from '../../../../utils/dimensions';
@@ -22,7 +23,11 @@ interface GridProps {
   chartDimensions: Dimensions;
 }
 
-class GridComponent extends React.PureComponent<GridProps> {
+class GridComponent extends React.Component<GridProps> {
+  shouldComponentUpdate(nextProps: GridProps) {
+    return !deepEqual(this.props, nextProps);
+  }
+
   render() {
     const { axesGridLinesPositions, axesSpecs, chartDimensions, chartTheme } = this.props;
     const gridComponents: JSX.Element[] = [];

--- a/src/chart_types/xy_chart/renderer/canvas/line_annotation.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/line_annotation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Group, Line } from 'react-konva';
+import deepEqual from 'fast-deep-equal/es6/react';
 import { LineAnnotationStyle } from '../../../../utils/themes/theme';
 import { AnnotationLineProps } from '../../annotations/line_annotation_tooltip';
 
@@ -8,7 +9,11 @@ interface LineAnnotationProps {
   lineStyle: LineAnnotationStyle;
 }
 
-export class LineAnnotation extends React.PureComponent<LineAnnotationProps> {
+export class LineAnnotation extends React.Component<LineAnnotationProps> {
+  shouldComponentUpdate(nextProps: LineAnnotationProps) {
+    return !deepEqual(this.props, nextProps);
+  }
+
   render() {
     const { lines } = this.props;
 

--- a/src/chart_types/xy_chart/renderer/canvas/line_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/line_geometries.tsx
@@ -22,10 +22,8 @@ interface LineGeometriesDataProps {
   highlightedLegendItem: LegendItem | null;
   clippings: Clippings;
 }
-interface LineGeometriesDataState {
-  overPoint?: PointGeometry;
-}
-export class LineGeometries extends React.Component<LineGeometriesDataProps, LineGeometriesDataState> {
+
+export class LineGeometries extends React.Component<LineGeometriesDataProps> {
   static defaultProps: Partial<LineGeometriesDataProps> = {
     animated: false,
   };
@@ -38,8 +36,8 @@ export class LineGeometries extends React.Component<LineGeometriesDataProps, Lin
     };
   }
 
-  shouldComponentUpdate(nextProps: LineGeometriesDataProps, nextState: LineGeometriesDataState) {
-    return !deepEqual(this.props, nextProps) || !deepEqual(this.state, nextState);
+  shouldComponentUpdate(nextProps: LineGeometriesDataProps) {
+    return !deepEqual(this.props, nextProps);
   }
 
   render() {

--- a/src/chart_types/xy_chart/renderer/canvas/line_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/line_geometries.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Group as KonvaGroup } from 'konva/types/Group';
 import { Circle, Group, Path } from 'react-konva';
+import deepEqual from 'fast-deep-equal/es6/react';
 import {
   buildLineRenderProps,
   buildPointStyleProps,
@@ -24,7 +25,7 @@ interface LineGeometriesDataProps {
 interface LineGeometriesDataState {
   overPoint?: PointGeometry;
 }
-export class LineGeometries extends React.PureComponent<LineGeometriesDataProps, LineGeometriesDataState> {
+export class LineGeometries extends React.Component<LineGeometriesDataProps, LineGeometriesDataState> {
   static defaultProps: Partial<LineGeometriesDataProps> = {
     animated: false,
   };
@@ -35,6 +36,10 @@ export class LineGeometries extends React.PureComponent<LineGeometriesDataProps,
     this.state = {
       overPoint: undefined,
     };
+  }
+
+  shouldComponentUpdate(nextProps: LineGeometriesDataProps, nextState: LineGeometriesDataState) {
+    return !deepEqual(this.props, nextProps) || !deepEqual(this.state, nextState);
   }
 
   render() {

--- a/src/chart_types/xy_chart/renderer/canvas/rect_annotation.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/rect_annotation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Group, Rect } from 'react-konva';
+import deepEqual from 'fast-deep-equal/es6';
 import { RectAnnotationStyle } from '../../../../utils/themes/theme';
 import { AnnotationRectProps } from '../../annotations/rect_annotation_tooltip';
 
@@ -8,7 +9,11 @@ interface Props {
   rectStyle: RectAnnotationStyle;
 }
 
-export class RectAnnotation extends React.PureComponent<Props> {
+export class RectAnnotation extends React.Component<Props> {
+  shouldComponentUpdate(nextProps: Props) {
+    return !deepEqual(this.props, nextProps);
+  }
+
   render() {
     const { rects } = this.props;
     return <Group>{rects.map(this.renderAnnotationRect)}</Group>;

--- a/src/chart_types/xy_chart/specs/line_annotation.tsx
+++ b/src/chart_types/xy_chart/specs/line_annotation.tsx
@@ -1,4 +1,5 @@
-import React, { createRef, CSSProperties, PureComponent } from 'react';
+import React, { createRef, CSSProperties, Component } from 'react';
+import deepEqual from 'fast-deep-equal/es6/react';
 import { LineAnnotationSpec, DEFAULT_GLOBAL_ID, AnnotationTypes } from '../utils/specs';
 import { DEFAULT_ANNOTATION_LINE_STYLE } from '../../../utils/themes/theme';
 import { bindActionCreators, Dispatch } from 'redux';
@@ -12,7 +13,7 @@ type InjectedProps = LineAnnotationSpec &
   Readonly<{
     children?: React.ReactNode;
   }>;
-export class LineAnnotationSpecComponent extends PureComponent<LineAnnotationSpec> {
+export class LineAnnotationSpecComponent extends Component<LineAnnotationSpec> {
   static defaultProps: Partial<LineAnnotationSpec> = {
     chartType: ChartTypes.XYAxis,
     specType: SpecTypes.Annotation,
@@ -38,6 +39,11 @@ export class LineAnnotationSpecComponent extends PureComponent<LineAnnotationSpe
     }
     upsertSpec({ ...config });
   }
+
+  shouldComponentUpdate(nextProps: LineAnnotationSpec) {
+    return !deepEqual(this.props, nextProps);
+  }
+
   componentDidUpdate() {
     const { upsertSpec, removeSpec, children, ...config } = this.props as InjectedProps;
     if (this.markerRef.current) {

--- a/src/components/chart_container.tsx
+++ b/src/components/chart_container.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { bindActionCreators, Dispatch } from 'redux';
 import { connect } from 'react-redux';
+import deepEqual from 'fast-deep-equal/es6/react';
 import { GlobalChartState, BackwardRef } from '../state/chart_state';
 import { onMouseUp, onMouseDown, onPointerMove } from '../state/actions/mouse';
 import { getInternalChartRendererSelector } from '../state/selectors/get_chart_type_components';
@@ -38,9 +39,10 @@ type ReactiveChartProps = ReactiveChartStateProps & ReactiveChartDispatchProps &
 class ChartContainerComponent extends React.Component<ReactiveChartProps> {
   static displayName = 'ChartContainer';
 
-  shouldComponentUpdate(props: ReactiveChartProps) {
-    return props.initialized;
+  shouldComponentUpdate(nextProps: ReactiveChartProps) {
+    return !deepEqual(this.props, nextProps);
   }
+
   handleMouseMove = ({
     nativeEvent: { offsetX, offsetY, timeStamp },
   }: React.MouseEvent<HTMLDivElement, MouseEvent>) => {

--- a/src/components/icons/assets/dot.tsx
+++ b/src/components/icons/assets/dot.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
+import deepEqual from 'fast-deep-equal/es6/react';
 import { Props } from '../icon';
 
-export class DotIcon extends React.PureComponent<Props> {
+export class DotIcon extends React.Component<Props> {
+  shouldComponentUpdate(nextProps: Props) {
+    return !deepEqual(this.props, nextProps);
+  }
+
   render() {
     return (
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" {...this.props}>

--- a/src/components/icons/icon.tsx
+++ b/src/components/icons/icon.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React, { SVGAttributes } from 'react';
+import deepEqual from 'fast-deep-equal/es6/react';
 import { AlertIcon } from './assets/alert';
 import { DotIcon } from './assets/dot';
 import { EmptyIcon } from './assets/empty';
@@ -31,7 +32,11 @@ export interface IconProps {
 
 export type Props = Omit<SVGAttributes<SVGElement>, 'color' | 'type'> & IconProps;
 
-export class Icon extends React.PureComponent<Props> {
+export class Icon extends React.Component<Props> {
+  shouldComponentUpdate(nextProps: Props) {
+    return !deepEqual(this.props, nextProps);
+  }
+
   render() {
     const { type, color, className, tabIndex, ...rest } = this.props;
     let optionalCustomStyles = null;

--- a/src/components/legend/legend_item.tsx
+++ b/src/components/legend/legend_item.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import deepEqual from 'fast-deep-equal/es6/react';
 import { Icon } from '../icons/icon';
 import { LegendItemListener, BasicListener } from '../../specs/settings';
 import { LegendItem } from '../../chart_types/xy_chart/legend/legend';
@@ -20,10 +21,6 @@ interface LegendItemProps {
   legendItemOutAction: typeof onLegendItemOutAction;
   legendItemOverAction: typeof onLegendItemOverAction;
   toggleDeselectSeriesAction: (legendItemId: SeriesIdentifier) => void;
-}
-
-interface LegendItemState {
-  isColorPickerOpen: boolean;
 }
 
 /**
@@ -92,8 +89,12 @@ function renderColor(color: string, isSeriesVisible = true) {
   );
 }
 
-export class LegendListItem extends React.PureComponent<LegendItemProps, LegendItemState> {
+export class LegendListItem extends React.Component<LegendItemProps> {
   static displayName = 'LegendItem';
+
+  shouldComponentUpdate(nextProps: LegendItemProps) {
+    return !deepEqual(this.props, nextProps);
+  }
 
   render() {
     const { displayValue, legendItem, legendPosition, label } = this.props;

--- a/src/components/react_canvas/grid.tsx
+++ b/src/components/react_canvas/grid.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Group, Line } from 'react-konva';
+import deepEqual from 'fast-deep-equal/es6/react';
 import { AxisLinePosition } from '../../chart_types/xy_chart/utils/axis_utils';
 import { GridLineConfig } from '../../utils/themes/theme';
 import { Dimensions } from '../../utils/dimensions';
@@ -11,7 +12,11 @@ interface GridProps {
   linesPositions: AxisLinePosition[];
 }
 
-export class Grid extends React.PureComponent<GridProps> {
+export class Grid extends React.Component<GridProps> {
+  shouldComponentUpdate(nextProps: GridProps) {
+    return !deepEqual(this.props, nextProps);
+  }
+
   render() {
     return this.renderGrid();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7535,6 +7535,11 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
+fast-deep-equal@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
+  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
 fast-diff@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"


### PR DESCRIPTION
## Summary
During working on https://github.com/elastic/kibana/pull/56587 I have found out that charts-related components are probably re-renders unnecessarily, so I have decided to verify that and here is the outcome from https://github.com/welldone-software/why-did-you-render

Each line in the console means unnecessary component's re-render and after the row is expanded we can see which props are equal by value but not by reference, so it causes `PureComponent` to re-render.
![Untitled_ Feb 3, 2020 11_16 PM (1)](https://user-images.githubusercontent.com/5188868/73696381-7b15d800-46dc-11ea-997d-f629650549b0.gif)

After my changes
![Untitled_ Feb 3, 2020 11_13 PM](https://user-images.githubusercontent.com/5188868/73696651-01cab500-46dd-11ea-897a-1d0ea80d5611.gif)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
- [ ] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)