### PR TITLE
ci: add console errors to smoke tests

### DIFF
--- a/.playground/index.tsx
+++ b/.playground/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import 'core-js';
+// import 'core-js';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/browsers/browsers.test.ts
+++ b/browsers/browsers.test.ts
@@ -19,7 +19,7 @@
 
 import path from 'path';
 
-import webdriver, { By } from 'selenium-webdriver';
+import webdriver, { By, logging } from 'selenium-webdriver';
 
 jest.setTimeout(30000);
 
@@ -60,6 +60,15 @@ describe('smoke tests', () => {
   });
 
   afterAll(async() => {
+    const entries = await driver.manage().logs().get(logging.Type.BROWSER);
+    console.log(JSON.stringify(entries));
+
+    entries.forEach((entry) => {
+      if (entry.level.name === 'error') {
+        console.log('[%s] %s', entry.level.name, entry.message);
+      }
+    });
+
     await driver.quit();
   });
 

--- a/browsers/browsers.test.ts
+++ b/browsers/browsers.test.ts
@@ -19,9 +19,9 @@
 
 import path from 'path';
 
-import webdriver, { By, logging } from 'selenium-webdriver';
+import webdriver, { By } from 'selenium-webdriver';
 
-jest.setTimeout(6000);
+jest.setTimeout(30000);
 
 /* eslint-disable global-require */
 
@@ -56,19 +56,17 @@ describe('smoke tests', () => {
     }
     if (capabilities) {
       driver = await new webdriver.Builder().withCapabilities(capabilities).build();
-    }
-  });
 
-  beforeAll(async() => {
-    await driver.executeScript(() => {
-      // @ts-ignore
-      window.browserErrors = [];
-
-      window.console.error = (...args: any[]) => {
+      await driver.executeScript(() => {
         // @ts-ignore
-        window.browserErrors.push(...args);
-      };
-    });
+        window.browserErrors = [];
+
+        window.console.error = (...args: any[]) => {
+          // @ts-ignore
+          window.browserErrors.push(...args);
+        };
+      });
+    }
   });
 
   afterAll(async() => {

--- a/browsers/browsers.test.ts
+++ b/browsers/browsers.test.ts
@@ -21,7 +21,7 @@ import path from 'path';
 
 import webdriver, { By, logging } from 'selenium-webdriver';
 
-jest.setTimeout(30000);
+jest.setTimeout(6000);
 
 /* eslint-disable global-require */
 
@@ -59,17 +59,27 @@ describe('smoke tests', () => {
     }
   });
 
-  afterAll(async() => {
-    const entries = await driver.manage().logs().get(logging.Type.BROWSER);
-    const entries2 = await driver.manage().logs().get(logging.Type.CLIENT);
-    console.log('ERRRORS BROWSER', JSON.stringify(entries));
-    console.log('ERRRORS CLIENT', JSON.stringify(entries2));
+  beforeAll(async() => {
+    await driver.executeScript(() => {
+      // @ts-ignore
+      window.browserErrors = [];
 
-    entries.forEach((entry) => {
-      if (entry.level.name === 'error') {
-        console.log('[%s] %s', entry.level.name, entry.message);
-      }
+      window.console.error = (...args: any[]) => {
+        // @ts-ignore
+        window.browserErrors.push(...args);
+      };
     });
+  });
+
+  afterAll(async() => {
+    const errors = await driver.executeScript(() =>
+      // @ts-ignore
+      JSON.stringify(window.browserErrors)
+      // if (entry.level.name === 'error') {
+      //   console.log('[%s] %s', entry.level.name, entry.message);
+      // }
+    );
+    console.log('ERRRORS CLIENT', JSON.stringify(errors));
 
     await driver.quit();
   });

--- a/browsers/browsers.test.ts
+++ b/browsers/browsers.test.ts
@@ -61,7 +61,9 @@ describe('smoke tests', () => {
 
   afterAll(async() => {
     const entries = await driver.manage().logs().get(logging.Type.BROWSER);
-    console.log(JSON.stringify(entries));
+    const entries2 = await driver.manage().logs().get(logging.Type.CLIENT);
+    console.log('ERRRORS BROWSER', JSON.stringify(entries));
+    console.log('ERRRORS CLIENT', JSON.stringify(entries2));
 
     entries.forEach((entry) => {
       if (entry.level.name === 'error') {

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -68,6 +68,9 @@ export class Chart extends React.Component<ChartProps, ChartState> {
     this.chartContainerRef = createRef();
     this.chartStageRef = createRef();
 
+    // eslint-disable-next-line no-console
+    console.error('this thing errored');
+
     const id = props.id ?? uuid.v4();
     const storeReducer = chartStoreReducer(id);
     const enhancers = typeof window !== 'undefined' && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__


### PR DESCRIPTION
## Summary

Add console errors to smoke tests to help identify the issue. Currently the test just fails and doesn't output the `console.errors`.