### PR TITLE
docs: add randomness toggle on fit stacked series story

### DIFF
--- a/stories/mixed/6_fitting_stacked.tsx
+++ b/stories/mixed/6_fitting_stacked.tsx
@@ -26,7 +26,7 @@ import { getRandomNumberGenerator } from '../../src/mocks/utils';
 import { SB_KNOBS_PANEL } from '../utils/storybook';
 
 export const Example = () => {
-  const randomizeBoundingData = boolean('randomize bounding data', false);
+  const randomizeBoundingData = process.env.RNG_SEED !== null ? false : boolean('randomize bounding data', false);
   const dataTypes: Record<string, Array<{ x: number | string; y: number | null }>> = {
     isolated: [
       { x: 0, y: 3 },
@@ -159,7 +159,8 @@ export const Example = () => {
   const parsedEndValue: number | 'nearest' = Number.isNaN(Number(endValue)) ? 'nearest' : Number(endValue);
   const value = number('Explicit value (using Fit.Explicit)', 5);
   const xScaleType = dataKey === 'ordinal' ? ScaleType.Ordinal : ScaleType.Linear;
-  const rng = getRandomNumberGenerator(randomizeBoundingData ? undefined : '__seed__');
+  const rngSeed = randomizeBoundingData ? undefined : process.env.RNG_SEED ?? '__seed__';
+  const rng = getRandomNumberGenerator(rngSeed);
   const tickFormat = stackMode === 'percentage' ? (d: any) => numeral(d).format('0[.]00%') : undefined;
   return (
     <Chart className="story-chart">

--- a/stories/mixed/6_fitting_stacked.tsx
+++ b/stories/mixed/6_fitting_stacked.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { select, number } from '@storybook/addon-knobs';
+import { select, number, boolean } from '@storybook/addon-knobs';
 import numeral from 'numeral';
 import React from 'react';
 
@@ -26,6 +26,7 @@ import { getRandomNumberGenerator } from '../../src/mocks/utils';
 import { SB_KNOBS_PANEL } from '../utils/storybook';
 
 export const Example = () => {
+  const randomizeBoundingData = boolean('randomize bounding data', false);
   const dataTypes: Record<string, Array<{ x: number | string; y: number | null }>> = {
     isolated: [
       { x: 0, y: 3 },
@@ -158,7 +159,7 @@ export const Example = () => {
   const parsedEndValue: number | 'nearest' = Number.isNaN(Number(endValue)) ? 'nearest' : Number(endValue);
   const value = number('Explicit value (using Fit.Explicit)', 5);
   const xScaleType = dataKey === 'ordinal' ? ScaleType.Ordinal : ScaleType.Linear;
-  const rng = getRandomNumberGenerator();
+  const rng = getRandomNumberGenerator(randomizeBoundingData ? undefined : '__seed__');
   const tickFormat = stackMode === 'percentage' ? (d: any) => numeral(d).format('0[.]00%') : undefined;
   return (
     <Chart className="story-chart">


### PR DESCRIPTION
## Summary

Add randomness toggle on fit stacked series story per chat with @wylieconlon. Should be disabled by default to easily see the difference.

![Screen Recording 2020-11-05 at 02 01 PM](https://user-images.githubusercontent.com/19007109/98290871-e7757e80-1f6f-11eb-9f6e-93f5f1b2e8f5.gif)


### Checklist
- [x] Proper documentation or storybook story was added for features that require explanation or tutorials

