### PR TITLE
feat(bar_chart): add shadow prop for value labels

### DIFF
--- a/src/chart_types/xy_chart/renderer/canvas/primitives/text.ts
+++ b/src/chart_types/xy_chart/renderer/canvas/primitives/text.ts
@@ -32,6 +32,7 @@ export function renderText(
     fontSize: number;
     align: TextAlign;
     baseline: TextBaseline;
+    shadow?: string;
   },
   degree: number = 0,
   translation?: Partial<Point>,
@@ -48,6 +49,12 @@ export function renderText(
       ctx.font = cssFontShorthand(font, font.fontSize);
       if (translation?.x || translation?.y) {
         ctx.translate(translation?.x ?? 0, translation?.y ?? 0);
+      }
+      if (font.shadow) {
+        ctx.lineWidth = 1.5;
+        ctx.strokeStyle = font.shadow;
+        ctx.strokeText(text, origin.x, origin.y);
+        ctx.shadowBlur = 0;
       }
       ctx.fillText(text, origin.x, origin.y);
     });

--- a/src/chart_types/xy_chart/renderer/canvas/values/bar.ts
+++ b/src/chart_types/xy_chart/renderer/canvas/values/bar.ts
@@ -38,7 +38,7 @@ interface BarValuesProps {
 /** @internal */
 export function renderBarValues(ctx: CanvasRenderingContext2D, props: BarValuesProps) {
   const { bars, debug, chartRotation, chartDimensions, theme } = props;
-  const { fontFamily, fontStyle, fill, fontSize } = theme.barSeriesStyle.displayValue;
+  const { fontFamily, fontStyle, fill, fontSize, shadowColor } = theme.barSeriesStyle.displayValue;
   const barsLength = bars.length;
   for (let i = 0; i < barsLength; i++) {
     const { displayValue } = bars[i];
@@ -93,6 +93,7 @@ export function renderBarValues(ctx: CanvasRenderingContext2D, props: BarValuesP
           fontSize,
           align,
           baseline,
+          shadow: shadowColor,
         },
         -chartRotation,
       );

--- a/src/utils/themes/theme.ts
+++ b/src/utils/themes/theme.ts
@@ -293,6 +293,7 @@ export type PartialTheme = RecursivePartial<Theme>;
 export type DisplayValueStyle = TextStyle & {
   offsetX: number;
   offsetY: number;
+  shadowColor?: Color;
 };
 
 export interface PointStyle {

--- a/stories/bar/2_label_value.tsx
+++ b/stories/bar/2_label_value.tsx
@@ -61,6 +61,7 @@ export const Example = () => {
         fontStyle: 'normal',
         padding: 0,
         fill: color('value color', '#000'),
+        shadowColor: color('shadow color', 'transparent'),
         offsetX: number('offsetX', 0),
         offsetY: number('offsetY', 0),
       },


### PR DESCRIPTION
## Summary

This is just a small PoC that came up while talking with @markov00 about value labels readability.
This PR introduces a new "stroke" level around the value labels in order to increase the contrast with the bar colour: this is particular efficient when the value text color is white and the stroke is some dark color. Using a darker color for the text fill does not provide the same quality result.

![value-stroke](https://user-images.githubusercontent.com/924948/90620865-4fd77e00-e213-11ea-99d0-a2da6fe28be8.gif)


There are still some open questions, like:
* [ ] would it make sense to dynamically assign the stroke color based on the fill color by default?
  * I made some experiments here as well, using brightness to measure the appropriate contrast, and results are not great. But maybe there's a better heuristic.
* [ ] Should `transparent` be the default value? I think so, but maybe there's a better idea.
* [ ] Should the name of the feature be `shadow` or something else? I started with a `box shadow` technique to start with, hence the name `shadow`. But now it is probably something different.

### Checklist

- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [ ] This was checked for cross-browser compatibility
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
