### PR TITLE
fix(line_annotation): keep the spec in state after chart rerender

### DIFF
--- a/src/chart_types/xy_chart/specs/line_annotation.test.tsx
+++ b/src/chart_types/xy_chart/specs/line_annotation.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License. */
+
+import React from 'react';
+import { createStore, Store } from 'redux';
+import { Provider } from 'react-redux';
+import { mount } from 'enzyme';
+
+import { chartStoreReducer, GlobalChartState } from '../../../state/chart_state';
+import { SpecsParser } from '../../../specs/specs_parser';
+import { LineSeries } from './line_series';
+import { LineAnnotation, AnnotationDomainTypes } from '../../../specs';
+
+function LineAnnotationChart(props: { chartStore: Store<GlobalChartState> }) {
+  return (
+    <Provider store={props.chartStore}>
+      <SpecsParser>
+        <LineSeries
+          id="line"
+          data={[
+            [1585126720460, 0],
+            [1585126780460, 22],
+            [1585126840460, 100],
+            [1585126900460, 333],
+            [1585126960460, 444],
+          ]}
+          xAccessor={0}
+          yAccessors={[1]}
+        />
+        <LineAnnotation
+          id="threashold"
+          domainType={AnnotationDomainTypes.YDomain}
+          dataValues={[{ dataValue: 120, details: 'threashold' }]}
+        />
+      </SpecsParser>
+    </Provider>
+  );
+}
+
+describe('Line annotation', () => {
+  it('Should always be available on the on every render', () => {
+    const storeReducer = chartStoreReducer('chart_id');
+    const chartStore = createStore(storeReducer);
+    const wrapper = mount(<LineAnnotationChart chartStore={chartStore} />);
+    expect(chartStore.getState().specs['threashold']).toBeDefined();
+    wrapper.setProps({});
+    expect(chartStore.getState().specs['threashold']).toBeDefined();
+  });
+});

--- a/src/chart_types/xy_chart/specs/line_annotation.test.tsx
+++ b/src/chart_types/xy_chart/specs/line_annotation.test.tsx
@@ -43,9 +43,9 @@ function LineAnnotationChart(props: { chartStore: Store<GlobalChartState> }) {
           yAccessors={[1]}
         />
         <LineAnnotation
-          id="threashold"
+          id="threshold"
           domainType={AnnotationDomainTypes.YDomain}
-          dataValues={[{ dataValue: 120, details: 'threashold' }]}
+          dataValues={[{ dataValue: 120, details: 'threshold' }]}
         />
       </SpecsParser>
     </Provider>
@@ -57,8 +57,8 @@ describe('Line annotation', () => {
     const storeReducer = chartStoreReducer('chart_id');
     const chartStore = createStore(storeReducer);
     const wrapper = mount(<LineAnnotationChart chartStore={chartStore} />);
-    expect(chartStore.getState().specs['threashold']).toBeDefined();
+    expect(chartStore.getState().specs['threshold']).toBeDefined();
     wrapper.setProps({});
-    expect(chartStore.getState().specs['threashold']).toBeDefined();
+    expect(chartStore.getState().specs['threshold']).toBeDefined();
   });
 });

--- a/src/chart_types/xy_chart/specs/line_annotation.tsx
+++ b/src/chart_types/xy_chart/specs/line_annotation.tsx
@@ -17,7 +17,6 @@
  * under the License. */
 
 import React, { createRef, CSSProperties, Component } from 'react';
-import { deepEqual } from '../../../utils/fast_deep_equal';
 import { LineAnnotationSpec, DEFAULT_GLOBAL_ID, AnnotationTypes } from '../utils/specs';
 import { DEFAULT_ANNOTATION_LINE_STYLE, mergeWithDefaultAnnotationLine } from '../../../utils/themes/theme';
 import { bindActionCreators, Dispatch } from 'redux';
@@ -62,9 +61,9 @@ export class LineAnnotationSpecComponent extends Component<LineAnnotationSpec> {
     upsertSpec(spec);
   }
 
-  shouldComponentUpdate(nextProps: LineAnnotationSpec) {
-    return !deepEqual(this.props, nextProps);
-  }
+  // shouldComponentUpdate(nextProps: LineAnnotationSpec) {
+  //   return !deepEqual(this.props, nextProps);
+  // }
 
   componentDidUpdate() {
     const { upsertSpec, removeSpec, children, ...config } = this.props as InjectedProps;

--- a/src/chart_types/xy_chart/specs/line_annotation.tsx
+++ b/src/chart_types/xy_chart/specs/line_annotation.tsx
@@ -61,10 +61,6 @@ export class LineAnnotationSpecComponent extends Component<LineAnnotationSpec> {
     upsertSpec(spec);
   }
 
-  // shouldComponentUpdate(nextProps: LineAnnotationSpec) {
-  //   return !deepEqual(this.props, nextProps);
-  // }
-
   componentDidUpdate() {
     const { upsertSpec, removeSpec, children, ...config } = this.props as InjectedProps;
     if (this.markerRef.current) {


### PR DESCRIPTION
## Summary

The `LineAnnotation` component doesn't use the `specComponentFactory` because it render the marker
if available. We have to always keep the spec updating the state on every lifecycle thus removing
the deepEqual check on the shouldComponentUpdate did the trick.

fix #604

### Checklist

Delete any items that are not applicable to this PR.

- [x] Unit tests were updated or added to match the most common scenarios
