### PR TITLE
fix: tickFormat called on mark value

### DIFF
--- a/src/chart_types/xy_chart/tooltip/tooltip.test.ts
+++ b/src/chart_types/xy_chart/tooltip/tooltip.test.ts
@@ -55,7 +55,7 @@ describe('Tooltip formatting', () => {
     showOverlappingTicks: false,
     tickPadding: 0,
     tickSize: 0,
-    tickFormat: (d) => `${d}`,
+    tickFormat: jest.fn((d) => `${d}`),
   };
   const seriesStyle = {
     rect: {
@@ -125,6 +125,7 @@ describe('Tooltip formatting', () => {
     expect(tooltipValue.isHighlighted).toBe(false);
     expect(tooltipValue.color).toBe('blue');
     expect(tooltipValue.value).toBe('10');
+    expect(YAXIS_SPEC.tickFormat).not.toBeCalledWith(null, undefined);
   });
   it('should set name as spec name when provided', () => {
     const name = 'test - spec';

--- a/src/chart_types/xy_chart/tooltip/tooltip.ts
+++ b/src/chart_types/xy_chart/tooltip/tooltip.ts
@@ -82,14 +82,13 @@ export function formatTooltip(
 
   const value = isHeader ? x : y;
   const tickFormatOptions: TickFormatterOptions | undefined = spec.timeZone ? { timeZone: spec.timeZone } : undefined;
-  const markValue = axisSpec ? axisSpec.tickFormat(mark, tickFormatOptions) : emptyFormatter(mark);
 
   return {
     seriesIdentifier,
     valueAccessor: accessor,
     label,
     value: axisSpec ? axisSpec.tickFormat(value, tickFormatOptions) : emptyFormatter(value),
-    markValue: isHeader || mark === null ? null : markValue,
+    markValue: isHeader || mark === null ? null : mark,
     color,
     isHighlighted: isHeader ? false : isHighlighted,
     isVisible,


### PR DESCRIPTION
## Summary

Mark value was being called with the axis `tickFormat` function with null values. I don't think the mark value would ever be called with an axis formatted so I removed that and just pass the mark value.

### Checklist

- [x] Unit tests were updated or added to match the most common scenarios
