### PR TITLE
feat: support color mappings for series

### DIFF
--- a/api/charts.api.md
+++ b/api/charts.api.md
@@ -1195,7 +1195,7 @@ export interface SeriesAccessors {
 export type SeriesColorAccessor = string | SeriesColorsArray | SeriesColorAccessorFn;
 
 // @public (undocumented)
-export type SeriesColorAccessorFn = (seriesIdentifier: XYChartSeriesIdentifier) => string | null;
+export type SeriesColorAccessorFn = (seriesIdentifier: XYChartSeriesIdentifier, allSeries: XYChartSeriesIdentifier[]) => string | null;
 
 // @public (undocumented)
 export type SeriesColorsArray = string[];

--- a/src/chart_types/xy_chart/state/utils/utils.ts
+++ b/src/chart_types/xy_chart/state/utils/utils.ts
@@ -102,6 +102,8 @@ export function getCustomSeriesColors(
   const updatedCustomSeriesColors = new Map<SeriesKey, Color>();
   const counters = new Map<SpecId, number>();
 
+  let allSeries: XYChartSeriesIdentifier[] | null = null;
+
   seriesCollection.forEach(({ seriesIdentifier }, seriesKey) => {
     const spec = getSpecsById(seriesSpecs, seriesIdentifier.specId);
 
@@ -117,7 +119,16 @@ export function getCustomSeriesColors(
         color = spec.color;
       } else {
         const counter = counters.get(seriesIdentifier.specId) || 0;
-        color = Array.isArray(spec.color) ? spec.color[counter % spec.color.length] : spec.color(seriesIdentifier);
+
+        if (Array.isArray(spec.color)) {
+          color = spec.color[counter % spec.color.length];
+        } else {
+          if (!allSeries) {
+            allSeries = [...seriesCollection.values()].map(({ seriesIdentifier: si }) => si);
+          }
+
+          color = spec.color(seriesIdentifier, allSeries);
+        }
         counters.set(seriesIdentifier.specId, counter + 1);
       }
     }

--- a/src/chart_types/xy_chart/utils/specs.ts
+++ b/src/chart_types/xy_chart/utils/specs.ts
@@ -402,7 +402,10 @@ export interface Postfixes {
 /** @public */
 export type SeriesColorsArray = string[];
 /** @public */
-export type SeriesColorAccessorFn = (seriesIdentifier: XYChartSeriesIdentifier) => string | null;
+export type SeriesColorAccessorFn = (
+  seriesIdentifier: XYChartSeriesIdentifier,
+  allSeries: XYChartSeriesIdentifier[],
+) => string | null;
 /** @public */
 export type SeriesColorAccessor = string | SeriesColorsArray | SeriesColorAccessorFn;
 

--- a/stories/stylings/9_custom_series_colors_function.tsx
+++ b/stories/stylings/9_custom_series_colors_function.tsx
@@ -37,7 +37,7 @@ export const Example = () => {
     return null;
   };
 
-  const lineColor = color('linelineSeriesColor', '#ff0');
+  const lineColor = color('lineSeriesColor', '#ff0');
   const lineSeriesColorAccessor: SeriesColorAccessor = ({ specId, yAccessor, splitAccessors }) => {
     if (specId === 'lines' && yAccessor === 'y1' && splitAccessors.size === 0) {
       return lineColor;


### PR DESCRIPTION
## Summary

To replicate the current color functionality of the `ColorMappings` in kibana, we need to know all the series in the chart to allocate a set of unique colors.

This PR adds an array of all `SeriesIdentifiers` to the `SeriesColorAccessorFn`.

### Checklist

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [ ] Unit tests were updated or added to match the most common scenarios
