### PR TITLE
feat(legend): allow legend text to be copyable

### DIFF
--- a/src/components/legend/_legend_item.scss
+++ b/src/components/legend/_legend_item.scss
@@ -5,7 +5,7 @@ $legendItemVerticalPadding: $echLegendRowGap / 2;
   display: flex;
   flex-wrap: nowrap;
   justify-content: space-between;
-  user-select: none;
+  user-select: all;
   align-items: center;
   width: 100%;
 

--- a/src/components/legend/_legend_item.scss
+++ b/src/components/legend/_legend_item.scss
@@ -5,7 +5,6 @@ $legendItemVerticalPadding: $echLegendRowGap / 2;
   display: flex;
   flex-wrap: nowrap;
   justify-content: space-between;
-  user-select: auto;
   align-items: center;
   width: 100%;
 

--- a/src/components/legend/_legend_item.scss
+++ b/src/components/legend/_legend_item.scss
@@ -5,7 +5,7 @@ $legendItemVerticalPadding: $echLegendRowGap / 2;
   display: flex;
   flex-wrap: nowrap;
   justify-content: space-between;
-  user-select: all;
+  user-select: auto;
   align-items: center;
   width: 100%;
 


### PR DESCRIPTION
## Summary

Fixes #710 Text from the legend can be selected and copied.
![Oct-26-2020 13-05-32](https://user-images.githubusercontent.com/20343860/97216798-fac46500-178b-11eb-9f00-562e8535e149.gif)

