### PR TITLE
fix: detect dragging only by the delta changes

### DIFF
--- a/src/chart_types/xy_chart/state/chart_state.interactions.test.ts
+++ b/src/chart_types/xy_chart/state/chart_state.interactions.test.ts
@@ -880,9 +880,9 @@ function mouseOverTestSuite(scaleType: XScaleType) {
         expect(brushEndListener.mock.calls[3][0]).toEqual({ x: [0, 0.5] });
       }
 
-      store.dispatch(onMouseDown(start4, 1300));
-      store.dispatch(onPointerMove(end4, 1390));
-      store.dispatch(onMouseUp(end4, 1400));
+      store.dispatch(onMouseDown({ x: 25, y: 0 }, 1300));
+      store.dispatch(onPointerMove({ x: 28, y: 0 }, 1390));
+      store.dispatch(onMouseUp({ x: 28, y: 0 }, 1400));
       if (scaleType === ScaleType.Ordinal) {
         expect(brushEndListener).not.toBeCalled();
       } else {

--- a/src/state/reducers/interactions.ts
+++ b/src/state/reducers/interactions.ts
@@ -63,9 +63,8 @@ export function interactionsReducer(
 
     case ON_POINTER_MOVE:
       // enable the dragging flag only if the pixel delta between down and move is greater then 4 pixel
-      const dragging = !!(
-        state.pointer.down && getDelta(state.pointer.down.position, action.position) > DRAG_DETECTION_PIXEL_DELTA
-      );
+      const dragging =
+        !!state.pointer.down && getDelta(state.pointer.down.position, action.position) > DRAG_DETECTION_PIXEL_DELTA;
       return {
         ...state,
         pointer: {

--- a/src/state/reducers/interactions.ts
+++ b/src/state/reducers/interactions.ts
@@ -62,14 +62,15 @@ export function interactionsReducer(
       return state;
 
     case ON_POINTER_MOVE:
-      const delta =
-        state.pointer.down && getDelta(state.pointer.down.position, action.position) > DRAG_DETECTION_PIXEL_DELTA;
+      const isDragging = !!(
+        state.pointer.down && getDelta(state.pointer.down.position, action.position) > DRAG_DETECTION_PIXEL_DELTA
+      );
       return {
         ...state,
         pointer: {
           ...state.pointer,
-          // enable the dragging flag only if the time between the down action and the move action is > 100ms
-          dragging: !!(state.pointer.down && action.time - state.pointer.down.time >= DRAG_DETECTION_TIMEOUT && delta),
+          // enable the dragging flag only if the pixel delta between down and move is greater then 4 pixel
+          dragging: isDragging,
           current: {
             position: {
               ...action.position,

--- a/src/state/reducers/interactions.ts
+++ b/src/state/reducers/interactions.ts
@@ -62,15 +62,15 @@ export function interactionsReducer(
       return state;
 
     case ON_POINTER_MOVE:
-      const isDragging = !!(
+      // enable the dragging flag only if the pixel delta between down and move is greater then 4 pixel
+      const dragging = !!(
         state.pointer.down && getDelta(state.pointer.down.position, action.position) > DRAG_DETECTION_PIXEL_DELTA
       );
       return {
         ...state,
         pointer: {
           ...state.pointer,
-          // enable the dragging flag only if the pixel delta between down and move is greater then 4 pixel
-          dragging: isDragging,
+          dragging,
           current: {
             position: {
               ...action.position,


### PR DESCRIPTION
## Summary


This fix changes the drag detection checking only the delta change between the mouse down position and the current mouse move removing the time check. This allows fast interaction used in CI functional tests without the need to add a delay between actions.

