### PR TITLE
fix: build/type issue with DataGenerator

### DIFF
--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -18,7 +18,7 @@
 
 import seedrandom from 'seedrandom';
 
-import { DataGenerator } from '../utils/data_generators/data_generator';
+import { DataGenerator, RandomNumberGenerator } from '../utils/data_generators/data_generator';
 
 /**
  * Forces object to be partial type for mocking tests
@@ -30,13 +30,6 @@ import { DataGenerator } from '../utils/data_generators/data_generator';
 export const forcedType = <T extends object>(obj: Partial<T>): T => {
   return obj as T;
 };
-
-export type RandomNumberGenerator = (
-  min?: number,
-  max?: number,
-  fractionDigits?: number,
-  inclusive?: boolean,
-) => number;
 
 /**
  * Return rng function with optional `min`, `max` and `fractionDigits` params

--- a/src/utils/data_generators/data_generator.ts
+++ b/src/utils/data_generators/data_generator.ts
@@ -17,15 +17,31 @@
  * under the License. */
 
 import { Simple1DNoise } from './simple_noise';
-import { RandomNumberGenerator } from '../../mocks/utils';
+
+export type RandomNumberGenerator = (
+  min?: number,
+  max?: number,
+  fractionDigits?: number,
+  inclusive?: boolean,
+) => number;
+
+function defaultRNG(min = 0, max = 1, fractionDigits = 0, inclusive = true) {
+  const precision = Math.pow(10, Math.max(fractionDigits, 0));
+  const scaledMax = max * precision;
+  const scaledMin = min * precision;
+  const offset = inclusive ? 1 : 0;
+  const num = Math.floor(Math.random() * (scaledMax - scaledMin + offset)) + scaledMin;
+
+  return num / precision;
+}
 
 export class DataGenerator {
   private randomNumberGenerator: RandomNumberGenerator;
   private generator: Simple1DNoise;
   private frequency: number;
-  constructor(frequency = 500, randomNumberGenerator: RandomNumberGenerator) {
+  constructor(frequency = 500, randomNumberGenerator: RandomNumberGenerator = defaultRNG) {
     this.randomNumberGenerator = randomNumberGenerator;
-    this.generator = new Simple1DNoise(randomNumberGenerator);
+    this.generator = new Simple1DNoise(this.randomNumberGenerator);
     this.frequency = frequency;
   }
   generateBasicSeries(totalPoints = 50, offset = 0, amplitude = 1) {

--- a/src/utils/data_generators/simple_noise.ts
+++ b/src/utils/data_generators/simple_noise.ts
@@ -1,5 +1,3 @@
-import { RandomNumberGenerator } from '../../mocks/utils';
-
 /*
  * Licensed to Elasticsearch B.V. under one or more contributor
  * license agreements. See the NOTICE file distributed with
@@ -17,6 +15,8 @@ import { RandomNumberGenerator } from '../../mocks/utils';
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License. */
+
+import { RandomNumberGenerator } from './data_generator';
 
 export class Simple1DNoise {
   private maxVertices: number;

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -5,5 +5,5 @@
   },
   "extends": "./tsconfig",
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.*", "**/__mocks__"]
+  "exclude": ["**/*.test.*", "**/__mocks__", "src/mocks/**/*"]
 }


### PR DESCRIPTION
## Summary

Bug caused by `DataGenerator` Class now expecting a random number generator. Broke EUI docs.

- Move around types to exclude mocks directory
- Remove import of seedrandom from dist files
- Add default rng function for DataGenerator

> We should move `pallettes.ts` out of `mocks/` all prevent any src code in this directory, might be best to move it to the root folder or in a testing utils root directory.

### Checklist

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
