### PR TITLE
fix: move redux dev deps to optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,8 +186,6 @@
     "react-dom": "^16.13.0",
     "react-is": "^16.13.0",
     "redux-devtools-extension": "^2.13.8",
-    "redux-immutable-state-invariant": "^2.1.0",
-    "redux-logger": "^3.0.6",
     "sass-graph": "^3.0.4",
     "sass-loader": "^7.1.0",
     "seedrandom": "^3.0.5",
@@ -207,6 +205,10 @@
     "moment-timezone": "^0.5.27",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
+  },
+  "optionalDependencies": {
+    "redux-immutable-state-invariant": "^2.1.0",
+    "redux-logger": "^3.0.6"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
## Summary

Fix `yarn kbn bootstrap` in kibana. Adding them to `devDependencies` created an error with yarn. Moving these to `optionalDependencies` is a temporary solution until the we switch to yarn workspaces.

The error is posted below.

```node
> yarn kbn bootstrap
yarn run v1.21.1
$ node scripts/kbn bootstrap
 info [kibana] running yarn

$ node ./preinstall_check
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
warning Resolution field "typescript@3.9.5" is incompatible with requested version "typescript@~3.7.2"
success Already up-to-date.

 succ 13 bootsrap builds are cached
 info [@kbn/ui-shared-deps] running [kbn:bootstrap] script
ERROR [bootstrap] failed:
ERROR Error: Command failed with exit code 1: /usr/local/Cellar/yarn/1.21.1/libexec/bin/yarn.js run kbn:bootstrap
      error Command failed with exit code 1.
      $ node scripts/build --dev
       info cleaning previous build output
      ERROR webpack failure in about 8 seconds
               3331 modules

            ERROR in /Users/nicholaspartridge/Documents/repos/kibana/node_modules/@elastic/charts/dist/components/chart.js
            Module not found: Error: Can't resolve 'redux-immutable-state-invariant' in '/Users/nicholaspartridge/Documents/repos/kibana/node_modules/@elastic/charts/dist/components'

            ERROR in /Users/nicholaspartridge/Documents/repos/kibana/node_modules/@elastic/charts/dist/components/chart.js
            Module not found: Error: Can't resolve 'redux-logger' in '/Users/nicholaspartridge/Documents/repos/kibana/node_modules/@elastic/charts/dist/components'
      info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
          at makeError (/Users/nicholaspartridge/Documents/repos/kibana/packages/kbn-pm/dist/index.js:25161:11)
          at handlePromise (/Users/nicholaspartridge/Documents/repos/kibana/packages/kbn-pm/dist/index.js:24096:26)
          at process._tickCallback (internal/process/next_tick.js:68:7)
error Command failed with exit code 1.
```
