### PR TITLE
fix(ie11): replace fast-deep-equal with a IE11 safe ver (#542)

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "d3-collection": "^1.0.7",
     "d3-scale": "^1.0.7",
     "d3-shape": "^1.3.4",
-    "fast-deep-equal": "^3.1.1",
     "konva": "^4.0.18",
     "newtype-ts": "^0.2.4",
     "prop-types": "^15.7.2",

--- a/src/chart_types/xy_chart/renderer/canvas/area_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/area_geometries.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Group as KonvaGroup } from 'konva/types/Group';
 import { PathConfig } from 'konva/types/shapes/Path';
 import { Circle, Group, Path } from 'react-konva';
-import deepEqual from 'fast-deep-equal/es6/react';
+import { deepEqual } from '../../../../utils/fast_deep_equal';
 import {
   buildAreaRenderProps,
   buildPointStyleProps,

--- a/src/chart_types/xy_chart/renderer/canvas/axis.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/axis.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Group, Line, Rect, Text } from 'react-konva';
-import deepEqual from 'fast-deep-equal/es6/react';
+import { deepEqual } from '../../../../utils/fast_deep_equal';
 import {
   AxisTick,
   AxisTicksDimensions,

--- a/src/chart_types/xy_chart/renderer/canvas/bar_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/bar_geometries.tsx
@@ -2,7 +2,7 @@ import { Group as KonvaGroup } from 'konva/types/Group';
 import React from 'react';
 import { Group, Rect } from 'react-konva';
 import { animated, Spring } from 'react-spring/renderprops-konva.cjs';
-import deepEqual from 'fast-deep-equal/es6/react';
+import { deepEqual } from '../../../../utils/fast_deep_equal';
 import { buildBarRenderProps, buildBarBorderRenderProps } from './utils/rendering_props_utils';
 import { BarGeometry } from '../../../../utils/geometry';
 import { LegendItem } from '../../../../chart_types/xy_chart/legend/legend';

--- a/src/chart_types/xy_chart/renderer/canvas/bar_values.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/bar_values.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Group, Rect, Text } from 'react-konva';
-import deepEqual from 'fast-deep-equal/es6/react';
+import { deepEqual } from '../../../../utils/fast_deep_equal';
 import { Rotation } from '../../utils/specs';
 import { Theme } from '../../../../utils/themes/theme';
 import { Dimensions } from '../../../../utils/dimensions';

--- a/src/chart_types/xy_chart/renderer/canvas/grid.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/grid.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Group, Line } from 'react-konva';
 import { connect } from 'react-redux';
-import deepEqual from 'fast-deep-equal/es6/react';
+import { deepEqual } from '../../../../utils/fast_deep_equal';
 import { AxisLinePosition, isVerticalGrid } from '../../utils/axis_utils';
 import { GridLineConfig, mergeGridLineConfigs, Theme } from '../../../../utils/themes/theme';
 import { Dimensions } from '../../../../utils/dimensions';

--- a/src/chart_types/xy_chart/renderer/canvas/line_annotation.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/line_annotation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Group, Line } from 'react-konva';
-import deepEqual from 'fast-deep-equal/es6/react';
+import { deepEqual } from '../../../../utils/fast_deep_equal';
 import { LineAnnotationStyle } from '../../../../utils/themes/theme';
 import { AnnotationLineProps } from '../../annotations/line_annotation_tooltip';
 

--- a/src/chart_types/xy_chart/renderer/canvas/line_geometries.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/line_geometries.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Group as KonvaGroup } from 'konva/types/Group';
 import { Circle, Group, Path } from 'react-konva';
-import deepEqual from 'fast-deep-equal/es6/react';
+import { deepEqual } from '../../../../utils/fast_deep_equal';
 import {
   buildLineRenderProps,
   buildPointStyleProps,

--- a/src/chart_types/xy_chart/renderer/canvas/rect_annotation.tsx
+++ b/src/chart_types/xy_chart/renderer/canvas/rect_annotation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Group, Rect } from 'react-konva';
-import deepEqual from 'fast-deep-equal/es6';
+import { deepEqual } from '../../../../utils/fast_deep_equal';
 import { RectAnnotationStyle } from '../../../../utils/themes/theme';
 import { AnnotationRectProps } from '../../annotations/rect_annotation_tooltip';
 

--- a/src/chart_types/xy_chart/specs/line_annotation.tsx
+++ b/src/chart_types/xy_chart/specs/line_annotation.tsx
@@ -1,8 +1,8 @@
 import React, { createRef, CSSProperties, Component } from 'react';
 import { bindActionCreators, Dispatch } from 'redux';
 import { connect } from 'react-redux';
-import deepEqual from 'fast-deep-equal/es6/react';
 
