### PR TITLE
ci: fix browser-ie failure

### DIFF
--- a/.github/workflows/smoke_tests.yaml
+++ b/.github/workflows/smoke_tests.yaml
@@ -6,6 +6,7 @@ jobs:
   browser-ie:
     runs-on: windows-latest
     steps:
+      - run: git config --system core.longpaths true
       - uses: actions/checkout@v1
       - uses: warrenbuckley/Setup-Nuget@v1
       - uses: actions/setup-node@v1


### PR DESCRIPTION
## Summary

Fix `browser-ie` pr check

fix per https://stackoverflow.com/questions/22575662/filename-too-long-in-git-for-windows
