### PR TITLE
fix: apply positioning to hidden tooltip

### DIFF
--- a/.storybook/style.scss
+++ b/.storybook/style.scss
@@ -14,6 +14,10 @@ html {
   background: #1a1b20;
 }
 
+.echInvisible {
+  visibility: hidden;
+}
+
 #story-root {
   padding: 20px;
   width: 100%;

--- a/integration/page_objects/common.ts
+++ b/integration/page_objects/common.ts
@@ -157,7 +157,7 @@ class CommonPage {
   async toggleElementVisibility(selector: string) {
     await page.$$eval(selector, (elements) => {
       elements.forEach((element) => {
-        element.classList.toggle('invisible');
+        element.classList.toggle('echInvisible');
       });
     });
   }

--- a/src/components/_global.scss
+++ b/src/components/_global.scss
@@ -1,4 +1,5 @@
-.invisible {
+.echInvisible {
+  position: fixed;
   visibility: hidden;
 }
 

--- a/src/components/_global.scss
+++ b/src/components/_global.scss
@@ -1,8 +1,3 @@
-.echInvisible {
-  position: fixed;
-  visibility: hidden;
-}
-
 .echChartStatus {
   visibility: hidden;
   pointer-events: none;

--- a/src/components/portal/_portal.scss
+++ b/src/components/portal/_portal.scss
@@ -7,3 +7,8 @@
   position: absolute;
   pointer-events: none;
 }
+
+.echPortalInvisible {
+  position: fixed;
+  visibility: hidden;
+}

--- a/src/components/portal/_portal.scss
+++ b/src/components/portal/_portal.scss
@@ -8,7 +8,7 @@
   pointer-events: none;
 }
 
-.echPortalInvisible {
+.echTooltipPortal__invisible {
   position: fixed;
   visibility: hidden;
 }

--- a/src/components/portal/tooltip_portal.tsx
+++ b/src/components/portal/tooltip_portal.tsx
@@ -199,7 +199,12 @@ const TooltipPortalComponent = ({ anchor, scope, settings, children, visible, ch
     }
   }, [updateAnchorDimensions, popper]);
 
-  return createPortal(<div className={classNames({ echInvisible: invisible })}>{children}</div>, portalNode.current);
+  return createPortal(
+    <div className={classNames({ echPortalInvisible: invisible })}>
+      {children}
+    </div>,
+    portalNode.current,
+  );
 };
 
 TooltipPortalComponent.displayName = 'TooltipPortal';

--- a/src/components/portal/tooltip_portal.tsx
+++ b/src/components/portal/tooltip_portal.tsx
@@ -199,7 +199,7 @@ const TooltipPortalComponent = ({ anchor, scope, settings, children, visible, ch
     }
   }, [updateAnchorDimensions, popper]);
 
-  return createPortal(<div className={classNames({ invisible })}>{children}</div>, portalNode.current);
+  return createPortal(<div className={classNames({ echInvisible: invisible })}>{children}</div>, portalNode.current);
 };
 
 TooltipPortalComponent.displayName = 'TooltipPortal';

--- a/src/components/portal/tooltip_portal.tsx
+++ b/src/components/portal/tooltip_portal.tsx
@@ -200,7 +200,7 @@ const TooltipPortalComponent = ({ anchor, scope, settings, children, visible, ch
   }, [updateAnchorDimensions, popper]);
 
   return createPortal(
-    <div className={classNames({ echPortalInvisible: invisible })}>
+    <div className={classNames({ echTooltipPortal__invisible: invisible })}>
       {children}
     </div>,
     portalNode.current,


### PR DESCRIPTION
## Summary

Fix the scrollbar appearance when showing a tooltip on Lens/Kibana.
This was caused by the `invisible` class and its child taking space on the bottom of the page before popperjs can position the tooltip on the page