+import { deepEqual } from '../../../utils/fast_deep_equal';
 import { LineAnnotationSpec, DEFAULT_GLOBAL_ID, SpecTypes, AnnotationTypes } from '../utils/specs';
 import { DEFAULT_ANNOTATION_LINE_STYLE } from '../../../utils/themes/theme';
 import { upsertSpec, removeSpec } from '../../../state/actions/specs';

--- a/src/components/chart_container.tsx
+++ b/src/components/chart_container.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { bindActionCreators, Dispatch } from 'redux';
 import { connect } from 'react-redux';
-import deepEqual from 'fast-deep-equal/es6/react';
+import { deepEqual } from '../utils/fast_deep_equal';
 import { GlobalChartState, BackwardRef } from '../state/chart_state';
 import { onMouseUp, onMouseDown, onPointerMove } from '../state/actions/mouse';
 import { getInternalChartRendererSelector } from '../state/selectors/get_chart_type_components';

--- a/src/components/icons/assets/dot.tsx
+++ b/src/components/icons/assets/dot.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import deepEqual from 'fast-deep-equal/es6/react';
+import { deepEqual } from '../../../utils/fast_deep_equal';
 import { Props } from '../icon';
 
 export class DotIcon extends React.Component<Props> {

--- a/src/components/icons/icon.tsx
+++ b/src/components/icons/icon.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React, { SVGAttributes } from 'react';
-import deepEqual from 'fast-deep-equal/es6/react';
+import { deepEqual } from '../../utils/fast_deep_equal';
 import { AlertIcon } from './assets/alert';
 import { DotIcon } from './assets/dot';
 import { EmptyIcon } from './assets/empty';

--- a/src/components/legend/legend_item.tsx
+++ b/src/components/legend/legend_item.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
-import deepEqual from 'fast-deep-equal/es6/react';
+import { deepEqual } from '../../utils/fast_deep_equal';
 import { Icon } from '../icons/icon';
 import { LegendItemListener, BasicListener } from '../../specs/settings';
 import { LegendItem } from '../../chart_types/xy_chart/legend/legend';

--- a/src/components/react_canvas/grid.tsx
+++ b/src/components/react_canvas/grid.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Group, Line } from 'react-konva';
-import deepEqual from 'fast-deep-equal/es6/react';
+import { deepEqual } from '../../utils/fast_deep_equal';
 import { AxisLinePosition } from '../../chart_types/xy_chart/utils/axis_utils';
 import { GridLineConfig } from '../../utils/themes/theme';
 import { Dimensions } from '../../utils/dimensions';

--- a/src/utils/fast_deep_equal.ts
+++ b/src/utils/fast_deep_equal.ts
@@ -1,0 +1,79 @@
+// MIT License
+
+// Copyright (c) 2017 Evgeny Poberezkin
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+export function deepEqual(a: any, b: any): boolean {
+  if (a === b) return true;
+
+  if (a && b && typeof a == 'object' && typeof b == 'object') {
+    if (a.constructor !== b.constructor) return false;
+
+    let length: number;
+    let i: any;
+
+    if (Array.isArray(a)) {
+      length = a.length;
+      if (length != b.length) return false;
+      for (i = length; i-- !== 0; ) if (!deepEqual(a[i], b[i])) return false;
+      return true;
+    }
+    if (a instanceof Map && b instanceof Map) {
+      if (a.size !== b.size) return false;
+      // @ts-ignore
+      for (i of a.entries()) if (!b.has(i[0])) return false;
+      // @ts-ignore
+      for (i of a.entries()) if (!deepEqual(i[1], b.get(i[0]))) return false;
+      return true;
+    }
+
+    if (a instanceof Set && b instanceof Set) {
+      if (a.size !== b.size) return false;
+      // @ts-ignore
+      for (i of a.entries()) if (!b.has(i[0])) return false;
+      return true;
+    }
+
+    if (a.constructor === RegExp) return a.source === b.source && a.flags === b.flags;
+    if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
+    if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
+
+    const keys = Object.keys(a);
+    length = keys.length;
+    if (length !== Object.keys(b).length) return false;
+
+    for (i = length; i-- !== 0; ) if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
+
+    for (i = length; i-- !== 0; ) {
+      const key = keys[i];
+      if (key === '_owner' && a.$$typeof) {
+        // React-specific: avoid traversing React elements' _owner.
+        //  _owner contains circular references
+        // and is not needed when comparing the actual elements (and not their owners)
+        continue;
+      }
+      if (!deepEqual(a[key], b[key])) return false;
+    }
+
+    return true;
+  }
+
+  // true if both NaN, false otherwise
+  return a !== a && b !== b;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7472,11 +7472,6 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-deep-equal@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
-  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
-
 fast-diff@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"


### PR DESCRIPTION
Backports the following commits to 16.1.x:
 - fix(ie11): replace fast-deep-equal with an internal copy IE11 safe (#542)