### PR TITLE
refactor(partition): code compliance and improvements

### DIFF
--- a/.playground/playground.tsx
+++ b/.playground/playground.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 
-import { Example } from '../stories/icicle/02_unix_flame';
+import { Example } from '../stories/sunburst/9_sunburst_three_layers';
 
 export class Playground extends React.Component {
   render() {

--- a/api/charts.api.md
+++ b/api/charts.api.md
@@ -1741,7 +1741,7 @@ export type ScaleType = $Values<typeof ScaleType>;
 
 // Warning: (ae-missing-release-tag) "SectorGeomSpecY" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export interface SectorGeomSpecY {
     // Warning: (ae-forgotten-export) The symbol "Distance" needs to be exported by the entry point index.d.ts
     //
@@ -2224,7 +2224,7 @@ export type TreeLevel = number;
 
 // Warning: (ae-missing-release-tag) "TreeNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export interface TreeNode extends AngleFromTo {
     // (undocumented)
     fill?: Color;

--- a/src/chart_types/goal_chart/state/selectors/on_element_out_caller.ts
+++ b/src/chart_types/goal_chart/state/selectors/on_element_out_caller.ts
@@ -21,6 +21,7 @@ import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartTypes } from '../../..';
+import { getOnElementOutSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
@@ -34,26 +35,13 @@ import { getPickedShapesLayerValues } from './picked_shapes';
  * @internal
  */
 export function createOnElementOutCaller(): (state: GlobalChartState) => void {
-  let prevPickedShapes: number | null = null;
+  const prev: { pickedShapes: number | null } = { pickedShapes: null };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartTypes.Goal) {
       selector = createCachedSelector(
         [getSpecOrNull, getPickedShapesLayerValues, getSettingsSpecSelector],
-        (spec, pickedShapes, settings): void => {
-          if (!spec) {
-            return;
-          }
-          if (!settings.onElementOut) {
-            return;
-          }
-          const nextPickedShapes = pickedShapes.length;
-
-          if (prevPickedShapes !== null && prevPickedShapes > 0 && nextPickedShapes === 0) {
-            settings.onElementOut();
-          }
-          prevPickedShapes = nextPickedShapes;
-        },
+        getOnElementOutSelector(prev),
       )(getChartIdSelector);
     }
     if (selector) {

--- a/src/chart_types/partition_chart/layout/types/viewmodel_types.ts
+++ b/src/chart_types/partition_chart/layout/types/viewmodel_types.ts
@@ -144,6 +144,13 @@ export interface AngleFromTo {
   x1: Radian;
 }
 
+/** @internal */
+export interface LayerFromTo {
+  y0: TreeLevel;
+  y1: TreeLevel;
+}
+
+/** potential internal */
 export interface TreeNode extends AngleFromTo {
   x0: Radian;
   x1: Radian;
@@ -152,6 +159,7 @@ export interface TreeNode extends AngleFromTo {
   fill?: Color;
 }
 
+/** potential internal */
 export interface SectorGeomSpecY {
   y0px: Distance;
   y1px: Distance;

--- a/src/chart_types/partition_chart/layout/utils/highlighted_geoms.ts
+++ b/src/chart_types/partition_chart/layout/utils/highlighted_geoms.ts
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { $Values as Values } from 'utility-types';
+
+import { LegendPath } from '../../../../state/actions/legend';
+import { DataName, QuadViewModel } from '../types/viewmodel_types';
+
+type LegendStrategyFn = (legendPath: LegendPath) => (partialShape: { path: LegendPath; dataName: DataName }) => boolean;
+
+const legendStrategies: Record<LegendStrategy, LegendStrategyFn> = {
+  node: (legendPath) => ({ path }) =>
+    // highlight exact match in the path only
+    legendPath.length === path.length &&
+    legendPath.every(({ index, value }, i) => index === path[i]?.index && value === path[i]?.value),
+
+  path: (legendPath) => ({ path }) =>
+    // highlight members of the exact path; ie. exact match in the path, plus all its ancestors
+    path.every(({ index, value }, i) => index === legendPath[i]?.index && value === legendPath[i]?.value),
+
+  keyInLayer: (legendPath) => ({ path, dataName }) =>
+    // highlight all identically named items which are within the same depth (ring) as the hovered legend depth
+    legendPath.length === path.length && dataName === legendPath[legendPath.length - 1].value,
+
+  key: (legendPath) => ({ dataName }) =>
+    // highlight all identically named items, no matter where they are
+    dataName === legendPath[legendPath.length - 1].value,
+
+  nodeWithDescendants: (legendPath) => ({ path }) =>
+    // highlight exact match in the path, and everything that is its descendant in that branch
+    legendPath.every(({ index, value }, i) => index === path[i]?.index && value === path[i]?.value),
+
+  pathWithDescendants: (legendPath) => ({ path }) =>
+    // highlight exact match in the path, and everything that is its ancestor, or its descendant in that branch
+    legendPath
+      .slice(0, path.length)
+      .every(({ index, value }, i) => index === path[i]?.index && value === path[i]?.value),
+};
+
+/** @public */
+export const LegendStrategy = Object.freeze({
+  /**
+   * Highlight the specific node(s) that the legend item stands for.
+   */
+  Node: 'node' as const,
+  /**
+   * Highlight members of the exact path; ie. like `Node`, plus all its ancestors
+   */
+  Path: 'path' as const,
+  /**
+   * Highlight all identically named (labelled) items within the tree layer (depth or ring) of the specific node(s) that the legend item stands for
+   */
+  KeyInLayer: 'keyInLayer' as const,
+  /**
+   * Highlight all identically named (labelled) items, no matter where they are
+   */
+  Key: 'key' as const,
+  /**
+   * Highlight the specific node(s) that the legend item stands for, plus all descendants
+   */
+  NodeWithDescendants: 'nodeWithDescendants' as const,
+  /**
+   * Highlight the specific node(s) that the legend item stands for, plus all ancestors and descendants
+   */
+  PathWithDescendants: 'pathWithDescendants' as const,
+});
+
+/** @public */
+export type LegendStrategy = Values<typeof LegendStrategy>;
+
+const defaultStrategy: LegendStrategy = LegendStrategy.Key;
+
+/** @internal */
+export function highlightedGeoms(
+  legendStrategy: LegendStrategy | undefined,
+  quadViewModel: QuadViewModel[],
+  highlightedLegendItemPath: LegendPath,
+) {
+  const pickedLogic: LegendStrategy = legendStrategy ?? defaultStrategy;
+  return quadViewModel.filter(legendStrategies[pickedLogic](highlightedLegendItemPath));
+}

--- a/src/chart_types/partition_chart/layout/utils/legend.ts
+++ b/src/chart_types/partition_chart/layout/utils/legend.ts
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CategoryKey } from '../../../../common/category';
+import { map } from '../../../../common/iterables';
+import { LegendItem } from '../../../../common/legend';
+import { identity, Position } from '../../../../utils/common';
+import { isHierarchicalLegend } from '../../../../utils/legend';
+import { Layer } from '../../specs';
+import { QuadViewModel } from '../types/viewmodel_types';
+
+function makeKey(...keyParts: CategoryKey[]): string {
+  return keyParts.join('---');
+}
+
+function compareTreePaths({ path: a }: QuadViewModel, { path: b }: QuadViewModel): number {
+  for (let i = 0; i < Math.min(a.length, b.length); i++) {
+    const diff = a[i].index - b[i].index;
+    if (diff) {
+      return diff;
+    }
+  }
+  return a.length - b.length; // if one path is fully contained in the other, then parent (shorter) goes first
+}
+
+/** @internal */
+export function getLegendItems(
+  id: string,
+  layers: Layer[],
+  flatLegend: boolean | undefined,
+  legendMaxDepth: number,
+  legendPosition: Position,
+  quadViewModel: QuadViewModel[],
+): LegendItem[] {
+  const uniqueNames = new Set(map(({ dataName, fillColor }) => makeKey(dataName, fillColor), quadViewModel));
+  const useHierarchicalLegend = isHierarchicalLegend(flatLegend, legendPosition);
+
+  const excluded: Set<string> = new Set();
+  const items = quadViewModel.filter(({ depth, dataName, fillColor }) => {
+    if (legendMaxDepth != null) {
+      return depth <= legendMaxDepth;
+    }
+    if (!useHierarchicalLegend) {
+      const key = makeKey(dataName, fillColor);
+      if (uniqueNames.has(key) && excluded.has(key)) {
+        return false;
+      }
+      excluded.add(key);
+    }
+    return true;
+  });
+
+  items.sort(compareTreePaths);
+
+  return items.map<LegendItem>(({ dataName, fillColor, depth, path }) => {
+    const formatter = layers[depth - 1]?.nodeLabel ?? identity;
+    return {
+      color: fillColor,
+      label: formatter(dataName),
+      childId: dataName,
+      depth: useHierarchicalLegend ? depth - 1 : 0,
+      path,
+      seriesIdentifier: { key: dataName, specId: id },
+    };
+  });
+}

--- a/src/chart_types/partition_chart/layout/utils/legend_labels.ts
+++ b/src/chart_types/partition_chart/layout/utils/legend_labels.ts
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { LegendItemLabel } from '../../../../state/selectors/get_legend_items_labels';
+import { Layer } from '../../specs';
+import { CHILDREN_KEY, HIERARCHY_ROOT_KEY, HierarchyOfArrays } from './group_by_rollup';
+
+/** @internal */
+export function getLegendLabels(layers: Layer[], tree: HierarchyOfArrays, legendMaxDepth: number) {
+  return flatSlicesNames(layers, 0, tree).filter(({ depth }) => depth <= legendMaxDepth);
+}
+
+function flatSlicesNames(
+  layers: Layer[],
+  depth: number,
+  tree: HierarchyOfArrays,
+  keys: Map<string, number> = new Map(),
+): LegendItemLabel[] {
+  if (tree.length === 0) {
+    return [];
+  }
+
+  for (let i = 0; i < tree.length; i++) {
+    const branch = tree[i];
+    const arrayNode = branch[1];
+    const key = branch[0];
+
+    // format the key with the layer formatter
+    const layer = layers[depth - 1];
+    const formatter = layer?.nodeLabel;
+    let formattedValue = '';
+    if (key != null) {
+      formattedValue = formatter ? formatter(key) : `${key}`;
+    }
+    // preventing errors from external formatters
+    if (formattedValue != null && formattedValue !== '' && formattedValue !== HIERARCHY_ROOT_KEY) {
+      // save only the max depth, so we can compute the the max extension of the legend
+      keys.set(formattedValue, Math.max(depth, keys.get(formattedValue) ?? 0));
+    }
+
+    const children = arrayNode[CHILDREN_KEY];
+    flatSlicesNames(layers, depth + 1, children, keys);
+  }
+  return [...keys.keys()].map((k) => ({
+    label: k,
+    depth: keys.get(k) ?? 0,
+  }));
+}

--- a/src/chart_types/partition_chart/layout/viewmodel/fill_text_layout.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/fill_text_layout.ts
@@ -20,29 +20,29 @@
 import chroma from 'chroma-js';
 
 import {
-  combineColors,
-  makeHighContrastColor,
   colorIsDark,
+  combineColors,
   getTextColorIfTextInvertible,
   isColorValid,
+  makeHighContrastColor,
 } from '../../../../common/color_calcs';
 import { TAU } from '../../../../common/constants';
 import {
   Coordinate,
   Distance,
   Pixels,
+  PointTuple,
   Radian,
   Radius,
   Ratio,
   RingSectorConstruction,
-  PointTuple,
   trueBearingToStandardPositionAngle,
   wrapToTau,
 } from '../../../../common/geometry';
 import { logarithm } from '../../../../common/math';
 import { integerSnap, monotonicHillClimb } from '../../../../common/optimize';
 import { Box, Font, PartialFont, TextContrast, TextMeasure, VerticalAlignments } from '../../../../common/text_utils';
-import { ValueFormatter, Color } from '../../../../utils/common';
+import { Color, ValueFormatter } from '../../../../utils/common';
 import { Logger } from '../../../../utils/logger';
 import { Layer } from '../../specs';
 import { Config, Padding } from '../types/config_types';
@@ -85,8 +85,7 @@ function angleToCircline(
   const normalAngle = alpha + (direction * Math.PI) / 2;
   const x = sectorRadiusLineX + INFINITY_RADIUS * Math.cos(normalAngle);
   const y = sectorRadiusLineY + INFINITY_RADIUS * Math.sin(normalAngle);
-  const sectorRadiusCircline = { x, y, r: INFINITY_RADIUS, inside: false, from: 0, to: TAU };
-  return sectorRadiusCircline;
+  return { x, y, r: INFINITY_RADIUS, inside: false, from: 0, to: TAU };
 }
 
 /** @internal */
@@ -154,8 +153,7 @@ function makeRowCircline(
   const topRadius = r - offset;
   const x = cx + topRadius * Math.cos(-rotation + TAU / 4);
   const y = cy + topRadius * Math.cos(-rotation + TAU / 2);
-  const circline = { r: r + radialOffset, x, y };
-  return circline;
+  return { r: r + radialOffset, x, y };
 }
 
 /** @internal */
@@ -319,7 +317,7 @@ export function getFillTextColor(
     if (bgColorAlpha < 1) {
       Logger.expected('Text contrast requires a background color with an alpha value of 1', 1, bgColorAlpha);
     } else if (containerBackgroundColor !== 'transparent') {
-      Logger.warn(`Invalid background color "${containerBackgroundColor}"`);
+      Logger.warn(`Invalid background color "${String(containerBackgroundColor)}"`);
     }
 
     return getTextColorIfTextInvertible(
@@ -356,6 +354,7 @@ export function getFillTextColor(
 
   return adjustedTextColor;
 }
+
 type GetShapeRowGeometry<C> = (
   container: C,
   cx: Distance,

--- a/src/chart_types/partition_chart/layout/viewmodel/fill_text_layout.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/fill_text_layout.ts
@@ -33,7 +33,6 @@ import {
   Pixels,
   PointTuple,
   Radian,
-  Radius,
   Ratio,
   RingSectorConstruction,
   trueBearingToStandardPositionAngle,
@@ -55,105 +54,13 @@ import {
   ShapeTreeNode,
   ValueGetterFunction,
 } from '../types/viewmodel_types';
-import { conjunctiveConstraint } from '../utils/circline_geometry';
+import { conjunctiveConstraint, INFINITY_RADIUS, makeRowCircline } from '../utils/circline_geometry';
 import { RectangleConstruction } from './viewmodel';
-
-const INFINITY_RADIUS = 1e4; // far enough for a sub-2px precision on a 4k screen, good enough for text bounds; 64 bit floats still work well with it
-
-function ringSectorStartAngle(d: ShapeTreeNode): Radian {
-  return trueBearingToStandardPositionAngle(d.x0 + Math.max(0, d.x1 - d.x0 - TAU / 2) / 2);
-}
-
-function ringSectorEndAngle(d: ShapeTreeNode): Radian {
-  return trueBearingToStandardPositionAngle(d.x1 - Math.max(0, d.x1 - d.x0 - TAU / 2) / 2);
-}
-
-function ringSectorInnerRadius(innerRadius: Radian, ringThickness: Distance) {
-  return (d: ShapeTreeNode): Radius => innerRadius + d.y0 * ringThickness;
-}
-function ringSectorOuterRadius(innerRadius: Radian, ringThickness: Distance) {
-  return (d: ShapeTreeNode): Radius => innerRadius + (d.y0 + 1) * ringThickness;
-}
-
-function angleToCircline(
-  midRadius: Radius,
-  alpha: Radian,
-  direction: 1 | -1 /* 1 for clockwise and -1 for anticlockwise circline */,
-) {
-  const sectorRadiusLineX = Math.cos(alpha) * midRadius;
-  const sectorRadiusLineY = Math.sin(alpha) * midRadius;
-  const normalAngle = alpha + (direction * Math.PI) / 2;
-  const x = sectorRadiusLineX + INFINITY_RADIUS * Math.cos(normalAngle);
-  const y = sectorRadiusLineY + INFINITY_RADIUS * Math.sin(normalAngle);
-  return { x, y, r: INFINITY_RADIUS, inside: false, from: 0, to: TAU };
-}
 
 /** @internal */
 // todo pick a better unique key for the slices (D3 doesn't keep track of an index)
 export function nodeId(node: ShapeTreeNode): string {
   return `${node.x0}|${node.y0}`;
-}
-
-/** @internal */
-export function ringSectorConstruction(config: Config, innerRadius: Radius, ringThickness: Distance) {
-  return (ringSector: ShapeTreeNode): RingSectorConstruction => {
-    const {
-      circlePadding,
-      radialPadding,
-      fillOutside,
-      radiusOutside,
-      fillRectangleWidth,
-      fillRectangleHeight,
-    } = config;
-    const radiusGetter = fillOutside ? ringSectorOuterRadius : ringSectorInnerRadius;
-    const geometricInnerRadius = radiusGetter(innerRadius, ringThickness)(ringSector);
-    const innerR = geometricInnerRadius + circlePadding * 2;
-    const outerR = Math.max(
-      innerR,
-      ringSectorOuterRadius(innerRadius, ringThickness)(ringSector) - circlePadding + (fillOutside ? radiusOutside : 0),
-    );
-    const startAngle = ringSectorStartAngle(ringSector);
-    const endAngle = ringSectorEndAngle(ringSector);
-    const innerCircline = { x: 0, y: 0, r: innerR, inside: true, from: 0, to: TAU };
-    const outerCircline = { x: 0, y: 0, r: outerR, inside: false, from: 0, to: TAU };
-    const midRadius = (innerR + outerR) / 2;
-    const sectorStartCircle = angleToCircline(midRadius, startAngle - radialPadding, -1);
-    const sectorEndCircle = angleToCircline(midRadius, endAngle + radialPadding, 1);
-    const outerRadiusFromRectangleWidth = fillRectangleWidth / 2;
-    const outerRadiusFromRectanglHeight = fillRectangleHeight / 2;
-    const fullCircle = ringSector.x0 === 0 && ringSector.x1 === TAU && geometricInnerRadius === 0;
-    const sectorCirclines = [
-      ...(fullCircle && innerRadius === 0 ? [] : [innerCircline]),
-      outerCircline,
-      ...(fullCircle ? [] : [sectorStartCircle, sectorEndCircle]),
-    ];
-    const rectangleCirclines =
-      outerRadiusFromRectangleWidth === Infinity && outerRadiusFromRectanglHeight === Infinity
-        ? []
-        : [
-            { x: INFINITY_RADIUS - outerRadiusFromRectangleWidth, y: 0, r: INFINITY_RADIUS, inside: true },
-            { x: -INFINITY_RADIUS + outerRadiusFromRectangleWidth, y: 0, r: INFINITY_RADIUS, inside: true },
-            { x: 0, y: INFINITY_RADIUS - outerRadiusFromRectanglHeight, r: INFINITY_RADIUS, inside: true },
-            { x: 0, y: -INFINITY_RADIUS + outerRadiusFromRectanglHeight, r: INFINITY_RADIUS, inside: true },
-          ];
-    return [...sectorCirclines, ...rectangleCirclines];
-  };
-}
-
-function makeRowCircline(
-  cx: Coordinate,
-  cy: Coordinate,
-  radialOffset: Distance,
-  rotation: Radian,
-  fontSize: number,
-  offsetSign: -1 | 0 | 1,
-) {
-  const r = INFINITY_RADIUS;
-  const offset = (offsetSign * fontSize) / 2;
-  const topRadius = r - offset;
-  const x = cx + topRadius * Math.cos(-rotation + TAU / 4);
-  const y = cy + topRadius * Math.cos(-rotation + TAU / 2);
-  return { r: r + radialOffset, x, y };
 }
 
 /** @internal */

--- a/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { isColorValid, makeHighContrastColor } from '../../../../common/color_calcs';
+import { getOnPaperColorSet } from '../../../../common/color_calcs';
 import { TAU } from '../../../../common/constants';
 import {
   Distance,
@@ -61,25 +61,14 @@ export function linkTextLayout(
   const maxDepth = nodesWithoutRoom.reduce((p: number, n: ShapeTreeNode) => Math.max(p, n.depth), 0);
   const yRelativeIncrement = Math.sin(linkLabel.stemAngle) * linkLabel.minimumStemLength;
   const rowPitch = linkLabel.fontSize + linkLabel.spacing;
-  // determine the ideal contrast color for the link labels
-  const validBackgroundColor = isColorValid(containerBackgroundColor)
-    ? containerBackgroundColor
-    : 'rgba(255, 255, 255, 0)';
-  const contrastTextColor = containerBackgroundColor
-    ? makeHighContrastColor(linkLabel.textColor, validBackgroundColor)
-    : linkLabel.textColor;
-  const strokeColor = containerBackgroundColor
-    ? makeHighContrastColor(sectorLineStroke, validBackgroundColor)
-    : undefined;
-  const labelFontSpec = {
-    ...linkLabel,
-    textColor: contrastTextColor,
-  };
-  const valueFontSpec = {
-    ...linkLabel,
-    ...linkLabel.valueFont,
-    textColor: contrastTextColor,
-  };
+
+  const { contrastTextColor, strokeColor } = getOnPaperColorSet(
+    linkLabel.textColor,
+    sectorLineStroke,
+    containerBackgroundColor,
+  );
+  const labelFontSpec: Font = { ...linkLabel, textColor: contrastTextColor };
+  const valueFontSpec: Font = { ...linkLabel, ...linkLabel.valueFont, textColor: contrastTextColor };
 
   const linkLabels: LinkLabelVM[] = nodesWithoutRoom
     .filter((n: ShapeTreeNode) => n.depth === maxDepth) // only the outermost ring can have links

--- a/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
@@ -223,8 +223,6 @@ function nodeToLinkLabel({
       width,
       valueWidth,
       verticalOffset,
-      labelFontSpec,
-      valueFontSpec,
     };
   };
 }

--- a/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
@@ -119,9 +119,11 @@ export function linkTextLayout(
       const labelText = cutToLength(rawText, maxTextLength);
       const valueText = valueFormatter(valueGetter(node));
 
+      // eslint-disable-next-line no-shadow
       const labelFontSpec: Font = {
         ...linkLabel,
       };
+      // eslint-disable-next-line no-shadow
       const valueFontSpec: Font = {
         ...linkLabel,
         ...linkLabel.valueFont,
@@ -142,6 +144,7 @@ export function linkTextLayout(
               text: labelText,
             })
           : { text: '', width: 0, verticalOffset: 0 };
+      // eslint-disable-next-line no-shadow
       const linkLabels: PointTuples = [
         [x0, y0],
         [stemFromX, stemFromY],
@@ -165,17 +168,17 @@ export function linkTextLayout(
     })
     .filter(({ text }) => text !== ''); // cull linked labels whose text was truncated to nothing;
   return { linkLabels, valueFontSpec, labelFontSpec, strokeColor };
+}
 
-  function fitText(measure: TextMeasure, desiredText: string, allottedWidth: number, fontSize: number, box: Box) {
-    const desiredLength = desiredText.length;
-    const response = (v: number) => measure(fontSize, [{ ...box, text: box.text.slice(0, Math.max(0, v)) }])[0].width;
-    const visibleLength = monotonicHillClimb(response, desiredLength, allottedWidth, integerSnap);
-    const text = visibleLength < 2 && desiredLength >= 2 ? '' : cutToLength(box.text, visibleLength);
-    const { width, emHeightAscent, emHeightDescent } = measure(fontSize, [{ ...box, text }])[0];
-    return {
-      width,
-      verticalOffset: -(emHeightDescent + emHeightAscent) / 2, // meaning, `middle`
-      text,
-    };
-  }
+function fitText(measure: TextMeasure, desiredText: string, allottedWidth: number, fontSize: number, box: Box) {
+  const desiredLength = desiredText.length;
+  const response = (v: number) => measure(fontSize, [{ ...box, text: box.text.slice(0, Math.max(0, v)) }])[0].width;
+  const visibleLength = monotonicHillClimb(response, desiredLength, allottedWidth, integerSnap);
+  const text = visibleLength < 2 && desiredLength >= 2 ? '' : cutToLength(box.text, visibleLength);
+  const { width, emHeightAscent, emHeightDescent } = measure(fontSize, [{ ...box, text }])[0];
+  return {
+    width,
+    verticalOffset: -(emHeightDescent + emHeightAscent) / 2, // meaning, `middle`
+    text,
+  };
 }

--- a/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
@@ -27,8 +27,7 @@ import {
   PointTuples,
   trueBearingToStandardPositionAngle,
 } from '../../../../common/geometry';
-import { integerSnap, monotonicHillClimb } from '../../../../common/optimize';
-import { Box, Font, TextMeasure } from '../../../../common/text_utils';
+import { cutToLength, fitText, Font, measureOneBoxWidth, TextMeasure } from '../../../../common/text_utils';
 import { Color, ValueFormatter } from '../../../../utils/common';
 import { Point } from '../../../../utils/point';
 import { Config, LinkLabelConfig } from '../types/config_types';
@@ -210,26 +209,5 @@ function nodeToLinkLabel({
       verticalOffset,
       textAlign: rightSide ? 'left' : 'right',
     };
-  };
-}
-
-function measureOneBoxWidth(measure: TextMeasure, fontSize: number, box: Box) {
-  return measure(fontSize, [box])[0].width;
-}
-
-function cutToLength(s: string, maxLength: number) {
-  return s.length <= maxLength ? s : `${s.slice(0, Math.max(0, maxLength - 1))}…`; // ellipsis is one char
-}
-
-function fitText(measure: TextMeasure, desiredText: string, allottedWidth: number, fontSize: number, font: Font) {
-  const desiredLength = desiredText.length;
-  const response = (v: number) => measure(fontSize, [{ ...font, text: desiredText.slice(0, Math.max(0, v)) }])[0].width;
-  const visibleLength = monotonicHillClimb(response, desiredLength, allottedWidth, integerSnap);
-  const text = visibleLength < 2 && desiredLength >= 2 ? '' : cutToLength(desiredText, visibleLength);
-  const { width, emHeightAscent, emHeightDescent } = measure(fontSize, [{ ...font, text }])[0];
-  return {
-    width,
-    verticalOffset: -(emHeightDescent + emHeightAscent) / 2, // meaning, `middle`
-    text,
   };
 }

--- a/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { makeHighContrastColor, isColorValid } from '../../../../common/color_calcs';
+import { isColorValid, makeHighContrastColor } from '../../../../common/color_calcs';
 import { TAU } from '../../../../common/constants';
 import {
   Distance,
@@ -29,7 +29,7 @@ import {
 } from '../../../../common/geometry';
 import { integerSnap, monotonicHillClimb } from '../../../../common/optimize';
 import { Box, Font, TextAlign, TextMeasure } from '../../../../common/text_utils';
-import { ValueFormatter, Color } from '../../../../utils/common';
+import { Color, ValueFormatter } from '../../../../utils/common';
 import { Point } from '../../../../utils/point';
 import { Config, LinkLabelConfig } from '../types/config_types';
 import { LinkLabelVM, RawTextGetter, ShapeTreeNode, ValueGetterFunction } from '../types/viewmodel_types';
@@ -184,16 +184,14 @@ function nodeToLinkLabel({
     const rawText = rawTextGetter(node);
     const labelText = cutToLength(rawText, maxTextLength);
     const valueText = valueFormatter(valueGetter(node));
-
-    const labelFontSpec: Font = {
-      ...linkLabel,
-    };
-    const valueFontSpec: Font = {
-      ...linkLabel,
-      ...linkLabel.valueFont,
-    };
     const translateX = stemToX + west * (linkLabel.horizontalStemLength + linkLabel.gap);
-    const { width: valueWidth } = measure(linkLabel.fontSize, [{ ...valueFontSpec, text: valueText }])[0];
+    const { width: valueWidth } = measure(linkLabel.fontSize, [
+      {
+        ...linkLabel,
+        ...linkLabel.valueFont,
+        text: valueText,
+      },
+    ])[0];
     const widthAdjustment = valueWidth + 2 * linkLabel.fontSize; // gap between label and value, plus possibly 2em wide ellipsis
     const allottedLabelWidth = Math.max(
       0,
@@ -202,7 +200,7 @@ function nodeToLinkLabel({
     const { text, width, verticalOffset } =
       linkLabel.fontSize / 2 <= cy + diskCenter.y && cy + diskCenter.y <= rectHeight - linkLabel.fontSize / 2
         ? fitText(measure, labelText, allottedLabelWidth, linkLabel.fontSize, {
-            ...labelFontSpec,
+            ...linkLabel,
             text: labelText,
           })
         : { text: '', width: 0, verticalOffset: 0 };

--- a/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
@@ -185,13 +185,8 @@ function nodeToLinkLabel({
     const labelText = cutToLength(rawText, maxTextLength);
     const valueText = valueFormatter(valueGetter(node));
     const translateX = stemToX + west * (linkLabel.horizontalStemLength + linkLabel.gap);
-    const { width: valueWidth } = measure(linkLabel.fontSize, [
-      {
-        ...linkLabel,
-        ...linkLabel.valueFont,
-        text: valueText,
-      },
-    ])[0];
+    const fontSpec: Font = { ...linkLabel, ...linkLabel.valueFont }; // only interested in the font properties
+    const valueWidth = measureOneBoxWidth(measure, linkLabel.fontSize, fontSpec, valueText);
     const widthAdjustment = valueWidth + 2 * linkLabel.fontSize; // gap between label and value, plus possibly 2em wide ellipsis
     const allottedLabelWidth = Math.max(
       0,
@@ -223,4 +218,8 @@ function nodeToLinkLabel({
       verticalOffset,
     };
   };
+}
+
+function measureOneBoxWidth(measure: TextMeasure, fontSize: number, fontSpec: Font, text: string) {
+  return measure(fontSize, [{ ...fontSpec, text }])[0].width;
 }

--- a/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/link_text_layout.ts
@@ -22,6 +22,7 @@ import { TAU } from '../../../../common/constants';
 import {
   Distance,
   meanAngle,
+  Pixels,
   PointTuple,
   PointTuples,
   trueBearingToStandardPositionAngle,
@@ -30,7 +31,7 @@ import { integerSnap, monotonicHillClimb } from '../../../../common/optimize';
 import { Box, Font, TextAlign, TextMeasure } from '../../../../common/text_utils';
 import { ValueFormatter, Color } from '../../../../utils/common';
 import { Point } from '../../../../utils/point';
-import { Config } from '../types/config_types';
+import { Config, LinkLabelConfig } from '../types/config_types';
 import { LinkLabelVM, RawTextGetter, ShapeTreeNode, ValueGetterFunction } from '../types/viewmodel_types';
 
 function cutToLength(s: string, maxLength: number) {
@@ -89,83 +90,24 @@ export function linkTextLayout(
     .filter((n: ShapeTreeNode) => n.depth === maxDepth) // only the outermost ring can have links
     .sort((n1: ShapeTreeNode, n2: ShapeTreeNode) => Math.abs(n2.x0 - n2.x1) - Math.abs(n1.x0 - n1.x1))
     .slice(0, linkLabel.maxCount) // largest linkLabel.MaxCount slices
-    .sort((n1: ShapeTreeNode, n2: ShapeTreeNode) => {
-      const mid1 = meanAngle(n1.x0, n1.x1);
-      const mid2 = meanAngle(n2.x0, n2.x1);
-      const dist1 = Math.min(Math.abs(mid1 - TAU / 4), Math.abs(mid1 - (3 * TAU) / 4));
-      const dist2 = Math.min(Math.abs(mid2 - TAU / 4), Math.abs(mid2 - (3 * TAU) / 4));
-      return dist1 - dist2;
-    })
-    .map((node: ShapeTreeNode) => {
-      const midAngle = trueBearingToStandardPositionAngle((node.x0 + node.x1) / 2);
-      const north = midAngle < TAU / 2 ? 1 : -1;
-      const rightSide = TAU / 4 < midAngle && midAngle < (3 * TAU) / 4 ? 0 : 1;
-      const west = rightSide ? 1 : -1;
-      const cos = Math.cos(midAngle);
-      const sin = Math.sin(midAngle);
-      const x0 = cos * anchorRadius;
-      const y0 = sin * anchorRadius;
-      const x = cos * (anchorRadius + linkLabel.radiusPadding);
-      const y = sin * (anchorRadius + linkLabel.radiusPadding);
-      const poolIndex = rightSide + (1 - north);
-      const relativeY = north * y;
-      currentY[poolIndex] = Math.max(currentY[poolIndex] + rowPitch, relativeY + yRelativeIncrement, rowPitch / 2);
-      const cy = north * currentY[poolIndex];
-      const stemFromX = x;
-      const stemFromY = y;
-      const stemToX = x + north * west * cy - west * relativeY;
-      const stemToY = cy;
-      const rawText = rawTextGetter(node);
-      const labelText = cutToLength(rawText, maxTextLength);
-      const valueText = valueFormatter(valueGetter(node));
-
-      // eslint-disable-next-line no-shadow
-      const labelFontSpec: Font = {
-        ...linkLabel,
-      };
-      // eslint-disable-next-line no-shadow
-      const valueFontSpec: Font = {
-        ...linkLabel,
-        ...linkLabel.valueFont,
-      };
-      const translateX = stemToX + west * (linkLabel.horizontalStemLength + linkLabel.gap);
-      const { width: valueWidth } = measure(linkLabel.fontSize, [{ ...valueFontSpec, text: valueText }])[0];
-      const widthAdjustment = valueWidth + 2 * linkLabel.fontSize; // gap between label and value, plus possibly 2em wide ellipsis
-      const allottedLabelWidth = Math.max(
-        0,
-        rightSide
-          ? rectWidth - diskCenter.x - translateX - widthAdjustment
-          : diskCenter.x + translateX - widthAdjustment,
-      );
-      const { text, width, verticalOffset } =
-        linkLabel.fontSize / 2 <= cy + diskCenter.y && cy + diskCenter.y <= rectHeight - linkLabel.fontSize / 2
-          ? fitText(measure, labelText, allottedLabelWidth, linkLabel.fontSize, {
-              ...labelFontSpec,
-              text: labelText,
-            })
-          : { text: '', width: 0, verticalOffset: 0 };
-      // eslint-disable-next-line no-shadow
-      const linkLabels: PointTuples = [
-        [x0, y0],
-        [stemFromX, stemFromY],
-        [stemToX, stemToY],
-        [stemToX + west * linkLabel.horizontalStemLength, stemToY],
-      ];
-      const translate: PointTuple = [translateX, stemToY];
-      const textAlign: TextAlign = rightSide ? 'left' : 'right';
-      return {
-        linkLabels,
-        translate,
-        textAlign,
-        text,
-        valueText,
-        width,
-        valueWidth,
-        verticalOffset,
-        labelFontSpec,
-        valueFontSpec,
-      };
-    })
+    .sort(linkLabelCompare)
+    .map(
+      nodeToLinkLabel({
+        linkLabel,
+        anchorRadius,
+        currentY,
+        rowPitch,
+        yRelativeIncrement,
+        rawTextGetter,
+        maxTextLength,
+        valueFormatter,
+        valueGetter,
+        measure,
+        rectWidth,
+        rectHeight,
+        diskCenter,
+      }),
+    )
     .filter(({ text }) => text !== ''); // cull linked labels whose text was truncated to nothing;
   return { linkLabels, valueFontSpec, labelFontSpec, strokeColor };
 }
@@ -180,5 +122,109 @@ function fitText(measure: TextMeasure, desiredText: string, allottedWidth: numbe
     width,
     verticalOffset: -(emHeightDescent + emHeightAscent) / 2, // meaning, `middle`
     text,
+  };
+}
+
+function linkLabelCompare(n1: ShapeTreeNode, n2: ShapeTreeNode) {
+  const mid1 = meanAngle(n1.x0, n1.x1);
+  const mid2 = meanAngle(n2.x0, n2.x1);
+  const dist1 = Math.min(Math.abs(mid1 - TAU / 4), Math.abs(mid1 - (3 * TAU) / 4));
+  const dist2 = Math.min(Math.abs(mid2 - TAU / 4), Math.abs(mid2 - (3 * TAU) / 4));
+  return dist1 - dist2;
+}
+
+function nodeToLinkLabel({
+  linkLabel,
+  anchorRadius,
+  currentY,
+  rowPitch,
+  yRelativeIncrement,
+  rawTextGetter,
+  maxTextLength,
+  valueFormatter,
+  valueGetter,
+  measure,
+  rectWidth,
+  rectHeight,
+  diskCenter,
+}: {
+  linkLabel: LinkLabelConfig;
+  anchorRadius: Distance;
+  currentY: Distance[];
+  rowPitch: Pixels;
+  yRelativeIncrement: Distance;
+  rawTextGetter: RawTextGetter;
+  maxTextLength: number;
+  valueFormatter: ValueFormatter;
+  valueGetter: ValueGetterFunction;
+  measure: TextMeasure;
+  rectWidth: Distance;
+  rectHeight: Distance;
+  diskCenter: Point;
+}) {
+  return function nodeToLinkLabelMap(node: ShapeTreeNode): LinkLabelVM {
+    const midAngle = trueBearingToStandardPositionAngle((node.x0 + node.x1) / 2);
+    const north = midAngle < TAU / 2 ? 1 : -1;
+    const rightSide = TAU / 4 < midAngle && midAngle < (3 * TAU) / 4 ? 0 : 1;
+    const west = rightSide ? 1 : -1;
+    const cos = Math.cos(midAngle);
+    const sin = Math.sin(midAngle);
+    const x0 = cos * anchorRadius;
+    const y0 = sin * anchorRadius;
+    const x = cos * (anchorRadius + linkLabel.radiusPadding);
+    const y = sin * (anchorRadius + linkLabel.radiusPadding);
+    const poolIndex = rightSide + (1 - north);
+    const relativeY = north * y;
+    currentY[poolIndex] = Math.max(currentY[poolIndex] + rowPitch, relativeY + yRelativeIncrement, rowPitch / 2);
+    const cy = north * currentY[poolIndex];
+    const stemFromX = x;
+    const stemFromY = y;
+    const stemToX = x + north * west * cy - west * relativeY;
+    const stemToY = cy;
+    const rawText = rawTextGetter(node);
+    const labelText = cutToLength(rawText, maxTextLength);
+    const valueText = valueFormatter(valueGetter(node));
+
+    const labelFontSpec: Font = {
+      ...linkLabel,
+    };
+    const valueFontSpec: Font = {
+      ...linkLabel,
+      ...linkLabel.valueFont,
+    };
+    const translateX = stemToX + west * (linkLabel.horizontalStemLength + linkLabel.gap);
+    const { width: valueWidth } = measure(linkLabel.fontSize, [{ ...valueFontSpec, text: valueText }])[0];
+    const widthAdjustment = valueWidth + 2 * linkLabel.fontSize; // gap between label and value, plus possibly 2em wide ellipsis
+    const allottedLabelWidth = Math.max(
+      0,
+      rightSide ? rectWidth - diskCenter.x - translateX - widthAdjustment : diskCenter.x + translateX - widthAdjustment,
+    );
+    const { text, width, verticalOffset } =
+      linkLabel.fontSize / 2 <= cy + diskCenter.y && cy + diskCenter.y <= rectHeight - linkLabel.fontSize / 2
+        ? fitText(measure, labelText, allottedLabelWidth, linkLabel.fontSize, {
+            ...labelFontSpec,
+            text: labelText,
+          })
+        : { text: '', width: 0, verticalOffset: 0 };
+    const linkLabels: PointTuples = [
+      [x0, y0],
+      [stemFromX, stemFromY],
+      [stemToX, stemToY],
+      [stemToX + west * linkLabel.horizontalStemLength, stemToY],
+    ];
+    const translate: PointTuple = [translateX, stemToY];
+    const textAlign: TextAlign = rightSide ? 'left' : 'right';
+    return {
+      linkLabels,
+      translate,
+      textAlign,
+      text,
+      valueText,
+      width,
+      valueWidth,
+      verticalOffset,
+      labelFontSpec,
+      valueFontSpec,
+    };
   };
 }

--- a/src/chart_types/partition_chart/layout/viewmodel/picked_shapes.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/picked_shapes.ts
@@ -33,7 +33,7 @@ export const pickedShapes = (geoms: ShapeViewModel, pointerPosition: Point): Qua
 };
 
 /** @internal */
-export function pickShapesLayerValues(shapes: QuadViewModel[]): Array<Array<LayerValue>> {
+export function pickShapesLayerValues(shapes: QuadViewModel[]): LayerValue[][] {
   const maxDepth = shapes.reduce((acc, curr) => Math.max(acc, curr.depth), 0);
   return shapes
     .filter(({ depth }) => depth === maxDepth) // eg. lowest layer in a treemap, where layers overlap in screen space; doesn't apply to sunburst/flame

--- a/src/chart_types/partition_chart/layout/viewmodel/picked_shapes.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/picked_shapes.ts
@@ -24,7 +24,8 @@ import { QuadViewModel, ShapeViewModel } from '../types/viewmodel_types';
 import { AGGREGATE_KEY, DEPTH_KEY, getNodeName, PARENT_KEY, PATH_KEY, SORT_INDEX_KEY } from '../utils/group_by_rollup';
 
 /** @internal */
-export const pickedShapes = (geoms: ShapeViewModel, pointerPosition: Point): QuadViewModel[] => {
+export const pickedShapes = (models: ShapeViewModel[], pointerPosition: Point): QuadViewModel[] => {
+  const geoms = models[0];
   const picker = geoms.pickQuads;
   const { diskCenter } = geoms;
   const x = pointerPosition.x - diskCenter.x;

--- a/src/chart_types/partition_chart/layout/viewmodel/picked_shapes.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/picked_shapes.ts
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { LayerValue } from '../../../../specs';
+import { Point } from '../../../../utils/point';
+import { MODEL_KEY } from '../config';
+import { QuadViewModel, ShapeViewModel } from '../types/viewmodel_types';
+import { AGGREGATE_KEY, DEPTH_KEY, getNodeName, PARENT_KEY, PATH_KEY, SORT_INDEX_KEY } from '../utils/group_by_rollup';
+
+/** @internal */
+export const pickedShapes = (geoms: ShapeViewModel, pointerPosition: Point): QuadViewModel[] => {
+  const picker = geoms.pickQuads;
+  const { diskCenter } = geoms;
+  const x = pointerPosition.x - diskCenter.x;
+  const y = pointerPosition.y - diskCenter.y;
+  return picker(x, y);
+};
+
+/** @internal */
+export function pickShapesLayerValues(shapes: QuadViewModel[]): Array<Array<LayerValue>> {
+  const maxDepth = shapes.reduce((acc, curr) => Math.max(acc, curr.depth), 0);
+  return shapes
+    .filter(({ depth }) => depth === maxDepth) // eg. lowest layer in a treemap, where layers overlap in screen space; doesn't apply to sunburst/flame
+    .map<Array<LayerValue>>((viewModel) => {
+      const values: Array<LayerValue> = [];
+      values.push({
+        groupByRollup: viewModel.dataName,
+        value: viewModel[AGGREGATE_KEY],
+        depth: viewModel[DEPTH_KEY],
+        sortIndex: viewModel[SORT_INDEX_KEY],
+        path: viewModel[PATH_KEY],
+      });
+      let node = viewModel[MODEL_KEY];
+      while (node[DEPTH_KEY] > 0) {
+        const value = node[AGGREGATE_KEY];
+        const dataName = getNodeName(node);
+        values.push({
+          groupByRollup: dataName,
+          value,
+          depth: node[DEPTH_KEY],
+          sortIndex: node[SORT_INDEX_KEY],
+          path: node[PATH_KEY],
+        });
+
+        node = node[PARENT_KEY];
+      }
+      return values.reverse();
+    });
+}

--- a/src/chart_types/partition_chart/layout/viewmodel/scenegraph.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/scenegraph.ts
@@ -20,18 +20,18 @@
 import { measureText } from '../../../../common/text_utils';
 import { identity, mergePartial, RecursivePartial, Color } from '../../../../utils/common';
 import { Dimensions } from '../../../../utils/dimensions';
-import { config as defaultConfig, VALUE_GETTERS } from '../../layout/config';
-import { Config } from '../../layout/types/config_types';
+import { PartitionSpec, Layer } from '../../specs';
+import { config as defaultConfig, VALUE_GETTERS } from '../config';
+import { Config } from '../types/config_types';
 import {
   ShapeTreeNode,
   ShapeViewModel,
   RawTextGetter,
   nullShapeViewModel,
   ValueGetter,
-} from '../../layout/types/viewmodel_types';
-import { DEPTH_KEY, HierarchyOfArrays } from '../../layout/utils/group_by_rollup';
-import { shapeViewModel } from '../../layout/viewmodel/viewmodel';
-import { PartitionSpec, Layer } from '../../specs';
+} from '../types/viewmodel_types';
+import { DEPTH_KEY, HierarchyOfArrays } from '../utils/group_by_rollup';
+import { shapeViewModel } from './viewmodel';
 
 function rawTextGetter(layers: Layer[]): RawTextGetter {
   return (node: ShapeTreeNode) => {

--- a/src/chart_types/partition_chart/layout/viewmodel/tooltip_info.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/tooltip_info.ts
@@ -18,8 +18,7 @@
  */
 
 import { TooltipInfo } from '../../../../components/tooltip/types';
-import { ValueFormatter } from '../../../../utils/common';
-import { Layer } from '../../specs';
+import { LabelAccessor, ValueFormatter } from '../../../../utils/common';
 import { percentValueGetter, sumValueGetter } from '../config';
 import { QuadViewModel, ValueGetter } from '../types/viewmodel_types';
 import { valueGetterFunction } from './scenegraph';
@@ -33,7 +32,7 @@ export const EMPTY_TOOLTIP = Object.freeze({
 /** @internal */
 export function getTooltipInfo(
   pickedShapes: QuadViewModel[],
-  labelFormatters: Layer[],
+  labelFormatters: (LabelAccessor | undefined)[],
   valueGetter: ValueGetter,
   valueFormatter: ValueFormatter,
   percentFormatter: ValueFormatter,
@@ -51,8 +50,7 @@ export function getTooltipInfo(
   const valueGetterFun = valueGetterFunction(valueGetter);
   const primaryValueGetterFun = valueGetterFun === percentValueGetter ? sumValueGetter : valueGetterFun;
   pickedShapes.forEach((shape) => {
-    const labelFormatter = labelFormatters[shape.depth - 1];
-    const formatter = labelFormatter?.nodeLabel;
+    const formatter = labelFormatters[shape.depth - 1];
     const value = primaryValueGetterFun(shape);
 
     tooltipInfo.values.push({

--- a/src/chart_types/partition_chart/layout/viewmodel/tooltip_info.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/tooltip_info.ts
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TooltipInfo } from '../../../../components/tooltip/types';
+import { ValueFormatter } from '../../../../utils/common';
+import { Layer } from '../../specs';
+import { percentValueGetter, sumValueGetter } from '../config';
+import { QuadViewModel, ValueGetter } from '../types/viewmodel_types';
+import { valueGetterFunction } from './scenegraph';
+
+/** @internal */
+export const EMPTY_TOOLTIP = Object.freeze({
+  header: null,
+  values: [],
+});
+
+/** @internal */
+export function getTooltipInfo(
+  pickedShapes: QuadViewModel[],
+  labelFormatters: Layer[],
+  valueGetter: ValueGetter,
+  valueFormatter: ValueFormatter,
+  percentFormatter: ValueFormatter,
+  id: string,
+) {
+  if (!valueFormatter || !labelFormatters) {
+    return EMPTY_TOOLTIP;
+  }
+
+  const tooltipInfo: TooltipInfo = {
+    header: null,
+    values: [],
+  };
+
+  const valueGetterFun = valueGetterFunction(valueGetter);
+  const primaryValueGetterFun = valueGetterFun === percentValueGetter ? sumValueGetter : valueGetterFun;
+  pickedShapes.forEach((shape) => {
+    const labelFormatter = labelFormatters[shape.depth - 1];
+    const formatter = labelFormatter?.nodeLabel;
+    const value = primaryValueGetterFun(shape);
+
+    tooltipInfo.values.push({
+      label: formatter ? formatter(shape.dataName) : shape.dataName,
+      color: shape.fillColor,
+      isHighlighted: false,
+      isVisible: true,
+      seriesIdentifier: {
+        specId: id,
+        key: id,
+      },
+      value,
+      formattedValue: `${valueFormatter(value)} (${percentFormatter(percentValueGetter(shape))})`,
+      valueAccessor: shape.depth,
+    });
+  });
+
+  return tooltipInfo;
+}

--- a/src/chart_types/partition_chart/layout/viewmodel/viewmodel.ts
+++ b/src/chart_types/partition_chart/layout/viewmodel/viewmodel.ts
@@ -43,6 +43,7 @@ import {
   ShapeViewModel,
   ValueGetterFunction,
 } from '../types/viewmodel_types';
+import { ringSectorConstruction } from '../utils/circline_geometry';
 import {
   aggregateAccessor,
   ArrayEntry,
@@ -60,7 +61,6 @@ import { getTopPadding, treemap } from '../utils/treemap';
 import {
   fillTextLayout,
   getRectangleRowGeometry,
-  ringSectorConstruction,
   getSectorRowGeometry,
   inSectorRotation,
   nodeId,

--- a/src/chart_types/partition_chart/renderer/canvas/canvas_renderers.ts
+++ b/src/chart_types/partition_chart/renderer/canvas/canvas_renderers.ts
@@ -21,7 +21,7 @@ import { addOpacity } from '../../../../common/color_calcs';
 import { TAU } from '../../../../common/constants';
 import { Pixels } from '../../../../common/geometry';
 import { cssFontShorthand } from '../../../../common/text_utils';
-import { clearCanvas, renderLayers, withContext } from '../../../../renderers/canvas';
+import { renderLayers, withContext } from '../../../../renderers/canvas';
 import { Color } from '../../../../utils/common';
 import {
   LinkLabelVM,
@@ -261,9 +261,6 @@ export function renderPartitionCanvas2d(
     // unlike SVG and esp. WebGL, Canvas2d doesn't support the 3rd dimension well, see ctx.transform / ctx.setTransform).
     // The layers are callbacks, because of the need to not bake in the `ctx`, it feels more composable and uncoupled this way.
     renderLayers(ctx, [
-      // clear the canvas
-      (ctx: CanvasRenderingContext2D) => clearCanvas(ctx, 200000, 200000),
-
       // bottom layer: sectors (pie slices, ring sectors etc.)
       (ctx: CanvasRenderingContext2D) =>
         isSunburst(config.partitionLayout) ? renderSectors(ctx, quadViewModel) : renderRectangles(ctx, quadViewModel),

--- a/src/chart_types/partition_chart/renderer/canvas/partition.tsx
+++ b/src/chart_types/partition_chart/renderer/canvas/partition.tsx
@@ -29,12 +29,13 @@ import { Dimensions } from '../../../../utils/dimensions';
 import { MODEL_KEY } from '../../layout/config';
 import { nullShapeViewModel, QuadViewModel, ShapeViewModel } from '../../layout/types/viewmodel_types';
 import { INPUT_KEY } from '../../layout/utils/group_by_rollup';
-import { partitionGeometries } from '../../state/selectors/geometries';
+import { partitionMultiGeometries } from '../../state/selectors/geometries';
 import { renderPartitionCanvas2d } from './canvas_renderers';
 
 interface ReactiveChartStateProps {
   initialized: boolean;
   geometries: ShapeViewModel;
+  multiGeometries: ShapeViewModel[];
   chartContainerDimensions: Dimensions;
 }
 
@@ -46,10 +47,11 @@ interface ReactiveChartOwnProps {
 }
 
 type PartitionProps = ReactiveChartStateProps & ReactiveChartDispatchProps & ReactiveChartOwnProps;
+
 class PartitionComponent extends React.Component<PartitionProps> {
   static displayName = 'Partition';
 
-  // firstRender = true; // this'll be useful for stable resizing of treemaps
+  // firstRender = true; // this will be useful for stable resizing of treemaps
   private ctx: CanvasRenderingContext2D | null;
 
   // see example https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#Example
@@ -137,13 +139,16 @@ class PartitionComponent extends React.Component<PartitionProps> {
   }
 
   private drawCanvas() {
-    if (this.ctx) {
-      const { width, height }: Dimensions = this.props.chartContainerDimensions;
-      renderPartitionCanvas2d(this.ctx, this.devicePixelRatio, {
-        ...this.props.geometries,
-        config: { ...this.props.geometries.config, width, height },
-      });
-    }
+    const { width, height }: Dimensions = this.props.chartContainerDimensions;
+    this.props.multiGeometries.forEach((geometries) => {
+      if (this.ctx) {
+        // TS weirdness for the ctx check to need to be inside the forEach
+        renderPartitionCanvas2d(this.ctx, this.devicePixelRatio, {
+          ...geometries,
+          config: { ...geometries.config, width, height },
+        });
+      }
+    });
   }
 
   private tryCanvasContext() {
@@ -163,6 +168,7 @@ const mapDispatchToProps = (dispatch: Dispatch): ReactiveChartDispatchProps =>
 const DEFAULT_PROPS: ReactiveChartStateProps = {
   initialized: false,
   geometries: nullShapeViewModel(),
+  multiGeometries: [],
   chartContainerDimensions: {
     width: 0,
     height: 0,
@@ -175,9 +181,11 @@ const mapStateToProps = (state: GlobalChartState): ReactiveChartStateProps => {
   if (getInternalIsInitializedSelector(state) !== InitStatus.Initialized) {
     return DEFAULT_PROPS;
   }
+  const multiGeometries = partitionMultiGeometries(state);
   return {
     initialized: true,
-    geometries: partitionGeometries(state),
+    geometries: multiGeometries.length > 0 ? multiGeometries[0] : nullShapeViewModel(),
+    multiGeometries,
     chartContainerDimensions: getChartContainerDimensionsSelector(state),
   };
 };

--- a/src/chart_types/partition_chart/renderer/canvas/partition.tsx
+++ b/src/chart_types/partition_chart/renderer/canvas/partition.tsx
@@ -21,6 +21,7 @@ import React, { MouseEvent, RefObject } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
+import { clearCanvas } from '../../../../renderers/canvas';
 import { onChartRendered } from '../../../../state/actions/chart';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartContainerDimensionsSelector } from '../../../../state/selectors/get_chart_container_dimensions';
@@ -139,16 +140,16 @@ class PartitionComponent extends React.Component<PartitionProps> {
   }
 
   private drawCanvas() {
-    const { width, height }: Dimensions = this.props.chartContainerDimensions;
-    this.props.multiGeometries.forEach((geometries) => {
-      if (this.ctx) {
-        // TS weirdness for the ctx check to need to be inside the forEach
+    if (this.ctx) {
+      const { width, height }: Dimensions = this.props.chartContainerDimensions;
+      clearCanvas(this.ctx, width * this.devicePixelRatio, height * this.devicePixelRatio);
+      for (const geometries of this.props.multiGeometries) {
         renderPartitionCanvas2d(this.ctx, this.devicePixelRatio, {
           ...geometries,
           config: { ...geometries.config, width, height },
         });
       }
-    });
+    }
   }
 
   private tryCanvasContext() {

--- a/src/chart_types/partition_chart/renderer/dom/highlighter_hover.tsx
+++ b/src/chart_types/partition_chart/renderer/dom/highlighter_hover.tsx
@@ -36,7 +36,7 @@ const hoverMapStateToProps = (state: GlobalChartState): HighlighterProps => {
     outerRadius,
     diskCenter,
     config: { partitionLayout },
-  } = partitionGeometries(state);
+  } = partitionGeometries(state)[0];
 
   const geometries = getPickedShapes(state);
   const canvasDimension = getChartContainerDimensionsSelector(state);

--- a/src/chart_types/partition_chart/renderer/dom/highlighter_legend.tsx
+++ b/src/chart_types/partition_chart/renderer/dom/highlighter_legend.tsx
@@ -36,7 +36,7 @@ const legendMapStateToProps = (state: GlobalChartState): HighlighterProps => {
     outerRadius,
     diskCenter,
     config: { partitionLayout },
-  } = partitionGeometries(state);
+  } = partitionGeometries(state)[0];
 
   const geometries = legendHoverHighlightNodes(state);
   const canvasDimension = getChartContainerDimensionsSelector(state);

--- a/src/chart_types/partition_chart/renderer/dom/layered_partition_chart.tsx
+++ b/src/chart_types/partition_chart/renderer/dom/layered_partition_chart.tsx
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { RefObject } from 'react';
+
+import { Tooltip } from '../../../../components/tooltip';
+import { BackwardRef } from '../../../../state/chart_state';
+import { Partition } from '../canvas/partition';
+import { HighlighterFromHover } from './highlighter_hover';
+import { HighlighterFromLegend } from './highlighter_legend';
+
+export function render(containerRef: BackwardRef, forwardStageRef: RefObject<HTMLCanvasElement>) {
+  return (
+    <>
+      <Tooltip getChartContainerRef={containerRef} />
+      <Partition forwardStageRef={forwardStageRef} />
+      <HighlighterFromHover />
+      <HighlighterFromLegend />
+    </>
+  );
+}

--- a/src/chart_types/partition_chart/state/chart_state.tsx
+++ b/src/chart_types/partition_chart/state/chart_state.tsx
@@ -17,18 +17,15 @@
  * under the License.
  */
 
-import React, { RefObject } from 'react';
+import { RefObject } from 'react';
 
 import { ChartTypes } from '../..';
 import { DEFAULT_CSS_CURSOR } from '../../../common/constants';
-import { Tooltip } from '../../../components/tooltip';
 import { BackwardRef, GlobalChartState, InternalChartState } from '../../../state/chart_state';
 import { InitStatus } from '../../../state/selectors/get_internal_is_intialized';
 import { DebugState } from '../../../state/types';
 import { Dimensions } from '../../../utils/dimensions';
-import { Partition } from '../renderer/canvas/partition';
-import { HighlighterFromHover } from '../renderer/dom/highlighter_hover';
-import { HighlighterFromLegend } from '../renderer/dom/highlighter_legend';
+import { render } from '../renderer/dom/layered_partition_chart';
 import { computeLegendSelector } from './selectors/compute_legend';
 import { getLegendItemsExtra } from './selectors/get_legend_items_extra';
 import { getLegendItemsLabels } from './selectors/get_legend_items_labels';
@@ -38,17 +35,6 @@ import { createOnElementOutCaller } from './selectors/on_element_out_caller';
 import { createOnElementOverCaller } from './selectors/on_element_over_caller';
 import { getPartitionSpec } from './selectors/partition_spec';
 import { getTooltipInfoSelector } from './selectors/tooltip';
-
-function render(containerRef: BackwardRef, forwardStageRef: RefObject<HTMLCanvasElement>) {
-  return (
-    <>
-      <Tooltip getChartContainerRef={containerRef} />
-      <Partition forwardStageRef={forwardStageRef} />
-      <HighlighterFromHover />
-      <HighlighterFromLegend />
-    </>
-  );
-}
 
 /** @internal */
 export class PartitionState implements InternalChartState {

--- a/src/chart_types/partition_chart/state/selectors/compute_legend.ts
+++ b/src/chart_types/partition_chart/state/selectors/compute_legend.ts
@@ -33,8 +33,8 @@ import { getPartitionSpec } from './partition_spec';
 /** @internal */
 export const computeLegendSelector = createCachedSelector(
   [getPartitionSpec, getSettingsSpecSelector, partitionGeometries],
-  (pieSpec, { flatLegend, legendMaxDepth, legendPosition }, { quadViewModel }): LegendItem[] => {
-    if (!pieSpec) {
+  (partitionSpec, { flatLegend, legendMaxDepth, legendPosition }, { quadViewModel }): LegendItem[] => {
+    if (!partitionSpec) {
       return [];
     }
 
@@ -59,14 +59,14 @@ export const computeLegendSelector = createCachedSelector(
     items.sort(compareTreePaths);
 
     return items.map<LegendItem>(({ dataName, fillColor, depth, path }) => {
-      const formatter = pieSpec.layers[depth - 1]?.nodeLabel ?? identity;
+      const formatter = partitionSpec.layers[depth - 1]?.nodeLabel ?? identity;
       return {
         color: fillColor,
         label: formatter(dataName),
         childId: dataName,
         depth: useHierarchicalLegend ? depth - 1 : 0,
         path,
-        seriesIdentifier: { key: dataName, specId: pieSpec.id },
+        seriesIdentifier: { key: dataName, specId: partitionSpec.id },
       };
     });
   },

--- a/src/chart_types/partition_chart/state/selectors/compute_legend.ts
+++ b/src/chart_types/partition_chart/state/selectors/compute_legend.ts
@@ -29,7 +29,8 @@ import { getPartitionSpec } from './partition_spec';
 /** @internal */
 export const computeLegendSelector = createCachedSelector(
   [getPartitionSpec, getSettingsSpecSelector, partitionGeometries],
-  (partitionSpec, { flatLegend, legendMaxDepth, legendPosition }, { quadViewModel }): LegendItem[] => {
+  (partitionSpec, { flatLegend, legendMaxDepth, legendPosition }, geometries): LegendItem[] => {
+    const { quadViewModel } = geometries[0];
     return partitionSpec
       ? getLegendItems(
           partitionSpec.id,

--- a/src/chart_types/partition_chart/state/selectors/compute_legend.ts
+++ b/src/chart_types/partition_chart/state/selectors/compute_legend.ts
@@ -19,14 +19,10 @@
 
 import createCachedSelector from 're-reselect';
 
-import { CategoryKey } from '../../../../common/category';
-import { map } from '../../../../common/iterables';
 import { LegendItem } from '../../../../common/legend';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
-import { identity } from '../../../../utils/common';
-import { isHierarchicalLegend } from '../../../../utils/legend';
-import { QuadViewModel } from '../../layout/types/viewmodel_types';
+import { getLegendItems } from '../../layout/utils/legend';
 import { partitionGeometries } from './geometries';
 import { getPartitionSpec } from './partition_spec';
 
@@ -37,51 +33,13 @@ export const computeLegendSelector = createCachedSelector(
     if (!partitionSpec) {
       return [];
     }
-
-    const uniqueNames = new Set(map(({ dataName, fillColor }) => makeKey(dataName, fillColor), quadViewModel));
-    const useHierarchicalLegend = isHierarchicalLegend(flatLegend, legendPosition);
-
-    const excluded: Set<string> = new Set();
-    const items = quadViewModel.filter(({ depth, dataName, fillColor }) => {
-      if (legendMaxDepth != null) {
-        return depth <= legendMaxDepth;
-      }
-      if (!useHierarchicalLegend) {
-        const key = makeKey(dataName, fillColor);
-        if (uniqueNames.has(key) && excluded.has(key)) {
-          return false;
-        }
-        excluded.add(key);
-      }
-      return true;
-    });
-
-    items.sort(compareTreePaths);
-
-    return items.map<LegendItem>(({ dataName, fillColor, depth, path }) => {
-      const formatter = partitionSpec.layers[depth - 1]?.nodeLabel ?? identity;
-      return {
-        color: fillColor,
-        label: formatter(dataName),
-        childId: dataName,
-        depth: useHierarchicalLegend ? depth - 1 : 0,
-        path,
-        seriesIdentifier: { key: dataName, specId: partitionSpec.id },
-      };
-    });
+    return getLegendItems(
+      partitionSpec.id,
+      partitionSpec.layers,
+      flatLegend,
+      legendMaxDepth,
+      legendPosition,
+      quadViewModel,
+    );
   },
 )(getChartIdSelector);
-
-function makeKey(...keyParts: CategoryKey[]): string {
-  return keyParts.join('---');
-}
-
-function compareTreePaths({ path: a }: QuadViewModel, { path: b }: QuadViewModel): number {
-  for (let i = 0; i < Math.min(a.length, b.length); i++) {
-    const diff = a[i].index - b[i].index;
-    if (diff) {
-      return diff;
-    }
-  }
-  return a.length - b.length; // if one path is fully contained in the other, then parent (shorter) goes first
-}

--- a/src/chart_types/partition_chart/state/selectors/compute_legend.ts
+++ b/src/chart_types/partition_chart/state/selectors/compute_legend.ts
@@ -30,16 +30,15 @@ import { getPartitionSpec } from './partition_spec';
 export const computeLegendSelector = createCachedSelector(
   [getPartitionSpec, getSettingsSpecSelector, partitionGeometries],
   (partitionSpec, { flatLegend, legendMaxDepth, legendPosition }, { quadViewModel }): LegendItem[] => {
-    if (!partitionSpec) {
-      return [];
-    }
-    return getLegendItems(
-      partitionSpec.id,
-      partitionSpec.layers,
-      flatLegend,
-      legendMaxDepth,
-      legendPosition,
-      quadViewModel,
-    );
+    return partitionSpec
+      ? getLegendItems(
+          partitionSpec.id,
+          partitionSpec.layers,
+          flatLegend,
+          legendMaxDepth,
+          legendPosition,
+          quadViewModel,
+        )
+      : [];
   },
 )(getChartIdSelector);

--- a/src/chart_types/partition_chart/state/selectors/geometries.ts
+++ b/src/chart_types/partition_chart/state/selectors/geometries.ts
@@ -27,7 +27,7 @@ import { getChartThemeSelector } from '../../../../state/selectors/get_chart_the
 import { getSpecsFromStore } from '../../../../state/utils';
 import { nullShapeViewModel, ShapeViewModel } from '../../layout/types/viewmodel_types';
 import { PartitionSpec } from '../../specs';
-import { render } from './scenegraph';
+import { getShapeViewModel } from './scenegraph';
 import { getTree } from './tree';
 
 const getSpecs = (state: GlobalChartState) => state.specs;
@@ -36,8 +36,9 @@ const getSpecs = (state: GlobalChartState) => state.specs;
 export const partitionGeometries = createCachedSelector(
   [getSpecs, getChartContainerDimensionsSelector, getTree, getChartThemeSelector],
   (specs, parentDimensions, tree, { background }): ShapeViewModel => {
-    const pieSpecs = getSpecsFromStore<PartitionSpec>(specs, ChartTypes.Partition, SpecTypes.Series);
-
-    return pieSpecs.length === 1 ? render(pieSpecs[0], parentDimensions, tree, background.color) : nullShapeViewModel();
+    const partitionSpecs = getSpecsFromStore<PartitionSpec>(specs, ChartTypes.Partition, SpecTypes.Series);
+    return partitionSpecs.length === 1 // singleton!
+      ? getShapeViewModel(partitionSpecs[0], parentDimensions, tree, background.color)
+      : nullShapeViewModel();
   },
 )((state) => state.chartId);

--- a/src/chart_types/partition_chart/state/selectors/geometries.ts
+++ b/src/chart_types/partition_chart/state/selectors/geometries.ts
@@ -29,9 +29,19 @@ import { getTree } from './tree';
 /** @internal */
 export const partitionGeometries = createCachedSelector(
   [getPartitionSpecs, getChartContainerDimensionsSelector, getTree, getChartThemeSelector],
-  (partitionSpecs, parentDimensions, tree, { background }): ShapeViewModel => {
-    return partitionSpecs.length === 1 // singleton!
-      ? getShapeViewModel(partitionSpecs[0], parentDimensions, tree, background.color)
-      : nullShapeViewModel();
+  (partitionSpecs, parentDimensions, tree, { background }): ShapeViewModel[] => {
+    return [
+      partitionSpecs.length > 0 // singleton!
+        ? getShapeViewModel(partitionSpecs[0], parentDimensions, tree, background.color)
+        : nullShapeViewModel(),
+    ];
+  },
+)((state) => state.chartId);
+
+/** @internal */
+export const partitionMultiGeometries = createCachedSelector(
+  [getPartitionSpecs, getChartContainerDimensionsSelector, getTree, getChartThemeSelector],
+  (partitionSpecs, parentDimensions, tree, { background }): ShapeViewModel[] => {
+    return partitionSpecs.map((spec) => getShapeViewModel(spec, parentDimensions, tree, background.color));
   },
 )((state) => state.chartId);

--- a/src/chart_types/partition_chart/state/selectors/geometries.ts
+++ b/src/chart_types/partition_chart/state/selectors/geometries.ts
@@ -19,24 +19,17 @@
 
 import createCachedSelector from 're-reselect';
 
-import { ChartTypes } from '../../..';
-import { SpecTypes } from '../../../../specs/constants';
-import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartContainerDimensionsSelector } from '../../../../state/selectors/get_chart_container_dimensions';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
-import { getSpecsFromStore } from '../../../../state/utils';
 import { nullShapeViewModel, ShapeViewModel } from '../../layout/types/viewmodel_types';
-import { PartitionSpec } from '../../specs';
-import { getShapeViewModel } from './scenegraph';
+import { getShapeViewModel } from '../../layout/viewmodel/scenegraph';
+import { getPartitionSpecs } from './get_partition_specs';
 import { getTree } from './tree';
-
-const getSpecs = (state: GlobalChartState) => state.specs;
 
 /** @internal */
 export const partitionGeometries = createCachedSelector(
-  [getSpecs, getChartContainerDimensionsSelector, getTree, getChartThemeSelector],
-  (specs, parentDimensions, tree, { background }): ShapeViewModel => {
-    const partitionSpecs = getSpecsFromStore<PartitionSpec>(specs, ChartTypes.Partition, SpecTypes.Series);
+  [getPartitionSpecs, getChartContainerDimensionsSelector, getTree, getChartThemeSelector],
+  (partitionSpecs, parentDimensions, tree, { background }): ShapeViewModel => {
     return partitionSpecs.length === 1 // singleton!
       ? getShapeViewModel(partitionSpecs[0], parentDimensions, tree, background.color)
       : nullShapeViewModel();

--- a/src/chart_types/partition_chart/state/selectors/get_highlighted_shapes.ts
+++ b/src/chart_types/partition_chart/state/selectors/get_highlighted_shapes.ts
@@ -18,88 +18,22 @@
  */
 
 import createCachedSelector from 're-reselect';
-import { $Values } from 'utility-types';
 
-import { LegendPath } from '../../../../state/actions/legend';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
-import { DataName, QuadViewModel } from '../../layout/types/viewmodel_types';
+import { QuadViewModel } from '../../layout/types/viewmodel_types';
+import { highlightedGeoms } from '../../layout/utils/highlighted_geoms';
 import { partitionGeometries } from './geometries';
 
 const getHighlightedLegendItemPath = (state: GlobalChartState) => state.interactions.highlightedLegendPath;
 
-type LegendStrategyFn = (legendPath: LegendPath) => (partialShape: { path: LegendPath; dataName: DataName }) => boolean;
-
-const legendStrategies: Record<LegendStrategy, LegendStrategyFn> = {
-  node: (legendPath) => ({ path }) =>
-    // highlight exact match in the path only
-    legendPath.length === path.length &&
-    legendPath.every(({ index, value }, i) => index === path[i]?.index && value === path[i]?.value),
-
-  path: (legendPath) => ({ path }) =>
-    // highlight members of the exact path; ie. exact match in the path, plus all its ancestors
-    path.every(({ index, value }, i) => index === legendPath[i]?.index && value === legendPath[i]?.value),
-
-  keyInLayer: (legendPath) => ({ path, dataName }) =>
-    // highlight all identically named items which are within the same depth (ring) as the hovered legend depth
-    legendPath.length === path.length && dataName === legendPath[legendPath.length - 1].value,
-
-  key: (legendPath) => ({ dataName }) =>
-    // highlight all identically named items, no matter where they are
-    dataName === legendPath[legendPath.length - 1].value,
-
-  nodeWithDescendants: (legendPath) => ({ path }) =>
-    // highlight exact match in the path, and everything that is its descendant in that branch
-    legendPath.every(({ index, value }, i) => index === path[i]?.index && value === path[i]?.value),
-
-  pathWithDescendants: (legendPath) => ({ path }) =>
-    // highlight exact match in the path, and everything that is its ancestor, or its descendant in that branch
-    legendPath
-      .slice(0, path.length)
-      .every(({ index, value }, i) => index === path[i]?.index && value === path[i]?.value),
-};
-
-/** @public */
-export const LegendStrategy = Object.freeze({
-  /**
-   * Highlight the specific node(s) that the legend item stands for.
-   */
-  Node: 'node' as const,
-  /**
-   * Highlight members of the exact path; ie. like `Node`, plus all its ancestors
-   */
-  Path: 'path' as const,
-  /**
-   * Highlight all identically named (labelled) items within the tree layer (depth or ring) of the specific node(s) that the legend item stands for
-   */
-  KeyInLayer: 'keyInLayer' as const,
-  /**
-   * Highlight all identically named (labelled) items, no matter where they are
-   */
-  Key: 'key' as const,
-  /**
-   * Highlight the specific node(s) that the legend item stands for, plus all descendants
-   */
-  NodeWithDescendants: 'nodeWithDescendants' as const,
-  /**
-   * Highlight the specific node(s) that the legend item stands for, plus all ancestors and descendants
-   */
-  PathWithDescendants: 'pathWithDescendants' as const,
-});
-
-/** @public */
-export type LegendStrategy = $Values<typeof LegendStrategy>;
-const defaultStrategy: LegendStrategy = LegendStrategy.Key;
-
 /** @internal */
 export const legendHoverHighlightNodes = createCachedSelector(
   [getSettingsSpecSelector, getHighlightedLegendItemPath, partitionGeometries],
-  (specs, highlightedLegendItemPath, geoms): QuadViewModel[] => {
-    if (highlightedLegendItemPath.length === 0) {
-      return [];
-    }
-    const pickedLogic: LegendStrategy = specs.legendStrategy ?? defaultStrategy;
-    return geoms.quadViewModel.filter(legendStrategies[pickedLogic](highlightedLegendItemPath));
+  ({ legendStrategy }, highlightedLegendItemPath, { quadViewModel }): QuadViewModel[] => {
+    return highlightedLegendItemPath.length > 0
+      ? highlightedGeoms(legendStrategy, quadViewModel, highlightedLegendItemPath)
+      : [];
   },
 )(getChartIdSelector);

--- a/src/chart_types/partition_chart/state/selectors/get_highlighted_shapes.ts
+++ b/src/chart_types/partition_chart/state/selectors/get_highlighted_shapes.ts
@@ -31,7 +31,8 @@ const getHighlightedLegendItemPath = (state: GlobalChartState) => state.interact
 /** @internal */
 export const legendHoverHighlightNodes = createCachedSelector(
   [getSettingsSpecSelector, getHighlightedLegendItemPath, partitionGeometries],
-  ({ legendStrategy }, highlightedLegendItemPath, { quadViewModel }): QuadViewModel[] => {
+  ({ legendStrategy }, highlightedLegendItemPath, geometries): QuadViewModel[] => {
+    const { quadViewModel } = geometries[0];
     return highlightedLegendItemPath.length > 0
       ? highlightedGeoms(legendStrategy, quadViewModel, highlightedLegendItemPath)
       : [];

--- a/src/chart_types/partition_chart/state/selectors/get_legend_items_extra.ts
+++ b/src/chart_types/partition_chart/state/selectors/get_legend_items_extra.ts
@@ -47,7 +47,7 @@ export const getLegendItemsExtra = createCachedSelector(
  * @param legendMaxDepth - SettingsSpec['legendMaxDepth']
  */
 function isValidLegendMaxDepth(legendMaxDepth: SettingsSpec['legendMaxDepth']): boolean {
-  return typeof legendMaxDepth === 'number' && !Number.isNaN(legendMaxDepth) && legendMaxDepth > 0;
+  return Number.isFinite(legendMaxDepth) && legendMaxDepth > 0;
 }
 
 /**

--- a/src/chart_types/partition_chart/state/selectors/get_legend_items_extra.ts
+++ b/src/chart_types/partition_chart/state/selectors/get_legend_items_extra.ts
@@ -32,11 +32,11 @@ import { getTree } from './tree';
 /** @internal */
 export const getLegendItemsExtra = createCachedSelector(
   [getPartitionSpec, getSettingsSpecSelector, getTree],
-  (pieSpec, { legendMaxDepth }, tree): Map<SeriesKey, LegendItemExtraValues> => {
+  (partitionSpec, { legendMaxDepth }, tree): Map<SeriesKey, LegendItemExtraValues> => {
     const legendExtraValues = new Map<SeriesKey, LegendItemExtraValues>();
 
-    return pieSpec && isValidLegendMaxDepth(legendMaxDepth)
-      ? getExtraValueMap(pieSpec, tree, legendMaxDepth)
+    return partitionSpec && isValidLegendMaxDepth(legendMaxDepth)
+      ? getExtraValueMap(partitionSpec, tree, legendMaxDepth)
       : legendExtraValues;
   },
 )(getChartIdSelector);

--- a/src/chart_types/partition_chart/state/selectors/get_legend_items_extra.ts
+++ b/src/chart_types/partition_chart/state/selectors/get_legend_items_extra.ts
@@ -23,9 +23,7 @@ import { LegendItemExtraValues } from '../../../../common/legend';
 import { SeriesKey } from '../../../../common/series_id';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
-import { ValueFormatter } from '../../../../utils/common';
-import { CHILDREN_KEY, HierarchyOfArrays } from '../../layout/utils/group_by_rollup';
-import { Layer } from '../../specs';
+import { getExtraValueMap } from '../../layout/viewmodel/hierarchy_of_arrays';
 import { getPartitionSpec } from './partition_spec';
 import { getTree } from './tree';
 
@@ -38,34 +36,3 @@ export const getLegendItemsExtra = createCachedSelector(
       : new Map<SeriesKey, LegendItemExtraValues>();
   },
 )(getChartIdSelector);
-
-/**
- * Creates flat extra value map from nested key path
- */
-function getExtraValueMap(
-  layers: Layer[],
-  valueFormatter: ValueFormatter,
-  tree: HierarchyOfArrays,
-  maxDepth: number,
-  depth: number = 0,
-  keys: Map<SeriesKey, LegendItemExtraValues> = new Map(),
-): Map<SeriesKey, LegendItemExtraValues> {
-  for (let i = 0; i < tree.length; i++) {
-    const branch = tree[i];
-    const [key, arrayNode] = branch;
-    const { value, path, [CHILDREN_KEY]: children } = arrayNode;
-
-    if (key != null) {
-      const values: LegendItemExtraValues = new Map();
-      const formattedValue = valueFormatter ? valueFormatter(value) : value;
-
-      values.set(key, formattedValue);
-      keys.set(path.map(({ index }) => index).join('__'), values);
-    }
-
-    if (depth < maxDepth) {
-      getExtraValueMap(layers, valueFormatter, children, maxDepth, depth + 1, keys);
-    }
-  }
-  return keys;
-}

--- a/src/chart_types/partition_chart/state/selectors/get_legend_items_extra.ts
+++ b/src/chart_types/partition_chart/state/selectors/get_legend_items_extra.ts
@@ -47,7 +47,7 @@ export const getLegendItemsExtra = createCachedSelector(
  * @param legendMaxDepth - SettingsSpec['legendMaxDepth']
  */
 function isValidLegendMaxDepth(legendMaxDepth: SettingsSpec['legendMaxDepth']): boolean {
-  return Number.isFinite(legendMaxDepth) && legendMaxDepth > 0;
+  return !Number.isNaN(legendMaxDepth) && legendMaxDepth > 0;
 }
 
 /**

--- a/src/chart_types/partition_chart/state/selectors/get_legend_items_labels.ts
+++ b/src/chart_types/partition_chart/state/selectors/get_legend_items_labels.ts
@@ -30,8 +30,8 @@ import { getTree } from './tree';
 /** @internal */
 export const getLegendItemsLabels = createCachedSelector(
   [getPartitionSpec, getSettingsSpecSelector, getTree],
-  (pieSpec, { legendMaxDepth }, tree): LegendItemLabel[] =>
-    pieSpec ? flatSlicesNames(pieSpec.layers, 0, tree).filter(({ depth }) => depth <= legendMaxDepth) : [],
+  (partitionSpec, { legendMaxDepth }, tree): LegendItemLabel[] =>
+    partitionSpec ? flatSlicesNames(partitionSpec.layers, 0, tree).filter(({ depth }) => depth <= legendMaxDepth) : [],
 )(getChartIdSelector);
 
 function flatSlicesNames(

--- a/src/chart_types/partition_chart/state/selectors/get_legend_items_labels.ts
+++ b/src/chart_types/partition_chart/state/selectors/get_legend_items_labels.ts
@@ -22,51 +22,13 @@ import createCachedSelector from 're-reselect';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { LegendItemLabel } from '../../../../state/selectors/get_legend_items_labels';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
-import { CHILDREN_KEY, HierarchyOfArrays, HIERARCHY_ROOT_KEY } from '../../layout/utils/group_by_rollup';
-import { Layer } from '../../specs';
+import { getLegendLabels } from '../../layout/utils/legend_labels';
 import { getPartitionSpec } from './partition_spec';
 import { getTree } from './tree';
 
 /** @internal */
 export const getLegendItemsLabels = createCachedSelector(
   [getPartitionSpec, getSettingsSpecSelector, getTree],
-  (partitionSpec, { legendMaxDepth }, tree): LegendItemLabel[] =>
-    partitionSpec ? flatSlicesNames(partitionSpec.layers, 0, tree).filter(({ depth }) => depth <= legendMaxDepth) : [],
+  (spec, { legendMaxDepth }, tree): LegendItemLabel[] =>
+    spec ? getLegendLabels(spec.layers, tree, legendMaxDepth) : [],
 )(getChartIdSelector);
-
-function flatSlicesNames(
-  layers: Layer[],
-  depth: number,
-  tree: HierarchyOfArrays,
-  keys: Map<string, number> = new Map(),
-): LegendItemLabel[] {
-  if (tree.length === 0) {
-    return [];
-  }
-
-  for (let i = 0; i < tree.length; i++) {
-    const branch = tree[i];
-    const arrayNode = branch[1];
-    const key = branch[0];
-
-    // format the key with the layer formatter
-    const layer = layers[depth - 1];
-    const formatter = layer?.nodeLabel;
-    let formattedValue = '';
-    if (key != null) {
-      formattedValue = formatter ? formatter(key) : `${key}`;
-    }
-    // preventing errors from external formatters
-    if (formattedValue != null && formattedValue !== '' && formattedValue !== HIERARCHY_ROOT_KEY) {
-      // save only the max depth, so we can compute the the max extension of the legend
-      keys.set(formattedValue, Math.max(depth, keys.get(formattedValue) ?? 0));
-    }
-
-    const children = arrayNode[CHILDREN_KEY];
-    flatSlicesNames(layers, depth + 1, children, keys);
-  }
-  return [...keys.keys()].map((k) => ({
-    label: k,
-    depth: keys.get(k) ?? 0,
-  }));
-}

--- a/src/chart_types/partition_chart/state/selectors/get_partition_specs.ts
+++ b/src/chart_types/partition_chart/state/selectors/get_partition_specs.ts
@@ -17,14 +17,17 @@
  * under the License.
  */
 
+import createCachedSelector from 're-reselect';
+
 import { ChartTypes } from '../../..';
 import { SpecTypes } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getSpecsFromStore } from '../../../../state/utils';
 import { PartitionSpec } from '../../specs';
 
+const getSpecs = (state: GlobalChartState) => state.specs;
+
 /** @internal */
-export function getPartitionSpec(state: GlobalChartState): PartitionSpec | null {
-  const pieSpecs = getSpecsFromStore<PartitionSpec>(state.specs, ChartTypes.Partition, SpecTypes.Series);
-  return pieSpecs.length > 0 ? pieSpecs[0] : null; // singleton!
-}
+export const getPartitionSpecs = createCachedSelector([getSpecs], (specs) => {
+  return getSpecsFromStore<PartitionSpec>(specs, ChartTypes.Partition, SpecTypes.Series);
+})((state) => state.chartId);

--- a/src/chart_types/partition_chart/state/selectors/is_tooltip_visible.ts
+++ b/src/chart_types/partition_chart/state/selectors/is_tooltip_visible.ts
@@ -33,9 +33,6 @@ import { getTooltipInfoSelector } from './tooltip';
 export const isTooltipVisibleSelector = createCachedSelector(
   [getSettingsSpecSelector, getTooltipInfoSelector],
   (settingsSpec, tooltipInfo): boolean => {
-    if (getTooltipType(settingsSpec) === TooltipType.None) {
-      return false;
-    }
-    return tooltipInfo.values.length > 0;
+    return getTooltipType(settingsSpec) !== TooltipType.None && tooltipInfo.values.length > 0;
   },
 )(getChartIdSelector);

--- a/src/chart_types/partition_chart/state/selectors/on_element_click_caller.ts
+++ b/src/chart_types/partition_chart/state/selectors/on_element_click_caller.ts
@@ -21,12 +21,10 @@ import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
 import { ChartTypes } from '../../..';
-import { SeriesIdentifier } from '../../../../common/series_id';
-import { SettingsSpec, LayerValue } from '../../../../specs';
-import { GlobalChartState, PointerState } from '../../../../state/chart_state';
+import { getOnElementClickSelector } from '../../../../common/event_handler_selectors';
+import { GlobalChartState, PointerStates } from '../../../../state/chart_state';
 import { getLastClickSelector } from '../../../../state/selectors/get_last_click';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
-import { isClicking } from '../../../../state/utils';
 import { getPartitionSpec } from './partition_spec';
 import { getPickedShapesLayerValues } from './picked_shapes';
 
@@ -38,34 +36,15 @@ import { getPickedShapesLayerValues } from './picked_shapes';
  * @internal
  */
 export function createOnElementClickCaller(): (state: GlobalChartState) => void {
-  let prevClick: PointerState | null = null;
+  const prev: { click: PointerStates['lastClick'] } = { click: null };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartTypes.Partition) {
       selector = createCachedSelector(
         [getPartitionSpec, getLastClickSelector, getSettingsSpecSelector, getPickedShapesLayerValues],
-        (partitionSpec, lastClick: PointerState | null, settings: SettingsSpec, pickedShapes): void => {
-          if (!partitionSpec) {
-            return;
-          }
-          if (!settings.onElementClick) {
-            return;
-          }
-          const nextPickedShapesLength = pickedShapes.length;
-          if (nextPickedShapesLength > 0 && isClicking(prevClick, lastClick) && settings && settings.onElementClick) {
-            const elements = pickedShapes.map<[Array<LayerValue>, SeriesIdentifier]>((values) => [
-              values,
-              {
-                specId: partitionSpec.id,
-                key: `spec{${partitionSpec.id}}`,
-              },
-            ]);
-            settings.onElementClick(elements);
-          }
-          prevClick = lastClick;
-        },
+        getOnElementClickSelector(prev),
       )({
-        keySelector: (state: GlobalChartState) => state.chartId,
+        keySelector: (s: GlobalChartState) => s.chartId,
       });
     }
     if (selector) {

--- a/src/chart_types/partition_chart/state/selectors/on_element_click_caller.ts
+++ b/src/chart_types/partition_chart/state/selectors/on_element_click_caller.ts
@@ -44,8 +44,8 @@ export function createOnElementClickCaller(): (state: GlobalChartState) => void 
     if (selector === null && state.chartType === ChartTypes.Partition) {
       selector = createCachedSelector(
         [getPartitionSpec, getLastClickSelector, getSettingsSpecSelector, getPickedShapesLayerValues],
-        (pieSpec, lastClick: PointerState | null, settings: SettingsSpec, pickedShapes): void => {
-          if (!pieSpec) {
+        (partitionSpec, lastClick: PointerState | null, settings: SettingsSpec, pickedShapes): void => {
+          if (!partitionSpec) {
             return;
           }
           if (!settings.onElementClick) {
@@ -56,8 +56,8 @@ export function createOnElementClickCaller(): (state: GlobalChartState) => void 
             const elements = pickedShapes.map<[Array<LayerValue>, SeriesIdentifier]>((values) => [
               values,
               {
-                specId: pieSpec.id,
-                key: `spec{${pieSpec.id}}`,
+                specId: partitionSpec.id,
+                key: `spec{${partitionSpec.id}}`,
               },
             ]);
             settings.onElementClick(elements);

--- a/src/chart_types/partition_chart/state/selectors/on_element_out_caller.ts
+++ b/src/chart_types/partition_chart/state/selectors/on_element_out_caller.ts
@@ -40,8 +40,8 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
     if (selector === null && state.chartType === ChartTypes.Partition) {
       selector = createCachedSelector(
         [getPartitionSpec, getPickedShapesLayerValues, getSettingsSpecSelector],
-        (pieSpec, pickedShapes, settings): void => {
-          if (!pieSpec) {
+        (partitionSpec, pickedShapes, settings): void => {
+          if (!partitionSpec) {
             return;
           }
           if (!settings.onElementOut) {

--- a/src/chart_types/partition_chart/state/selectors/on_element_out_caller.ts
+++ b/src/chart_types/partition_chart/state/selectors/on_element_out_caller.ts
@@ -21,6 +21,7 @@ import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartTypes } from '../../..';
+import { getOnElementOutSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
@@ -34,26 +35,13 @@ import { getPickedShapesLayerValues } from './picked_shapes';
  * @internal
  */
 export function createOnElementOutCaller(): (state: GlobalChartState) => void {
-  let prevPickedShapes: number | null = null;
+  const prev: { pickedShapes: number | null } = { pickedShapes: null };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartTypes.Partition) {
       selector = createCachedSelector(
         [getPartitionSpec, getPickedShapesLayerValues, getSettingsSpecSelector],
-        (partitionSpec, pickedShapes, settings): void => {
-          if (!partitionSpec) {
-            return;
-          }
-          if (!settings.onElementOut) {
-            return;
-          }
-          const nextPickedShapes = pickedShapes.length;
-
-          if (prevPickedShapes !== null && prevPickedShapes > 0 && nextPickedShapes === 0) {
-            settings.onElementOut();
-          }
-          prevPickedShapes = nextPickedShapes;
-        },
+        getOnElementOutSelector(prev),
       )({
         keySelector: getChartIdSelector,
       });

--- a/src/chart_types/partition_chart/state/selectors/on_element_over_caller.ts
+++ b/src/chart_types/partition_chart/state/selectors/on_element_over_caller.ts
@@ -67,8 +67,8 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
     if (selector === null && state.chartType === ChartTypes.Partition) {
       selector = createCachedSelector(
         [getPartitionSpec, getPickedShapesLayerValues, getSettingsSpecSelector],
-        (pieSpec, nextPickedShapes, settings): void => {
-          if (!pieSpec) {
+        (partitionSpec, nextPickedShapes, settings): void => {
+          if (!partitionSpec) {
             return;
           }
           if (!settings.onElementOver) {
@@ -79,8 +79,8 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
             const elements = nextPickedShapes.map<[Array<LayerValue>, SeriesIdentifier]>((values) => [
               values,
               {
-                specId: pieSpec.id,
-                key: `spec{${pieSpec.id}}`,
+                specId: partitionSpec.id,
+                key: `spec{${partitionSpec.id}}`,
               },
             ]);
             settings.onElementOver(elements);

--- a/src/chart_types/partition_chart/state/selectors/on_element_over_caller.ts
+++ b/src/chart_types/partition_chart/state/selectors/on_element_over_caller.ts
@@ -21,38 +21,13 @@ import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartTypes } from '../../..';
-import { SeriesIdentifier } from '../../../../common/series_id';
+import { getOnElementOverSelector } from '../../../../common/event_handler_selectors';
 import { LayerValue } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getPartitionSpec } from './partition_spec';
 import { getPickedShapesLayerValues } from './picked_shapes';
-
-function isOverElement(prevPickedShapes: Array<Array<LayerValue>> = [], nextPickedShapes: Array<Array<LayerValue>>) {
-  if (nextPickedShapes.length === 0) {
-    return;
-  }
-  if (nextPickedShapes.length !== prevPickedShapes.length) {
-    return true;
-  }
-  return !nextPickedShapes.every((nextPickedShapeValues, index) => {
-    const prevPickedShapeValues = prevPickedShapes[index];
-    if (prevPickedShapeValues === null) {
-      return false;
-    }
-    if (prevPickedShapeValues.length !== nextPickedShapeValues.length) {
-      return false;
-    }
-    return nextPickedShapeValues.every((layerValue, i) => {
-      const prevPickedValue = prevPickedShapeValues[i];
-      if (!prevPickedValue) {
-        return false;
-      }
-      return layerValue.value === prevPickedValue.value && layerValue.groupByRollup === prevPickedValue.groupByRollup;
-    });
-  });
-}
 
 /**
  * Will call the onElementOver listener every time the following preconditions are met:
@@ -61,32 +36,13 @@ function isOverElement(prevPickedShapes: Array<Array<LayerValue>> = [], nextPick
  * @internal
  */
 export function createOnElementOverCaller(): (state: GlobalChartState) => void {
-  let prevPickedShapes: Array<Array<LayerValue>> = [];
+  const prev: { pickedShapes: LayerValue[][] } = { pickedShapes: [] };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartTypes.Partition) {
       selector = createCachedSelector(
         [getPartitionSpec, getPickedShapesLayerValues, getSettingsSpecSelector],
-        (partitionSpec, nextPickedShapes, settings): void => {
-          if (!partitionSpec) {
-            return;
-          }
-          if (!settings.onElementOver) {
-            return;
-          }
-
-          if (isOverElement(prevPickedShapes, nextPickedShapes)) {
-            const elements = nextPickedShapes.map<[Array<LayerValue>, SeriesIdentifier]>((values) => [
-              values,
-              {
-                specId: partitionSpec.id,
-                key: `spec{${partitionSpec.id}}`,
-              },
-            ]);
-            settings.onElementOver(elements);
-          }
-          prevPickedShapes = nextPickedShapes;
-        },
+        getOnElementOverSelector(prev),
       )({
         keySelector: getChartIdSelector,
       });

--- a/src/chart_types/partition_chart/state/selectors/partition_spec.ts
+++ b/src/chart_types/partition_chart/state/selectors/partition_spec.ts
@@ -25,6 +25,6 @@ import { PartitionSpec } from '../../specs';
 
 /** @internal */
 export function getPartitionSpec(state: GlobalChartState): PartitionSpec | null {
-  const pieSpecs = getSpecsFromStore<PartitionSpec>(state.specs, ChartTypes.Partition, SpecTypes.Series);
-  return pieSpecs.length > 0 ? pieSpecs[0] : null; // singleton!
+  const partitionSpecs = getSpecsFromStore<PartitionSpec>(state.specs, ChartTypes.Partition, SpecTypes.Series);
+  return partitionSpecs.length > 0 ? partitionSpecs[0] : null; // singleton!
 }

--- a/src/chart_types/partition_chart/state/selectors/picked_shapes.test.ts
+++ b/src/chart_types/partition_chart/state/selectors/picked_shapes.test.ts
@@ -68,11 +68,11 @@ describe('Picked shapes selector', () => {
   });
   test('check initial geoms', () => {
     addSeries(store, treemapSpec);
-    const treemapGeometries = partitionGeometries(store.getState());
+    const treemapGeometries = partitionGeometries(store.getState())[0];
     expect(treemapGeometries.quadViewModel).toHaveLength(6);
 
     addSeries(store, sunburstSpec);
-    const sunburstGeometries = partitionGeometries(store.getState());
+    const sunburstGeometries = partitionGeometries(store.getState())[0];
     expect(sunburstGeometries.quadViewModel).toHaveLength(6);
   });
   test('treemap check picked geometries', () => {
@@ -83,7 +83,7 @@ describe('Picked shapes selector', () => {
     addSeries(store, treemapSpec, {
       onElementClick: onClickListener,
     });
-    const geometries = partitionGeometries(store.getState());
+    const geometries = partitionGeometries(store.getState())[0];
     expect(geometries.quadViewModel).toHaveLength(6);
 
     const onElementClickCaller = createOnElementClickCaller();
@@ -134,7 +134,7 @@ describe('Picked shapes selector', () => {
     addSeries(store, sunburstSpec, {
       onElementClick: onClickListener,
     });
-    const geometries = partitionGeometries(store.getState());
+    const geometries = partitionGeometries(store.getState())[0];
     expect(geometries.quadViewModel).toHaveLength(6);
 
     const onElementClickCaller = createOnElementClickCaller();

--- a/src/chart_types/partition_chart/state/selectors/picked_shapes.ts
+++ b/src/chart_types/partition_chart/state/selectors/picked_shapes.ts
@@ -19,18 +19,8 @@
 
 import createCachedSelector from 're-reselect';
 
-import { LayerValue } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { MODEL_KEY } from '../../layout/config';
-import { QuadViewModel } from '../../layout/types/viewmodel_types';
-import {
-  AGGREGATE_KEY,
-  DEPTH_KEY,
-  getNodeName,
-  PARENT_KEY,
-  PATH_KEY,
-  SORT_INDEX_KEY,
-} from '../../layout/utils/group_by_rollup';
+import { pickedShapes, pickShapesLayerValues } from '../../layout/viewmodel/picked_shapes';
 import { partitionGeometries } from './geometries';
 
 function getCurrentPointerPosition(state: GlobalChartState) {
@@ -40,13 +30,7 @@ function getCurrentPointerPosition(state: GlobalChartState) {
 /** @internal */
 export const getPickedShapes = createCachedSelector(
   [partitionGeometries, getCurrentPointerPosition],
-  (geoms, pointerPosition): QuadViewModel[] => {
-    const picker = geoms.pickQuads;
-    const { diskCenter } = geoms;
-    const x = pointerPosition.x - diskCenter.x;
-    const y = pointerPosition.y - diskCenter.y;
-    return picker(x, y);
-  },
+  pickedShapes,
 )((state) => state.chartId);
 
 /** @internal */
@@ -54,35 +38,3 @@ export const getPickedShapesLayerValues = createCachedSelector(
   [getPickedShapes],
   pickShapesLayerValues,
 )((state) => state.chartId);
-
-/** @internal */
-export function pickShapesLayerValues(pickedShapes: QuadViewModel[]): Array<Array<LayerValue>> {
-  const maxDepth = pickedShapes.reduce((acc, curr) => Math.max(acc, curr.depth), 0);
-  return pickedShapes
-    .filter(({ depth }) => depth === maxDepth) // eg. lowest layer in a treemap, where layers overlap in screen space; doesn't apply to sunburst/flame
-    .map<Array<LayerValue>>((viewModel) => {
-      const values: Array<LayerValue> = [];
-      values.push({
-        groupByRollup: viewModel.dataName,
-        value: viewModel[AGGREGATE_KEY],
-        depth: viewModel[DEPTH_KEY],
-        sortIndex: viewModel[SORT_INDEX_KEY],
-        path: viewModel[PATH_KEY],
-      });
-      let node = viewModel[MODEL_KEY];
-      while (node[DEPTH_KEY] > 0) {
-        const value = node[AGGREGATE_KEY];
-        const dataName = getNodeName(node);
-        values.push({
-          groupByRollup: dataName,
-          value,
-          depth: node[DEPTH_KEY],
-          sortIndex: node[SORT_INDEX_KEY],
-          path: node[PATH_KEY],
-        });
-
-        node = node[PARENT_KEY];
-      }
-      return values.reverse();
-    });
-}

--- a/src/chart_types/partition_chart/state/selectors/scenegraph.ts
+++ b/src/chart_types/partition_chart/state/selectors/scenegraph.ts
@@ -46,7 +46,7 @@ export function valueGetterFunction(valueGetter: ValueGetter) {
 }
 
 /** @internal */
-export function render(
+export function getShapeViewModel(
   partitionSpec: PartitionSpec,
   parentDimensions: Dimensions,
   tree: HierarchyOfArrays,

--- a/src/chart_types/partition_chart/state/selectors/tooltip.ts
+++ b/src/chart_types/partition_chart/state/selectors/tooltip.ts
@@ -33,11 +33,11 @@ const EMPTY_TOOLTIP = Object.freeze({
 /** @internal */
 export const getTooltipInfoSelector = createCachedSelector(
   [getPartitionSpec, getPickedShapes],
-  (pieSpec, pickedShapes): TooltipInfo => {
-    if (!pieSpec) {
+  (partitionSpec, pickedShapes): TooltipInfo => {
+    if (!partitionSpec) {
       return EMPTY_TOOLTIP;
     }
-    const { valueGetter, valueFormatter, layers: labelFormatters } = pieSpec;
+    const { valueGetter, valueFormatter, layers: labelFormatters } = partitionSpec;
     if (!valueFormatter || !labelFormatters) {
       return EMPTY_TOOLTIP;
     }
@@ -60,11 +60,11 @@ export const getTooltipInfoSelector = createCachedSelector(
         isHighlighted: false,
         isVisible: true,
         seriesIdentifier: {
-          specId: pieSpec.id,
-          key: pieSpec.id,
+          specId: partitionSpec.id,
+          key: partitionSpec.id,
         },
         value,
-        formattedValue: `${valueFormatter(value)} (${pieSpec.percentFormatter(percentValueGetter(shape))})`,
+        formattedValue: `${valueFormatter(value)} (${partitionSpec.percentFormatter(percentValueGetter(shape))})`,
         valueAccessor: shape.depth,
       });
     });

--- a/src/chart_types/partition_chart/state/selectors/tooltip.ts
+++ b/src/chart_types/partition_chart/state/selectors/tooltip.ts
@@ -29,7 +29,14 @@ export const getTooltipInfoSelector = createCachedSelector(
   [getPartitionSpec, getPickedShapes],
   (spec, pickedShapes): TooltipInfo => {
     return spec
-      ? getTooltipInfo(pickedShapes, spec.layers, spec.valueGetter, spec.valueFormatter, spec.percentFormatter, spec.id)
+      ? getTooltipInfo(
+          pickedShapes,
+          spec.layers.map((l) => l.nodeLabel),
+          spec.valueGetter,
+          spec.valueFormatter,
+          spec.percentFormatter,
+          spec.id,
+        )
       : EMPTY_TOOLTIP;
   },
 )((state) => state.chartId);

--- a/src/chart_types/partition_chart/state/selectors/tooltip.ts
+++ b/src/chart_types/partition_chart/state/selectors/tooltip.ts
@@ -21,9 +21,9 @@ import createCachedSelector from 're-reselect';
 
 import { TooltipInfo } from '../../../../components/tooltip/types';
 import { percentValueGetter, sumValueGetter } from '../../layout/config';
+import { valueGetterFunction } from '../../layout/viewmodel/scenegraph';
 import { getPartitionSpec } from './partition_spec';
 import { getPickedShapes } from './picked_shapes';
-import { valueGetterFunction } from './scenegraph';
 
 const EMPTY_TOOLTIP = Object.freeze({
   header: null,

--- a/src/chart_types/partition_chart/state/selectors/tree.ts
+++ b/src/chart_types/partition_chart/state/selectors/tree.ts
@@ -19,17 +19,12 @@
 
 import createCachedSelector from 're-reselect';
 
-import { ChartTypes } from '../../..';
-import { SpecTypes } from '../../../../specs';
-import { GlobalChartState } from '../../../../state/chart_state';
-import { getSpecsFromStore } from '../../../../state/utils';
 import { configMetadata } from '../../layout/config';
 import { childOrders, HierarchyOfArrays, HIERARCHY_ROOT_KEY } from '../../layout/utils/group_by_rollup';
 import { getHierarchyOfArrays } from '../../layout/viewmodel/hierarchy_of_arrays';
 import { isSunburst, isTreemap } from '../../layout/viewmodel/viewmodel';
 import { PartitionSpec } from '../../specs';
-
-const getSpecs = (state: GlobalChartState) => state.specs;
+import { getPartitionSpecs } from './get_partition_specs';
 
 function getTreeForSpec(spec: PartitionSpec) {
   const { data, valueAccessor, layers } = spec;
@@ -45,9 +40,8 @@ function getTreeForSpec(spec: PartitionSpec) {
 
 /** @internal */
 export const getTree = createCachedSelector(
-  [getSpecs],
-  (specs): HierarchyOfArrays => {
-    const partitionSpecs = getSpecsFromStore<PartitionSpec>(specs, ChartTypes.Partition, SpecTypes.Series);
+  [getPartitionSpecs],
+  (partitionSpecs): HierarchyOfArrays => {
     return partitionSpecs.length === 1 ? getTreeForSpec(partitionSpecs[0]) : []; // singleton!
   },
 )((state) => state.chartId);

--- a/src/chart_types/partition_chart/state/selectors/tree.ts
+++ b/src/chart_types/partition_chart/state/selectors/tree.ts
@@ -19,30 +19,11 @@
 
 import createCachedSelector from 're-reselect';
 
-import { Datum } from '../../../../utils/common';
 import { configMetadata } from '../../layout/config';
-import { PartitionLayout } from '../../layout/types/config_types';
-import { childOrders, HierarchyOfArrays, HIERARCHY_ROOT_KEY } from '../../layout/utils/group_by_rollup';
-import { getHierarchyOfArrays } from '../../layout/viewmodel/hierarchy_of_arrays';
-import { isSunburst, isTreemap } from '../../layout/viewmodel/viewmodel';
-import { Layer, PartitionSpec } from '../../specs';
+import { HierarchyOfArrays } from '../../layout/utils/group_by_rollup';
+import { partitionTree } from '../../layout/viewmodel/hierarchy_of_arrays';
+import { PartitionSpec } from '../../specs';
 import { getPartitionSpecs } from './get_partition_specs';
-
-function partitionTree(
-  data: Datum[],
-  valueAccessor: any,
-  layers: Layer[],
-  defaultLayout: PartitionLayout,
-  layout: PartitionLayout = defaultLayout,
-) {
-  const sorter = isTreemap(layout) || isSunburst(layout) ? childOrders.descending : null;
-  return getHierarchyOfArrays(
-    data,
-    valueAccessor,
-    [() => HIERARCHY_ROOT_KEY, ...layers.map(({ groupByRollup }) => groupByRollup)],
-    sorter,
-  );
-}
 
 function getTreeForSpec(spec: PartitionSpec) {
   const { data, valueAccessor, layers, config } = spec;

--- a/src/chart_types/partition_chart/state/selectors/tree.ts
+++ b/src/chart_types/partition_chart/state/selectors/tree.ts
@@ -19,16 +19,22 @@
 
 import createCachedSelector from 're-reselect';
 
+import { Datum } from '../../../../utils/common';
 import { configMetadata } from '../../layout/config';
+import { PartitionLayout } from '../../layout/types/config_types';
 import { childOrders, HierarchyOfArrays, HIERARCHY_ROOT_KEY } from '../../layout/utils/group_by_rollup';
 import { getHierarchyOfArrays } from '../../layout/viewmodel/hierarchy_of_arrays';
 import { isSunburst, isTreemap } from '../../layout/viewmodel/viewmodel';
-import { PartitionSpec } from '../../specs';
+import { Layer, PartitionSpec } from '../../specs';
 import { getPartitionSpecs } from './get_partition_specs';
 
-function getTreeForSpec(spec: PartitionSpec) {
-  const { data, valueAccessor, layers } = spec;
-  const layout = spec.config.partitionLayout ?? configMetadata.partitionLayout.dflt;
+function partitionTree(
+  data: Datum[],
+  valueAccessor: any,
+  layers: Layer[],
+  defaultLayout: PartitionLayout,
+  layout: PartitionLayout = defaultLayout,
+) {
   const sorter = isTreemap(layout) || isSunburst(layout) ? childOrders.descending : null;
   return getHierarchyOfArrays(
     data,
@@ -36,6 +42,11 @@ function getTreeForSpec(spec: PartitionSpec) {
     [() => HIERARCHY_ROOT_KEY, ...layers.map(({ groupByRollup }) => groupByRollup)],
     sorter,
   );
+}
+
+function getTreeForSpec(spec: PartitionSpec) {
+  const { data, valueAccessor, layers, config } = spec;
+  return partitionTree(data, valueAccessor, layers, configMetadata.partitionLayout.dflt, config.partitionLayout);
 }
 
 /** @internal */

--- a/src/chart_types/partition_chart/state/selectors/tree.ts
+++ b/src/chart_types/partition_chart/state/selectors/tree.ts
@@ -34,6 +34,6 @@ function getTreeForSpec(spec: PartitionSpec) {
 export const getTree = createCachedSelector(
   [getPartitionSpecs],
   (partitionSpecs): HierarchyOfArrays => {
-    return partitionSpecs.length === 1 ? getTreeForSpec(partitionSpecs[0]) : []; // singleton!
+    return partitionSpecs.length > 0 ? getTreeForSpec(partitionSpecs[0]) : []; // singleton!
   },
 )((state) => state.chartId);

--- a/src/common/color_calcs.ts
+++ b/src/common/color_calcs.ts
@@ -167,3 +167,23 @@ export function getTextColorIfTextInvertible(
       : makeHighContrastColor(textColor, backgroundColor, textContrast);
   }
 }
+
+/**
+ * This function generates color for non-occluded text rendering directly on the
+ * paper, with possible background color, ie. not on some data ink
+ *
+ * @internal
+ */
+export function getOnPaperColorSet(textColor: Color, sectorLineStroke: Color, containerBackgroundColor?: Color) {
+  // determine the ideal contrast color for the link labels
+  const validBackgroundColor = isColorValid(containerBackgroundColor)
+    ? containerBackgroundColor
+    : 'rgba(255, 255, 255, 0)';
+  const contrastTextColor = containerBackgroundColor
+    ? makeHighContrastColor(textColor, validBackgroundColor)
+    : textColor;
+  const strokeColor = containerBackgroundColor
+    ? makeHighContrastColor(sectorLineStroke, validBackgroundColor)
+    : undefined;
+  return { contrastTextColor, strokeColor };
+}

--- a/src/common/event_handler_selectors.ts
+++ b/src/common/event_handler_selectors.ts
@@ -1,0 +1,121 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { LayerValue, SettingsSpec, Spec } from '../specs';
+import { PointerStates } from '../state/chart_state';
+import { isClicking } from '../state/utils';
+import { SeriesIdentifier } from './series_id';
+
+/** @internal */
+export const getOnElementClickSelector = (prev: { click: PointerStates['lastClick'] }) => (
+  spec: Spec | null,
+  lastClick: PointerStates['lastClick'],
+  settings: SettingsSpec,
+  pickedShapes: LayerValue[][],
+): void => {
+  if (!spec) {
+    return;
+  }
+  if (!settings.onElementClick) {
+    return;
+  }
+  const nextPickedShapesLength = pickedShapes.length;
+  if (nextPickedShapesLength > 0 && isClicking(prev.click, lastClick) && settings && settings.onElementClick) {
+    const elements = pickedShapes.map<[Array<LayerValue>, SeriesIdentifier]>((values) => [
+      values,
+      {
+        specId: spec.id,
+        key: `spec{${spec.id}}`,
+      },
+    ]);
+    settings.onElementClick(elements);
+  }
+  prev.click = lastClick;
+};
+
+/** @internal */
+export const getOnElementOutSelector = (prev: { pickedShapes: number | null }) => (
+  spec: Spec | null,
+  pickedShapes: LayerValue[][],
+  settings: SettingsSpec,
+): void => {
+  if (!spec) {
+    return;
+  }
+  if (!settings.onElementOut) {
+    return;
+  }
+  const nextPickedShapes = pickedShapes.length;
+
+  if (prev.pickedShapes !== null && prev.pickedShapes > 0 && nextPickedShapes === 0) {
+    settings.onElementOut();
+  }
+  prev.pickedShapes = nextPickedShapes;
+};
+
+function isOverElement(prevPickedShapes: Array<Array<LayerValue>> = [], nextPickedShapes: Array<Array<LayerValue>>) {
+  if (nextPickedShapes.length === 0) {
+    return;
+  }
+  if (nextPickedShapes.length !== prevPickedShapes.length) {
+    return true;
+  }
+  return !nextPickedShapes.every((nextPickedShapeValues, index) => {
+    const prevPickedShapeValues = prevPickedShapes[index];
+    if (prevPickedShapeValues === null) {
+      return false;
+    }
+    if (prevPickedShapeValues.length !== nextPickedShapeValues.length) {
+      return false;
+    }
+    return nextPickedShapeValues.every((layerValue, i) => {
+      const prevPickedValue = prevPickedShapeValues[i];
+      if (!prevPickedValue) {
+        return false;
+      }
+      return layerValue.value === prevPickedValue.value && layerValue.groupByRollup === prevPickedValue.groupByRollup;
+    });
+  });
+}
+
+/** @internal */
+export const getOnElementOverSelector = (prev: { pickedShapes: LayerValue[][] }) => (
+  spec: Spec | null,
+  nextPickedShapes: LayerValue[][],
+  settings: SettingsSpec,
+): void => {
+  if (!spec) {
+    return;
+  }
+  if (!settings.onElementOver) {
+    return;
+  }
+
+  if (isOverElement(prev.pickedShapes, nextPickedShapes)) {
+    const elements = nextPickedShapes.map<[Array<LayerValue>, SeriesIdentifier]>((values) => [
+      values,
+      {
+        specId: spec.id,
+        key: `spec{${spec.id}}`,
+      },
+    ]);
+    settings.onElementOver(elements);
+  }
+  prev.pickedShapes = nextPickedShapes;
+};

--- a/src/common/text_utils.ts
+++ b/src/common/text_utils.ts
@@ -130,17 +130,17 @@ export const VerticalAlignments = Object.freeze({
 
 export type VerticalAlignments = Values<typeof VerticalAlignments>;
 
-/** internal */
+/** @internal */
 export function measureOneBoxWidth(measure: TextMeasure, fontSize: number, box: Box) {
   return measure(fontSize, [box])[0].width;
 }
 
-/** internal */
+/** @internal */
 export function cutToLength(s: string, maxLength: number) {
   return s.length <= maxLength ? s : `${s.slice(0, Math.max(0, maxLength - 1))}…`; // ellipsis is one char
 }
 
-/** internal */
+/** @internal */
 export function fitText(
   measure: TextMeasure,
   desiredText: string,

--- a/src/common/text_utils.ts
+++ b/src/common/text_utils.ts
@@ -22,6 +22,7 @@ import { $Values as Values } from 'utility-types';
 import { ArrayEntry } from '../chart_types/partition_chart/layout/utils/group_by_rollup';
 import { Datum } from '../utils/common';
 import { Pixels } from './geometry';
+import { integerSnap, monotonicHillClimb } from './optimize';
 
 export const FONT_VARIANTS = Object.freeze(['normal', 'small-caps'] as const);
 export type FontVariant = typeof FONT_VARIANTS[number];
@@ -128,3 +129,33 @@ export const VerticalAlignments = Object.freeze({
 });
 
 export type VerticalAlignments = Values<typeof VerticalAlignments>;
+
+/** internal */
+export function measureOneBoxWidth(measure: TextMeasure, fontSize: number, box: Box) {
+  return measure(fontSize, [box])[0].width;
+}
+
+/** internal */
+export function cutToLength(s: string, maxLength: number) {
+  return s.length <= maxLength ? s : `${s.slice(0, Math.max(0, maxLength - 1))}…`; // ellipsis is one char
+}
+
+/** internal */
+export function fitText(
+  measure: TextMeasure,
+  desiredText: string,
+  allottedWidth: number,
+  fontSize: number,
+  font: Font,
+) {
+  const desiredLength = desiredText.length;
+  const response = (v: number) => measure(fontSize, [{ ...font, text: desiredText.slice(0, Math.max(0, v)) }])[0].width;
+  const visibleLength = monotonicHillClimb(response, desiredLength, allottedWidth, integerSnap);
+  const text = visibleLength < 2 && desiredLength >= 2 ? '' : cutToLength(desiredText, visibleLength);
+  const { width, emHeightAscent, emHeightDescent } = measure(fontSize, [{ ...font, text }])[0];
+  return {
+    width,
+    verticalOffset: -(emHeightDescent + emHeightAscent) / 2, // meaning, `middle`
+    text,
+  };
+}

--- a/src/common/text_utils.ts
+++ b/src/common/text_utils.ts
@@ -48,6 +48,7 @@ export type NumericFontWeight = number & typeof FONT_WEIGHTS[number];
 export const FONT_STYLES = Object.freeze(['normal', 'italic', 'oblique', 'inherit', 'initial', 'unset'] as const);
 export type FontStyle = typeof FONT_STYLES[number];
 
+// this doesn't include the font size, so it's more like a font face (?) - unfortunately all vague terms
 export interface Font {
   fontStyle: FontStyle;
   fontVariant: FontVariant;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,6 @@ export { SeriesIdentifier } from './common/series_id';
 export { XYChartSeriesIdentifier, DataSeriesDatum, FilledValues } from './chart_types/xy_chart/utils/series';
 export { AnnotationTooltipFormatter, CustomAnnotationTooltip } from './chart_types/xy_chart/annotations/types';
 export { GeometryValue, BandedAccessorType } from './utils/geometry';
-export { LegendStrategy } from './chart_types/partition_chart/state/selectors/get_highlighted_shapes';
 export { LegendPath, LegendPathElement } from './state/actions/legend';
 export { CategoryKey } from './common/category';
 export {
@@ -89,3 +88,4 @@ export {
 export { DataGenerator } from './utils/data_generators/data_generator';
 export * from './utils/themes/merge_utils';
 export { MODEL_KEY } from './chart_types/partition_chart/layout/config';
+export { LegendStrategy } from './chart_types/partition_chart/layout/utils/highlighted_geoms';

--- a/src/specs/settings.tsx
+++ b/src/specs/settings.tsx
@@ -22,7 +22,7 @@ import React, { ComponentType, ReactChild } from 'react';
 import { Spec } from '.';
 import { Cell } from '../chart_types/heatmap/layout/types/viewmodel_types';
 import { PrimitiveValue } from '../chart_types/partition_chart/layout/utils/group_by_rollup';
-import { LegendStrategy } from '../chart_types/partition_chart/state/selectors/get_highlighted_shapes';
+import { LegendStrategy } from '../chart_types/partition_chart/layout/utils/highlighted_geoms';
 import { XYChartSeriesIdentifier } from '../chart_types/xy_chart/utils/series';
 import { DomainRange } from '../chart_types/xy_chart/utils/specs';
 import { SeriesIdentifier } from '../common/series_id';

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -36,7 +36,7 @@ import { Point } from '../utils/point';
 import { StateActions } from './actions';
 import { CHART_RENDERED } from './actions/chart';
 import { UPDATE_PARENT_DIMENSION } from './actions/chart_settings';
-import { SET_PERSISTED_COLOR, SET_TEMPORARY_COLOR, CLEAR_TEMPORARY_COLORS } from './actions/colors';
+import { CLEAR_TEMPORARY_COLORS, SET_PERSISTED_COLOR, SET_TEMPORARY_COLOR } from './actions/colors';
 import { DOMElement } from './actions/dom_element';
 import { EXTERNAL_POINTER_EVENT } from './actions/events';
 import { LegendPath } from './actions/legend';
@@ -410,17 +410,14 @@ function chartTypeFromSpecs(specs: SpecList): ChartTypes | null {
   return nonGlobalTypes[0];
 }
 
+const constructors: Record<ChartTypes, () => InternalChartState | null> = {
+  [ChartTypes.Goal]: () => new GoalState(),
+  [ChartTypes.Partition]: () => new PartitionState(),
+  [ChartTypes.XYAxis]: () => new XYAxisChartState(),
+  [ChartTypes.Heatmap]: () => new HeatmapState(),
+  [ChartTypes.Global]: () => null,
+}; // with no default, TS signals if a new chart type isn't added here too
+
 function newInternalState(chartType: ChartTypes | null): InternalChartState | null {
-  switch (chartType) {
-    case ChartTypes.Goal:
-      return new GoalState();
-    case ChartTypes.Partition:
-      return new PartitionState();
-    case ChartTypes.XYAxis:
-      return new XYAxisChartState();
-    case ChartTypes.Heatmap:
-      return new HeatmapState();
-    default:
-      return null;
-  }
+  return chartType ? constructors[chartType]() : null;
 }

--- a/stories/icicle/02_unix_flame.tsx
+++ b/stories/icicle/02_unix_flame.tsx
@@ -24,7 +24,7 @@ import { STORYBOOK_LIGHT_THEME } from '../shared';
 import { config, getFlatData, getLayerSpec, maxDepth } from '../utils/hierarchical_input_utils';
 import { plasma18 as palette } from '../utils/utils';
 
-const color = palette.slice().reverse();
+const color = [...palette].reverse();
 
 export const Example = () => {
   return (
@@ -32,13 +32,10 @@ export const Example = () => {
       <Settings
         showLegend
         flatLegend
+        legendPosition="right"
         legendStrategy={LegendStrategy.PathWithDescendants}
         legendMaxDepth={maxDepth}
         theme={STORYBOOK_LIGHT_THEME}
-        onElementClick={(e) => {
-          // eslint-disable-next-line no-console
-          console.log(e);
-        }}
       />
       <Partition
         id="spec_1"


### PR DESCRIPTION
## Summary

No external changes. Preparation for small multiples via general code improvements.

Implementation changes, easiest to see by commit:
- stronger separation of API from logic: partition selector files contain no logic; previous code contained in selector bodies got split to 
  - an API related part (remained in the selector file) and 
  - a calculation part (got moved out of selector files)  
- extracted out common partition and goal event handler selector makers https://github.com/elastic/elastic-charts/pull/1020/commits/2503531f4f3952d3b9ad23f93017d9419a84a134
- linting implementation files to new coding rules
- more precise and explicit types
- breaking up some overly large functions
- formulating, extracting out text and color utils, and moving them out
- more documentation and restructuring for better readability
- follow-up to #1016: moving out a renderer
