### PR TITLE
ci: lint only staged files

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,5 +2,5 @@ module.exports = {
   // TODO: make this `lint:fix` if ever added to `pre-commit`
   // using in `commit-msg` doesn't save fixed changes so
   // in the meantime should error on bad linting when committing
-  '*.{js,ts,tsx}': ['yarn lint'],
+  '*.{js,ts,tsx}': 'cross-env NODE_ENV=production eslint --quiet',
 };

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "circular-dependency-plugin": "^5.2.0",
     "commitizen": "^4.0.3",
     "core-js": "^3.6.4",
+    "cross-env": "^7.0.2",
     "css-loader": "^2.1.0",
     "cz-conventional-changelog": "^3.0.2",
     "enzyme": "^3.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8209,6 +8209,13 @@ cross-env@^6.0.3:
   dependencies:
     cross-spawn "^7.0.0"
 
+cross-env@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
+  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -8246,7 +8253,7 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cross-spawn@^7.0.2:
+cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
## Summary

This PR updates the `commit-msg` hook to only lint staged files on commit.

Before we called `yarn lint` which defines all files to be linted in the project regardless.
