### PR TITLE
ci: split VRTs in two parts

### DIFF
--- a/.ci/jobs/elastic+elastic-charts+pr-vrts-2.yml
+++ b/.ci/jobs/elastic+elastic-charts+pr-vrts-2.yml
@@ -1,0 +1,15 @@
+---
+- job:
+    name: elastic+elastic-charts+pr-vrts-2
+    display-name: 'elastic / elastic-charts # pull-request VRTs - 2'
+    description: Visual Regression Testing of elastic-charts pull requests - plain storybook.
+    scm:
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    builders:
+      - shell: |-
+          #!/usr/local/bin/runbld
+
+          set -euo pipefail
+
+          ./.ci/vrts.sh all.test.ts

--- a/.ci/jobs/elastic+elastic-charts+pr-vrts.yml
+++ b/.ci/jobs/elastic+elastic-charts+pr-vrts.yml
@@ -12,4 +12,4 @@
 
           set -euo pipefail
 
-          ./.ci/vrts.sh
+          ./.ci/vrts.sh "^((?\!all.test.ts).)*$"

--- a/.ci/jobs/elastic+elastic-charts+pull-request.yml
+++ b/.ci/jobs/elastic+elastic-charts+pull-request.yml
@@ -25,5 +25,7 @@
               predefined-parameters: branch_specifier=${ghprbActualCommit}
             - name: elastic+elastic-charts+pr-vrts
               predefined-parameters: branch_specifier=${ghprbActualCommit}
+            - name: elastic+elastic-charts+pr-vrts-2
+                predefined-parameters: branch_specifier=${ghprbActualCommit}
             - name: elastic+elastic-charts+pr-license-scan
               predefined-parameters: branch_specifier=${ghprbActualCommit}

--- a/.ci/vrts.sh
+++ b/.ci/vrts.sh
@@ -5,6 +5,7 @@
 ###
 source .ci/global_setup.sh
 
+VRT_FILES=$1
 ###
 ### visual testing
 ###


### PR DESCRIPTION
## Summary

Split VRTs in two parts: one for the `all.test.ts` and another for all the others
