### PR TITLE
fix: remove unused redux dev middlewares

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,8 +188,6 @@
     "react-dom": "^16.13.0",
     "react-is": "^16.13.0",
     "redux-devtools-extension": "^2.13.8",
-    "redux-immutable-state-invariant": "^2.1.0",
-    "redux-logger": "^3.0.6",
     "sass-graph": "^3.0.5",
     "sass-loader": "^9.0.2",
     "seedrandom": "^3.0.5",

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -57,25 +57,6 @@ interface ChartState {
 const getMiddlware = (id: string): StoreEnhancer => {
   const middlware: Middleware<any, any, any>[] = [];
 
-  if (process.env.DEBUG_REDUX === 'true') {
-    /* eslint-disable no-console, global-require, @typescript-eslint/no-var-requires, import/no-extraneous-dependencies, @typescript-eslint/no-unsafe-call */
-    try {
-      const mw = require('redux-immutable-state-invariant');
-      middlware.push(mw.default());
-    } catch {
-      console.warn('`redux-immutable-state-invariant` not found with DEBUG_REDUX enabled');
-    }
-
-    try {
-      // https://github.com/LogRocket/redux-logger#options-description
-      const mw = require('redux-logger');
-      middlware.push(mw.createLogger({}));
-    } catch {
-      console.warn('`redux-logger` not found with DEBUG_REDUX enabled');
-    }
-    /* eslint-enable */
-  }
-
   if (typeof window !== 'undefined' && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     return (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({

--- a/yarn.lock
+++ b/yarn.lock
@@ -9777,11 +9777,6 @@ dedent@0.7.0, dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
-deep-diff@^0.3.5:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
-  integrity sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=
-
 deep-equal@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -13239,7 +13234,7 @@ into-stream@^5.0.0:
     from2 "^2.3.0"
     p-is-promise "^3.0.0"
 
-invariant@2.2.4, invariant@^2.1.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -19323,21 +19318,6 @@ redux-devtools-extension@^2.13.8:
   version "2.13.8"
   resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
   integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
-
-redux-immutable-state-invariant@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/redux-immutable-state-invariant/-/redux-immutable-state-invariant-2.1.0.tgz#308fd3cc7415a0e7f11f51ec997b6379c7055ce1"
-  integrity sha512-3czbDKs35FwiBRsx/3KabUk5zSOoTXC+cgVofGkpBNv3jQcqIe5JrHcF5AmVt7B/4hyJ8MijBIpCJ8cife6yJg==
-  dependencies:
-    invariant "^2.1.0"
-    json-stringify-safe "^5.0.1"
-
-redux-logger@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
-  integrity sha1-91VZZvMJjzyIYExEnPC69XeCdL8=
-  dependencies:
-    deep-diff "^0.3.5"
 
 redux@^4.0.0, redux@^4.0.4:
   version "4.0.4"


### PR DESCRIPTION
## Summary

Resolve dependency issue with `@elastic/charts@21.1.1`

```
WARNING in /Users/nicholaspartridge/Documents/repos/kibana/node_modules/@elastic/charts/dist/components/chart.js
Module not found: Error: Can't resolve 'redux-immutable-state-invariant' in '/Users/nicholaspartridge/Documents/repos/kibana/node_modules/@elastic/charts/dist/components'

WARNING in /Users/nicholaspartridge/Documents/repos/kibana/node_modules/@elastic/charts/dist/components/chart.js
Module not found: Error: Can't resolve 'redux-logger' in '/Users/nicholaspartridge/Documents/repos/kibana/node_modules/@elastic/charts/dist/components'
```
