### PR TITLE
fix: redux connect issue related to spec upserting

### DIFF
--- a/src/state/spec_factory.ts
+++ b/src/state/spec_factory.ts
@@ -51,5 +51,12 @@ const mapDispatchToProps = (dispatch: Dispatch): DispatchProps =>
   );
 
 export function getConnect() {
-  return connect(null, mapDispatchToProps);
+  /**
+   * Redux assumes shallowEqual for all connected components
+   *
+   * This causes an issue where the specs are cleared and memoized spec components will never be
+   * rerendered and thus never re-upserted to the state. Setting pure to false solves this issue
+   * and doesn't cause traditional performance degradations.
+   */
+  return connect(null, mapDispatchToProps, null, { pure: false });
 }


### PR DESCRIPTION
## Summary

Fix issue with redux state clearing specs after consumer state update.

The redux chart state requires all specs are called every time the `Chart` component is updated. This was not happening due to the [pure](https://react-redux.js.org/api/connect#pure-boolean) option that defaults to false, basically creating a shallow equal or `memo` react component.

### Checklist
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
