### PR TITLE
build: add prefer-template eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,6 +70,7 @@ module.exports = {
     '@typescript-eslint/no-inferrable-types': 'off',
     'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never' }],
     'react/prop-types': 0,
+    'prefer-template': 'error',
   },
   settings: {
     'import/resolver': {

--- a/src/chart_types/partition_chart/layout/utils/calcs.ts
+++ b/src/chart_types/partition_chart/layout/utils/calcs.ts
@@ -17,8 +17,8 @@ export function addOpacity(hexColorString: string, opacity: Ratio) {
     ? hexColorString
     : hexColorString.slice(0, 7) +
         (hexColorString.slice(7).length === 0 || parseInt(hexColorString.slice(7, 2), 16) === 255
-          ? ('00' + Math.round(opacity * 255).toString(16)).substr(-2) // color was of full opacity
-          : ('00' + Math.round((parseInt(hexColorString.slice(7, 2), 16) / 255) * opacity * 255).toString(16)).substr(
+          ? `00${Math.round(opacity * 255).toString(16)}`.substr(-2) // color was of full opacity
+          : `00${Math.round((parseInt(hexColorString.slice(7, 2), 16) / 255) * opacity * 255).toString(16)}`.substr(
               -2,
             ));
 }

--- a/src/chart_types/partition_chart/layout/viewmodel/fill_text_layout.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/fill_text_layout.ts
@@ -44,7 +44,7 @@ function angleToCircline(
 
 // todo pick a better unique key for the slices (D3 doesn't keep track of an index)
 export function nodeId(node: ShapeTreeNode): string {
-  return node.x0 + '|' + node.y0;
+  return `${node.x0}|${node.y0}`;
 }
 
 export function rectangleConstruction(node: ShapeTreeNode) {


### PR DESCRIPTION
## Summary

Add `prefer-template` eslint rule to the eslint to suggest using template literals instead of string concatenation.

https://eslint.org/docs/rules/prefer-template
