### PR TITLE
feat: blind sorting option for vislib

### DIFF
--- a/src/chart_types/xy_chart/state/selectors/compute_series_domains.ts
+++ b/src/chart_types/xy_chart/state/selectors/compute_series_domains.ts
@@ -38,6 +38,8 @@ export const computeSeriesDomainsSelector = createCachedSelector(
       customYDomainsByGroupId,
       deselectedDataSeries,
       settingsSpec.xDomain,
+      // @ts-ignore blind sort option for vislib
+      settingsSpec.vislibSort,
     );
     return domains;
   },

--- a/src/chart_types/xy_chart/state/selectors/compute_series_domains.ts
+++ b/src/chart_types/xy_chart/state/selectors/compute_series_domains.ts
@@ -39,7 +39,7 @@ export const computeSeriesDomainsSelector = createCachedSelector(
       deselectedDataSeries,
       settingsSpec.xDomain,
       // @ts-ignore blind sort option for vislib
-      settingsSpec.vislibSort,
+      settingsSpec.enableVislibSeriesSort,
     );
     return domains;
   },

--- a/src/chart_types/xy_chart/state/utils/utils.ts
+++ b/src/chart_types/xy_chart/state/utils/utils.ts
@@ -193,7 +193,7 @@ function getLastValues(formattedDataSeries: {
  * @param customXDomain if specified in <Settings />, the custom X domain
  * @param deselectedDataSeries is optional; if not supplied,
  * @param customXDomain is optional; if not supplied,
- * @param vislibSort is optional; if not specified in <Settings />,
+ * @param enableVislibSeriesSort is optional; if not specified in <Settings />,
  * then all series will be factored into computations. Otherwise, selectedDataSeries
  * is used to restrict the computation for just the selected series
  * @returns `SeriesDomainsAndData`
@@ -204,12 +204,12 @@ export function computeSeriesDomains(
   customYDomainsByGroupId: Map<GroupId, YDomainRange> = new Map(),
   deselectedDataSeries: SeriesIdentifier[] = [],
   customXDomain?: DomainRange | Domain,
-  vislibSort?: boolean,
+  enableVislibSeriesSort?: boolean,
 ): SeriesDomainsAndData {
   const { dataSeriesBySpecId, xValues, seriesCollection, fallbackScale } = getDataSeriesBySpecId(
     seriesSpecs,
     deselectedDataSeries,
-    vislibSort,
+    enableVislibSeriesSort,
   );
 
   // compute the x domain merging any custom domain

--- a/src/chart_types/xy_chart/state/utils/utils.ts
+++ b/src/chart_types/xy_chart/state/utils/utils.ts
@@ -192,6 +192,8 @@ function getLastValues(formattedDataSeries: {
  * @param customYDomainsByGroupId custom Y domains grouped by GroupId
  * @param customXDomain if specified in <Settings />, the custom X domain
  * @param deselectedDataSeries is optional; if not supplied,
+ * @param customXDomain is optional; if not supplied,
+ * @param vislibSort is optional; if not specified in <Settings />,
  * then all series will be factored into computations. Otherwise, selectedDataSeries
  * is used to restrict the computation for just the selected series
  * @returns `SeriesDomainsAndData`
@@ -202,10 +204,12 @@ export function computeSeriesDomains(
   customYDomainsByGroupId: Map<GroupId, YDomainRange> = new Map(),
   deselectedDataSeries: SeriesIdentifier[] = [],
   customXDomain?: DomainRange | Domain,
+  vislibSort?: boolean,
 ): SeriesDomainsAndData {
   const { dataSeriesBySpecId, xValues, seriesCollection, fallbackScale } = getDataSeriesBySpecId(
     seriesSpecs,
     deselectedDataSeries,
+    vislibSort,
   );
 
   // compute the x domain merging any custom domain

--- a/src/chart_types/xy_chart/utils/series.ts
+++ b/src/chart_types/xy_chart/utils/series.ts
@@ -124,7 +124,7 @@ export function splitSeriesDataByAccessors(
     BasicSeriesSpec,
     'id' | 'data' | 'xAccessor' | 'yAccessors' | 'y0Accessors' | 'splitSeriesAccessors' | 'markSizeAccessor'
   >,
-  vislibSort = false,
+  enableVislibSeriesSort = false,
 ): {
   dataSeries: Map<SeriesKey, DataSeries>;
   xValues: Array<string | number>;
@@ -133,7 +133,7 @@ export function splitSeriesDataByAccessors(
   const xValues: Array<string | number> = [];
   const nonNumericValues: any[] = [];
 
-  if (vislibSort) {
+  if (enableVislibSeriesSort) {
     /*
      * This logic is mostly duplicated from below but is a temporary fix before
      * https://github.com/elastic/elastic-charts/issues/795 is completed to allow sorting
@@ -149,14 +149,14 @@ export function splitSeriesDataByAccessors(
 
         // skip if the datum is not an object or null
         if (typeof datum !== 'object' || datum === null) {
-          return null;
+          return;
         }
 
         const x = getAccessorValue(datum, xAccessor);
 
         // skip if the x value is not a string or a number
         if (typeof x !== 'string' && typeof x !== 'number') {
-          return null;
+          return;
         }
 
         xValues.push(x);
@@ -200,14 +200,14 @@ export function splitSeriesDataByAccessors(
 
       // skip if the datum is not an object or null
       if (typeof datum !== 'object' || datum === null) {
-        return null;
+        return;
       }
 
       const x = getAccessorValue(datum, xAccessor);
 
       // skip if the x value is not a string or a number
       if (typeof x !== 'string' && typeof x !== 'number') {
-        return null;
+        return;
       }
 
       xValues.push(x);
@@ -412,13 +412,13 @@ function getDataSeriesBySpecGroup(
  *
  * @param seriesSpecs the map for all the series spec
  * @param deselectedDataSeries the array of deselected/hidden data series
- * @param vislibSort is optional; if not specified in <Settings />,
+ * @param enableVislibSeriesSort is optional; if not specified in <Settings />,
  * @internal
  */
 export function getDataSeriesBySpecId(
   seriesSpecs: BasicSeriesSpec[],
   deselectedDataSeries: SeriesIdentifier[] = [],
-  vislibSort?: boolean,
+  enableVislibSeriesSort?: boolean,
 ): {
   dataSeriesBySpecId: Map<SpecId, DataSeries[]>;
   seriesCollection: Map<SeriesKey, SeriesCollectionValue>;
@@ -441,7 +441,7 @@ export function getDataSeriesBySpecId(
       isOrdinalScale = true;
     }
 
-    const { dataSeries, xValues } = splitSeriesDataByAccessors(spec, vislibSort);
+    const { dataSeries, xValues } = splitSeriesDataByAccessors(spec, enableVislibSeriesSort);
 
     // filter deleselected dataseries
     let filteredDataSeries: DataSeries[] = [...dataSeries.values()];

--- a/src/chart_types/xy_chart/utils/series.ts
+++ b/src/chart_types/xy_chart/utils/series.ts
@@ -111,18 +111,21 @@ export function getSeriesIndex(series: SeriesIdentifier[], target: SeriesIdentif
  * `y` values and `mark` values are casted to number or null.
  * @internal
  */
-export function splitSeriesDataByAccessors({
-  id: specId,
-  data,
-  xAccessor,
-  yAccessors,
-  y0Accessors,
-  markSizeAccessor,
-  splitSeriesAccessors = [],
-}: Pick<
-  BasicSeriesSpec,
-  'id' | 'data' | 'xAccessor' | 'yAccessors' | 'y0Accessors' | 'splitSeriesAccessors' | 'markSizeAccessor'
->): {
+export function splitSeriesDataByAccessors(
+  {
+    id: specId,
+    data,
+    xAccessor,
+    yAccessors,
+    y0Accessors,
+    markSizeAccessor,
+    splitSeriesAccessors = [],
+  }: Pick<
+    BasicSeriesSpec,
+    'id' | 'data' | 'xAccessor' | 'yAccessors' | 'y0Accessors' | 'splitSeriesAccessors' | 'markSizeAccessor'
+  >,
+  vislibSort = false,
+): {
   dataSeries: Map<SeriesKey, DataSeries>;
   xValues: Array<string | number>;
 } {
@@ -130,57 +133,116 @@ export function splitSeriesDataByAccessors({
   const xValues: Array<string | number> = [];
   const nonNumericValues: any[] = [];
 
-  data.forEach((datum) => {
-    const splitAccessors = getSplitAccessors(datum, splitSeriesAccessors);
-    // if splitSeriesAccessors are defined we should have at least one split value to include datum
-    if (splitSeriesAccessors.length > 0 && splitAccessors.size < 1) {
-      return;
-    }
-
-    // skip if the datum is not an object or null
-    if (typeof datum !== 'object' || datum === null) {
-      return null;
-    }
-
-    const x = getAccessorValue(datum, xAccessor);
-
-    // skip if the x value is not a string or a number
-    if (typeof x !== 'string' && typeof x !== 'number') {
-      return null;
-    }
-
-    xValues.push(x);
-
+  if (vislibSort) {
+    /*
+     * This logic is mostly duplicated from below but is a temporary fix before
+     * https://github.com/elastic/elastic-charts/issues/795 is completed to allow sorting
+     * The difference from below is that it loops through all the yAsccessors before the data.
+     */
     yAccessors.forEach((accessor, index) => {
-      const cleanedDatum = extractYandMarkFromDatum(
-        datum,
-        accessor,
-        nonNumericValues,
-        y0Accessors && y0Accessors[index],
-        markSizeAccessor,
-      );
-      const seriesKeys = [...splitAccessors.values(), accessor];
-      const seriesKey = getSeriesKey({
-        specId,
-        yAccessor: accessor,
-        splitAccessors,
-      });
-      const newDatum = { x, ...cleanedDatum };
-      const series = dataSeries.get(seriesKey);
-      if (series) {
-        series.data.push(newDatum);
-      } else {
-        dataSeries.set(seriesKey, {
+      data.forEach((datum) => {
+        const splitAccessors = getSplitAccessors(datum, splitSeriesAccessors);
+        // if splitSeriesAccessors are defined we should have at least one split value to include datum
+        if (splitSeriesAccessors.length > 0 && splitAccessors.size < 1) {
+          return;
+        }
+
+        // skip if the datum is not an object or null
+        if (typeof datum !== 'object' || datum === null) {
+          return null;
+        }
+
+        const x = getAccessorValue(datum, xAccessor);
+
+        // skip if the x value is not a string or a number
+        if (typeof x !== 'string' && typeof x !== 'number') {
+          return null;
+        }
+
+        xValues.push(x);
+
+        const cleanedDatum = extractYandMarkFromDatum(
+          datum,
+          accessor,
+          nonNumericValues,
+          y0Accessors && y0Accessors[index],
+          markSizeAccessor,
+        );
+        const seriesKeys = [...splitAccessors.values(), accessor];
+        const seriesKey = getSeriesKey({
           specId,
           yAccessor: accessor,
           splitAccessors,
-          data: [newDatum],
-          key: seriesKey,
-          seriesKeys,
         });
-      }
+        const newDatum = { x, ...cleanedDatum };
+        const series = dataSeries.get(seriesKey);
+        if (series) {
+          series.data.push(newDatum);
+        } else {
+          dataSeries.set(seriesKey, {
+            specId,
+            yAccessor: accessor,
+            splitAccessors,
+            data: [newDatum],
+            key: seriesKey,
+            seriesKeys,
+          });
+        }
+      });
     });
-  });
+  } else {
+    data.forEach((datum) => {
+      const splitAccessors = getSplitAccessors(datum, splitSeriesAccessors);
+      // if splitSeriesAccessors are defined we should have at least one split value to include datum
+      if (splitSeriesAccessors.length > 0 && splitAccessors.size < 1) {
+        return;
+      }
+
+      // skip if the datum is not an object or null
+      if (typeof datum !== 'object' || datum === null) {
+        return null;
+      }
+
+      const x = getAccessorValue(datum, xAccessor);
+
+      // skip if the x value is not a string or a number
+      if (typeof x !== 'string' && typeof x !== 'number') {
+        return null;
+      }
+
+      xValues.push(x);
+
+      yAccessors.forEach((accessor, index) => {
+        const cleanedDatum = extractYandMarkFromDatum(
+          datum,
+          accessor,
+          nonNumericValues,
+          y0Accessors && y0Accessors[index],
+          markSizeAccessor,
+        );
+        const seriesKeys = [...splitAccessors.values(), accessor];
+        const seriesKey = getSeriesKey({
+          specId,
+          yAccessor: accessor,
+          splitAccessors,
+        });
+        const newDatum = { x, ...cleanedDatum };
+        const series = dataSeries.get(seriesKey);
+        if (series) {
+          series.data.push(newDatum);
+        } else {
+          dataSeries.set(seriesKey, {
+            specId,
+            yAccessor: accessor,
+            splitAccessors,
+            data: [newDatum],
+            key: seriesKey,
+            seriesKeys,
+          });
+        }
+      });
+    });
+  }
 
   if (nonNumericValues.length > 0) {
     Logger.warn(
@@ -350,11 +412,13 @@ function getDataSeriesBySpecGroup(
  *
  * @param seriesSpecs the map for all the series spec
  * @param deselectedDataSeries the array of deselected/hidden data series
+ * @param vislibSort is optional; if not specified in <Settings />,
  * @internal
  */
 export function getDataSeriesBySpecId(
   seriesSpecs: BasicSeriesSpec[],
   deselectedDataSeries: SeriesIdentifier[] = [],
+  vislibSort?: boolean,
 ): {
   dataSeriesBySpecId: Map<SpecId, DataSeries[]>;
   seriesCollection: Map<SeriesKey, SeriesCollectionValue>;
@@ -377,7 +441,7 @@ export function getDataSeriesBySpecId(
       isOrdinalScale = true;
     }
 
-    const { dataSeries, xValues } = splitSeriesDataByAccessors(spec);
+    const { dataSeries, xValues } = splitSeriesDataByAccessors(spec, vislibSort);
 
     // filter deleselected dataseries
     let filteredDataSeries: DataSeries[] = [...dataSeries.values()];


### PR DESCRIPTION
## Summary

Allows a blind sorting option on `Settings` called `enableVislibSeriesSort` to loop through all `yAccessors` then all the data.

This option is bind as in not added to the `SettingSpec` to avoid usage, outside of vislib, until #795 allows a sorting alternative.

## Screenshot
![Screen Recording 2020-09-09 at 10 50 AM](https://user-images.githubusercontent.com/19007109/92623654-28ad2300-f28c-11ea-919a-9797b20b63fe.gif)

> Notice the change in the order of the y accessors between the options.

## Sample playground

```tsx
import React from 'react';

import { Chart, Settings, Position, Axis, BarSeries, ScaleType } from '../src';

const data = [
  // Flight Delay Minutes |	Cancelled: Descending |	OriginAirportID: Descending	Count |	Max AvgTicketPrice
  { x: 0, g1: 'false', g2: 'USA', y1: 2, y2: 847.323974609375 },
  { x: 0, g1: 'true', g2: 'Canada', y1: 1, y2: 652.268005371094 },
  { x: 30, g1: 'false', g2: 'Canada', y1: 5, y2: 1127.20959472656 },
  { x: 30, g1: 'true', g2: 'USA', y1: 1, y2: 214.78987121582 },
  { x: 60, g1: 'false', g2: 'Canada', y1: 4, y2: 990.88916015625 },
  { x: 60, g1: 'true', g2: 'USA', y1: 1, y2: 724.3603515625 },
  { x: 90, g1: 'false', g2: 'USA', y1: 3, y2: 951.81787109375 },
  { x: 90, g1: 'true', g2: 'USA', y1: 1, y2: 430.475891113281 },
  { x: 120, g1: 'false', g2: 'Canada', y1: 2, y2: 447.469512939453 },
  { x: 120, g1: 'true', g2: 'Canada', y1: 1, y2: 834.467712402344 },
  { x: 150, g1: 'false', g2: 'Canada', y1: 2, y2: 887.178100585938 },
  { x: 150, g1: 'true', g2: 'Canada', y1: 1, y2: 1176.63818359375 },
  { x: 180, g1: 'false', g2: 'USA', y1: 2, y2: 985.899963378906 },
  { x: 180, g1: 'true', g2: 'Canada', y1: 1, y2: 441.242462158203 },
  { x: 210, g1: 'false', g2: 'Canada', y1: 3, y2: 732.609436035156 },
  { x: 210, g1: 'true', g2: 'USA', y1: 1, y2: 728.790283203125 },
  { x: 240, g1: 'false', g2: 'Canada', y1: 3, y2: 526.108581542969 },
  { x: 240, g1: 'true', g2: 'USA', y1: 2, y2: 759.218139648438 },
  { x: 270, g1: 'false', g2: 'USA', y1: 3, y2: 754.231323242188 },
  { x: 270, g1: 'true', g2: 'Canada', y1: 1, y2: 574.996276855469 },
  { x: 300, g1: 'false', g2: 'Canada', y1: 4, y2: 946.468078613281 },
  { x: 300, g1: 'true', g2: 'Canada', y1: 2, y2: 999.1396484375 },
  { x: 330, g1: 'false', g2: 'USA', y1: 2, y2: 881.044494628906 },
  { x: 330, g1: 'true', g2: 'Canada', y1: 1, y2: 382.457763671875 },
  { x: 360, g1: 'false', g2: 'Canada', y1: 2, y2: 1165.59765625 },
  { x: 360, g1: 'true', g2: 'Canada', y1: 1, y2: 820.462463378906 },
];

export class Playground extends React.Component {
  render() {
    return (
      <div className="testing">
        <div className="chart">
          <Chart className="story-chart">
            <Settings
              // @ts-ignore
              enableVislibSeriesSort
              showLegend
              showLegendExtra
              legendPosition={Position.Right}
            />
            <Axis id="bottom" position={Position.Bottom} title="Bottom axis" showOverlappingTicks />
            <Axis id="left2" title="Left axis" position={Position.Left} tickFormat={(d: any) => Number(d).toFixed(2)} />

            <BarSeries
              id="bars1"
              xScaleType={ScaleType.Linear}
              yScaleType={ScaleType.Linear}
              xAccessor="x"
              yAccessors={['y1', 'y2']}
              splitSeriesAccessors={['g1', 'g2']}
              data={data}
            />
          </Chart>
        </div>
      </div>
    );
  }
}
```

### Checklist

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] Unit tests were updated or added to match the most common scenarios
