### PR TITLE
fix: external tooltip legend extra value sync (#993) [24.4.x]

### DIFF
--- a/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
@@ -118,7 +118,7 @@ function getTooltipAndHighlightFromValue(
     return EMPTY_VALUES;
   }
 
-  if (tooltipType === TooltipType.None) {
+  if (tooltipType === TooltipType.None && !externalPointerEvent) {
     return EMPTY_VALUES;
   }
 


### PR DESCRIPTION
Backports the following commits to 24.4.x:
 - fix: external tooltip legend extra value sync (#993)