### PR TITLE
fix: empty labels on debug state

### DIFF
--- a/src/chart_types/xy_chart/state/selectors/get_debug_state.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_debug_state.ts
@@ -80,9 +80,9 @@ function getAxes(axesGeoms: AxisGeometry[], axesSpecs: AxisSpec[], gridLines: Li
         return acc;
       }
 
-      const { ticks } = geom;
-      const labels = ticks.map(({ label }) => label);
-      const values = ticks.map(({ value }) => value);
+      const visibleTicks = geom.visibleTicks.filter(({ label }) => label !== '');
+      const labels = visibleTicks.map(({ label }) => label);
+      const values = visibleTicks.map(({ value }) => value);
 
       const gridlines = gridLines
         .reduce<Line[]>((accLines, { lineGroups }) => {


### PR DESCRIPTION
## Summary

When using the new `debugState`, the axis labels where using the non-filtered ticks when using either `showOverlappingLabels` or `showOverlappingTicks` options. This PR uses only the visible ticks and filters out empty string labels.

### Checklist
- [x] Unit tests were updated or added to match the most common scenarios
