### PR TITLE
feat: heatmap tooltip enhancements and fixes

### DIFF
--- a/.playground/playground.tsx
+++ b/.playground/playground.tsx
@@ -98,6 +98,7 @@ export class Playground extends React.Component<any, { highlightedData?: Heatmap
             />
             <Heatmap
               id="heatmap1"
+              name="maxAnomalyScore"
               ranges={[0, 3, 25, 50, 75]}
               colorScale={ScaleType.Threshold}
               colors={['#ffffff', '#d2e9f7', '#8bc8fb', '#fdec25', '#fba740', '#fe5050']}

--- a/.playground/playground.tsx
+++ b/.playground/playground.tsx
@@ -69,6 +69,7 @@ export class Playground extends React.Component<any, { highlightedData?: Heatmap
         fill: 'red',
       },
       yAxisLabel: {
+        name: 'instance',
         visible: true,
         width: { max: 50 },
         padding: 5,
@@ -105,7 +106,7 @@ export class Playground extends React.Component<any, { highlightedData?: Heatmap
               xAccessor="time"
               yAccessor={(d) => d.laneLabel}
               valueAccessor="value"
-              valueFormatter={(d) => d.toFixed(0.2)}
+              valueFormatter={(d) => d.toFixed(2)}
               ySortPredicate="numAsc"
               xScaleType={ScaleType.Time}
               config={heatmapConfig}

--- a/api/charts.api.md
+++ b/api/charts.api.md
@@ -713,7 +713,7 @@ export interface GoalSpec extends Spec {
     // Warning: (ae-forgotten-export) The symbol "Config" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    config: RecursivePartial<Config>;
+    config: RecursivePartial<Config_2>;
     // (undocumented)
     labelMajor: string | BandFillColorAccessor;
     // (undocumented)
@@ -765,114 +765,11 @@ export type GroupId = string;
 // @alpha (undocumented)
 export const Heatmap: React.FunctionComponent<SpecRequiredProps_8 & SpecOptionalProps_8>;
 
-// Warning: (ae-missing-release-tag) "Config" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-forgotten-export) The symbol "Config" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "HeatmapConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export interface HeatmapConfig {
-    brushArea: {
-        visible: boolean;
-        fill: Color;
-        stroke: Color;
-        strokeWidth: number;
-    };
-    brushMask: {
-        visible: boolean;
-        fill: Color;
-    };
-    brushTool: {
-        visible: boolean;
-        fill: Color;
-    };
-    // (undocumented)
-    cell: {
-        maxWidth: Pixels | 'fill';
-        maxHeight: Pixels | 'fill';
-        align: 'center';
-        label: Font & {
-            fontSize: Pixels;
-            maxWidth: Pixels | 'fill';
-            fill: string;
-            align: TextAlign;
-            baseline: TextBaseline;
-            visible: boolean;
-        };
-        border: {
-            strokeWidth: Pixels;
-            stroke: Color;
-        };
-    };
-    // Warning: (ae-forgotten-export) The symbol "FontFamily" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    fontFamily: FontFamily;
-    // (undocumented)
-    grid: {
-        cellWidth: {
-            min: Pixels;
-            max: Pixels | 'fill';
-        };
-        cellHeight: {
-            min: Pixels;
-            max: Pixels | 'fill';
-        };
-        stroke: {
-            color: string;
-            width: number;
-        };
-    };
-    // (undocumented)
-    height: Pixels;
-    // (undocumented)
-    margin: {
-        left: SizeRatio;
-        right: SizeRatio;
-        top: SizeRatio;
-        bottom: SizeRatio;
-    };
-    // (undocumented)
-    maxColumnWidth: Pixels;
-    // (undocumented)
-    maxRowHeight: Pixels;
-    // Warning: (ae-forgotten-export) The symbol "HeatmapBrushEvent" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    onBrushEnd?: (brushArea: HeatmapBrushEvent) => void;
-    // (undocumented)
-    timeZone: string;
-    // Warning: (ae-forgotten-export) The symbol "Pixels" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    width: Pixels;
-    // Warning: (ae-forgotten-export) The symbol "Font" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    xAxisLabel: Font & {
-        fontSize: Pixels;
-        fill: string;
-        align: TextAlign;
-        baseline: TextBaseline;
-        visible: boolean;
-        padding: number;
-        formatter: (value: string | number) => string;
-    };
-    // (undocumented)
-    yAxisLabel: Font & {
-        fontSize: Pixels;
-        width: Pixels | 'auto' | {
-            max: Pixels;
-        };
-        fill: string;
-        baseline: TextBaseline;
-        visible: boolean;
-        padding: number | {
-            left?: number;
-            right?: number;
-            top?: number;
-            bottom?: number;
-        };
-        formatter: (value: string | number) => string;
-    };
-}
+export type HeatmapConfig = RecursivePartial<Config>;
 
 // Warning: (ae-forgotten-export) The symbol "Cell" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "HeatmapElementEvent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -891,7 +788,7 @@ export interface HeatmapSpec extends Spec {
     // (undocumented)
     colorScale?: HeatmapScaleType;
     // (undocumented)
-    config: RecursivePartial<HeatmapConfig>;
+    config: RecursivePartial<Config>;
     // (undocumented)
     data: Datum[];
     // (undocumented)
@@ -1865,9 +1762,6 @@ export type YDomainRange = YDomainBase & DomainRange;
 
 // Warnings were encountered during analysis:
 //
-// src/chart_types/heatmap/layout/types/config_types.ts:28:13 - (ae-forgotten-export) The symbol "SizeRatio" needs to be exported by the entry point index.d.ts
-// src/chart_types/heatmap/layout/types/config_types.ts:58:5 - (ae-forgotten-export) The symbol "TextAlign" needs to be exported by the entry point index.d.ts
-// src/chart_types/heatmap/layout/types/config_types.ts:59:5 - (ae-forgotten-export) The symbol "TextBaseline" needs to be exported by the entry point index.d.ts
 // src/chart_types/partition_chart/layout/types/config_types.ts:126:5 - (ae-forgotten-export) The symbol "TimeMs" needs to be exported by the entry point index.d.ts
 // src/chart_types/partition_chart/layout/types/config_types.ts:127:5 - (ae-forgotten-export) The symbol "AnimKeyframe" needs to be exported by the entry point index.d.ts
 // src/chart_types/partition_chart/specs/index.ts:48:13 - (ae-forgotten-export) The symbol "NodeColorAccessor" needs to be exported by the entry point index.d.ts

--- a/api/charts.api.md
+++ b/api/charts.api.md
@@ -713,7 +713,7 @@ export interface GoalSpec extends Spec {
     // Warning: (ae-forgotten-export) The symbol "Config" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    config: RecursivePartial<Config_2>;
+    config: RecursivePartial<Config>;
     // (undocumented)
     labelMajor: string | BandFillColorAccessor;
     // (undocumented)
@@ -765,11 +765,116 @@ export type GroupId = string;
 // @alpha (undocumented)
 export const Heatmap: React.FunctionComponent<SpecRequiredProps_8 & SpecOptionalProps_8>;
 
-// Warning: (ae-forgotten-export) The symbol "Config" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "HeatmapConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Config" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type HeatmapConfig = RecursivePartial<Config>;
+export interface HeatmapConfig {
+    brushArea: {
+        visible: boolean;
+        fill: Color;
+        stroke: Color;
+        strokeWidth: number;
+    };
+    brushMask: {
+        visible: boolean;
+        fill: Color;
+    };
+    brushTool: {
+        visible: boolean;
+        fill: Color;
+    };
+    // (undocumented)
+    cell: {
+        maxWidth: Pixels | 'fill';
+        maxHeight: Pixels | 'fill';
+        align: 'center';
+        label: Font & {
+            fontSize: Pixels;
+            maxWidth: Pixels | 'fill';
+            fill: string;
+            align: TextAlign;
+            baseline: TextBaseline;
+            visible: boolean;
+        };
+        border: {
+            strokeWidth: Pixels;
+            stroke: Color;
+        };
+    };
+    // Warning: (ae-forgotten-export) The symbol "FontFamily" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    fontFamily: FontFamily;
+    // (undocumented)
+    grid: {
+        cellWidth: {
+            min: Pixels;
+            max: Pixels | 'fill';
+        };
+        cellHeight: {
+            min: Pixels;
+            max: Pixels | 'fill';
+        };
+        stroke: {
+            color: string;
+            width: number;
+        };
+    };
+    // (undocumented)
+    height: Pixels;
+    // (undocumented)
+    margin: {
+        left: SizeRatio;
+        right: SizeRatio;
+        top: SizeRatio;
+        bottom: SizeRatio;
+    };
+    // (undocumented)
+    maxColumnWidth: Pixels;
+    // (undocumented)
+    maxRowHeight: Pixels;
+    // Warning: (ae-forgotten-export) The symbol "HeatmapBrushEvent" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    onBrushEnd?: (brushArea: HeatmapBrushEvent) => void;
+    // (undocumented)
+    timeZone: string;
+    // Warning: (ae-forgotten-export) The symbol "Pixels" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    width: Pixels;
+    // Warning: (ae-forgotten-export) The symbol "Font" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    xAxisLabel: Font & {
+        name: string;
+        fontSize: Pixels;
+        fill: string;
+        align: TextAlign;
+        baseline: TextBaseline;
+        visible: boolean;
+        padding: number;
+        formatter: (value: string | number) => string;
+    };
+    // (undocumented)
+    yAxisLabel: Font & {
+        name: string;
+        fontSize: Pixels;
+        width: Pixels | 'auto' | {
+            max: Pixels;
+        };
+        fill: string;
+        baseline: TextBaseline;
+        visible: boolean;
+        padding: number | {
+            left?: number;
+            right?: number;
+            top?: number;
+            bottom?: number;
+        };
+        formatter: (value: string | number) => string;
+    };
+}
 
 // Warning: (ae-forgotten-export) The symbol "Cell" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "HeatmapElementEvent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -788,7 +893,7 @@ export interface HeatmapSpec extends Spec {
     // (undocumented)
     colorScale?: HeatmapScaleType;
     // (undocumented)
-    config: RecursivePartial<Config>;
+    config: RecursivePartial<HeatmapConfig>;
     // (undocumented)
     data: Datum[];
     // (undocumented)
@@ -796,6 +901,8 @@ export interface HeatmapSpec extends Spec {
         x: any[];
         y: any[];
     };
+    // (undocumented)
+    name?: string;
     // (undocumented)
     ranges?: number[] | [number, number];
     // (undocumented)
@@ -1762,6 +1869,9 @@ export type YDomainRange = YDomainBase & DomainRange;
 
 // Warnings were encountered during analysis:
 //
+// src/chart_types/heatmap/layout/types/config_types.ts:28:13 - (ae-forgotten-export) The symbol "SizeRatio" needs to be exported by the entry point index.d.ts
+// src/chart_types/heatmap/layout/types/config_types.ts:59:5 - (ae-forgotten-export) The symbol "TextAlign" needs to be exported by the entry point index.d.ts
+// src/chart_types/heatmap/layout/types/config_types.ts:60:5 - (ae-forgotten-export) The symbol "TextBaseline" needs to be exported by the entry point index.d.ts
 // src/chart_types/partition_chart/layout/types/config_types.ts:126:5 - (ae-forgotten-export) The symbol "TimeMs" needs to be exported by the entry point index.d.ts
 // src/chart_types/partition_chart/layout/types/config_types.ts:127:5 - (ae-forgotten-export) The symbol "AnimKeyframe" needs to be exported by the entry point index.d.ts
 // src/chart_types/partition_chart/specs/index.ts:48:13 - (ae-forgotten-export) The symbol "NodeColorAccessor" needs to be exported by the entry point index.d.ts

--- a/src/chart_types/heatmap/layout/config/config.ts
+++ b/src/chart_types/heatmap/layout/config/config.ts
@@ -48,7 +48,7 @@ export const config: Config = {
   timeZone: 'UTC',
 
   xAxisLabel: {
-    name: '',
+    name: 'X Value',
     visible: true,
     fill: 'black',
     fontSize: 12,
@@ -64,7 +64,7 @@ export const config: Config = {
     formatter: String,
   },
   yAxisLabel: {
-    name: '',
+    name: 'Y Value',
     visible: true,
     width: 'auto',
     fill: 'black',

--- a/src/chart_types/heatmap/layout/config/config.ts
+++ b/src/chart_types/heatmap/layout/config/config.ts
@@ -48,6 +48,7 @@ export const config: Config = {
   timeZone: 'UTC',
 
   xAxisLabel: {
+    name: '',
     visible: true,
     fill: 'black',
     fontSize: 12,
@@ -63,6 +64,7 @@ export const config: Config = {
     formatter: String,
   },
   yAxisLabel: {
+    name: '',
     visible: true,
     width: 'auto',
     fill: 'black',

--- a/src/chart_types/heatmap/layout/types/config_types.ts
+++ b/src/chart_types/heatmap/layout/types/config_types.ts
@@ -17,10 +17,12 @@
  * under the License.
  */
 
-import { Color } from '../../../../utils/commons';
+import { Color, RecursivePartial } from '../../../../utils/commons';
 import { Pixels, SizeRatio } from '../../../partition_chart/layout/types/geometry_types';
 import { Font, FontFamily, TextAlign, TextBaseline } from '../../../partition_chart/layout/types/types';
 import { Cell } from './viewmodel_types';
+
+export type HeatmapConfig = RecursivePartial<Config>;
 
 export interface Config {
   width: Pixels;
@@ -53,6 +55,7 @@ export interface Config {
   };
 
   xAxisLabel: Font & {
+    name: string;
     fontSize: Pixels;
     fill: string;
     align: TextAlign;
@@ -62,6 +65,7 @@ export interface Config {
     formatter: (value: string | number) => string;
   };
   yAxisLabel: Font & {
+    name: string;
     fontSize: Pixels;
     width: Pixels | 'auto' | { max: Pixels };
     fill: string;

--- a/src/chart_types/heatmap/layout/types/config_types.ts
+++ b/src/chart_types/heatmap/layout/types/config_types.ts
@@ -17,12 +17,10 @@
  * under the License.
  */
 
-import { Color, RecursivePartial } from '../../../../utils/commons';
+import { Color } from '../../../../utils/commons';
 import { Pixels, SizeRatio } from '../../../partition_chart/layout/types/geometry_types';
 import { Font, FontFamily, TextAlign, TextBaseline } from '../../../partition_chart/layout/types/types';
 import { Cell } from './viewmodel_types';
-
-export type HeatmapConfig = RecursivePartial<Config>;
 
 export interface Config {
   width: Pixels;

--- a/src/chart_types/heatmap/specs/heatmap.ts
+++ b/src/chart_types/heatmap/specs/heatmap.ts
@@ -69,6 +69,7 @@ export interface HeatmapSpec extends Spec {
   xScaleType: SeriesScales['xScaleType'];
   config: RecursivePartial<Config>;
   highlightedData?: { x: any[]; y: any[] };
+  name?: string;
 }
 
 type SpecRequiredProps = Pick<HeatmapSpec, 'id' | 'data'>;

--- a/src/chart_types/heatmap/state/selectors/tooltip.ts
+++ b/src/chart_types/heatmap/state/selectors/tooltip.ts
@@ -51,7 +51,7 @@ export const getTooltipInfoSelector = createCachedSelector(
           // X-axis value
           tooltipInfo.values.push({
             label: config.xAxisLabel.name,
-            color: RGBtoString(shape.fill.color),
+            color: 'transparent',
             isHighlighted: false,
             isVisible: true,
             seriesIdentifier: {
@@ -65,7 +65,7 @@ export const getTooltipInfoSelector = createCachedSelector(
           // Y-axis value
           tooltipInfo.values.push({
             label: config.yAxisLabel.name,
-            color: RGBtoString(shape.fill.color),
+            color: 'transparent',
             isHighlighted: false,
             isVisible: true,
             seriesIdentifier: {
@@ -78,7 +78,7 @@ export const getTooltipInfoSelector = createCachedSelector(
 
           // Cell value
           tooltipInfo.values.push({
-            label: '',
+            label: spec.name ?? spec.id,
             color: RGBtoString(shape.fill.color),
             isHighlighted: false,
             isVisible: true,

--- a/src/chart_types/heatmap/state/selectors/tooltip.ts
+++ b/src/chart_types/heatmap/state/selectors/tooltip.ts
@@ -48,9 +48,37 @@ export const getTooltipInfoSelector = createCachedSelector(
       pickedShapes
         .filter(({ visible }) => visible)
         .forEach((shape) => {
-          const xValueLabel = config.xAxisLabel.formatter(shape.datum.x);
+          // X-axis value
           tooltipInfo.values.push({
-            label: `${shape.datum.y} - ${xValueLabel}`,
+            label: config.xAxisLabel.name,
+            color: RGBtoString(shape.fill.color),
+            isHighlighted: false,
+            isVisible: true,
+            seriesIdentifier: {
+              specId: spec.id,
+              key: spec.id,
+            },
+            value: `${shape.datum.x}`,
+            formattedValue: config.xAxisLabel.formatter(shape.datum.x),
+          });
+
+          // Y-axis value
+          tooltipInfo.values.push({
+            label: config.yAxisLabel.name,
+            color: RGBtoString(shape.fill.color),
+            isHighlighted: false,
+            isVisible: true,
+            seriesIdentifier: {
+              specId: spec.id,
+              key: spec.id,
+            },
+            value: `${shape.datum.y}`,
+            formattedValue: config.yAxisLabel.formatter(shape.datum.y),
+          });
+
+          // Cell value
+          tooltipInfo.values.push({
+            label: '',
             color: RGBtoString(shape.fill.color),
             isHighlighted: false,
             isVisible: true,
@@ -59,7 +87,7 @@ export const getTooltipInfoSelector = createCachedSelector(
               key: spec.id,
             },
             value: `${shape.value}`,
-            formattedValue: `${shape.value}`,
+            formattedValue: `${shape.formatted}`,
           });
         });
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export {
   FillLabelConfig as PartitionFillLabel,
   PartitionLayout,
 } from './chart_types/partition_chart/layout/types/config_types';
-export { HeatmapConfig } from './chart_types/heatmap/layout/types/config_types';
+export { Config as HeatmapConfig } from './chart_types/heatmap/layout/types/config_types';
 export { Layer as PartitionLayer } from './chart_types/partition_chart/specs/index';
 export * from './chart_types/goal_chart/specs/index';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export {
   FillLabelConfig as PartitionFillLabel,
   PartitionLayout,
 } from './chart_types/partition_chart/layout/types/config_types';
-export { Config as HeatmapConfig } from './chart_types/heatmap/layout/types/config_types';
+export { HeatmapConfig } from './chart_types/heatmap/layout/types/config_types';
 export { Layer as PartitionLayer } from './chart_types/partition_chart/specs/index';
 export * from './chart_types/goal_chart/specs/index';
 export {

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -135,7 +135,7 @@ export interface TooltipValue {
    */
   isVisible: boolean;
   /**
-   * The idenfitier of the related series
+   * The identifier of the related series
    */
   seriesIdentifier: SeriesIdentifier;
   /**


### PR DESCRIPTION
## Summary

- Add configurable names for X and Y axes labels 
- Add extra values to the tooltip info for X and Y axes, fix `formattedValue` for the cell value
- Export `HeatmapConfig` as `RecursivePartial`
