### PR TITLE
fix: set uninitialized state when removeSpec action is called

### DIFF
--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -320,6 +320,9 @@ export const chartStoreReducer = (chartId: string) => {
         const { [action.id]: specToRemove, ...rest } = state.specs;
         return {
           ...state,
+          specsInitialized: false,
+          chartRendered: false,
+          specParsing: true,
           specs: {
             ...rest,
           },


### PR DESCRIPTION
## Summary

This commit reset the chart state to not initialized when removing a spec. After #723 PR that
reduced the number of steps on the state machine when parsing, the removeSpec action wasn't
accounted on that refactoring causing side effects when removing/switching a spec on the chart
configuration due to the state being in an wrong status.

fix #738

### Checklist

- [x] Unit tests were updated or added to match the most common scenarios
