### PR TITLE
refactor: rename enum types to singular

### DIFF
--- a/api/charts.api.md
+++ b/api/charts.api.md
@@ -44,13 +44,13 @@ export interface AngleFromTo {
 }
 
 // @public
-export type AnnotationDomainType = $Values<typeof AnnotationDomainTypes>;
-
-// @public
-export const AnnotationDomainTypes: Readonly<{
+export const AnnotationDomainType: Readonly<{
     XDomain: "xDomain";
     YDomain: "yDomain";
 }>;
+
+// @public
+export type AnnotationDomainType = $Values<typeof AnnotationDomainType>;
 
 // @public (undocumented)
 export type AnnotationId = string;
@@ -67,17 +67,17 @@ export type AnnotationSpec = LineAnnotationSpec | RectAnnotationSpec;
 // @public (undocumented)
 export type AnnotationTooltipFormatter = (details?: string) => JSX.Element | null;
 
-// @public (undocumented)
-export type AnnotationType = $Values<typeof AnnotationTypes>;
-
-// Warning: (ae-missing-release-tag) "AnnotationTypes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AnnotationType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const AnnotationTypes: Readonly<{
+export const AnnotationType: Readonly<{
     Line: "line";
     Rectangle: "rectangle";
     Text: "text";
 }>;
+
+// @public (undocumented)
+export type AnnotationType = $Values<typeof AnnotationType>;
 
 // Warning: (ae-missing-release-tag) "ArcSeriesStyle" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -107,7 +107,7 @@ export const AreaSeries: React_2.FunctionComponent<SpecRequiredProps & SpecOptio
 
 // @public
 export type AreaSeriesSpec = BasicSeriesSpec & HistogramConfig & Postfixes & {
-    seriesType: typeof SeriesTypes.Area;
+    seriesType: typeof SeriesType.Area;
     curve?: CurveType;
     areaSeriesStyle?: RecursivePartial<AreaSeriesStyle>;
     stackMode?: StackMode;
@@ -170,7 +170,7 @@ export type AxisId = string;
 // @public
 export interface AxisSpec extends Spec {
     // (undocumented)
-    chartType: typeof ChartTypes.XYAxis;
+    chartType: typeof ChartType.XYAxis;
     domain?: YDomainRange;
     gridLine?: Partial<GridLineStyle>;
     groupId: GroupId;
@@ -185,7 +185,7 @@ export interface AxisSpec extends Spec {
     showOverlappingLabels: boolean;
     showOverlappingTicks: boolean;
     // (undocumented)
-    specType: typeof SpecTypes.Axis;
+    specType: typeof SpecType.Axis;
     style?: RecursivePartial<Omit<AxisStyle, 'gridLine'>>;
     tickFormat?: TickFormatter;
     ticks?: number;
@@ -266,7 +266,7 @@ export const BarSeries: React_2.FunctionComponent<SpecRequiredProps_2 & SpecOpti
 
 // @public
 export type BarSeriesSpec = BasicSeriesSpec & Postfixes & {
-    seriesType: typeof SeriesTypes.Bar;
+    seriesType: typeof SeriesType.Bar;
     enableHistogramMode?: boolean;
     barSeriesStyle?: RecursivePartial<BarSeriesStyle>;
     stackMode?: StackMode;
@@ -295,15 +295,15 @@ export type BarStyleOverride = RecursivePartial<BarSeriesStyle> | Color | null;
 // Warning: (ae-missing-release-tag) "BaseAnnotationSpec" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export interface BaseAnnotationSpec<T extends typeof AnnotationTypes.Rectangle | typeof AnnotationTypes.Line, D extends RectAnnotationDatum | LineAnnotationDatum, S extends RectAnnotationStyle | LineAnnotationStyle> extends Spec, AnnotationPortalSettings {
+export interface BaseAnnotationSpec<T extends typeof AnnotationType.Rectangle | typeof AnnotationType.Line, D extends RectAnnotationDatum | LineAnnotationDatum, S extends RectAnnotationStyle | LineAnnotationStyle> extends Spec, AnnotationPortalSettings {
     annotationType: T;
     // (undocumented)
-    chartType: typeof ChartTypes.XYAxis;
+    chartType: typeof ChartType.XYAxis;
     dataValues: D[];
     groupId: GroupId;
     hideTooltips?: boolean;
     // (undocumented)
-    specType: typeof SpecTypes.Annotation;
+    specType: typeof SpecType.Annotation;
     style?: Partial<S>;
     zIndex?: number;
 }
@@ -364,7 +364,7 @@ export const BubbleSeries: React_2.FunctionComponent<SpecRequiredProps_3 & SpecO
 
 // @alpha
 export type BubbleSeriesSpec = BasicSeriesSpec & {
-    seriesType: typeof SeriesTypes.Bubble;
+    seriesType: typeof SeriesType.Bubble;
     bubbleSeriesStyle?: RecursivePartial<BubbleSeriesStyle>;
     pointStyleAccessor?: PointStyleAccessor;
 };
@@ -459,10 +459,10 @@ export interface ChartSizeObject {
     width?: number | string;
 }
 
-// Warning: (ae-missing-release-tag) "ChartTypes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ChartType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export const ChartTypes: Readonly<{
+export const ChartType: Readonly<{
     Global: "global";
     Goal: "goal";
     Partition: "partition";
@@ -472,7 +472,7 @@ export const ChartTypes: Readonly<{
 }>;
 
 // @public (undocumented)
-export type ChartTypes = $Values<typeof ChartTypes>;
+export type ChartType = $Values<typeof ChartType>;
 
 // Warning: (ae-missing-release-tag) "CHILDREN_KEY" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -886,7 +886,7 @@ export interface GoalSpec extends Spec {
     // (undocumented)
     centralMinor: string | BandFillColorAccessor;
     // (undocumented)
-    chartType: typeof ChartTypes.Goal;
+    chartType: typeof ChartType.Goal;
     // Warning: (ae-forgotten-export) The symbol "Config" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -896,7 +896,7 @@ export interface GoalSpec extends Spec {
     // (undocumented)
     labelMinor: string | BandFillColorAccessor;
     // (undocumented)
-    specType: typeof SpecTypes.Series;
+    specType: typeof SpecType.Series;
     // Warning: (ae-forgotten-export) The symbol "GoalSubtype" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -1094,7 +1094,7 @@ export type HeatmapElementEvent = [Cell, SeriesIdentifier];
 // @alpha (undocumented)
 export interface HeatmapSpec extends Spec {
     // (undocumented)
-    chartType: typeof ChartTypes.Heatmap;
+    chartType: typeof ChartType.Heatmap;
     // (undocumented)
     colors: Color[];
     // Warning: (ae-forgotten-export) The symbol "HeatmapScaleType" needs to be exported by the entry point index.d.ts
@@ -1115,7 +1115,7 @@ export interface HeatmapSpec extends Spec {
     // (undocumented)
     ranges?: number[] | [number, number];
     // (undocumented)
-    specType: typeof SpecTypes.Series;
+    specType: typeof SpecType.Series;
     // (undocumented)
     valueAccessor: Accessor | AccessorFn;
     // (undocumented)
@@ -1346,7 +1346,7 @@ export interface LineAnnotationDatum {
 }
 
 // @public (undocumented)
-export type LineAnnotationSpec = BaseAnnotationSpec<typeof AnnotationTypes.Line, LineAnnotationDatum, LineAnnotationStyle> & {
+export type LineAnnotationSpec = BaseAnnotationSpec<typeof AnnotationType.Line, LineAnnotationDatum, LineAnnotationStyle> & {
     domainType: AnnotationDomainType;
     marker?: JSX.Element;
     markerDimensions?: {
@@ -1375,7 +1375,7 @@ export const LineSeries: React_2.FunctionComponent<SpecRequiredProps_6 & SpecOpt
 
 // @public
 export type LineSeriesSpec = BasicSeriesSpec & HistogramConfig & {
-    seriesType: typeof SeriesTypes.Line;
+    seriesType: typeof SeriesType.Line;
     curve?: CurveType;
     lineSeriesStyle?: RecursivePartial<LineSeriesStyle>;
     pointStyleAccessor?: PointStyleAccessor;
@@ -1764,7 +1764,7 @@ export interface RectAnnotationDatum {
 }
 
 // @public (undocumented)
-export type RectAnnotationSpec = BaseAnnotationSpec<typeof AnnotationTypes.Rectangle, RectAnnotationDatum, RectAnnotationStyle> & {
+export type RectAnnotationSpec = BaseAnnotationSpec<typeof AnnotationType.Rectangle, RectAnnotationDatum, RectAnnotationStyle> & {
     renderTooltip?: AnnotationTooltipFormatter;
     zIndex?: number;
 };
@@ -1939,7 +1939,7 @@ export interface SeriesScales {
 // @public (undocumented)
 export interface SeriesSpec extends Spec {
     // (undocumented)
-    chartType: typeof ChartTypes.XYAxis;
+    chartType: typeof ChartType.XYAxis;
     color?: SeriesColorAccessor;
     data: Datum[];
     // (undocumented)
@@ -1948,11 +1948,11 @@ export interface SeriesSpec extends Spec {
     groupId: string;
     hideInLegend?: boolean;
     name?: SeriesNameAccessor;
-    seriesType: SeriesTypes;
+    seriesType: SeriesType;
     // @deprecated
     sortIndex?: number;
     // (undocumented)
-    specType: typeof SpecTypes.Series;
+    specType: typeof SpecType.Series;
     tickFormat?: TickFormatter;
     useDefaultGroupDomain?: boolean | string;
     // Warning: (ae-forgotten-export) The symbol "AccessorFormat" needs to be exported by the entry point index.d.ts
@@ -1965,10 +1965,10 @@ export interface SeriesSpec extends Spec {
 // @public (undocumented)
 export type SeriesSpecs<S extends BasicSeriesSpec = BasicSeriesSpec> = Array<S>;
 
-// Warning: (ae-missing-release-tag) "SeriesTypes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SeriesType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const SeriesTypes: Readonly<{
+export const SeriesType: Readonly<{
     Area: "area";
     Bar: "bar";
     Line: "line";
@@ -1976,7 +1976,7 @@ export const SeriesTypes: Readonly<{
 }>;
 
 // @public
-export type SeriesTypes = $Values<typeof SeriesTypes>;
+export type SeriesType = $Values<typeof SeriesType>;
 
 // Warning: (ae-missing-release-tag) "Settings" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2127,7 +2127,7 @@ export interface SortSeriesByConfig {
 //
 // @public (undocumented)
 export interface Spec {
-    chartType: ChartTypes;
+    chartType: ChartType;
     id: string;
     specType: string;
 }
@@ -2135,10 +2135,10 @@ export interface Spec {
 // @public (undocumented)
 export type SpecId = string;
 
-// Warning: (ae-missing-release-tag) "SpecTypes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SpecType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const SpecTypes: Readonly<{
+export const SpecType: Readonly<{
     Series: "series";
     Axis: "axis";
     Annotation: "annotation";
@@ -2148,7 +2148,7 @@ export const SpecTypes: Readonly<{
 }>;
 
 // @public (undocumented)
-export type SpecTypes = $Values<typeof SpecTypes>;
+export type SpecType = $Values<typeof SpecType>;
 
 // @public
 export const StackMode: Readonly<{
@@ -2411,7 +2411,7 @@ export interface WordcloudSpec extends Spec {
     // (undocumented)
     angleCount: number;
     // (undocumented)
-    chartType: typeof ChartTypes.Wordcloud;
+    chartType: typeof ChartType.Wordcloud;
     // (undocumented)
     config: RecursivePartial<PartitionConfig>;
     // Warning: (ae-forgotten-export) The symbol "WordModel" needs to be exported by the entry point index.d.ts
@@ -2439,7 +2439,7 @@ export interface WordcloudSpec extends Spec {
     // (undocumented)
     padding: number;
     // (undocumented)
-    specType: typeof SpecTypes.Series;
+    specType: typeof SpecType.Series;
     // (undocumented)
     spiral: string;
     // (undocumented)

--- a/docs/0-Intro/1-Overview.mdx
+++ b/docs/0-Intro/1-Overview.mdx
@@ -143,7 +143,7 @@ export interface SeriesSpec {
   /** An array of data */
   data: Datum[];
   /** The type of series you are looking to render */
-  seriesType: SeriesTypes;
+  seriesType: SeriesType;
   /** Set colors for specific series */
   customSeriesColors?: CustomSeriesColors;
   /** If the series should appear in the legend
@@ -201,7 +201,7 @@ A `BarSeriesSpec` for example is the following intersection type:
 export type BarSeriesSpec = SeriesSpec &
   SeriesAccessors &
   SeriesScales & {
-    seriesType: SeriesTypes.Bar;
+    seriesType: SeriesType.Bar;
   };
 ```
 

--- a/docs/1-Typesofchart/5-AnnotatingBars.mdx
+++ b/docs/1-Typesofchart/5-AnnotatingBars.mdx
@@ -1,6 +1,6 @@
 import { boolean, color, number, select } from '@storybook/addon-knobs';
 import {
-  AnnotationDomainTypes,
+  AnnotationDomainType,
   AnnotationTooltipFormatter,
   Axis,
   BarSeries,
@@ -31,7 +31,7 @@ Here is a basic `line` annotation with `x domain continuous`
     <Settings showLegend debug={boolean('debug', false)} rotation={getChartRotationKnob} />
     <LineAnnotation
       id="anno_1"
-      domainType={AnnotationDomainTypes.XDomain}
+      domainType={AnnotationDomainType.XDomain}
       dataValues={[{dataValue:2.5, details:'detail-0'}, {dataValue: 7.2, details: 'detail-1'}]}
       marker={<Icon type="alert" />}
       style = {{line: {
@@ -64,7 +64,7 @@ Here is a basic `line` annotation with `x domain continuous`
 </Chart>
 
 The code sample for the above chart is shown below in the details. What you should especially pay attention to is:
-* dataValues within the `<LineAnnotation/>` component 
+* dataValues within the `<LineAnnotation/>` component
 * You can add the style prop within `<LineAnnotation/>` to customize further
 
 <details>
@@ -74,7 +74,7 @@ The code sample for the above chart is shown below in the details. What you shou
     <Settings showLegend debug={boolean('debug', false)} rotation={getChartRotationKnob} />
     <LineAnnotation
       id="anno_1"
-      domainType={AnnotationDomainTypes.XDomain}
+      domainType={AnnotationDomainType.XDomain}
       dataValues={[{dataValue:2.5, details:'detail-0'}, {dataValue: 7.2, details: 'detail-1'}]}
       marker={<Icon type="alert" />}
       style = {{line: {
@@ -114,7 +114,7 @@ Instead of `continuous` you can use `ordinal` annotations
     <Settings debug={boolean('debug', false)} rotation={getChartRotationKnob} />
     <LineAnnotation
     id="anno_1"
-    domainType={AnnotationDomainTypes.XDomain}
+    domainType={AnnotationDomainType.XDomain}
     dataValues={[{dataValue: 'a', details: 'detail-0'}, {dataValue: 'c', details:'details-1'}]}
     marker={<Icon type="alert" />}
     />
@@ -136,7 +136,7 @@ Instead of `continuous` you can use `ordinal` annotations
     />
 </Chart>
 
-The code sample for the above chart can be seen below. 
+The code sample for the above chart can be seen below.
 <details>
 
 ```js
@@ -144,7 +144,7 @@ The code sample for the above chart can be seen below.
     <Settings debug={boolean('debug', false)} rotation={getChartRotationKnob} />
     <LineAnnotation
     id="anno_1"
-    domainType={AnnotationDomainTypes.XDomain}
+    domainType={AnnotationDomainType.XDomain}
     dataValues={[{dataValue: 'a', details: 'detail-0'}, {dataValue: 'c', details:'details-1'}]}
     marker={<Icon type="alert" />}
     />

--- a/docs/2-ChartPropTables/12-AxisProps.md
+++ b/docs/2-ChartPropTables/12-AxisProps.md
@@ -4,8 +4,8 @@ The bar chart with axis example in the `Types of charts` section includes only s
 
 | Prop | Type | Default | Note |
 |:------|:------:|:---------:|:------|
-| chartType | `typeof ChartTypes.XYAxis` | ChartTypes.XYAxis  |  |
-| specType  | `typeof SpecTypes.Axis` | SpecTypes.Axis  |  |
+| chartType | `typeof ChartType.XYAxis` | ChartType.XYAxis  |  |
+| specType  | `typeof SpecType.Axis` | SpecType.Axis  |  |
 | groupId | GroupId | `__global__`  | The ID of the axis group |
 | hide  | boolean  | false  | Hide this axis |
 | showOverlappingTicks | boolean | false  | Shows all ticks, also the one from the overlapping labels   |

--- a/docs/2-ChartPropTables/13-AreaProps.md
+++ b/docs/2-ChartPropTables/13-AreaProps.md
@@ -10,9 +10,9 @@ Default props are set in the area_series.tsx file
 | xAccessor `(required)`| Accessor |  | The field name of the x value on Datum object |
 | yAccessors `(required)`| Accessor[] |  | An array of field names one per y metric value |
 | data `(required)` | datum[] |  | An array of data |
-| chartType | `typeof ChartTypes.XYAxis` | ChartTypes.XYAxis  |  |
-| specType | `typeof SpecTypes.Series` | SpecTypes.Series | | 
-| seriesType| `typeof SeriesTypes.Area` | SeriesTypes.Area | |
+| chartType | `typeof ChartType.XYAxis` | ChartType.XYAxis  |  |
+| specType | `typeof SpecType.Series` | SpecType.Series | | 
+| seriesType| `typeof SeriesType.Area` | SeriesType.Area | |
 | groupId | string | DEFAULT_GLOBAL_ID | | 
 | yScaleToDataExtent | boolean | false | | 
 | hideInLegend | boolean | false | hide the series in the legend | 

--- a/docs/2-ChartPropTables/14-LineProps.md
+++ b/docs/2-ChartPropTables/14-LineProps.md
@@ -3,9 +3,9 @@
 | Prop | Type | Default | Note |
 |:------|:------:|:---------:|:------|
 | id `(required)`|`string` ||The id of the spec |
-| chartType | `typeof ChartTypes.XYAxis` | ChartTypes.XYAxis  |  |
-| specType  | `typeof SpecTypes.Series` | SpecTypes.Series  |  |    
-| seriesTypes  | | SeriesTypes.Line |  |
+| chartType | `typeof ChartType.XYAxis` | ChartType.XYAxis  |  |
+| specType  | `typeof SpecType.Series` | SpecType.Series  |  |    
+| seriesTypes  | | SeriesType.Line |  |
 | groupId  || DEFAULT_GROUP_ID |The ID of the line |
 | xScaleType `(required)`| `ScaleType (ScaleType.Ordinal or ScaleType.Linear or ScaleType.Time)`|ScaleType.Ordinal | The x axis scale type |
 | yScaleType `(required)`| `ScaleType (ScaleType.Ordinal or ScaleType.Linear or ScaleType.Time)`| ScaleType.Linear | The y axis scale type |

--- a/docs/charts.tsx
+++ b/docs/charts.tsx
@@ -28,7 +28,7 @@ import {
   Position,
   Settings,
   LineAnnotation,
-  AnnotationDomainTypes,
+  AnnotationDomainType,
   Axis,
   LineAnnotationDatum,
 } from '../src';
@@ -127,7 +127,7 @@ export const lineBasicXDomainContinuous = () => {
       <Settings showLegend debug={boolean('debug', false)} rotation={getChartRotationKnob()} />
       <LineAnnotation
         id="anno_1"
-        domainType={AnnotationDomainTypes.XDomain}
+        domainType={AnnotationDomainType.XDomain}
         dataValues={dataValues}
         style={style}
         marker={<Icon type="alert" />}
@@ -161,7 +161,7 @@ export const lineBasicXDomainOrdinal = () => {
       <Settings debug={boolean('debug', false)} rotation={getChartRotationKnob()} />
       <LineAnnotation
         id="anno_1"
-        domainType={AnnotationDomainTypes.XDomain}
+        domainType={AnnotationDomainType.XDomain}
         dataValues={dataValues}
         marker={<Icon type="alert" />}
       />

--- a/src/chart_types/goal_chart/layout/types/viewmodel_types.ts
+++ b/src/chart_types/goal_chart/layout/types/viewmodel_types.ts
@@ -18,7 +18,7 @@
  */
 
 import { Pixels, PointObject } from '../../../../common/geometry';
-import { SpecTypes } from '../../../../specs/constants';
+import { SpecType } from '../../../../specs/constants';
 import { BandFillColorAccessorInput } from '../../specs';
 import { GoalSubtype } from '../../specs/constants';
 import { config } from '../config/config';
@@ -64,7 +64,7 @@ export type ShapeViewModel = {
 };
 
 const commonDefaults = {
-  specType: SpecTypes.Series,
+  specType: SpecType.Series,
   subtype: GoalSubtype.Goal,
   base: 0,
   target: 100,

--- a/src/chart_types/goal_chart/specs/index.ts
+++ b/src/chart_types/goal_chart/specs/index.ts
@@ -19,9 +19,9 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { Spec } from '../../../specs';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { getConnect, specComponentFactory } from '../../../state/spec_factory';
 import { Color, RecursivePartial } from '../../../utils/common';
 import { config } from '../layout/config/config';
@@ -45,15 +45,15 @@ export interface BandFillColorAccessorInput {
 export type BandFillColorAccessor = (input: BandFillColorAccessorInput) => Color;
 
 const defaultProps = {
-  chartType: ChartTypes.Goal,
+  chartType: ChartType.Goal,
   ...defaultGoalSpec,
   config,
 };
 
 /** @alpha */
 export interface GoalSpec extends Spec {
-  specType: typeof SpecTypes.Series;
-  chartType: typeof ChartTypes.Goal;
+  specType: typeof SpecType.Series;
+  chartType: typeof ChartType.Goal;
   subtype: GoalSubtype;
   base: number;
   target: number;

--- a/src/chart_types/goal_chart/state/chart_state.tsx
+++ b/src/chart_types/goal_chart/state/chart_state.tsx
@@ -19,7 +19,7 @@
 
 import React, { RefObject } from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { DEFAULT_CSS_CURSOR } from '../../../common/constants';
 import { LegendItem } from '../../../common/legend';
 import { Tooltip } from '../../../components/tooltip';
@@ -42,7 +42,7 @@ const EMPTY_LEGEND_ITEM_LIST: LegendItemLabel[] = [];
 
 /** @internal */
 export class GoalState implements InternalChartState {
-  chartType = ChartTypes.Goal;
+  chartType = ChartType.Goal;
 
   onElementClickCaller: (state: GlobalChartState) => void;
 

--- a/src/chart_types/goal_chart/state/selectors/geometries.ts
+++ b/src/chart_types/goal_chart/state/selectors/geometries.ts
@@ -19,8 +19,8 @@
 
 import createCachedSelector from 're-reselect';
 
-import { ChartTypes } from '../../..';
-import { SpecTypes } from '../../../../specs/constants';
+import { ChartType } from '../../..';
+import { SpecType } from '../../../../specs/constants';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSpecs } from '../../../../state/selectors/get_settings_specs';
@@ -35,7 +35,7 @@ const getParentDimensions = (state: GlobalChartState) => state.parentDimensions;
 export const geometries = createCachedSelector(
   [getSpecs, getParentDimensions],
   (specs, parentDimensions): ShapeViewModel => {
-    const goalSpecs = getSpecsFromStore<GoalSpec>(specs, ChartTypes.Goal, SpecTypes.Series);
+    const goalSpecs = getSpecsFromStore<GoalSpec>(specs, ChartType.Goal, SpecType.Series);
     return goalSpecs.length === 1 ? render(goalSpecs[0], parentDimensions) : nullShapeViewModel();
   },
 )(getChartIdSelector);

--- a/src/chart_types/goal_chart/state/selectors/goal_spec.ts
+++ b/src/chart_types/goal_chart/state/selectors/goal_spec.ts
@@ -17,14 +17,14 @@
  * under the License.
  */
 
-import { ChartTypes } from '../../..';
-import { SpecTypes } from '../../../../specs/constants';
+import { ChartType } from '../../..';
+import { SpecType } from '../../../../specs/constants';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getSpecsFromStore } from '../../../../state/utils';
 import { GoalSpec } from '../../specs';
 
 /** @internal */
 export function getSpecOrNull(state: GlobalChartState): GoalSpec | null {
-  const specs = getSpecsFromStore<GoalSpec>(state.specs, ChartTypes.Goal, SpecTypes.Series);
+  const specs = getSpecsFromStore<GoalSpec>(state.specs, ChartType.Goal, SpecType.Series);
   return specs.length > 0 ? specs[0] : null;
 }

--- a/src/chart_types/goal_chart/state/selectors/on_element_click_caller.ts
+++ b/src/chart_types/goal_chart/state/selectors/on_element_click_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { getOnElementClickSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState, PointerStates } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
@@ -40,7 +40,7 @@ export function createOnElementClickCaller(): (state: GlobalChartState) => void 
   const prev: { click: PointerStates['lastClick'] } = { click: null };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Goal) {
+    if (selector === null && state.chartType === ChartType.Goal) {
       selector = createCachedSelector(
         [getSpecOrNull, getLastClickSelector, getSettingsSpecSelector, getPickedShapesLayerValues],
         getOnElementClickSelector(prev),

--- a/src/chart_types/goal_chart/state/selectors/on_element_out_caller.ts
+++ b/src/chart_types/goal_chart/state/selectors/on_element_out_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { getOnElementOutSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
@@ -38,7 +38,7 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
   const prev: { pickedShapes: number | null } = { pickedShapes: null };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Goal) {
+    if (selector === null && state.chartType === ChartType.Goal) {
       selector = createCachedSelector(
         [getSpecOrNull, getPickedShapesLayerValues, getSettingsSpecSelector],
         getOnElementOutSelector(prev),

--- a/src/chart_types/goal_chart/state/selectors/on_element_over_caller.ts
+++ b/src/chart_types/goal_chart/state/selectors/on_element_over_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { getOnElementOverSelector } from '../../../../common/event_handler_selectors';
 import { LayerValue } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
@@ -39,7 +39,7 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
   const prev: { pickedShapes: LayerValue[][] } = { pickedShapes: [] };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Goal) {
+    if (selector === null && state.chartType === ChartType.Goal) {
       selector = createCachedSelector(
         [getSpecOrNull, getPickedShapesLayerValues, getSettingsSpecSelector],
         getOnElementOverSelector(prev),

--- a/src/chart_types/heatmap/layout/types/viewmodel_types.ts
+++ b/src/chart_types/heatmap/layout/types/viewmodel_types.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { Pixels } from '../../../../common/geometry';
 import { Fill, Line, Stroke } from '../../../../geoms/types';
 import { Point } from '../../../../utils/point';
@@ -126,7 +126,7 @@ export const nullShapeViewModel = (specifiedConfig?: Config): ShapeViewModel => 
   config: specifiedConfig || config,
   heatmapViewModel: nullHeatmapViewModel,
   pickQuads: () => [],
-  pickDragArea: () => ({ cells: [], x: [], y: [], chartType: ChartTypes.Heatmap }),
+  pickDragArea: () => ({ cells: [], x: [], y: [], chartType: ChartType.Heatmap }),
   pickDragShape: () => ({ x: 0, y: 0, width: 0, height: 0 }),
   pickHighlightedArea: () => ({ x: 0, y: 0, width: 0, height: 0 }),
 });

--- a/src/chart_types/heatmap/specs/heatmap.ts
+++ b/src/chart_types/heatmap/specs/heatmap.ts
@@ -19,11 +19,11 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { Predicate } from '../../../common/predicate';
 import { ScaleType } from '../../../scales/constants';
 import { SeriesScales, Spec } from '../../../specs';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { getConnect, specComponentFactory } from '../../../state/spec_factory';
 import { Accessor, AccessorFn } from '../../../utils/accessor';
 import { Color, Datum, RecursivePartial } from '../../../utils/common';
@@ -31,8 +31,8 @@ import { config } from '../layout/config/config';
 import { Config } from '../layout/types/config_types';
 
 const defaultProps = {
-  chartType: ChartTypes.Heatmap,
-  specType: SpecTypes.Series,
+  chartType: ChartType.Heatmap,
+  specType: SpecType.Series,
   data: [],
   colors: ['red', 'yellow', 'green'],
   colorScale: ScaleType.Linear,
@@ -54,8 +54,8 @@ export type HeatmapScaleType =
 
 /** @alpha */
 export interface HeatmapSpec extends Spec {
-  specType: typeof SpecTypes.Series;
-  chartType: typeof ChartTypes.Heatmap;
+  specType: typeof SpecType.Series;
+  chartType: typeof ChartType.Heatmap;
   data: Datum[];
   colorScale?: HeatmapScaleType;
   ranges?: number[] | [number, number];

--- a/src/chart_types/heatmap/state/chart_state.tsx
+++ b/src/chart_types/heatmap/state/chart_state.tsx
@@ -19,7 +19,7 @@
 
 import React, { RefObject } from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { BrushTool } from '../../../components/brush/brush';
 import { Tooltip } from '../../../components/tooltip';
 import { InternalChartState, GlobalChartState, BackwardRef } from '../../../state/chart_state';
@@ -49,7 +49,7 @@ const EMPTY_MAP = new Map();
 
 /** @internal */
 export class HeatmapState implements InternalChartState {
-  chartType = ChartTypes.Heatmap;
+  chartType = ChartType.Heatmap;
 
   onElementClickCaller: (state: GlobalChartState) => void = createOnElementClickCaller();
 

--- a/src/chart_types/heatmap/state/selectors/get_heatmap_spec.ts
+++ b/src/chart_types/heatmap/state/selectors/get_heatmap_spec.ts
@@ -18,8 +18,8 @@
  */
 import createCachedSelector from 're-reselect';
 
-import { ChartTypes } from '../../..';
-import { SpecTypes } from '../../../../specs';
+import { ChartType } from '../../..';
+import { SpecType } from '../../../../specs';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSpecs } from '../../../../state/selectors/get_settings_specs';
 import { getSpecsFromStore } from '../../../../state/utils';
@@ -27,6 +27,6 @@ import { HeatmapSpec } from '../../specs';
 
 /** @internal */
 export const getHeatmapSpecSelector = createCachedSelector([getSpecs], (specs) => {
-  const spec = getSpecsFromStore<HeatmapSpec>(specs, ChartTypes.Heatmap, SpecTypes.Series);
+  const spec = getSpecsFromStore<HeatmapSpec>(specs, ChartType.Heatmap, SpecType.Series);
   return spec[0];
 })(getChartIdSelector);

--- a/src/chart_types/heatmap/state/selectors/heatmap_spec.ts
+++ b/src/chart_types/heatmap/state/selectors/heatmap_spec.ts
@@ -17,14 +17,14 @@
  * under the License.
  */
 
-import { ChartTypes } from '../../..';
-import { SpecTypes } from '../../../../specs/constants';
+import { ChartType } from '../../..';
+import { SpecType } from '../../../../specs/constants';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getSpecsFromStore } from '../../../../state/utils';
 import { HeatmapSpec } from '../../specs/heatmap';
 
 /** @internal */
 export function getSpecOrNull(state: GlobalChartState): HeatmapSpec | null {
-  const specs = getSpecsFromStore<HeatmapSpec>(state.specs, ChartTypes.Heatmap, SpecTypes.Series);
+  const specs = getSpecsFromStore<HeatmapSpec>(state.specs, ChartType.Heatmap, SpecType.Series);
   return specs.length > 0 ? specs[0] : null;
 }

--- a/src/chart_types/heatmap/state/selectors/on_brush_end_caller.ts
+++ b/src/chart_types/heatmap/state/selectors/on_brush_end_caller.ts
@@ -19,7 +19,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getLastDragSelector } from '../../../../state/selectors/get_last_drag';
@@ -39,7 +39,7 @@ export function createOnBrushEndCaller(): (state: GlobalChartState) => void {
   let prevProps: DragCheckProps | null = null;
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Heatmap) {
+    if (selector === null && state.chartType === ChartType.Heatmap) {
       if (!isBrushEndProvided(state)) {
         selector = null;
         prevProps = null;

--- a/src/chart_types/heatmap/state/selectors/on_element_click_caller.ts
+++ b/src/chart_types/heatmap/state/selectors/on_element_click_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { SeriesIdentifier } from '../../../../common/series_id';
 import { SettingsSpec } from '../../../../specs';
 import { GlobalChartState, PointerState } from '../../../../state/chart_state';
@@ -42,7 +42,7 @@ export function createOnElementClickCaller(): (state: GlobalChartState) => void 
   let prevClick: PointerState | null = null;
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Heatmap) {
+    if (selector === null && state.chartType === ChartType.Heatmap) {
       selector = createCachedSelector(
         [getSpecOrNull, getLastClickSelector, getSettingsSpecSelector, getPickedShapes],
         (spec, lastClick: PointerState | null, settings: SettingsSpec, pickedShapes): void => {

--- a/src/chart_types/heatmap/state/selectors/on_element_out_caller.ts
+++ b/src/chart_types/heatmap/state/selectors/on_element_out_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
@@ -38,7 +38,7 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
   let prevPickedShapes: number | null = null;
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Heatmap) {
+    if (selector === null && state.chartType === ChartType.Heatmap) {
       selector = createCachedSelector(
         [getSpecOrNull, getPickedShapes, getSettingsSpecSelector],
         (spec, pickedShapes, settings): void => {

--- a/src/chart_types/heatmap/state/selectors/on_element_over_caller.ts
+++ b/src/chart_types/heatmap/state/selectors/on_element_over_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { SeriesIdentifier } from '../../../../common/series_id';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
@@ -55,7 +55,7 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
   let prevPickedShapes: Cell[] = [];
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Heatmap) {
+    if (selector === null && state.chartType === ChartType.Heatmap) {
       selector = createCachedSelector(
         [getSpecOrNull, getPickedShapes, getSettingsSpecSelector],
         (spec, nextPickedShapes, settings): void => {

--- a/src/chart_types/index.ts
+++ b/src/chart_types/index.ts
@@ -23,7 +23,7 @@ import { $Values } from 'utility-types';
  * Available chart types
  * @public
  */
-export const ChartTypes = Object.freeze({
+export const ChartType = Object.freeze({
   Global: 'global' as const,
   Goal: 'goal' as const,
   Partition: 'partition' as const,
@@ -31,4 +31,4 @@ export const ChartTypes = Object.freeze({
   Heatmap: 'heatmap' as const,
   Wordcloud: 'wordcloud' as const,
 });
-export type ChartTypes = $Values<typeof ChartTypes>;
+export type ChartType = $Values<typeof ChartType>;

--- a/src/chart_types/partition_chart/specs/index.ts
+++ b/src/chart_types/partition_chart/specs/index.ts
@@ -19,10 +19,10 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { Pixels } from '../../../common/geometry';
 import { Spec } from '../../../specs';
-import { SpecTypes } from '../../../specs/constants'; // kept as unshortened import on separate line otherwise import circularity emerges
+import { SpecType } from '../../../specs/constants'; // kept as unshortened import on separate line otherwise import circularity emerges
 import { getConnect, specComponentFactory } from '../../../state/spec_factory';
 import { IndexedAccessorFn } from '../../../utils/accessor';
 import {
@@ -49,8 +49,8 @@ export interface Layer {
 }
 
 const defaultProps = {
-  chartType: ChartTypes.Partition,
-  specType: SpecTypes.Series,
+  chartType: ChartType.Partition,
+  specType: SpecType.Series,
   config,
   valueAccessor: (d: Datum) => (typeof d === 'number' ? d : 0),
   valueGetter: (n: ShapeTreeNode): number => n[AGGREGATE_KEY],
@@ -69,8 +69,8 @@ const defaultProps = {
 };
 
 export interface PartitionSpec extends Spec {
-  specType: typeof SpecTypes.Series;
-  chartType: typeof ChartTypes.Partition;
+  specType: typeof SpecType.Series;
+  chartType: typeof ChartType.Partition;
   config: RecursivePartial<Config>;
   data: Datum[];
   valueAccessor: ValueAccessor;

--- a/src/chart_types/partition_chart/state/chart_state.tsx
+++ b/src/chart_types/partition_chart/state/chart_state.tsx
@@ -19,7 +19,7 @@
 
 import { RefObject } from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { DEFAULT_CSS_CURSOR } from '../../../common/constants';
 import { BackwardRef, GlobalChartState, InternalChartState } from '../../../state/chart_state';
 import { InitStatus } from '../../../state/selectors/get_internal_is_intialized';
@@ -38,7 +38,7 @@ import { getTooltipInfoSelector } from './selectors/tooltip';
 
 /** @internal */
 export class PartitionState implements InternalChartState {
-  chartType = ChartTypes.Partition;
+  chartType = ChartType.Partition;
 
   onElementClickCaller: (state: GlobalChartState) => void;
 

--- a/src/chart_types/partition_chart/state/selectors/geometries.ts
+++ b/src/chart_types/partition_chart/state/selectors/geometries.ts
@@ -19,10 +19,10 @@
 
 import createCachedSelector from 're-reselect';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { CategoryKey } from '../../../../common/category';
 import { Pixels, Ratio } from '../../../../common/geometry';
-import { RelativeBandsPadding, SmallMultiplesSpec, SpecTypes } from '../../../../specs';
+import { RelativeBandsPadding, SmallMultiplesSpec, SpecType } from '../../../../specs';
 import { getChartContainerDimensionsSelector } from '../../../../state/selectors/get_chart_container_dimensions';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
@@ -52,11 +52,7 @@ function bandwidth(range: Pixels, bandCount: number, { outer, inner }: RelativeB
 export const partitionMultiGeometries = createCachedSelector(
   [getSpecs, getPartitionSpecs, getChartContainerDimensionsSelector, getTrees, getChartThemeSelector],
   (specs, partitionSpecs, parentDimensions, trees, { background }): ShapeViewModel[] => {
-    const smallMultiplesSpecs = getSpecsFromStore<SmallMultiplesSpec>(
-      specs,
-      ChartTypes.Global,
-      SpecTypes.SmallMultiples,
-    );
+    const smallMultiplesSpecs = getSpecsFromStore<SmallMultiplesSpec>(specs, ChartType.Global, SpecType.SmallMultiples);
 
     // todo make it part of configuration
     const outerSpecDirection = ['horizontal', 'vertical', 'zigzag'][0];

--- a/src/chart_types/partition_chart/state/selectors/get_partition_specs.ts
+++ b/src/chart_types/partition_chart/state/selectors/get_partition_specs.ts
@@ -19,8 +19,8 @@
 
 import createCachedSelector from 're-reselect';
 
-import { ChartTypes } from '../../..';
-import { SpecTypes } from '../../../../specs';
+import { ChartType } from '../../..';
+import { SpecType } from '../../../../specs';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSpecs } from '../../../../state/selectors/get_settings_specs';
 import { getSpecsFromStore } from '../../../../state/utils';
@@ -28,5 +28,5 @@ import { PartitionSpec } from '../../specs';
 
 /** @internal */
 export const getPartitionSpecs = createCachedSelector([getSpecs], (specs) => {
-  return getSpecsFromStore<PartitionSpec>(specs, ChartTypes.Partition, SpecTypes.Series);
+  return getSpecsFromStore<PartitionSpec>(specs, ChartType.Partition, SpecType.Series);
 })(getChartIdSelector);

--- a/src/chart_types/partition_chart/state/selectors/on_element_click_caller.ts
+++ b/src/chart_types/partition_chart/state/selectors/on_element_click_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { getOnElementClickSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState, PointerStates } from '../../../../state/chart_state';
 import { getLastClickSelector } from '../../../../state/selectors/get_last_click';
@@ -39,7 +39,7 @@ export function createOnElementClickCaller(): (state: GlobalChartState) => void 
   const prev: { click: PointerStates['lastClick'] } = { click: null };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Partition) {
+    if (selector === null && state.chartType === ChartType.Partition) {
       selector = createCachedSelector(
         [getPartitionSpec, getLastClickSelector, getSettingsSpecSelector, getPickedShapesLayerValues],
         getOnElementClickSelector(prev),

--- a/src/chart_types/partition_chart/state/selectors/on_element_out_caller.ts
+++ b/src/chart_types/partition_chart/state/selectors/on_element_out_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { getOnElementOutSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
@@ -38,7 +38,7 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
   const prev: { pickedShapes: number | null } = { pickedShapes: null };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Partition) {
+    if (selector === null && state.chartType === ChartType.Partition) {
       selector = createCachedSelector(
         [getPartitionSpec, getPickedShapesLayerValues, getSettingsSpecSelector],
         getOnElementOutSelector(prev),

--- a/src/chart_types/partition_chart/state/selectors/on_element_over_caller.ts
+++ b/src/chart_types/partition_chart/state/selectors/on_element_over_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { getOnElementOverSelector } from '../../../../common/event_handler_selectors';
 import { LayerValue } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
@@ -39,7 +39,7 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
   const prev: { pickedShapes: LayerValue[][] } = { pickedShapes: [] };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Partition) {
+    if (selector === null && state.chartType === ChartType.Partition) {
       selector = createCachedSelector(
         [getPartitionSpec, getPickedShapesLayerValues, getSettingsSpecSelector],
         getOnElementOverSelector(prev),

--- a/src/chart_types/partition_chart/state/selectors/partition_spec.ts
+++ b/src/chart_types/partition_chart/state/selectors/partition_spec.ts
@@ -17,15 +17,15 @@
  * under the License.
  */
 
-import { ChartTypes } from '../../..';
-import { SpecTypes } from '../../../../specs';
+import { ChartType } from '../../..';
+import { SpecType } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getSpecsFromStore } from '../../../../state/utils';
 import { PartitionSpec } from '../../specs';
 
 /** @internal */
 export function getPartitionSpecs(state: GlobalChartState): PartitionSpec[] {
-  return getSpecsFromStore<PartitionSpec>(state.specs, ChartTypes.Partition, SpecTypes.Series);
+  return getSpecsFromStore<PartitionSpec>(state.specs, ChartType.Partition, SpecType.Series);
 }
 
 /** @internal */

--- a/src/chart_types/partition_chart/state/selectors/tree.ts
+++ b/src/chart_types/partition_chart/state/selectors/tree.ts
@@ -19,7 +19,7 @@
 
 import createCachedSelector from 're-reselect';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { getPredicateFn } from '../../../../common/predicate';
 import {
   DEFAULT_SM_PANEL_PADDING,
@@ -27,7 +27,7 @@ import {
   GroupBySpec,
   SmallMultiplesSpec,
   SmallMultiplesStyle,
-  SpecTypes,
+  SpecType,
 } from '../../../../specs';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSpecs } from '../../../../state/selectors/get_settings_specs';
@@ -41,7 +41,7 @@ import { PartitionSpec } from '../../specs';
 import { getPartitionSpecs } from './get_partition_specs';
 
 const getGroupBySpecs = createCachedSelector([getSpecs], (specs) =>
-  getSpecsFromStore<GroupBySpec>(specs, ChartTypes.Global, SpecTypes.IndexOrder),
+  getSpecsFromStore<GroupBySpec>(specs, ChartType.Global, SpecType.IndexOrder),
 )(getChartIdSelector);
 
 /** @internal */
@@ -68,7 +68,7 @@ function getTreesForSpec(
 
   if (groupBySpec) {
     const { by, sort, format = (name) => String(name) } = groupBySpec;
-    const accessorSpec = { id: spec.id, chartType: spec.chartType, specType: SpecTypes.Series };
+    const accessorSpec = { id: spec.id, chartType: spec.chartType, specType: SpecType.Series };
     const groups = data.reduce((map: Map<ReturnType<GroupByAccessor>, Datum[]>, next) => {
       const groupingValue = by(accessorSpec, next);
       const preexistingGroup = map.get(groupingValue);

--- a/src/chart_types/wordcloud/specs/index.ts
+++ b/src/chart_types/wordcloud/specs/index.ts
@@ -19,9 +19,9 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { Spec } from '../../../specs';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { getConnect, specComponentFactory } from '../../../state/spec_factory';
 import { RecursivePartial } from '../../../utils/common';
 import { Config } from '../../partition_chart/layout/types/config_types';
@@ -29,16 +29,16 @@ import { config } from '../layout/config/config';
 import { WordModel, defaultWordcloudSpec, WeightFn, OutOfRoomCallback } from '../layout/types/viewmodel_types';
 
 const defaultProps = {
-  chartType: ChartTypes.Wordcloud,
-  specType: SpecTypes.Series,
+  chartType: ChartType.Wordcloud,
+  specType: SpecType.Series,
   ...defaultWordcloudSpec,
   config,
 };
 
 /** @alpha */
 export interface WordcloudSpec extends Spec {
-  specType: typeof SpecTypes.Series;
-  chartType: typeof ChartTypes.Wordcloud;
+  specType: typeof SpecType.Series;
+  chartType: typeof ChartType.Wordcloud;
   config: RecursivePartial<Config>;
   startAngle: number;
   endAngle: number;

--- a/src/chart_types/wordcloud/state/chart_state.tsx
+++ b/src/chart_types/wordcloud/state/chart_state.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { DEFAULT_CSS_CURSOR } from '../../../common/constants';
 import { LegendItem } from '../../../common/legend';
 import { InternalChartState, GlobalChartState } from '../../../state/chart_state';
@@ -40,7 +40,7 @@ const EMPTY_LEGEND_ITEM_LIST: LegendItemLabel[] = [];
 
 /** @internal */
 export class WordcloudState implements InternalChartState {
-  chartType = ChartTypes.Wordcloud;
+  chartType = ChartType.Wordcloud;
 
   onElementClickCaller: (state: GlobalChartState) => void;
 

--- a/src/chart_types/wordcloud/state/selectors/geometries.ts
+++ b/src/chart_types/wordcloud/state/selectors/geometries.ts
@@ -19,8 +19,8 @@
 
 import createCachedSelector from 're-reselect';
 
-import { ChartTypes } from '../../..';
-import { SpecTypes } from '../../../../specs/constants';
+import { ChartType } from '../../..';
+import { SpecType } from '../../../../specs/constants';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getSpecsFromStore } from '../../../../state/utils';
 import { nullShapeViewModel, ShapeViewModel } from '../../layout/types/viewmodel_types';
@@ -35,7 +35,7 @@ const getParentDimensions = (state: GlobalChartState) => state.parentDimensions;
 export const geometries = createCachedSelector(
   [getSpecs, getParentDimensions],
   (specs, parentDimensions): ShapeViewModel => {
-    const wordcloudSpecs = getSpecsFromStore<WordcloudSpec>(specs, ChartTypes.Wordcloud, SpecTypes.Series);
+    const wordcloudSpecs = getSpecsFromStore<WordcloudSpec>(specs, ChartType.Wordcloud, SpecType.Series);
     return wordcloudSpecs.length === 1 ? render(wordcloudSpecs[0], parentDimensions) : nullShapeViewModel();
   },
 )((state) => state.chartId);

--- a/src/chart_types/wordcloud/state/selectors/on_element_click_caller.ts
+++ b/src/chart_types/wordcloud/state/selectors/on_element_click_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { getOnElementClickSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState, PointerStates } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
@@ -40,7 +40,7 @@ export function createOnElementClickCaller(): (state: GlobalChartState) => void 
   const prev: { click: PointerStates['lastClick'] } = { click: null };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Wordcloud) {
+    if (selector === null && state.chartType === ChartType.Wordcloud) {
       selector = createCachedSelector(
         [getSpecOrNull, getLastClickSelector, getSettingsSpecSelector, getPickedShapesLayerValues],
         getOnElementClickSelector(prev),

--- a/src/chart_types/wordcloud/state/selectors/on_element_out_caller.ts
+++ b/src/chart_types/wordcloud/state/selectors/on_element_out_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { getOnElementOutSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
@@ -38,7 +38,7 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
   const prev: { pickedShapes: number | null } = { pickedShapes: null };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Wordcloud) {
+    if (selector === null && state.chartType === ChartType.Wordcloud) {
       selector = createCachedSelector(
         [getSpecOrNull, getPickedShapesLayerValues, getSettingsSpecSelector],
         getOnElementOutSelector(prev),

--- a/src/chart_types/wordcloud/state/selectors/on_element_over_caller.ts
+++ b/src/chart_types/wordcloud/state/selectors/on_element_over_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { getOnElementOverSelector } from '../../../../common/event_handler_selectors';
 import { LayerValue } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
@@ -39,7 +39,7 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
   const prev: { pickedShapes: LayerValue[][] } = { pickedShapes: [] };
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.Wordcloud) {
+    if (selector === null && state.chartType === ChartType.Wordcloud) {
       selector = createCachedSelector(
         [getSpecOrNull, getPickedShapesLayerValues, getSettingsSpecSelector],
         getOnElementOverSelector(prev),

--- a/src/chart_types/wordcloud/state/selectors/wordcloud_spec.ts
+++ b/src/chart_types/wordcloud/state/selectors/wordcloud_spec.ts
@@ -17,14 +17,14 @@
  * under the License.
  */
 
-import { ChartTypes } from '../../..';
-import { SpecTypes } from '../../../../specs/constants';
+import { ChartType } from '../../..';
+import { SpecType } from '../../../../specs/constants';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getSpecsFromStore } from '../../../../state/utils';
 import { WordcloudSpec } from '../../specs';
 
 /** @internal */
 export function getSpecOrNull(state: GlobalChartState): WordcloudSpec | null {
-  const specs = getSpecsFromStore<WordcloudSpec>(state.specs, ChartTypes.Wordcloud, SpecTypes.Series);
+  const specs = getSpecsFromStore<WordcloudSpec>(state.specs, ChartType.Wordcloud, SpecType.Series);
   return specs.length > 0 ? specs[0] : null;
 }

--- a/src/chart_types/xy_chart/annotations/line/dimensions.integration.test.ts
+++ b/src/chart_types/xy_chart/annotations/line/dimensions.integration.test.ts
@@ -22,7 +22,7 @@ import { MockSeriesSpec, MockAnnotationSpec, MockGlobalSpec } from '../../../../
 import { MockStore } from '../../../../mocks/store';
 import { ScaleType } from '../../../../scales/constants';
 import { computeAnnotationDimensionsSelector } from '../../state/selectors/compute_annotations';
-import { AnnotationDomainTypes } from '../../utils/specs';
+import { AnnotationDomainType } from '../../utils/specs';
 
 function expectAnnotationAtPosition(
   data: Array<{ x: number; y: number }>,
@@ -142,7 +142,7 @@ describe('Render vertical line annotation within', () => {
       ],
     });
     const annotation = MockAnnotationSpec.line({
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: 9.5, details: 'foo' }],
     });
 

--- a/src/chart_types/xy_chart/annotations/line/dimensions.test.ts
+++ b/src/chart_types/xy_chart/annotations/line/dimensions.test.ts
@@ -25,7 +25,7 @@ import { Position } from '../../../../utils/common';
 import { AnnotationId } from '../../../../utils/ids';
 import { DEFAULT_ANNOTATION_LINE_STYLE } from '../../../../utils/themes/merge_utils';
 import { computeAnnotationDimensionsSelector } from '../../state/selectors/compute_annotations';
-import { AnnotationDomainTypes } from '../../utils/specs';
+import { AnnotationDomainType } from '../../utils/specs';
 import { AnnotationDimensions } from '../types';
 import { AnnotationLineProps } from './types';
 
@@ -72,7 +72,7 @@ describe('Annotation utils', () => {
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo',
       groupId,
-      domainType: AnnotationDomainTypes.YDomain,
+      domainType: AnnotationDomainType.YDomain,
       dataValues: [{ dataValue: 2, details: 'foo' }],
     });
 
@@ -115,7 +115,7 @@ describe('Annotation utils', () => {
 
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo',
-      domainType: AnnotationDomainTypes.YDomain,
+      domainType: AnnotationDomainType.YDomain,
       dataValues: [{ dataValue: 2, details: 'foo' }],
       groupId,
       style: DEFAULT_ANNOTATION_LINE_STYLE,
@@ -134,7 +134,7 @@ describe('Annotation utils', () => {
 
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo-line',
-      domainType: AnnotationDomainTypes.YDomain,
+      domainType: AnnotationDomainType.YDomain,
       dataValues: [{ dataValue: 2, details: 'foo' }],
       groupId,
       style: DEFAULT_ANNOTATION_LINE_STYLE,
@@ -177,7 +177,7 @@ describe('Annotation utils', () => {
 
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo-line',
-      domainType: AnnotationDomainTypes.YDomain,
+      domainType: AnnotationDomainType.YDomain,
       dataValues: [{ dataValue: 2, details: 'foo' }],
       groupId,
       style: DEFAULT_ANNOTATION_LINE_STYLE,
@@ -221,7 +221,7 @@ describe('Annotation utils', () => {
 
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo-line',
-      domainType: AnnotationDomainTypes.YDomain,
+      domainType: AnnotationDomainType.YDomain,
       dataValues: [{ dataValue: 2, details: 'foo' }],
       groupId,
       style: DEFAULT_ANNOTATION_LINE_STYLE,
@@ -264,7 +264,7 @@ describe('Annotation utils', () => {
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo-line',
       groupId: 'other-group',
-      domainType: AnnotationDomainTypes.YDomain,
+      domainType: AnnotationDomainType.YDomain,
       dataValues: [],
       style: DEFAULT_ANNOTATION_LINE_STYLE,
     });
@@ -294,7 +294,7 @@ describe('Annotation utils', () => {
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo-line',
       groupId: 'other-group',
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: 'a', details: 'foo' }],
       style: DEFAULT_ANNOTATION_LINE_STYLE,
     });
@@ -337,7 +337,7 @@ describe('Annotation utils', () => {
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo-line',
       groupId: 'other-group',
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: 2, details: 'foo' }],
       style: DEFAULT_ANNOTATION_LINE_STYLE,
     });
@@ -379,7 +379,7 @@ describe('Annotation utils', () => {
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo-line',
       groupId: 'other-group',
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: 2, details: 'foo' }],
       style: DEFAULT_ANNOTATION_LINE_STYLE,
     });
@@ -421,7 +421,7 @@ describe('Annotation utils', () => {
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo-line',
       groupId: 'other-group',
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: 'a', details: 'foo' }],
       style: DEFAULT_ANNOTATION_LINE_STYLE,
     });
@@ -464,7 +464,7 @@ describe('Annotation utils', () => {
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo-line',
       groupId: 'other-group',
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: 2, details: 'foo' }],
       style: DEFAULT_ANNOTATION_LINE_STYLE,
     });
@@ -508,7 +508,7 @@ describe('Annotation utils', () => {
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo-line',
       groupId: 'other-group',
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: 2, details: 'foo' }],
       style: DEFAULT_ANNOTATION_LINE_STYLE,
     });
@@ -551,7 +551,7 @@ describe('Annotation utils', () => {
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo-line',
       groupId: 'other-group',
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: 2, details: 'foo' }],
       style: DEFAULT_ANNOTATION_LINE_STYLE,
     });
@@ -594,7 +594,7 @@ describe('Annotation utils', () => {
     const lineAnnotation = MockAnnotationSpec.line({
       id: 'foo-line',
       groupId: 'other-group',
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: 2, details: 'foo' }],
       style: DEFAULT_ANNOTATION_LINE_STYLE,
     });
@@ -636,7 +636,7 @@ describe('Annotation utils', () => {
     const annotationId = 'foo-line';
     const invalidXLineAnnotation = MockAnnotationSpec.line({
       id: annotationId,
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: 'e', details: 'foo' }],
       groupId,
       style: DEFAULT_ANNOTATION_LINE_STYLE,
@@ -649,7 +649,7 @@ describe('Annotation utils', () => {
 
     const invalidStringXLineAnnotation = MockAnnotationSpec.line({
       id: annotationId,
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: '', details: 'foo' }],
       groupId,
       style: DEFAULT_ANNOTATION_LINE_STYLE,
@@ -664,7 +664,7 @@ describe('Annotation utils', () => {
 
     const outOfBoundsXLineAnnotation = MockAnnotationSpec.line({
       id: annotationId,
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: -999, details: 'foo' }],
       groupId,
       style: DEFAULT_ANNOTATION_LINE_STYLE,
@@ -679,7 +679,7 @@ describe('Annotation utils', () => {
 
     const invalidYLineAnnotation = MockAnnotationSpec.line({
       id: annotationId,
-      domainType: AnnotationDomainTypes.YDomain,
+      domainType: AnnotationDomainType.YDomain,
       dataValues: [{ dataValue: 'e', details: 'foo' }],
       groupId,
       style: DEFAULT_ANNOTATION_LINE_STYLE,
@@ -694,7 +694,7 @@ describe('Annotation utils', () => {
 
     const outOfBoundsYLineAnnotation = MockAnnotationSpec.line({
       id: annotationId,
-      domainType: AnnotationDomainTypes.YDomain,
+      domainType: AnnotationDomainType.YDomain,
       dataValues: [{ dataValue: -999, details: 'foo' }],
       groupId,
       style: DEFAULT_ANNOTATION_LINE_STYLE,
@@ -709,7 +709,7 @@ describe('Annotation utils', () => {
 
     const invalidStringYLineAnnotation = MockAnnotationSpec.line({
       id: annotationId,
-      domainType: AnnotationDomainTypes.YDomain,
+      domainType: AnnotationDomainType.YDomain,
       dataValues: [{ dataValue: '', details: 'foo' }],
       groupId,
       style: DEFAULT_ANNOTATION_LINE_STYLE,
@@ -724,7 +724,7 @@ describe('Annotation utils', () => {
 
     const validHiddenAnnotation = MockAnnotationSpec.line({
       id: annotationId,
-      domainType: AnnotationDomainTypes.XDomain,
+      domainType: AnnotationDomainType.XDomain,
       dataValues: [{ dataValue: 2, details: 'foo' }],
       groupId,
       style: DEFAULT_ANNOTATION_LINE_STYLE,

--- a/src/chart_types/xy_chart/annotations/line/dimensions.ts
+++ b/src/chart_types/xy_chart/annotations/line/dimensions.ts
@@ -28,7 +28,7 @@ import { SmallMultipleScales } from '../../state/selectors/compute_small_multipl
 import { isHorizontalRotation } from '../../state/utils/common';
 import { computeXScaleOffset } from '../../state/utils/utils';
 import { getPanelSize } from '../../utils/panel';
-import { AnnotationDomainTypes, LineAnnotationSpec, LineAnnotationDatum } from '../../utils/specs';
+import { AnnotationDomainType, LineAnnotationSpec, LineAnnotationDatum } from '../../utils/specs';
 import { AnnotationLineProps } from './types';
 
 function computeYDomainLineAnnotationDimensions(
@@ -253,7 +253,7 @@ export function computeLineAnnotationDimensions(
     return null;
   }
 
-  if (domainType === AnnotationDomainTypes.XDomain) {
+  if (domainType === AnnotationDomainType.XDomain) {
     return computeXDomainLineAnnotationDimensions(
       annotationSpec,
       xScale,

--- a/src/chart_types/xy_chart/annotations/line/line.test.tsx
+++ b/src/chart_types/xy_chart/annotations/line/line.test.tsx
@@ -28,7 +28,7 @@ import { GlobalChartState } from '../../../../state/chart_state';
 import { Position } from '../../../../utils/common';
 import { DEFAULT_ANNOTATION_LINE_STYLE } from '../../../../utils/themes/merge_utils';
 import { computeAnnotationDimensionsSelector } from '../../state/selectors/compute_annotations';
-import { AnnotationDomainTypes } from '../../utils/specs';
+import { AnnotationDomainType } from '../../utils/specs';
 import { AnnotationLineProps } from './types';
 
 describe('annotation marker', () => {
@@ -43,7 +43,7 @@ describe('annotation marker', () => {
   });
   const lineYDomainAnnotation = MockAnnotationSpec.line({
     id,
-    domainType: AnnotationDomainTypes.YDomain,
+    domainType: AnnotationDomainType.YDomain,
     dataValues: [{ dataValue: 2, details: 'foo' }],
     style: DEFAULT_ANNOTATION_LINE_STYLE,
     marker: <div />,
@@ -51,7 +51,7 @@ describe('annotation marker', () => {
 
   const lineXDomainAnnotation = MockAnnotationSpec.line({
     id,
-    domainType: AnnotationDomainTypes.XDomain,
+    domainType: AnnotationDomainType.XDomain,
     dataValues: [{ dataValue: 2, details: 'foo' }],
     style: DEFAULT_ANNOTATION_LINE_STYLE,
     marker: <div />,

--- a/src/chart_types/xy_chart/annotations/line/tooltip.test.tsx
+++ b/src/chart_types/xy_chart/annotations/line/tooltip.test.tsx
@@ -19,18 +19,18 @@
 import { mount } from 'enzyme';
 import React from 'react';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { Chart } from '../../../../components/chart';
 import { MockAnnotationLineProps, MockAnnotationRectProps } from '../../../../mocks/annotations/annotations';
 import { ScaleType } from '../../../../scales/constants';
-import { SpecTypes } from '../../../../specs/constants';
+import { SpecType } from '../../../../specs/constants';
 import { Settings } from '../../../../specs/settings';
 import { Rotation } from '../../../../utils/common';
 import { Dimensions } from '../../../../utils/dimensions';
 import { AnnotationId } from '../../../../utils/ids';
 import { LineAnnotation } from '../../specs/line_annotation';
 import { LineSeries } from '../../specs/line_series';
-import { AnnotationDomainTypes, AnnotationTypes, AxisSpec, RectAnnotationSpec } from '../../utils/specs';
+import { AnnotationDomainType, AnnotationType, AxisSpec, RectAnnotationSpec } from '../../utils/specs';
 import { computeRectAnnotationTooltipState } from '../tooltip';
 import { AnnotationDimensions } from '../types';
 import { AnnotationLineProps } from './types';
@@ -57,7 +57,7 @@ describe('Annotation tooltips', () => {
           />
           <LineAnnotation
             id="foo"
-            domainType={AnnotationDomainTypes.YDomain}
+            domainType={AnnotationDomainType.YDomain}
             dataValues={[{ dataValue: 2, details: 'foo' }]}
             marker={<div style={{ width: '10px', height: '10px' }} />}
           />
@@ -95,7 +95,7 @@ describe('Annotation tooltips', () => {
           />
           <LineAnnotation
             id="foo"
-            domainType={AnnotationDomainTypes.YDomain}
+            domainType={AnnotationDomainType.YDomain}
             dataValues={[{ dataValue: 2, details: 'foo' }]}
             marker={<div style={{ width: '10px', height: '10px' }} />}
             hideTooltips
@@ -144,11 +144,11 @@ describe('Annotation tooltips', () => {
 
     // rect annotation tooltip
     const annotationRectangle: RectAnnotationSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Annotation,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Annotation,
       id: 'rect',
       groupId,
-      annotationType: AnnotationTypes.Rectangle,
+      annotationType: AnnotationType.Rectangle,
       dataValues: [{ coordinates: { x0: 1, x1: 2, y0: 3, y1: 5 } }],
     };
 
@@ -170,7 +170,7 @@ describe('Annotation tooltips', () => {
 
     expect(rectTooltipState).toMatchObject({
       isVisible: true,
-      annotationType: AnnotationTypes.Rectangle,
+      annotationType: AnnotationType.Rectangle,
       anchor: {
         left: 18,
         top: 9,

--- a/src/chart_types/xy_chart/annotations/rect/tooltip.test.ts
+++ b/src/chart_types/xy_chart/annotations/rect/tooltip.test.ts
@@ -18,7 +18,7 @@
  */
 import { MockAnnotationRectProps } from '../../../../mocks/annotations/annotations';
 import { Dimensions } from '../../../../utils/dimensions';
-import { AnnotationTypes } from '../../utils/specs';
+import { AnnotationType } from '../../utils/specs';
 import { AnnotationTooltipState } from '../types';
 import { getRectAnnotationTooltipState } from './tooltip';
 import { AnnotationRectProps } from './types';
@@ -43,7 +43,7 @@ describe('Rect annotation tooltip', () => {
     const visibleTooltip = getRectAnnotationTooltipState(cursorPosition, annotationRects, 0, chartDimensions);
     const expectedVisibleTooltipState: AnnotationTooltipState = {
       isVisible: true,
-      annotationType: AnnotationTypes.Rectangle,
+      annotationType: AnnotationType.Rectangle,
       anchor: {
         top: cursorPosition.y,
         left: cursorPosition.x,

--- a/src/chart_types/xy_chart/annotations/rect/tooltip.ts
+++ b/src/chart_types/xy_chart/annotations/rect/tooltip.ts
@@ -22,7 +22,7 @@ import { Rotation } from '../../../../utils/common';
 import { Dimensions } from '../../../../utils/dimensions';
 import { Point } from '../../../../utils/point';
 import { isHorizontalRotation } from '../../state/utils/common';
-import { AnnotationTypes } from '../../utils/specs';
+import { AnnotationType } from '../../utils/specs';
 import { AnnotationTooltipState, Bounds } from '../types';
 import { isWithinRectBounds } from './dimensions';
 import { AnnotationRectProps } from './types';
@@ -51,7 +51,7 @@ export function getRectAnnotationTooltipState(
     if (isWithinBounds) {
       return {
         isVisible: true,
-        annotationType: AnnotationTypes.Rectangle,
+        annotationType: AnnotationType.Rectangle,
         anchor: {
           left: cursorPosition.x,
           top: cursorPosition.y,

--- a/src/chart_types/xy_chart/annotations/utils.test.ts
+++ b/src/chart_types/xy_chart/annotations/utils.test.ts
@@ -20,7 +20,7 @@
 import { MockGlobalSpec } from '../../../mocks/specs';
 import { Position, Rotation } from '../../../utils/common';
 import { Dimensions } from '../../../utils/dimensions';
-import { AnnotationDomainTypes } from '../utils/specs';
+import { AnnotationDomainType } from '../utils/specs';
 import { getAnnotationAxis, getTransformedCursor, invertTranformedCursor } from './utils';
 
 describe('Annotation utils', () => {
@@ -38,15 +38,15 @@ describe('Annotation utils', () => {
   });
 
   test('should get associated axis for an annotation', () => {
-    const noAxis = getAnnotationAxis([], groupId, AnnotationDomainTypes.XDomain, 0);
+    const noAxis = getAnnotationAxis([], groupId, AnnotationDomainType.XDomain, 0);
     expect(noAxis).toBeUndefined();
 
     const localAxesSpecs = [horizontalAxisSpec, verticalAxisSpec];
 
-    const xAnnotationAxisPosition = getAnnotationAxis(localAxesSpecs, groupId, AnnotationDomainTypes.XDomain, 0);
+    const xAnnotationAxisPosition = getAnnotationAxis(localAxesSpecs, groupId, AnnotationDomainType.XDomain, 0);
     expect(xAnnotationAxisPosition).toEqual(Position.Bottom);
 
-    const yAnnotationAxisPosition = getAnnotationAxis(localAxesSpecs, groupId, AnnotationDomainTypes.YDomain, 0);
+    const yAnnotationAxisPosition = getAnnotationAxis(localAxesSpecs, groupId, AnnotationDomainType.YDomain, 0);
     expect(yAnnotationAxisPosition).toEqual(Position.Left);
   });
 

--- a/src/chart_types/xy_chart/annotations/utils.ts
+++ b/src/chart_types/xy_chart/annotations/utils.ts
@@ -25,13 +25,7 @@ import { Point } from '../../../utils/point';
 import { SmallMultipleScales } from '../state/selectors/compute_small_multiple_scales';
 import { isHorizontalRotation } from '../state/utils/common';
 import { getAxesSpecForSpecId } from '../state/utils/spec';
-import {
-  AnnotationDomainType,
-  AnnotationDomainTypes,
-  AnnotationSpec,
-  AxisSpec,
-  isLineAnnotation,
-} from '../utils/specs';
+import { AnnotationDomainType, AnnotationSpec, AxisSpec, isLineAnnotation } from '../utils/specs';
 import { computeLineAnnotationDimensions } from './line/dimensions';
 import { computeRectAnnotationDimensions } from './rect/dimensions';
 import { AnnotationDimensions } from './types';
@@ -53,7 +47,7 @@ export function getAnnotationAxis(
 
 /** @internal */
 export function isXDomain(domainType: AnnotationDomainType): boolean {
-  return domainType === AnnotationDomainTypes.XDomain;
+  return domainType === AnnotationDomainType.XDomain;
 }
 
 /** @internal */

--- a/src/chart_types/xy_chart/crosshair/crosshair_utils.linear_snap.test.ts
+++ b/src/chart_types/xy_chart/crosshair/crosshair_utils.linear_snap.test.ts
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { Dimensions } from '../../../utils/dimensions';
 import { computeSeriesDomains } from '../state/utils/utils';
 import { computeXScale } from '../utils/scales';
-import { BasicSeriesSpec, SeriesTypes } from '../utils/specs';
+import { BasicSeriesSpec, SeriesType } from '../utils/specs';
 import { getCursorBandPosition, getSnapPosition } from './crosshair_utils';
 
 describe('Crosshair utils linear scale', () => {
@@ -33,11 +33,11 @@ describe('Crosshair utils linear scale', () => {
   const lineSeries2SpecId = 'lineSeries2';
 
   const barSeries1: BasicSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: barSeries1SpecId,
     groupId: 'group1',
-    seriesType: SeriesTypes.Bar,
+    seriesType: SeriesType.Bar,
     data: [
       [0, 0],
       [1, 0],
@@ -49,11 +49,11 @@ describe('Crosshair utils linear scale', () => {
     yScaleType: ScaleType.Linear,
   };
   const barSeries2: BasicSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: barSeries2SpecId,
     groupId: 'group1',
-    seriesType: SeriesTypes.Bar,
+    seriesType: SeriesType.Bar,
     data: [
       [0, 2],
       [1, 2],
@@ -65,11 +65,11 @@ describe('Crosshair utils linear scale', () => {
     yScaleType: ScaleType.Linear,
   };
   const lineSeries1: BasicSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: lineSeries1SpecId,
     groupId: 'group1',
-    seriesType: SeriesTypes.Line,
+    seriesType: SeriesType.Line,
     data: [
       [0, 0],
       [1, 0],
@@ -81,11 +81,11 @@ describe('Crosshair utils linear scale', () => {
     yScaleType: ScaleType.Linear,
   };
   const lineSeries2: BasicSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: lineSeries2SpecId,
     groupId: 'group1',
-    seriesType: SeriesTypes.Line,
+    seriesType: SeriesType.Line,
     data: [
       [0, 2],
       [1, 2],

--- a/src/chart_types/xy_chart/crosshair/crosshair_utils.ordinal_snap.test.ts
+++ b/src/chart_types/xy_chart/crosshair/crosshair_utils.ordinal_snap.test.ts
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { computeSeriesDomains } from '../state/utils/utils';
 import { computeXScale } from '../utils/scales';
-import { BasicSeriesSpec, SeriesTypes } from '../utils/specs';
+import { BasicSeriesSpec, SeriesType } from '../utils/specs';
 import { getSnapPosition } from './crosshair_utils';
 
 describe('Crosshair utils ordinal scales', () => {
@@ -32,11 +32,11 @@ describe('Crosshair utils ordinal scales', () => {
   const lineSeries2SpecId = 'lineSeries2';
 
   const barSeries1: BasicSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: barSeries1SpecId,
     groupId: 'group1',
-    seriesType: SeriesTypes.Bar,
+    seriesType: SeriesType.Bar,
     data: [
       ['a', 0],
       ['b', 0],
@@ -48,11 +48,11 @@ describe('Crosshair utils ordinal scales', () => {
     yScaleType: ScaleType.Linear,
   };
   const barSeries2: BasicSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: barSeries2SpecId,
     groupId: 'group1',
-    seriesType: SeriesTypes.Bar,
+    seriesType: SeriesType.Bar,
     data: [
       ['a', 2],
       ['b', 2],
@@ -64,11 +64,11 @@ describe('Crosshair utils ordinal scales', () => {
     yScaleType: ScaleType.Linear,
   };
   const lineSeries1: BasicSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: lineSeries1SpecId,
     groupId: 'group1',
-    seriesType: SeriesTypes.Line,
+    seriesType: SeriesType.Line,
     data: [
       ['a', 0],
       ['b', 0],
@@ -80,11 +80,11 @@ describe('Crosshair utils ordinal scales', () => {
     yScaleType: ScaleType.Linear,
   };
   const lineSeries2: BasicSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: lineSeries2SpecId,
     groupId: 'group1',
-    seriesType: SeriesTypes.Line,
+    seriesType: SeriesType.Line,
     data: [
       ['a', 2],
       ['b', 2],

--- a/src/chart_types/xy_chart/domains/x_domain.test.ts
+++ b/src/chart_types/xy_chart/domains/x_domain.test.ts
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { MockSeriesSpecs } from '../../../mocks/specs';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes, Direction, BinAgg } from '../../../specs/constants';
+import { SpecType, Direction, BinAgg } from '../../../specs/constants';
 import { Logger } from '../../../utils/logger';
 import { getDataSeriesFromSpecs } from '../utils/series';
-import { BasicSeriesSpec, SeriesTypes } from '../utils/specs';
+import { BasicSeriesSpec, SeriesType } from '../utils/specs';
 import { convertXScaleTypes, findMinInterval, mergeXDomain } from './x_domain';
 
 jest.mock('../../../utils/logger', () => ({
@@ -48,7 +48,7 @@ describe('X Domain', () => {
   test('Should return correct scale type with single bar', () => {
     const seriesSpecs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType'>[] = [
       {
-        seriesType: SeriesTypes.Bar,
+        seriesType: SeriesType.Bar,
         xScaleType: ScaleType.Linear,
       },
     ];
@@ -62,7 +62,7 @@ describe('X Domain', () => {
   test('Should return correct scale type with single bar with Ordinal', () => {
     const seriesSpecs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType'>[] = [
       {
-        seriesType: SeriesTypes.Bar,
+        seriesType: SeriesType.Bar,
         xScaleType: ScaleType.Ordinal,
       },
     ];
@@ -76,7 +76,7 @@ describe('X Domain', () => {
   test('Should return correct scale type with single area', () => {
     const seriesSpecs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType'>[] = [
       {
-        seriesType: SeriesTypes.Area,
+        seriesType: SeriesType.Area,
         xScaleType: ScaleType.Linear,
       },
     ];
@@ -89,7 +89,7 @@ describe('X Domain', () => {
   test('Should return correct scale type with single line (time)', () => {
     const seriesSpecs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType' | 'timeZone'>[] = [
       {
-        seriesType: SeriesTypes.Line,
+        seriesType: SeriesType.Line,
         xScaleType: ScaleType.Time,
         timeZone: 'utc-3',
       },
@@ -104,12 +104,12 @@ describe('X Domain', () => {
   test('Should return correct scale type with multi line with same scale types (time) same tz', () => {
     const seriesSpecs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType' | 'timeZone'>[] = [
       {
-        seriesType: SeriesTypes.Line,
+        seriesType: SeriesType.Line,
         xScaleType: ScaleType.Time,
         timeZone: 'UTC-3',
       },
       {
-        seriesType: SeriesTypes.Line,
+        seriesType: SeriesType.Line,
         xScaleType: ScaleType.Time,
         timeZone: 'utc-3',
       },
@@ -124,12 +124,12 @@ describe('X Domain', () => {
   test('Should return correct scale type with multi line with same scale types (time) coerce to UTC', () => {
     const seriesSpecs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType' | 'timeZone'>[] = [
       {
-        seriesType: SeriesTypes.Line,
+        seriesType: SeriesType.Line,
         xScaleType: ScaleType.Time,
         timeZone: 'utc-3',
       },
       {
-        seriesType: SeriesTypes.Line,
+        seriesType: SeriesType.Line,
         xScaleType: ScaleType.Time,
         timeZone: 'utc+3',
       },
@@ -145,11 +145,11 @@ describe('X Domain', () => {
   test('Should return correct scale type with multi line with different scale types (linear, ordinal)', () => {
     const seriesSpecs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType'>[] = [
       {
-        seriesType: SeriesTypes.Line,
+        seriesType: SeriesType.Line,
         xScaleType: ScaleType.Linear,
       },
       {
-        seriesType: SeriesTypes.Line,
+        seriesType: SeriesType.Line,
         xScaleType: ScaleType.Ordinal,
       },
     ];
@@ -162,11 +162,11 @@ describe('X Domain', () => {
   test('Should return correct scale type with multi bar, area with different scale types (linear, ordinal)', () => {
     const seriesSpecs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType'>[] = [
       {
-        seriesType: SeriesTypes.Bar,
+        seriesType: SeriesType.Bar,
         xScaleType: ScaleType.Linear,
       },
       {
-        seriesType: SeriesTypes.Area,
+        seriesType: SeriesType.Area,
         xScaleType: ScaleType.Ordinal,
       },
     ];
@@ -179,11 +179,11 @@ describe('X Domain', () => {
   test('Should return correct scale type with multi bar, area with same scale types (linear, linear)', () => {
     const seriesSpecs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType' | 'timeZone'>[] = [
       {
-        seriesType: SeriesTypes.Bar,
+        seriesType: SeriesType.Bar,
         xScaleType: ScaleType.Linear,
       },
       {
-        seriesType: SeriesTypes.Area,
+        seriesType: SeriesType.Area,
         xScaleType: ScaleType.Time,
         timeZone: 'utc+3',
       },
@@ -197,11 +197,11 @@ describe('X Domain', () => {
 
   test('Should merge line series correctly', () => {
     const ds1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds1',
       groupId: 'g1',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -214,11 +214,11 @@ describe('X Domain', () => {
       ],
     };
     const ds2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds2',
       groupId: 'g1',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -233,7 +233,7 @@ describe('X Domain', () => {
     const mergedDomain = mergeXDomain(
       [
         {
-          seriesType: SeriesTypes.Line,
+          seriesType: SeriesType.Line,
           xScaleType: ScaleType.Linear,
         },
       ],
@@ -243,11 +243,11 @@ describe('X Domain', () => {
   });
   test('Should merge bar series correctly', () => {
     const ds1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds1',
       groupId: 'g1',
-      seriesType: SeriesTypes.Bar,
+      seriesType: SeriesType.Bar,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -260,11 +260,11 @@ describe('X Domain', () => {
       ],
     };
     const ds2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds2',
       groupId: 'g1',
-      seriesType: SeriesTypes.Bar,
+      seriesType: SeriesType.Bar,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -280,7 +280,7 @@ describe('X Domain', () => {
     const mergedDomain = mergeXDomain(
       [
         {
-          seriesType: SeriesTypes.Bar,
+          seriesType: SeriesType.Bar,
           xScaleType: ScaleType.Linear,
         },
       ],
@@ -290,11 +290,11 @@ describe('X Domain', () => {
   });
   test('Should merge multi bar series correctly', () => {
     const ds1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds1',
       groupId: 'g1',
-      seriesType: SeriesTypes.Bar,
+      seriesType: SeriesType.Bar,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -307,11 +307,11 @@ describe('X Domain', () => {
       ],
     };
     const ds2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds2',
       groupId: 'g2',
-      seriesType: SeriesTypes.Bar,
+      seriesType: SeriesType.Bar,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -327,11 +327,11 @@ describe('X Domain', () => {
     const mergedDomain = mergeXDomain(
       [
         {
-          seriesType: SeriesTypes.Bar,
+          seriesType: SeriesType.Bar,
           xScaleType: ScaleType.Linear,
         },
         {
-          seriesType: SeriesTypes.Bar,
+          seriesType: SeriesType.Bar,
           xScaleType: ScaleType.Linear,
         },
       ],
@@ -341,11 +341,11 @@ describe('X Domain', () => {
   });
   test('Should merge multi bar series correctly - 2', () => {
     const ds1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds1',
       groupId: 'g1',
-      seriesType: SeriesTypes.Bar,
+      seriesType: SeriesType.Bar,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -358,11 +358,11 @@ describe('X Domain', () => {
       ],
     };
     const ds2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds2',
       groupId: 'g2',
-      seriesType: SeriesTypes.Bar,
+      seriesType: SeriesType.Bar,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -378,11 +378,11 @@ describe('X Domain', () => {
     const mergedDomain = mergeXDomain(
       [
         {
-          seriesType: SeriesTypes.Bar,
+          seriesType: SeriesType.Bar,
           xScaleType: ScaleType.Linear,
         },
         {
-          seriesType: SeriesTypes.Bar,
+          seriesType: SeriesType.Bar,
           xScaleType: ScaleType.Linear,
         },
       ],
@@ -392,11 +392,11 @@ describe('X Domain', () => {
   });
   test('Should merge multi bar linear/bar ordinal series correctly', () => {
     const ds1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds1',
       groupId: 'g1',
-      seriesType: SeriesTypes.Bar,
+      seriesType: SeriesType.Bar,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -409,11 +409,11 @@ describe('X Domain', () => {
       ],
     };
     const ds2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds2',
       groupId: 'g2',
-      seriesType: SeriesTypes.Bar,
+      seriesType: SeriesType.Bar,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Ordinal,
@@ -429,11 +429,11 @@ describe('X Domain', () => {
     const mergedDomain = mergeXDomain(
       [
         {
-          seriesType: SeriesTypes.Bar,
+          seriesType: SeriesType.Bar,
           xScaleType: ScaleType.Linear,
         },
         {
-          seriesType: SeriesTypes.Bar,
+          seriesType: SeriesType.Bar,
           xScaleType: ScaleType.Ordinal,
         },
       ],
@@ -444,11 +444,11 @@ describe('X Domain', () => {
 
   test('Should fallback to ordinal scale if not array of numbers', () => {
     const ds1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds1',
       groupId: 'g1',
-      seriesType: SeriesTypes.Bar,
+      seriesType: SeriesType.Bar,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -462,11 +462,11 @@ describe('X Domain', () => {
       ],
     };
     const ds2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds2',
       groupId: 'g2',
-      seriesType: SeriesTypes.Bar,
+      seriesType: SeriesType.Bar,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -487,11 +487,11 @@ describe('X Domain', () => {
       mergeXDomain(
         [
           {
-            seriesType: SeriesTypes.Bar,
+            seriesType: SeriesType.Bar,
             xScaleType: ScaleType.Linear,
           },
           {
-            seriesType: SeriesTypes.Bar,
+            seriesType: SeriesType.Bar,
             xScaleType: ScaleType.Linear,
           },
         ],
@@ -509,11 +509,11 @@ describe('X Domain', () => {
 
   test('Should merge multi bar/line ordinal series correctly', () => {
     const ds1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds1',
       groupId: 'g1',
-      seriesType: SeriesTypes.Bar,
+      seriesType: SeriesType.Bar,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -526,11 +526,11 @@ describe('X Domain', () => {
       ],
     };
     const ds2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds2',
       groupId: 'g2',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Ordinal,
@@ -546,11 +546,11 @@ describe('X Domain', () => {
     const mergedDomain = mergeXDomain(
       [
         {
-          seriesType: SeriesTypes.Bar,
+          seriesType: SeriesType.Bar,
           xScaleType: ScaleType.Linear,
         },
         {
-          seriesType: SeriesTypes.Line,
+          seriesType: SeriesType.Line,
           xScaleType: ScaleType.Ordinal,
         },
       ],
@@ -560,11 +560,11 @@ describe('X Domain', () => {
   });
   test('Should merge multi bar/line time series correctly', () => {
     const ds1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds1',
       groupId: 'g1',
-      seriesType: SeriesTypes.Bar,
+      seriesType: SeriesType.Bar,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Ordinal,
@@ -577,11 +577,11 @@ describe('X Domain', () => {
       ],
     };
     const ds2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds2',
       groupId: 'g2',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Time,
@@ -597,11 +597,11 @@ describe('X Domain', () => {
     const mergedDomain = mergeXDomain(
       [
         {
-          seriesType: SeriesTypes.Bar,
+          seriesType: SeriesType.Bar,
           xScaleType: ScaleType.Ordinal,
         },
         {
-          seriesType: SeriesTypes.Line,
+          seriesType: SeriesType.Line,
           xScaleType: ScaleType.Time,
         },
       ],
@@ -611,11 +611,11 @@ describe('X Domain', () => {
   });
   test('Should merge multi lines series correctly', () => {
     const ds1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds1',
       groupId: 'g1',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Ordinal,
@@ -628,11 +628,11 @@ describe('X Domain', () => {
       ],
     };
     const ds2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds2',
       groupId: 'g2',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -648,11 +648,11 @@ describe('X Domain', () => {
     const mergedDomain = mergeXDomain(
       [
         {
-          seriesType: SeriesTypes.Line,
+          seriesType: SeriesType.Line,
           xScaleType: ScaleType.Ordinal,
         },
         {
-          seriesType: SeriesTypes.Line,
+          seriesType: SeriesType.Line,
           xScaleType: ScaleType.Linear,
         },
       ],
@@ -664,11 +664,11 @@ describe('X Domain', () => {
   test('Should merge X multi high volume of data', () => {
     const maxValues = 10000;
     const ds1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds1',
       groupId: 'g1',
-      seriesType: SeriesTypes.Area,
+      seriesType: SeriesType.Area,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Linear,
@@ -676,11 +676,11 @@ describe('X Domain', () => {
       data: new Array(maxValues).fill(0).map((d, i) => ({ x: i, y: i })),
     };
     const ds2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'ds2',
       groupId: 'g2',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       xAccessor: 'x',
       yAccessors: ['y'],
       xScaleType: ScaleType.Ordinal,
@@ -694,11 +694,11 @@ describe('X Domain', () => {
     const mergedDomain = mergeXDomain(
       [
         {
-          seriesType: SeriesTypes.Area,
+          seriesType: SeriesType.Area,
           xScaleType: ScaleType.Linear,
         },
         {
-          seriesType: SeriesTypes.Line,
+          seriesType: SeriesType.Line,
           xScaleType: ScaleType.Ordinal,
         },
       ],
@@ -738,7 +738,7 @@ describe('X Domain', () => {
     const xValues = new Set([1, 2, 3, 4, 5]);
     const xDomain = { min: 0, max: 3 };
     const specs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType'>[] = [
-      { seriesType: SeriesTypes.Line, xScaleType: ScaleType.Linear },
+      { seriesType: SeriesType.Line, xScaleType: ScaleType.Linear },
     ];
 
     const basicMergedDomain = mergeXDomain(specs, xValues, xDomain);
@@ -762,7 +762,7 @@ describe('X Domain', () => {
     const xValues = new Set([1, 2, 3, 4, 5]);
     const xDomain = { min: 0 };
     const specs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType'>[] = [
-      { seriesType: SeriesTypes.Line, xScaleType: ScaleType.Linear },
+      { seriesType: SeriesType.Line, xScaleType: ScaleType.Linear },
     ];
 
     const mergedDomain = mergeXDomain(specs, xValues, xDomain);
@@ -780,7 +780,7 @@ describe('X Domain', () => {
     const xValues = new Set([1, 2, 3, 4, 5]);
     const xDomain = { max: 3 };
     const specs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType'>[] = [
-      { seriesType: SeriesTypes.Line, xScaleType: ScaleType.Linear },
+      { seriesType: SeriesType.Line, xScaleType: ScaleType.Linear },
     ];
 
     const mergedDomain = mergeXDomain(specs, xValues, xDomain);
@@ -798,7 +798,7 @@ describe('X Domain', () => {
     const xValues = new Set(['a', 'b', 'c', 'd']);
     const xDomain = ['a', 'b', 'c'];
     const specs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType'>[] = [
-      { seriesType: SeriesTypes.Bar, xScaleType: ScaleType.Ordinal },
+      { seriesType: SeriesType.Bar, xScaleType: ScaleType.Ordinal },
     ];
     const basicMergedDomain = mergeXDomain(specs, xValues, xDomain);
     expect(basicMergedDomain.domain).toEqual(['a', 'b', 'c']);
@@ -814,7 +814,7 @@ describe('X Domain', () => {
   describe('should account for custom minInterval', () => {
     const xValues = new Set([1, 2, 3, 4, 5]);
     const specs: Pick<BasicSeriesSpec, 'seriesType' | 'xScaleType'>[] = [
-      { seriesType: SeriesTypes.Bar, xScaleType: ScaleType.Linear },
+      { seriesType: SeriesType.Bar, xScaleType: ScaleType.Linear },
     ];
 
     test('with valid minInterval', () => {
@@ -852,7 +852,7 @@ describe('X Domain', () => {
     const ordinalSpecs = MockSeriesSpecs.fromPartialSpecs([
       {
         id: 'ordinal1',
-        seriesType: SeriesTypes.Bar,
+        seriesType: SeriesType.Bar,
         xScaleType: ScaleType.Ordinal,
         data: [
           { x: 'a', y: 2 },
@@ -863,7 +863,7 @@ describe('X Domain', () => {
       },
       {
         id: 'ordinal2',
-        seriesType: SeriesTypes.Bar,
+        seriesType: SeriesType.Bar,
         xScaleType: ScaleType.Ordinal,
         data: [
           { x: 'a', y: 4 },
@@ -877,7 +877,7 @@ describe('X Domain', () => {
     const linearSpecs = MockSeriesSpecs.fromPartialSpecs([
       {
         id: 'linear1',
-        seriesType: SeriesTypes.Bar,
+        seriesType: SeriesType.Bar,
         xScaleType: ScaleType.Linear,
         data: [
           { x: 1, y: 2 },
@@ -888,7 +888,7 @@ describe('X Domain', () => {
       },
       {
         id: 'linear2',
-        seriesType: SeriesTypes.Bar,
+        seriesType: SeriesType.Bar,
         xScaleType: ScaleType.Linear,
         data: [
           { x: 1, y: 4 },

--- a/src/chart_types/xy_chart/domains/x_domain.ts
+++ b/src/chart_types/xy_chart/domains/x_domain.ts
@@ -24,7 +24,7 @@ import { compareByValueAsc, identity } from '../../../utils/common';
 import { computeContinuousDataDomain, computeOrdinalDataDomain } from '../../../utils/domain';
 import { Logger } from '../../../utils/logger';
 import { isCompleteBound, isLowerBound, isUpperBound } from '../utils/axis_type_utils';
-import { BasicSeriesSpec, CustomXDomain, SeriesTypes, XScaleType } from '../utils/specs';
+import { BasicSeriesSpec, CustomXDomain, SeriesType, XScaleType } from '../utils/specs';
 import { XDomain } from './types';
 
 /**
@@ -201,7 +201,7 @@ export function convertXScaleTypes(
   if (specs.length === 0 || seriesTypes.size === 0 || scaleTypes.size === 0) {
     return null;
   }
-  const isBandScale = seriesTypes.has(SeriesTypes.Bar);
+  const isBandScale = seriesTypes.has(SeriesType.Bar);
   if (scaleTypes.size === 1) {
     const scaleType = scaleTypes.values().next().value;
     let timeZone: string | undefined;

--- a/src/chart_types/xy_chart/domains/y_domain.test.ts
+++ b/src/chart_types/xy_chart/domains/y_domain.test.ts
@@ -17,16 +17,16 @@
  * under the License.
  */
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { MockSeriesSpec, MockGlobalSpec } from '../../../mocks/specs';
 import { MockStore } from '../../../mocks/store';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { Position } from '../../../utils/common';
 import { BARCHART_1Y0G } from '../../../utils/data_samples/test_dataset';
 import { Logger } from '../../../utils/logger';
 import { computeSeriesDomainsSelector } from '../state/selectors/compute_series_domains';
-import { BasicSeriesSpec, SeriesTypes, DEFAULT_GLOBAL_ID, StackMode } from '../utils/specs';
+import { BasicSeriesSpec, SeriesType, DEFAULT_GLOBAL_ID, StackMode } from '../utils/specs';
 import { coerceYScaleTypes, groupSeriesByYGroup } from './y_domain';
 
 jest.mock('../../../utils/logger', () => ({
@@ -227,11 +227,11 @@ describe('Y Domain', () => {
 
   test('Should split specs by groupId, two groups, non stacked', () => {
     const spec1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'spec1',
       groupId: 'group1',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',
@@ -239,11 +239,11 @@ describe('Y Domain', () => {
       data: BARCHART_1Y0G,
     };
     const spec2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'spec2',
       groupId: 'group2',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',
@@ -262,11 +262,11 @@ describe('Y Domain', () => {
   });
   test('Should split specs by groupId, two groups, stacked', () => {
     const spec1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'spec1',
       groupId: 'group1',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',
@@ -275,11 +275,11 @@ describe('Y Domain', () => {
       data: BARCHART_1Y0G,
     };
     const spec2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'spec2',
       groupId: 'group2',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',
@@ -299,11 +299,11 @@ describe('Y Domain', () => {
   });
   test('Should split specs by groupId, 1 group, stacked', () => {
     const spec1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'spec1',
       groupId: 'group',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',
@@ -312,11 +312,11 @@ describe('Y Domain', () => {
       data: BARCHART_1Y0G,
     };
     const spec2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'spec2',
       groupId: 'group',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',
@@ -334,11 +334,11 @@ describe('Y Domain', () => {
   });
   test('Should 3 split specs by groupId, 2 group, semi/stacked', () => {
     const spec1: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'spec1',
       groupId: 'group1',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',
@@ -347,11 +347,11 @@ describe('Y Domain', () => {
       data: BARCHART_1Y0G,
     };
     const spec2: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'spec2',
       groupId: 'group1',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',
@@ -360,11 +360,11 @@ describe('Y Domain', () => {
       data: BARCHART_1Y0G,
     };
     const spec3: BasicSeriesSpec = {
-      chartType: ChartTypes.XYAxis,
-      specType: SpecTypes.Series,
+      chartType: ChartType.XYAxis,
+      specType: SpecType.Series,
       id: 'spec3',
       groupId: 'group2',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',

--- a/src/chart_types/xy_chart/domains/y_domain.ts
+++ b/src/chart_types/xy_chart/domains/y_domain.ts
@@ -27,7 +27,7 @@ import { getSpecDomainGroupId } from '../state/utils/spec';
 import { isCompleteBound, isLowerBound, isUpperBound } from '../utils/axis_type_utils';
 import { groupBy } from '../utils/group_data_series';
 import { DataSeries } from '../utils/series';
-import { BasicSeriesSpec, YDomainRange, SeriesTypes, StackMode } from '../utils/specs';
+import { BasicSeriesSpec, YDomainRange, SeriesType, StackMode } from '../utils/specs';
 import { YDomain } from './types';
 
 export type YBasicSeriesSpec = Pick<
@@ -47,8 +47,7 @@ export function mergeYDomain(dataSeries: DataSeries[], domainsByGroupId: Map<Gro
     const nonStacked = groupedDataSeries.filter(({ isStacked, isFiltered }) => !isStacked && !isFiltered);
     const customDomain = domainsByGroupId.get(groupId);
     const hasNonZeroBaselineTypes = groupedDataSeries.some(
-      ({ seriesType, isFiltered }) =>
-        seriesType === SeriesTypes.Bar || (seriesType === SeriesTypes.Area && !isFiltered),
+      ({ seriesType, isFiltered }) => seriesType === SeriesType.Bar || (seriesType === SeriesType.Area && !isFiltered),
     );
     const domain = mergeYDomainForGroup(stacked, nonStacked, hasNonZeroBaselineTypes, customDomain);
     if (!domain) {
@@ -187,7 +186,7 @@ export function groupSeriesByYGroup(specs: YBasicSeriesSpec[]) {
  * @internal
  */
 export function isHistogramEnabled(specs: YBasicSeriesSpec[]) {
-  return specs.some(({ seriesType, enableHistogramMode }) => seriesType === SeriesTypes.Bar && enableHistogramMode);
+  return specs.some(({ seriesType, enableHistogramMode }) => seriesType === SeriesType.Bar && enableHistogramMode);
 }
 
 /**
@@ -197,7 +196,7 @@ export function isHistogramEnabled(specs: YBasicSeriesSpec[]) {
  * @internal
  */
 export function isStackedSpec(spec: YBasicSeriesSpec, histogramEnabled: boolean) {
-  const isBarAndHistogram = spec.seriesType === SeriesTypes.Bar && histogramEnabled;
+  const isBarAndHistogram = spec.seriesType === SeriesType.Bar && histogramEnabled;
   const hasStackAccessors = spec.stackAccessors && spec.stackAccessors.length > 0;
   return isBarAndHistogram || hasStackAccessors;
 }

--- a/src/chart_types/xy_chart/legend/legend.test.ts
+++ b/src/chart_types/xy_chart/legend/legend.test.ts
@@ -19,11 +19,11 @@
 
 import { Store } from 'redux';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { MockGlobalSpec, MockSeriesSpec } from '../../../mocks/specs/specs';
 import { MockStore } from '../../../mocks/store/store';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { onToggleDeselectSeriesAction } from '../../../state/actions/legend';
 import { GlobalChartState } from '../../../state/chart_state';
 import { Position, RecursivePartial } from '../../../utils/common';
@@ -31,7 +31,7 @@ import { AxisStyle } from '../../../utils/themes/theme';
 import { computeLegendSelector } from '../state/selectors/compute_legend';
 import { computeSeriesDomainsSelector } from '../state/selectors/compute_series_domains';
 import { getSeriesName } from '../utils/series';
-import { AxisSpec, BasicSeriesSpec, SeriesTypes } from '../utils/specs';
+import { AxisSpec, BasicSeriesSpec, SeriesType } from '../utils/specs';
 import { getLegendExtra } from './legend';
 
 const nullDisplayValue = {
@@ -41,12 +41,12 @@ const nullDisplayValue = {
 };
 
 const spec1: BasicSeriesSpec = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Series,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Series,
   id: 'spec1',
   name: 'Spec 1 title',
   groupId: 'group',
-  seriesType: SeriesTypes.Line,
+  seriesType: SeriesType.Line,
   yScaleType: ScaleType.Log,
   xScaleType: ScaleType.Linear,
   xAccessor: 'x',
@@ -55,11 +55,11 @@ const spec1: BasicSeriesSpec = {
   hideInLegend: false,
 };
 const spec2: BasicSeriesSpec = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Series,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Series,
   id: 'spec2',
   groupId: 'group',
-  seriesType: SeriesTypes.Line,
+  seriesType: SeriesType.Line,
   yScaleType: ScaleType.Log,
   xScaleType: ScaleType.Linear,
   xAccessor: 'x',
@@ -76,8 +76,8 @@ const style: RecursivePartial<AxisStyle> = {
 };
 const axesSpecs: AxisSpec[] = [];
 const axisSpec: AxisSpec = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Axis,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Axis,
   id: 'axis1',
   groupId: 'group1',
   hide: false,

--- a/src/chart_types/xy_chart/renderer/dom/annotations/tooltip_content.tsx
+++ b/src/chart_types/xy_chart/renderer/dom/annotations/tooltip_content.tsx
@@ -19,7 +19,7 @@
 
 import React, { useCallback } from 'react';
 
-import { AnnotationTypes, LineAnnotationDatum, RectAnnotationDatum } from '../../../../specs';
+import { AnnotationType, LineAnnotationDatum, RectAnnotationDatum } from '../../../../specs';
 import { AnnotationTooltipState } from '../../../annotations/types';
 
 /** @internal */
@@ -64,10 +64,10 @@ export const TooltipContent = ({
   }
 
   switch (annotationType) {
-    case AnnotationTypes.Line: {
+    case AnnotationType.Line: {
       return renderLine();
     }
-    case AnnotationTypes.Rectangle: {
+    case AnnotationType.Rectangle: {
       return renderRect();
     }
     default:

--- a/src/chart_types/xy_chart/rendering/rendering.areas.test.ts
+++ b/src/chart_types/xy_chart/rendering/rendering.areas.test.ts
@@ -916,11 +916,11 @@ describe('Rendering points - areas', () => {
 
   // describe('Error guards for scaled values', () => {
   //   const pointSeriesSpec: AreaSeriesSpec = {
-  //     chartType: ChartTypes.XYAxis,
-  //     specType: SpecTypes.Series,
+  //     chartType: ChartType.XYAxis,
+  //     specType: SpecType.Series,
   //     id: SPEC_ID,
   //     groupId: GROUP_ID,
-  //     seriesType: SeriesTypes.Area,
+  //     seriesType: SeriesType.Area,
   //     data: [
   //       [0, 10],
   //       [1, 5],

--- a/src/chart_types/xy_chart/rendering/rendering.bars.test.ts
+++ b/src/chart_types/xy_chart/rendering/rendering.bars.test.ts
@@ -213,11 +213,11 @@ describe('Rendering bars', () => {
   //   const spec1Id = 'bar1';
   //   const spec2Id = 'bar2';
   //   const barSeriesSpec1: BarSeriesSpec = {
-  //     chartType: ChartTypes.XYAxis,
-  //     specType: SpecTypes.Series,
+  //     chartType: ChartType.XYAxis,
+  //     specType: SpecType.Series,
   //     id: spec1Id,
   //     groupId: GROUP_ID,
-  //     seriesType: SeriesTypes.Bar,
+  //     seriesType: SeriesType.Bar,
   //     data: [
   //       [0, 10],
   //       [1, 5],
@@ -228,11 +228,11 @@ describe('Rendering bars', () => {
   //     yScaleType: ScaleType.Linear,
   //   };
   //   const barSeriesSpec2: BarSeriesSpec = {
-  //     chartType: ChartTypes.XYAxis,
-  //     specType: SpecTypes.Series,
+  //     chartType: ChartType.XYAxis,
+  //     specType: SpecType.Series,
   //     id: spec2Id,
   //     groupId: GROUP_ID,
-  //     seriesType: SeriesTypes.Bar,
+  //     seriesType: SeriesType.Bar,
   //     data: [
   //       [0, 20],
   //       [1, 10],
@@ -369,11 +369,11 @@ describe('Rendering bars', () => {
   // });
   // describe('Single series bar chart - linear', () => {
   //   const barSeriesSpec: BarSeriesSpec = {
-  //     chartType: ChartTypes.XYAxis,
-  //     specType: SpecTypes.Series,
+  //     chartType: ChartType.XYAxis,
+  //     specType: SpecType.Series,
   //     id: SPEC_ID,
   //     groupId: GROUP_ID,
-  //     seriesType: SeriesTypes.Bar,
+  //     seriesType: SeriesType.Bar,
   //     data: [
   //       [0, 10],
   //       [1, 5],
@@ -441,11 +441,11 @@ describe('Rendering bars', () => {
   // });
   // describe('Single series bar chart - log', () => {
   //   const barSeriesSpec: BarSeriesSpec = {
-  //     chartType: ChartTypes.XYAxis,
-  //     specType: SpecTypes.Series,
+  //     chartType: ChartType.XYAxis,
+  //     specType: SpecType.Series,
   //     id: SPEC_ID,
   //     groupId: GROUP_ID,
-  //     seriesType: SeriesTypes.Bar,
+  //     seriesType: SeriesType.Bar,
   //     data: [
   //       [1, 0],
   //       [2, 1],
@@ -487,11 +487,11 @@ describe('Rendering bars', () => {
   //   const spec1Id = 'bar1';
   //   const spec2Id = 'bar2';
   //   const barSeriesSpec1: BarSeriesSpec = {
-  //     chartType: ChartTypes.XYAxis,
-  //     specType: SpecTypes.Series,
+  //     chartType: ChartType.XYAxis,
+  //     specType: SpecType.Series,
   //     id: spec1Id,
   //     groupId: GROUP_ID,
-  //     seriesType: SeriesTypes.Bar,
+  //     seriesType: SeriesType.Bar,
   //     data: [
   //       [0, 10],
   //       [1, 5],
@@ -502,11 +502,11 @@ describe('Rendering bars', () => {
   //     yScaleType: ScaleType.Linear,
   //   };
   //   const barSeriesSpec2: BarSeriesSpec = {
-  //     chartType: ChartTypes.XYAxis,
-  //     specType: SpecTypes.Series,
+  //     chartType: ChartType.XYAxis,
+  //     specType: SpecType.Series,
   //     id: spec2Id,
   //     groupId: GROUP_ID,
-  //     seriesType: SeriesTypes.Bar,
+  //     seriesType: SeriesType.Bar,
   //     data: [
   //       [0, 20],
   //       [1, 10],
@@ -623,11 +623,11 @@ describe('Rendering bars', () => {
   //   const spec1Id = 'bar1';
   //   const spec2Id = 'bar2';
   //   const barSeriesSpec1: BarSeriesSpec = {
-  //     chartType: ChartTypes.XYAxis,
-  //     specType: SpecTypes.Series,
+  //     chartType: ChartType.XYAxis,
+  //     specType: SpecType.Series,
   //     id: spec1Id,
   //     groupId: GROUP_ID,
-  //     seriesType: SeriesTypes.Bar,
+  //     seriesType: SeriesType.Bar,
   //     data: [
   //       [1546300800000, 10],
   //       [1546387200000, 5],
@@ -638,11 +638,11 @@ describe('Rendering bars', () => {
   //     yScaleType: ScaleType.Linear,
   //   };
   //   const barSeriesSpec2: BarSeriesSpec = {
-  //     chartType: ChartTypes.XYAxis,
-  //     specType: SpecTypes.Series,
+  //     chartType: ChartType.XYAxis,
+  //     specType: SpecType.Series,
   //     id: spec2Id,
   //     groupId: GROUP_ID,
-  //     seriesType: SeriesTypes.Bar,
+  //     seriesType: SeriesType.Bar,
   //     data: [
   //       [1546300800000, 20],
   //       [1546387200000, 10],
@@ -762,11 +762,11 @@ describe('Rendering bars', () => {
   // });
   // describe('Remove points datum is not in domain', () => {
   //   const barSeriesSpec: BarSeriesSpec = {
-  //     chartType: ChartTypes.XYAxis,
-  //     specType: SpecTypes.Series,
+  //     chartType: ChartType.XYAxis,
+  //     specType: SpecType.Series,
   //     id: SPEC_ID,
   //     groupId: GROUP_ID,
-  //     seriesType: SeriesTypes.Bar,
+  //     seriesType: SeriesType.Bar,
   //     data: [
   //       [0, 0],
   //       [1, 1],
@@ -830,11 +830,11 @@ describe('Rendering bars', () => {
   //     [18, 100000],
   //   ];
   //   const barSeriesSpec: BarSeriesSpec = {
-  //     chartType: ChartTypes.XYAxis,
-  //     specType: SpecTypes.Series,
+  //     chartType: ChartType.XYAxis,
+  //     specType: SpecType.Series,
   //     id: SPEC_ID,
   //     groupId: GROUP_ID,
-  //     seriesType: SeriesTypes.Bar,
+  //     seriesType: SeriesType.Bar,
   //     data,
   //     xAccessor: 0,
   //     yAccessors: [1],

--- a/src/chart_types/xy_chart/rendering/rendering.lines.test.ts
+++ b/src/chart_types/xy_chart/rendering/rendering.lines.test.ts
@@ -26,7 +26,7 @@ import { Position } from '../../../utils/common';
 import { PointGeometry } from '../../../utils/geometry';
 import { LIGHT_THEME } from '../../../utils/themes/light_theme';
 import { computeSeriesGeometriesSelector } from '../state/selectors/compute_series_geometries';
-import { SeriesTypes } from '../utils/specs';
+import { SeriesType } from '../utils/specs';
 
 const SPEC_ID = 'spec_1';
 const GROUP_ID = 'group_1';
@@ -115,7 +115,7 @@ describe('Rendering points - line', () => {
     const pointSeriesSpec1 = MockSeriesSpec.line({
       id: spec1Id,
       groupId: GROUP_ID,
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       data: [
         [0, 10],
         [1, 5],

--- a/src/chart_types/xy_chart/specs/area_series.tsx
+++ b/src/chart_types/xy_chart/specs/area_series.tsx
@@ -19,16 +19,16 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { specComponentFactory, getConnect } from '../../../state/spec_factory';
-import { AreaSeriesSpec, HistogramModeAlignments, DEFAULT_GLOBAL_ID, SeriesTypes } from '../utils/specs';
+import { AreaSeriesSpec, HistogramModeAlignments, DEFAULT_GLOBAL_ID, SeriesType } from '../utils/specs';
 
 const defaultProps = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Series,
-  seriesType: SeriesTypes.Area,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Series,
+  seriesType: SeriesType.Area,
   groupId: DEFAULT_GLOBAL_ID,
   xScaleType: ScaleType.Linear,
   yScaleType: ScaleType.Linear,

--- a/src/chart_types/xy_chart/specs/axis.tsx
+++ b/src/chart_types/xy_chart/specs/axis.tsx
@@ -19,15 +19,15 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
-import { SpecTypes } from '../../../specs/constants';
+import { ChartType } from '../..';
+import { SpecType } from '../../../specs/constants';
 import { specComponentFactory, getConnect } from '../../../state/spec_factory';
 import { Position } from '../../../utils/common';
 import { AxisSpec, DEFAULT_GLOBAL_ID } from '../utils/specs';
 
 const defaultProps = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Axis,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Axis,
   groupId: DEFAULT_GLOBAL_ID,
   hide: false,
   showOverlappingTicks: false,

--- a/src/chart_types/xy_chart/specs/bar_series.tsx
+++ b/src/chart_types/xy_chart/specs/bar_series.tsx
@@ -19,16 +19,16 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { specComponentFactory, getConnect } from '../../../state/spec_factory';
-import { BarSeriesSpec, DEFAULT_GLOBAL_ID, SeriesTypes } from '../utils/specs';
+import { BarSeriesSpec, DEFAULT_GLOBAL_ID, SeriesType } from '../utils/specs';
 
 const defaultProps = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Series,
-  seriesType: SeriesTypes.Bar,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Series,
+  seriesType: SeriesType.Bar,
   groupId: DEFAULT_GLOBAL_ID,
   xScaleType: ScaleType.Ordinal,
   yScaleType: ScaleType.Linear,

--- a/src/chart_types/xy_chart/specs/bubble_series.tsx
+++ b/src/chart_types/xy_chart/specs/bubble_series.tsx
@@ -19,16 +19,16 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { specComponentFactory, getConnect } from '../../../state/spec_factory';
-import { BubbleSeriesSpec, DEFAULT_GLOBAL_ID, SeriesTypes } from '../utils/specs';
+import { BubbleSeriesSpec, DEFAULT_GLOBAL_ID, SeriesType } from '../utils/specs';
 
 const defaultProps = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Series,
-  seriesType: SeriesTypes.Bubble,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Series,
+  seriesType: SeriesType.Bubble,
   groupId: DEFAULT_GLOBAL_ID,
   xScaleType: ScaleType.Ordinal,
   yScaleType: ScaleType.Linear,

--- a/src/chart_types/xy_chart/specs/histogram_bar_series.tsx
+++ b/src/chart_types/xy_chart/specs/histogram_bar_series.tsx
@@ -19,16 +19,16 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { specComponentFactory, getConnect } from '../../../state/spec_factory';
-import { HistogramBarSeriesSpec, DEFAULT_GLOBAL_ID, SeriesTypes } from '../utils/specs';
+import { HistogramBarSeriesSpec, DEFAULT_GLOBAL_ID, SeriesType } from '../utils/specs';
 
 const defaultProps = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Series,
-  seriesType: SeriesTypes.Bar,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Series,
+  seriesType: SeriesType.Bar,
   groupId: DEFAULT_GLOBAL_ID,
   xScaleType: ScaleType.Linear,
   yScaleType: ScaleType.Linear,

--- a/src/chart_types/xy_chart/specs/line_annotation.test.tsx
+++ b/src/chart_types/xy_chart/specs/line_annotation.test.tsx
@@ -22,7 +22,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { createStore, Store } from 'redux';
 
-import { LineAnnotation, AnnotationDomainTypes } from '../../../specs';
+import { LineAnnotation, AnnotationDomainType } from '../../../specs';
 import { SpecsParser } from '../../../specs/specs_parser';
 import { chartStoreReducer, GlobalChartState } from '../../../state/chart_state';
 import { LineSeries } from './line_series';
@@ -45,7 +45,7 @@ function LineAnnotationChart(props: { chartStore: Store<GlobalChartState> }) {
         />
         <LineAnnotation
           id="threshold"
-          domainType={AnnotationDomainTypes.YDomain}
+          domainType={AnnotationDomainType.YDomain}
           dataValues={[{ dataValue: 120, details: 'threshold' }]}
         />
       </SpecsParser>

--- a/src/chart_types/xy_chart/specs/line_annotation.tsx
+++ b/src/chart_types/xy_chart/specs/line_annotation.tsx
@@ -19,17 +19,17 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
-import { SpecTypes } from '../../../specs/constants';
+import { ChartType } from '../..';
+import { SpecType } from '../../../specs/constants';
 import { getConnect, specComponentFactory } from '../../../state/spec_factory';
 import { DEFAULT_ANNOTATION_LINE_STYLE } from '../../../utils/themes/merge_utils';
-import { LineAnnotationSpec, DEFAULT_GLOBAL_ID, AnnotationTypes } from '../utils/specs';
+import { LineAnnotationSpec, DEFAULT_GLOBAL_ID, AnnotationType } from '../utils/specs';
 
 const defaultProps = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Annotation,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Annotation,
   groupId: DEFAULT_GLOBAL_ID,
-  annotationType: AnnotationTypes.Line,
+  annotationType: AnnotationType.Line,
   style: DEFAULT_ANNOTATION_LINE_STYLE,
   hideLines: false,
   hideTooltips: false,

--- a/src/chart_types/xy_chart/specs/line_series.tsx
+++ b/src/chart_types/xy_chart/specs/line_series.tsx
@@ -19,16 +19,16 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { specComponentFactory, getConnect } from '../../../state/spec_factory';
-import { LineSeriesSpec, DEFAULT_GLOBAL_ID, HistogramModeAlignments, SeriesTypes } from '../utils/specs';
+import { LineSeriesSpec, DEFAULT_GLOBAL_ID, HistogramModeAlignments, SeriesType } from '../utils/specs';
 
 const defaultProps = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Series,
-  seriesType: SeriesTypes.Line,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Series,
+  seriesType: SeriesType.Line,
   groupId: DEFAULT_GLOBAL_ID,
   xScaleType: ScaleType.Ordinal,
   yScaleType: ScaleType.Linear,

--- a/src/chart_types/xy_chart/specs/rect_annotation.tsx
+++ b/src/chart_types/xy_chart/specs/rect_annotation.tsx
@@ -19,17 +19,17 @@
 
 import React from 'react';
 
-import { ChartTypes } from '../..';
-import { SpecTypes } from '../../../specs/constants';
+import { ChartType } from '../..';
+import { SpecType } from '../../../specs/constants';
 import { specComponentFactory, getConnect } from '../../../state/spec_factory';
 import { DEFAULT_ANNOTATION_RECT_STYLE } from '../../../utils/themes/merge_utils';
-import { RectAnnotationSpec, DEFAULT_GLOBAL_ID, AnnotationTypes } from '../utils/specs';
+import { RectAnnotationSpec, DEFAULT_GLOBAL_ID, AnnotationType } from '../utils/specs';
 
 const defaultProps = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Annotation,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Annotation,
   groupId: DEFAULT_GLOBAL_ID,
-  annotationType: AnnotationTypes.Rectangle,
+  annotationType: AnnotationType.Rectangle,
   zIndex: -1,
   style: DEFAULT_ANNOTATION_RECT_STYLE,
 };

--- a/src/chart_types/xy_chart/state/chart_state.interactions.test.ts
+++ b/src/chart_types/xy_chart/state/chart_state.interactions.test.ts
@@ -21,19 +21,19 @@
 
 import { Store } from 'redux';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { Rect } from '../../../geoms/types';
 import { MockStore } from '../../../mocks/store';
 import { ScaleType } from '../../../scales/constants';
 import { SettingsSpec, XScaleType, XYBrushArea } from '../../../specs';
-import { SpecTypes, DEFAULT_SETTINGS_SPEC, TooltipType, BrushAxis } from '../../../specs/constants';
+import { SpecType, DEFAULT_SETTINGS_SPEC, TooltipType, BrushAxis } from '../../../specs/constants';
 import { onExternalPointerEvent } from '../../../state/actions/events';
 import { onPointerMove, onMouseDown, onMouseUp } from '../../../state/actions/mouse';
 import { GlobalChartState } from '../../../state/chart_state';
 import { getSettingsSpecSelector } from '../../../state/selectors/get_settings_specs';
 import { Position, RecursivePartial } from '../../../utils/common';
 import { AxisStyle } from '../../../utils/themes/theme';
-import { BarSeriesSpec, BasicSeriesSpec, AxisSpec, SeriesTypes } from '../utils/specs';
+import { BarSeriesSpec, BasicSeriesSpec, AxisSpec, SeriesType } from '../utils/specs';
 import { computeSeriesGeometriesSelector } from './selectors/compute_series_geometries';
 import { getCursorBandPositionSelector } from './selectors/get_cursor_band';
 import { getProjectedPointerPositionSelector } from './selectors/get_projected_pointer_position';
@@ -51,11 +51,11 @@ const SPEC_ID = 'spec_1';
 const GROUP_ID = 'group_1';
 
 const ordinalBarSeries: BarSeriesSpec = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Series,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Series,
   id: SPEC_ID,
   groupId: GROUP_ID,
-  seriesType: SeriesTypes.Bar,
+  seriesType: SeriesType.Bar,
   data: [
     [0, 10],
     [1, 5],
@@ -67,11 +67,11 @@ const ordinalBarSeries: BarSeriesSpec = {
   hideInLegend: false,
 };
 const linearBarSeries: BarSeriesSpec = {
-  chartType: ChartTypes.XYAxis,
-  specType: SpecTypes.Series,
+  chartType: ChartType.XYAxis,
+  specType: SpecType.Series,
   id: SPEC_ID,
   groupId: GROUP_ID,
-  seriesType: SeriesTypes.Bar,
+  seriesType: SeriesType.Bar,
   data: [
     [0, 10],
     [1, 5],
@@ -692,8 +692,8 @@ function mouseOverTestSuite(scaleType: XScaleType) {
     };
     beforeEach(() => {
       leftAxis = {
-        chartType: ChartTypes.XYAxis,
-        specType: SpecTypes.Axis,
+        chartType: ChartType.XYAxis,
+        specType: SpecType.Axis,
         hide: true,
         id: 'yaxis',
         groupId: GROUP_ID,
@@ -704,8 +704,8 @@ function mouseOverTestSuite(scaleType: XScaleType) {
         style,
       };
       bottomAxis = {
-        chartType: ChartTypes.XYAxis,
-        specType: SpecTypes.Axis,
+        chartType: ChartType.XYAxis,
+        specType: SpecType.Axis,
         hide: true,
         id: 'xaxis',
         groupId: GROUP_ID,

--- a/src/chart_types/xy_chart/state/chart_state.test.ts
+++ b/src/chart_types/xy_chart/state/chart_state.test.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { ChartTypes } from '../..';
-import { SpecTypes } from '../../../specs/constants';
+import { ChartType } from '../..';
+import { SpecType } from '../../../specs/constants';
 import { Position, RecursivePartial } from '../../../utils/common';
 import { AxisId } from '../../../utils/ids';
 import { AxisStyle } from '../../../utils/themes/theme';
@@ -35,8 +35,8 @@ describe('isDuplicateAxis', () => {
   const AXIS_1_ID = 'spec_1';
   const AXIS_2_ID = 'spec_1';
   const axis1: AxisSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Axis,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Axis,
     id: AXIS_1_ID,
     groupId: 'group_1',
     hide: false,

--- a/src/chart_types/xy_chart/state/chart_state.timescales.test.ts
+++ b/src/chart_types/xy_chart/state/chart_state.timescales.test.ts
@@ -20,17 +20,17 @@
 import { DateTime } from 'luxon';
 import { createStore, Store } from 'redux';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { ScaleType } from '../../../scales/constants';
 import { SettingsSpec } from '../../../specs';
-import { SpecTypes, DEFAULT_SETTINGS_SPEC } from '../../../specs/constants';
+import { SpecType, DEFAULT_SETTINGS_SPEC } from '../../../specs/constants';
 import { updateParentDimensions } from '../../../state/actions/chart_settings';
 import { onPointerMove } from '../../../state/actions/mouse';
 import { upsertSpec, specParsed } from '../../../state/actions/specs';
 import { chartStoreReducer, GlobalChartState } from '../../../state/chart_state';
 import { LIGHT_THEME } from '../../../utils/themes/light_theme';
 import { mergeWithDefaultTheme } from '../../../utils/themes/merge_utils';
-import { LineSeriesSpec, SeriesTypes } from '../utils/specs';
+import { LineSeriesSpec, SeriesType } from '../utils/specs';
 import { computeSeriesGeometriesSelector } from './selectors/compute_series_geometries';
 import { getComputedScalesSelector } from './selectors/get_computed_scales';
 import { getTooltipInfoSelector } from './selectors/get_tooltip_values_highlighted_geoms';
@@ -46,11 +46,11 @@ describe('Render chart', () => {
       store = createStore(storeReducer);
 
       const lineSeries: LineSeriesSpec = {
-        chartType: ChartTypes.XYAxis,
-        specType: SpecTypes.Series,
+        chartType: ChartType.XYAxis,
+        specType: SpecType.Series,
         id: 'lines',
         groupId: 'line',
-        seriesType: SeriesTypes.Line,
+        seriesType: SeriesType.Line,
         xScaleType: ScaleType.Time,
         yScaleType: ScaleType.Linear,
         xAccessor: 0,
@@ -78,7 +78,7 @@ describe('Render chart', () => {
       store.dispatch(updateParentDimensions({ width: 100, height: 100, top: 0, left: 0 }));
       const state = store.getState();
       expect(state.specs.lines).toBeDefined();
-      expect(state.chartType).toBe(ChartTypes.XYAxis);
+      expect(state.chartType).toBe(ChartType.XYAxis);
     });
     test('check rendered geometries', () => {
       const { geometries } = computeSeriesGeometriesSelector(store.getState());
@@ -121,11 +121,11 @@ describe('Render chart', () => {
       store = createStore(storeReducer);
 
       const lineSeries: LineSeriesSpec = {
-        chartType: ChartTypes.XYAxis,
-        specType: SpecTypes.Series,
+        chartType: ChartType.XYAxis,
+        specType: SpecType.Series,
         id: 'lines',
         groupId: 'line',
-        seriesType: SeriesTypes.Line,
+        seriesType: SeriesType.Line,
         xScaleType: ScaleType.Time,
         yScaleType: ScaleType.Linear,
         xAccessor: 0,
@@ -152,7 +152,7 @@ describe('Render chart', () => {
       store.dispatch(updateParentDimensions({ width: 100, height: 100, top: 0, left: 0 }));
       const state = store.getState();
       expect(state.specs.lines).toBeDefined();
-      expect(state.chartType).toBe(ChartTypes.XYAxis);
+      expect(state.chartType).toBe(ChartType.XYAxis);
     });
     test('check rendered geometries', () => {
       const { geometries } = computeSeriesGeometriesSelector(store.getState());
@@ -194,11 +194,11 @@ describe('Render chart', () => {
       const storeReducer = chartStoreReducer('chartId');
       store = createStore(storeReducer);
       const lineSeries: LineSeriesSpec = {
-        chartType: ChartTypes.XYAxis,
-        specType: SpecTypes.Series,
+        chartType: ChartType.XYAxis,
+        specType: SpecType.Series,
         id: 'lines',
         groupId: 'line',
-        seriesType: SeriesTypes.Line,
+        seriesType: SeriesType.Line,
         xScaleType: ScaleType.Time,
         yScaleType: ScaleType.Linear,
         xAccessor: 0,
@@ -225,7 +225,7 @@ describe('Render chart', () => {
       store.dispatch(updateParentDimensions({ width: 100, height: 100, top: 0, left: 0 }));
       const state = store.getState();
       expect(state.specs.lines).toBeDefined();
-      expect(state.chartType).toBe(ChartTypes.XYAxis);
+      expect(state.chartType).toBe(ChartType.XYAxis);
     });
     test('check rendered geometries', () => {
       const { geometries } = computeSeriesGeometriesSelector(store.getState());

--- a/src/chart_types/xy_chart/state/chart_state.tsx
+++ b/src/chart_types/xy_chart/state/chart_state.tsx
@@ -19,7 +19,7 @@
 
 import React, { RefObject } from 'react';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { LegendItemExtraValues } from '../../../common/legend';
 import { SeriesKey } from '../../../common/series_id';
 import { BrushTool } from '../../../components/brush/brush';
@@ -54,7 +54,7 @@ import { createOnPointerMoveCaller } from './selectors/on_pointer_move_caller';
 
 /** @internal */
 export class XYAxisChartState implements InternalChartState {
-  chartType: ChartTypes;
+  chartType: ChartType;
 
   legendId: string;
 
@@ -75,7 +75,7 @@ export class XYAxisChartState implements InternalChartState {
     this.onBrushEndCaller = createOnBrushEndCaller();
     this.onPointerMoveCaller = createOnPointerMoveCaller();
 
-    this.chartType = ChartTypes.XYAxis;
+    this.chartType = ChartType.XYAxis;
     this.legendId = htmlIdGenerator()('legend');
   }
 

--- a/src/chart_types/xy_chart/state/selectors/count_bars_in_cluster.ts
+++ b/src/chart_types/xy_chart/state/selectors/count_bars_in_cluster.ts
@@ -19,7 +19,7 @@
 
 import createCachedSelector from 're-reselect';
 
-import { SeriesTypes } from '../../../../specs';
+import { SeriesType } from '../../../../specs';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { groupBy } from '../../utils/group_data_series';
 import { SeriesDomainsAndData } from '../utils/types';
@@ -35,7 +35,7 @@ export const countBarsInClusterSelector = createCachedSelector(
 
 /** @internal */
 export function countBarsInCluster({ formattedDataSeries }: SeriesDomainsAndData, isHistogramEnabled: boolean): number {
-  const barDataSeries = formattedDataSeries.filter(({ seriesType }) => seriesType === SeriesTypes.Bar);
+  const barDataSeries = formattedDataSeries.filter(({ seriesType }) => seriesType === SeriesType.Bar);
 
   const dataSeriesGroupedByPanel = groupBy(
     barDataSeries,

--- a/src/chart_types/xy_chart/state/selectors/get_annotation_tooltip_state.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_annotation_tooltip_state.ts
@@ -33,7 +33,7 @@ import { AnnotationLineProps } from '../../annotations/line/types';
 import { AnnotationRectProps } from '../../annotations/rect/types';
 import { computeRectAnnotationTooltipState } from '../../annotations/tooltip';
 import { AnnotationTooltipState, AnnotationDimensions } from '../../annotations/types';
-import { AxisSpec, AnnotationSpec, AnnotationTypes } from '../../utils/specs';
+import { AxisSpec, AnnotationSpec, AnnotationType } from '../../utils/specs';
 import { ComputedGeometries } from '../utils/types';
 import { computeAnnotationDimensionsSelector } from './compute_annotations';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
@@ -107,7 +107,7 @@ function getAnnotationTooltipState(
   if (
     tooltipState &&
     tooltipState.isVisible &&
-    tooltipState.annotationType === AnnotationTypes.Rectangle &&
+    tooltipState.annotationType === AnnotationType.Rectangle &&
     isChartTooltipDisplayed
   ) {
     return null;
@@ -143,7 +143,7 @@ function getTooltipStateForDOMElements(
 
   return {
     isVisible: true,
-    annotationType: AnnotationTypes.Line,
+    annotationType: AnnotationType.Line,
     datum: dimension.datum,
     anchor: {
       top: (dimension.markers[0]?.position.top ?? 0) + dimension.panel.top + chartDimensions.top,

--- a/src/chart_types/xy_chart/state/selectors/get_specs.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_specs.ts
@@ -19,9 +19,9 @@
 
 import createCachedSelector from 're-reselect';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { GroupBySpec, SmallMultiplesSpec } from '../../../../specs';
-import { SpecTypes } from '../../../../specs/constants';
+import { SpecType } from '../../../../specs/constants';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSpecs } from '../../../../state/selectors/get_settings_specs';
 import { getSpecsFromStore } from '../../../../state/utils';
@@ -35,25 +35,25 @@ export interface SmallMultiplesGroupBy {
 
 /** @internal */
 export const getAxisSpecsSelector = createCachedSelector([getSpecs], (specs): AxisSpec[] =>
-  getSpecsFromStore<AxisSpec>(specs, ChartTypes.XYAxis, SpecTypes.Axis),
+  getSpecsFromStore<AxisSpec>(specs, ChartType.XYAxis, SpecType.Axis),
 )(getChartIdSelector);
 
 /** @internal */
 export const getSeriesSpecsSelector = createCachedSelector([getSpecs], (specs) => {
-  return getSpecsFromStore<BasicSeriesSpec>(specs, ChartTypes.XYAxis, SpecTypes.Series);
+  return getSpecsFromStore<BasicSeriesSpec>(specs, ChartType.XYAxis, SpecType.Series);
 })(getChartIdSelector);
 
 /** @internal */
 export const getAnnotationSpecsSelector = createCachedSelector([getSpecs], (specs) =>
-  getSpecsFromStore<AnnotationSpec>(specs, ChartTypes.XYAxis, SpecTypes.Annotation),
+  getSpecsFromStore<AnnotationSpec>(specs, ChartType.XYAxis, SpecType.Annotation),
 )(getChartIdSelector);
 
 /** @internal */
 export const getSmallMultiplesIndexOrderSelector = createCachedSelector([getSpecs], (specs):
   | SmallMultiplesGroupBy
   | undefined => {
-  const [smallMultiples] = getSpecsFromStore<SmallMultiplesSpec>(specs, ChartTypes.Global, SpecTypes.SmallMultiples);
-  const groupBySpecs = getSpecsFromStore<GroupBySpec>(specs, ChartTypes.Global, SpecTypes.IndexOrder);
+  const [smallMultiples] = getSpecsFromStore<SmallMultiplesSpec>(specs, ChartType.Global, SpecType.SmallMultiples);
+  const groupBySpecs = getSpecsFromStore<GroupBySpec>(specs, ChartType.Global, SpecType.IndexOrder);
   return {
     horizontal: groupBySpecs.find((s) => s.id === smallMultiples?.splitHorizontally),
     vertical: groupBySpecs.find((s) => s.id === smallMultiples?.splitVertically),

--- a/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
+++ b/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { Scale } from '../../../../scales';
 import { GroupBrushExtent, XYBrushArea } from '../../../../specs';
 import { BrushAxis } from '../../../../specs/constants';
@@ -51,7 +51,7 @@ export function createOnBrushEndCaller(): (state: GlobalChartState) => void {
   let prevProps: DragCheckProps | null = null;
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.XYAxis) {
+    if (selector === null && state.chartType === ChartType.XYAxis) {
       if (!isBrushAvailableSelector(state)) {
         selector = null;
         prevProps = null;

--- a/src/chart_types/xy_chart/state/selectors/on_click_caller.ts
+++ b/src/chart_types/xy_chart/state/selectors/on_click_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { ProjectedValues, SettingsSpec } from '../../../../specs';
 import { GlobalChartState, PointerState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
@@ -46,7 +46,7 @@ export function createOnClickCaller(): (state: GlobalChartState) => void {
     if (selector) {
       return selector(state);
     }
-    if (state.chartType !== ChartTypes.XYAxis) {
+    if (state.chartType !== ChartType.XYAxis) {
       return;
     }
     selector = createCachedSelector(

--- a/src/chart_types/xy_chart/state/selectors/on_element_out_caller.ts
+++ b/src/chart_types/xy_chart/state/selectors/on_element_out_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { SettingsSpec } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
@@ -59,7 +59,7 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
   let prevProps: Props | null = null;
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.XYAxis) {
+    if (selector === null && state.chartType === ChartType.XYAxis) {
       selector = createCachedSelector(
         [getTooltipInfoAndGeometriesSelector, getSettingsSpecSelector],
         ({ highlightedGeometries }: TooltipAndHighlightedGeoms, settings: SettingsSpec): void => {

--- a/src/chart_types/xy_chart/state/selectors/on_element_over_caller.ts
+++ b/src/chart_types/xy_chart/state/selectors/on_element_over_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { SettingsSpec } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
@@ -69,7 +69,7 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
   let prevProps: Props | null = null;
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.XYAxis) {
+    if (selector === null && state.chartType === ChartType.XYAxis) {
       selector = createCachedSelector(
         [getTooltipInfoAndGeometriesSelector, getSettingsSpecSelector],
         ({ highlightedGeometries }: TooltipAndHighlightedGeoms, settings: SettingsSpec): void => {

--- a/src/chart_types/xy_chart/state/selectors/on_pointer_move_caller.ts
+++ b/src/chart_types/xy_chart/state/selectors/on_pointer_move_caller.ts
@@ -20,7 +20,7 @@
 import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { Scale } from '../../../../scales';
 import { SettingsSpec, PointerEvent } from '../../../../specs';
 import { PointerEventType } from '../../../../specs/constants';
@@ -109,7 +109,7 @@ export function createOnPointerMoveCaller(): (state: GlobalChartState) => void {
   let prevPointerEvent: PointerEvent | null = null;
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
-    if (selector === null && state.chartType === ChartTypes.XYAxis) {
+    if (selector === null && state.chartType === ChartType.XYAxis) {
       selector = createCachedSelector(
         [getSettingsSpecSelector, getPointerEventSelector, getChartIdSelector],
         (settings: SettingsSpec, nextPointerEvent: PointerEvent, chartId: string): void => {

--- a/src/chart_types/xy_chart/state/utils/common.test.ts
+++ b/src/chart_types/xy_chart/state/utils/common.test.ts
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-import { ChartTypes } from '../../..';
+import { ChartType } from '../../..';
 import { LegendItem } from '../../../../common/legend';
 import { ScaleType } from '../../../../scales/constants';
-import { SpecTypes } from '../../../../specs';
+import { SpecType } from '../../../../specs';
 import { BARCHART_1Y1G } from '../../../../utils/data_samples/test_dataset';
 import { Point } from '../../../../utils/point';
-import { AreaSeriesSpec, SeriesTypes, LineSeriesSpec, BarSeriesSpec } from '../../utils/specs';
+import { AreaSeriesSpec, SeriesType, LineSeriesSpec, BarSeriesSpec } from '../../utils/specs';
 import {
   isHorizontalRotation,
   isVerticalRotation,
@@ -54,11 +54,11 @@ describe('Type Checks', () => {
   describe('#isLineAreaOnlyChart', () => {
     it('is an area or line only map', () => {
       const area: AreaSeriesSpec = {
-        chartType: ChartTypes.XYAxis,
-        specType: SpecTypes.Series,
+        chartType: ChartType.XYAxis,
+        specType: SpecType.Series,
         id: 'area',
         groupId: 'group1',
-        seriesType: SeriesTypes.Area,
+        seriesType: SeriesType.Area,
         yScaleType: ScaleType.Log,
         xScaleType: ScaleType.Linear,
         xAccessor: 'x',
@@ -67,11 +67,11 @@ describe('Type Checks', () => {
         data: BARCHART_1Y1G,
       };
       const line: LineSeriesSpec = {
-        chartType: ChartTypes.XYAxis,
-        specType: SpecTypes.Series,
+        chartType: ChartType.XYAxis,
+        specType: SpecType.Series,
         id: 'line',
         groupId: 'group2',
-        seriesType: SeriesTypes.Line,
+        seriesType: SeriesType.Line,
         yScaleType: ScaleType.Log,
         xScaleType: ScaleType.Linear,
         xAccessor: 'x',
@@ -81,11 +81,11 @@ describe('Type Checks', () => {
         data: BARCHART_1Y1G,
       };
       const bar: BarSeriesSpec = {
-        chartType: ChartTypes.XYAxis,
-        specType: SpecTypes.Series,
+        chartType: ChartType.XYAxis,
+        specType: SpecType.Series,
         id: 'bar',
         groupId: 'group2',
-        seriesType: SeriesTypes.Bar,
+        seriesType: SeriesType.Bar,
         yScaleType: ScaleType.Log,
         xScaleType: ScaleType.Linear,
         xAccessor: 'x',

--- a/src/chart_types/xy_chart/state/utils/common.ts
+++ b/src/chart_types/xy_chart/state/utils/common.ts
@@ -20,7 +20,7 @@
 import { LegendItem } from '../../../../common/legend';
 import { getDistance, Rotation } from '../../../../utils/common';
 import { Point } from '../../../../utils/point';
-import { BasicSeriesSpec, SeriesTypes } from '../../utils/specs';
+import { BasicSeriesSpec, SeriesType } from '../../utils/specs';
 import { GeometriesCounts } from './types';
 
 export const MAX_ANIMATABLE_BARS = 300;
@@ -41,7 +41,7 @@ export function isVerticalRotation(chartRotation: Rotation) {
  * @internal
  */
 export function isLineAreaOnlyChart(specs: BasicSeriesSpec[]) {
-  return !specs.some((spec) => spec.seriesType === SeriesTypes.Bar);
+  return !specs.some((spec) => spec.seriesType === SeriesType.Bar);
 }
 
 /** @internal */

--- a/src/chart_types/xy_chart/tooltip/tooltip.test.ts
+++ b/src/chart_types/xy_chart/tooltip/tooltip.test.ts
@@ -17,11 +17,11 @@
  * under the License.
  */
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { MockBarGeometry } from '../../../mocks';
 import { MockGlobalSpec, MockSeriesSpec } from '../../../mocks/specs';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { Position, RecursivePartial } from '../../../utils/common';
 import { BarGeometry } from '../../../utils/geometry';
 import { AxisStyle } from '../../../utils/themes/theme';
@@ -52,8 +52,8 @@ describe('Tooltip formatting', () => {
     y0Accessors: [1],
   });
   const YAXIS_SPEC = MockGlobalSpec.axis({
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Axis,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Axis,
     id: 'axis_1',
     groupId: SPEC_GROUP_ID_1,
     hide: false,

--- a/src/chart_types/xy_chart/utils/axis_utils.test.ts
+++ b/src/chart_types/xy_chart/utils/axis_utils.test.ts
@@ -20,12 +20,12 @@
 import { DateTime } from 'luxon';
 import moment from 'moment-timezone';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { MockGlobalSpec, MockSeriesSpec } from '../../../mocks/specs/specs';
 import { MockStore } from '../../../mocks/store/store';
 import { Scale } from '../../../scales';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { CanvasTextBBoxCalculator } from '../../../utils/bbox/canvas_text_bbox_calculator';
 import { SvgTextBBoxCalculator } from '../../../utils/bbox/svg_text_bbox_calculator';
 import { Position, mergePartial } from '../../../utils/common';
@@ -118,8 +118,8 @@ describe('Axis computational utils', () => {
     isHidden: false,
   };
   const verticalAxisSpec = MockGlobalSpec.axis({
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Axis,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Axis,
     id: 'axis_1',
     title: 'Axis 1',
     groupId: 'group_1',
@@ -133,8 +133,8 @@ describe('Axis computational utils', () => {
   });
 
   const horizontalAxisSpec = MockGlobalSpec.axis({
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Axis,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Axis,
     id: 'axis_2',
     title: 'Axis 2',
     groupId: 'group_1',
@@ -147,8 +147,8 @@ describe('Axis computational utils', () => {
   });
 
   const verticalAxisSpecWTitle = MockGlobalSpec.axis({
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Axis,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Axis,
     id: 'axis_1',
     groupId: 'group_1',
     title: 'v axis',
@@ -161,8 +161,8 @@ describe('Axis computational utils', () => {
     integersOnly: false,
   });
   const xAxisWithTime = MockGlobalSpec.axis({
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Axis,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Axis,
     id: 'axis_1',
     groupId: 'group_1',
     title: 'v axis',

--- a/src/chart_types/xy_chart/utils/dimensions.test.ts
+++ b/src/chart_types/xy_chart/utils/dimensions.test.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { ChartTypes } from '../..';
-import { SpecTypes } from '../../../specs/constants';
+import { ChartType } from '../..';
+import { SpecType } from '../../../specs/constants';
 import { Position } from '../../../utils/common';
 import { Margins } from '../../../utils/dimensions';
 import { AxisId } from '../../../utils/ids';
@@ -62,8 +62,8 @@ describe('Computed chart dimensions', () => {
     isHidden: false,
   };
   const axisLeftSpec: AxisSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Axis,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Axis,
     id: 'axis_1',
     groupId: 'group_1',
     hide: false,

--- a/src/chart_types/xy_chart/utils/series.test.ts
+++ b/src/chart_types/xy_chart/utils/series.test.ts
@@ -19,14 +19,14 @@
 
 import { flatten } from 'lodash';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { MockDataSeries } from '../../../mocks/series';
 import { MockSeriesIdentifier } from '../../../mocks/series/series_identifiers';
 import { MockSeriesSpec, MockGlobalSpec } from '../../../mocks/specs';
 import { MockStore } from '../../../mocks/store';
 import { SeededDataGenerator, getRandomNumberGenerator } from '../../../mocks/utils';
 import { ScaleType } from '../../../scales/constants';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { AccessorFn } from '../../../utils/accessor';
 import { Position } from '../../../utils/common';
 import * as TestDataset from '../../../utils/data_samples/test_dataset';
@@ -43,7 +43,7 @@ import {
   DataSeries,
   splitSeriesDataByAccessors,
 } from './series';
-import { BasicSeriesSpec, LineSeriesSpec, SeriesTypes, AreaSeriesSpec } from './specs';
+import { BasicSeriesSpec, LineSeriesSpec, SeriesType, AreaSeriesSpec } from './specs';
 import { formatStackedDataSeriesValues } from './stacked_series_utils';
 
 const dg = new SeededDataGenerator();
@@ -441,11 +441,11 @@ describe('Series', () => {
 
   test('should split an array of specs into data series', () => {
     const spec1: LineSeriesSpec = {
-      specType: SpecTypes.Series,
-      chartType: ChartTypes.XYAxis,
+      specType: SpecType.Series,
+      chartType: ChartType.XYAxis,
       id: 'spec1',
       groupId: 'group',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',
@@ -454,11 +454,11 @@ describe('Series', () => {
       hideInLegend: false,
     };
     const spec2: BasicSeriesSpec = {
-      specType: SpecTypes.Series,
-      chartType: ChartTypes.XYAxis,
+      specType: SpecType.Series,
+      chartType: ChartType.XYAxis,
       id: 'spec2',
       groupId: 'group2',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',
@@ -474,11 +474,11 @@ describe('Series', () => {
   });
   test('should compute data series for stacked specs', () => {
     const spec1: BasicSeriesSpec = {
-      specType: SpecTypes.Series,
-      chartType: ChartTypes.XYAxis,
+      specType: SpecType.Series,
+      chartType: ChartType.XYAxis,
       id: 'spec1',
       groupId: 'group',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',
@@ -487,11 +487,11 @@ describe('Series', () => {
       hideInLegend: false,
     };
     const spec2: BasicSeriesSpec = {
-      specType: SpecTypes.Series,
-      chartType: ChartTypes.XYAxis,
+      specType: SpecType.Series,
+      chartType: ChartType.XYAxis,
       id: 'spec2',
       groupId: 'group2',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',
@@ -576,11 +576,11 @@ describe('Series', () => {
     const id = 'splitSpec';
     const yAccessors = ['y1', 'y2'];
     const splitSpec: BasicSeriesSpec = {
-      specType: SpecTypes.Series,
-      chartType: ChartTypes.XYAxis,
+      specType: SpecType.Series,
+      chartType: ChartType.XYAxis,
       id,
       groupId: 'group',
-      seriesType: SeriesTypes.Line,
+      seriesType: SeriesType.Line,
       yScaleType: ScaleType.Log,
       xScaleType: ScaleType.Linear,
       xAccessor: 'x',

--- a/src/chart_types/xy_chart/utils/series.ts
+++ b/src/chart_types/xy_chart/utils/series.ts
@@ -31,7 +31,7 @@ import { groupSeriesByYGroup, isHistogramEnabled, isStackedSpec } from '../domai
 import { SmallMultiplesGroupBy } from '../state/selectors/get_specs';
 import { applyFitFunctionToDataSeries } from './fit_function_utils';
 import { groupBy } from './group_data_series';
-import { BasicSeriesSpec, SeriesNameConfigOptions, SeriesSpecs, SeriesTypes, StackMode } from './specs';
+import { BasicSeriesSpec, SeriesNameConfigOptions, SeriesSpecs, SeriesType, StackMode } from './specs';
 import { datumXSortPredicate, formatStackedDataSeriesValues } from './stacked_series_utils';
 
 /** @internal */
@@ -78,7 +78,7 @@ export interface XYChartSeriesIdentifier extends SeriesIdentifier {
 /** @internal */
 export type DataSeries = XYChartSeriesIdentifier & {
   groupId: GroupId;
-  seriesType: SeriesTypes;
+  seriesType: SeriesType;
   data: DataSeriesDatum[];
   isStacked: boolean;
   stackMode: StackMode | undefined;
@@ -88,7 +88,7 @@ export type DataSeries = XYChartSeriesIdentifier & {
 };
 
 /** @internal */
-export type DataSeriesCounts = { [key in SeriesTypes]: number };
+export type DataSeriesCounts = { [key in SeriesType]: number };
 
 /** @internal */
 export function getSeriesIndex(series: SeriesIdentifier[], target: SeriesIdentifier): number {

--- a/src/chart_types/xy_chart/utils/specs.ts
+++ b/src/chart_types/xy_chart/utils/specs.ts
@@ -19,13 +19,13 @@
 
 import { $Values } from 'utility-types';
 
-import { ChartTypes } from '../..';
+import { ChartType } from '../..';
 import { TooltipPortalSettings } from '../../../components/portal/types';
 import { ScaleContinuousType } from '../../../scales';
 import { ScaleType } from '../../../scales/constants';
 import { LogScaleOptions } from '../../../scales/scale_continuous';
 import { Spec } from '../../../specs';
-import { SpecTypes } from '../../../specs/constants';
+import { SpecType } from '../../../specs/constants';
 import { Accessor, AccessorFormat, AccessorFn } from '../../../utils/accessor';
 import { RecursivePartial, Color, Position, Datum } from '../../../utils/common';
 import { CurveType } from '../../../utils/curves';
@@ -51,7 +51,7 @@ export type BarStyleOverride = RecursivePartial<BarSeriesStyle> | Color | null;
 /** @public */
 export type PointStyleOverride = RecursivePartial<PointStyle> | Color | null;
 
-export const SeriesTypes = Object.freeze({
+export const SeriesType = Object.freeze({
   Area: 'area' as const,
   Bar: 'bar' as const,
   Line: 'line' as const,
@@ -62,7 +62,7 @@ export const SeriesTypes = Object.freeze({
  * XY series type
  * @public
  */
-export type SeriesTypes = $Values<typeof SeriesTypes>;
+export type SeriesType = $Values<typeof SeriesType>;
 
 /**
  * The offset and mode applied when stacking values
@@ -346,8 +346,8 @@ export interface DisplayValueSpec {
 }
 
 export interface SeriesSpec extends Spec {
-  specType: typeof SpecTypes.Series;
-  chartType: typeof ChartTypes.XYAxis;
+  specType: typeof SpecType.Series;
+  chartType: typeof ChartType.XYAxis;
   /**
    * The name of the spec. Also a mechanism to provide custom series names.
    */
@@ -366,7 +366,7 @@ export interface SeriesSpec extends Spec {
   /** An array of data */
   data: Datum[];
   /** The type of series you are looking to render */
-  seriesType: SeriesTypes;
+  seriesType: SeriesType;
   /** Set colors for specific series */
   color?: SeriesColorAccessor;
   /**
@@ -494,8 +494,8 @@ export type SeriesSpecs<S extends BasicSeriesSpec = BasicSeriesSpec> = Array<S>;
  */
 export type BarSeriesSpec = BasicSeriesSpec &
   Postfixes & {
-    /** @defaultValue `bar` {@link (SeriesTypes:type) | SeriesTypes.Bar} */
-    seriesType: typeof SeriesTypes.Bar;
+    /** @defaultValue `bar` {@link (SeriesType:type) | SeriesType.Bar} */
+    seriesType: typeof SeriesType.Bar;
     /** If true, will stack all BarSeries and align bars to ticks (instead of centered on ticks) */
     enableHistogramMode?: boolean;
     barSeriesStyle?: RecursivePartial<BarSeriesStyle>;
@@ -554,8 +554,8 @@ export type FitConfig = {
  */
 export type LineSeriesSpec = BasicSeriesSpec &
   HistogramConfig & {
-    /** @defaultValue `line` {@link (SeriesTypes:type) | SeriesTypes.Line} */
-    seriesType: typeof SeriesTypes.Line;
+    /** @defaultValue `line` {@link (SeriesType:type) | SeriesType.Line} */
+    seriesType: typeof SeriesType.Line;
     curve?: CurveType;
     lineSeriesStyle?: RecursivePartial<LineSeriesStyle>;
     /**
@@ -574,8 +574,8 @@ export type LineSeriesSpec = BasicSeriesSpec &
  * @alpha
  */
 export type BubbleSeriesSpec = BasicSeriesSpec & {
-  /** @defaultValue `bubble` {@link (SeriesTypes:type) | SeriesTypes.Bubble} */
-  seriesType: typeof SeriesTypes.Bubble;
+  /** @defaultValue `bubble` {@link (SeriesType:type) | SeriesType.Bubble} */
+  seriesType: typeof SeriesType.Bubble;
   bubbleSeriesStyle?: RecursivePartial<BubbleSeriesStyle>;
   /**
    * An optional functional accessor to return custom color or style for point datum
@@ -590,8 +590,8 @@ export type BubbleSeriesSpec = BasicSeriesSpec & {
 export type AreaSeriesSpec = BasicSeriesSpec &
   HistogramConfig &
   Postfixes & {
-    /** @defaultValue `area` {@link (SeriesTypes:type) | SeriesTypes.Area} */
-    seriesType: typeof SeriesTypes.Area;
+    /** @defaultValue `area` {@link (SeriesType:type) | SeriesType.Area} */
+    seriesType: typeof SeriesType.Area;
     /** The type of interpolator to be used to interpolate values between points */
     curve?: CurveType;
     areaSeriesStyle?: RecursivePartial<AreaSeriesStyle>;
@@ -631,8 +631,8 @@ export type HistogramModeAlignment = 'start' | 'center' | 'end';
  * This spec describe the configuration for a chart axis.
  */
 export interface AxisSpec extends Spec {
-  specType: typeof SpecTypes.Axis;
-  chartType: typeof ChartTypes.XYAxis;
+  specType: typeof SpecType.Axis;
+  chartType: typeof ChartType.XYAxis;
   /** The ID of the spec */
   id: AxisId;
   /** Style options for grid line */
@@ -694,19 +694,19 @@ export type TickFormatterOptions = {
 /** @public */
 export type TickFormatter<V = any> = (value: V, options?: TickFormatterOptions) => string;
 
-export const AnnotationTypes = Object.freeze({
+export const AnnotationType = Object.freeze({
   Line: 'line' as const,
   Rectangle: 'rectangle' as const,
   Text: 'text' as const,
 });
 /** @public */
-export type AnnotationType = $Values<typeof AnnotationTypes>;
+export type AnnotationType = $Values<typeof AnnotationType>;
 
 /**
  * The domain type enum that can be associated with an annotation
  * @public
  */
-export const AnnotationDomainTypes = Object.freeze({
+export const AnnotationDomainType = Object.freeze({
   XDomain: 'xDomain' as const,
   YDomain: 'yDomain' as const,
 });
@@ -715,7 +715,7 @@ export const AnnotationDomainTypes = Object.freeze({
  * The domain type that can be associated with an annotation
  * @public
  */
-export type AnnotationDomainType = $Values<typeof AnnotationDomainTypes>;
+export type AnnotationDomainType = $Values<typeof AnnotationDomainType>;
 
 /**
  * The descriptive object of a line annotation
@@ -738,7 +738,7 @@ export interface LineAnnotationDatum {
 
 /** @public */
 export type LineAnnotationSpec = BaseAnnotationSpec<
-  typeof AnnotationTypes.Line,
+  typeof AnnotationType.Line,
   LineAnnotationDatum,
   LineAnnotationStyle
 > & {
@@ -810,7 +810,7 @@ export interface RectAnnotationDatum {
 
 /** @public */
 export type RectAnnotationSpec = BaseAnnotationSpec<
-  typeof AnnotationTypes.Rectangle,
+  typeof AnnotationType.Rectangle,
   RectAnnotationDatum,
   RectAnnotationStyle
 > & {
@@ -844,13 +844,13 @@ export type AnnotationPortalSettings = TooltipPortalSettings<'chart'> & {
 };
 
 export interface BaseAnnotationSpec<
-  T extends typeof AnnotationTypes.Rectangle | typeof AnnotationTypes.Line,
+  T extends typeof AnnotationType.Rectangle | typeof AnnotationType.Line,
   D extends RectAnnotationDatum | LineAnnotationDatum,
   S extends RectAnnotationStyle | LineAnnotationStyle
 > extends Spec,
     AnnotationPortalSettings {
-  chartType: typeof ChartTypes.XYAxis;
-  specType: typeof SpecTypes.Annotation;
+  chartType: typeof ChartType.XYAxis;
+  specType: typeof SpecType.Annotation;
   /**
    * Annotation type: line, rectangle
    */
@@ -884,32 +884,32 @@ export type AnnotationSpec = LineAnnotationSpec | RectAnnotationSpec;
 
 /** @internal */
 export function isLineAnnotation(spec: AnnotationSpec): spec is LineAnnotationSpec {
-  return spec.annotationType === AnnotationTypes.Line;
+  return spec.annotationType === AnnotationType.Line;
 }
 
 /** @internal */
 export function isRectAnnotation(spec: AnnotationSpec): spec is RectAnnotationSpec {
-  return spec.annotationType === AnnotationTypes.Rectangle;
+  return spec.annotationType === AnnotationType.Rectangle;
 }
 
 /** @internal */
 export function isBarSeriesSpec(spec: BasicSeriesSpec): spec is BarSeriesSpec {
-  return spec.seriesType === SeriesTypes.Bar;
+  return spec.seriesType === SeriesType.Bar;
 }
 
 /** @internal */
 export function isBubbleSeriesSpec(spec: BasicSeriesSpec): spec is BubbleSeriesSpec {
-  return spec.seriesType === SeriesTypes.Bubble;
+  return spec.seriesType === SeriesType.Bubble;
 }
 
 /** @internal */
 export function isLineSeriesSpec(spec: BasicSeriesSpec): spec is LineSeriesSpec {
-  return spec.seriesType === SeriesTypes.Line;
+  return spec.seriesType === SeriesType.Line;
 }
 
 /** @internal */
 export function isAreaSeriesSpec(spec: BasicSeriesSpec): spec is AreaSeriesSpec {
-  return spec.seriesType === SeriesTypes.Area;
+  return spec.seriesType === SeriesType.Area;
 }
 
 /** @internal */

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 export * from './components';
-export { ChartTypes } from './chart_types';
+export { ChartType } from './chart_types';
 export { ChartSize, ChartSizeArray, ChartSizeObject } from './utils/chart_size';
 
 export { SpecId, GroupId, AxisId, AnnotationId } from './utils/ids';

--- a/src/mocks/series/series.ts
+++ b/src/mocks/series/series.ts
@@ -21,7 +21,7 @@ import { shuffle } from 'lodash';
 
 import { FullDataSeriesDatum, WithIndex } from '../../chart_types/xy_chart/utils/fit_function';
 import { DataSeries, DataSeriesDatum, XYChartSeriesIdentifier } from '../../chart_types/xy_chart/utils/series';
-import { SeriesTypes } from '../../specs';
+import { SeriesType } from '../../specs';
 import { mergePartial } from '../../utils/common';
 import { MockSeriesSpec } from '../specs';
 import { getRandomNumberGenerator } from '../utils';
@@ -46,7 +46,7 @@ export class MockDataSeries {
     key: 'spec1',
     data: [],
     groupId: 'group1',
-    seriesType: SeriesTypes.Bar,
+    seriesType: SeriesType.Bar,
     stackMode: undefined,
     spec: MockSeriesSpec.bar(),
     isStacked: false,

--- a/src/mocks/specs/specs.ts
+++ b/src/mocks/specs/specs.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ChartTypes } from '../../chart_types';
+import { ChartType } from '../../chart_types';
 import { config, percentFormatter } from '../../chart_types/partition_chart/layout/config';
 import { PartitionLayout } from '../../chart_types/partition_chart/layout/types/config_types';
 import { ShapeTreeNode } from '../../chart_types/partition_chart/layout/types/viewmodel_types';
@@ -32,27 +32,27 @@ import {
   HistogramBarSeriesSpec,
   LineSeriesSpec,
   BasicSeriesSpec,
-  SeriesTypes,
+  SeriesType,
   BubbleSeriesSpec,
   LineAnnotationSpec,
   RectAnnotationSpec,
-  AnnotationTypes,
-  AnnotationDomainTypes,
+  AnnotationType,
+  AnnotationDomainType,
   AxisSpec,
 } from '../../chart_types/xy_chart/utils/specs';
 import { Predicate } from '../../common/predicate';
 import { ScaleType } from '../../scales/constants';
-import { SettingsSpec, SpecTypes, DEFAULT_SETTINGS_SPEC, SmallMultiplesSpec, GroupBySpec, Spec } from '../../specs';
+import { SettingsSpec, SpecType, DEFAULT_SETTINGS_SPEC, SmallMultiplesSpec, GroupBySpec, Spec } from '../../specs';
 import { Datum, mergePartial, Position, RecursivePartial } from '../../utils/common';
 import { LIGHT_THEME } from '../../utils/themes/light_theme';
 
 /** @internal */
 export class MockSeriesSpec {
   private static readonly barBase: BarSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: 'spec1',
-    seriesType: SeriesTypes.Bar,
+    seriesType: SeriesType.Bar,
     groupId: DEFAULT_GLOBAL_ID,
     xScaleType: ScaleType.Ordinal,
     yScaleType: ScaleType.Linear,
@@ -64,10 +64,10 @@ export class MockSeriesSpec {
   };
 
   private static readonly histogramBarBase: HistogramBarSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: 'spec1',
-    seriesType: SeriesTypes.Bar,
+    seriesType: SeriesType.Bar,
     groupId: DEFAULT_GLOBAL_ID,
     xScaleType: ScaleType.Ordinal,
     yScaleType: ScaleType.Linear,
@@ -79,10 +79,10 @@ export class MockSeriesSpec {
   };
 
   private static readonly areaBase: AreaSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: 'spec1',
-    seriesType: SeriesTypes.Area,
+    seriesType: SeriesType.Area,
     groupId: DEFAULT_GLOBAL_ID,
     xScaleType: ScaleType.Ordinal,
     yScaleType: ScaleType.Linear,
@@ -94,10 +94,10 @@ export class MockSeriesSpec {
   };
 
   private static readonly lineBase: LineSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: 'spec1',
-    seriesType: SeriesTypes.Line,
+    seriesType: SeriesType.Line,
     groupId: DEFAULT_GLOBAL_ID,
     xScaleType: ScaleType.Ordinal,
     yScaleType: ScaleType.Linear,
@@ -109,10 +109,10 @@ export class MockSeriesSpec {
   };
 
   private static readonly bubbleBase: BubbleSeriesSpec = {
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Series,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Series,
     id: 'spec1',
-    seriesType: SeriesTypes.Bubble,
+    seriesType: SeriesType.Bubble,
     groupId: DEFAULT_GLOBAL_ID,
     xScaleType: ScaleType.Ordinal,
     yScaleType: ScaleType.Linear,
@@ -123,8 +123,8 @@ export class MockSeriesSpec {
   };
 
   private static readonly sunburstBase: PartitionSpec = {
-    chartType: ChartTypes.Partition,
-    specType: SpecTypes.Series,
+    chartType: ChartType.Partition,
+    specType: SpecType.Series,
     id: 'spec1',
     config: {
       ...config,
@@ -148,8 +148,8 @@ export class MockSeriesSpec {
   };
 
   private static readonly treemapBase: PartitionSpec = {
-    chartType: ChartTypes.Partition,
-    specType: SpecTypes.Series,
+    chartType: ChartType.Partition,
+    specType: SpecType.Series,
     id: 'spec1',
     config: {
       ...config,
@@ -218,17 +218,17 @@ export class MockSeriesSpec {
     });
   }
 
-  static byType(type?: SeriesTypes | 'histogram'): BasicSeriesSpec {
+  static byType(type?: SeriesType | 'histogram'): BasicSeriesSpec {
     switch (type) {
-      case SeriesTypes.Line:
+      case SeriesType.Line:
         return MockSeriesSpec.lineBase;
-      case SeriesTypes.Area:
+      case SeriesType.Area:
         return MockSeriesSpec.areaBase;
-      case SeriesTypes.Bubble:
+      case SeriesType.Bubble:
         return MockSeriesSpec.bubbleBase;
       case 'histogram':
         return MockSeriesSpec.histogramBarBase;
-      case SeriesTypes.Bar:
+      case SeriesType.Bar:
       default:
         return MockSeriesSpec.barBase;
     }
@@ -274,8 +274,8 @@ export class MockGlobalSpec {
 
   private static readonly axisBase: AxisSpec = {
     id: 'yAxis',
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Axis,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Axis,
     groupId: DEFAULT_GLOBAL_ID,
     hide: false,
     showOverlappingTicks: false,
@@ -298,8 +298,8 @@ export class MockGlobalSpec {
 
   private static readonly smallMultipleBase: SmallMultiplesSpec = {
     id: 'smallMultiple',
-    chartType: ChartTypes.Global,
-    specType: SpecTypes.SmallMultiples,
+    chartType: ChartType.Global,
+    specType: SpecType.SmallMultiples,
     style: {
       verticalPanelPadding: { outer: 0, inner: 0 },
       horizontalPanelPadding: { outer: 0, inner: 0 },
@@ -308,8 +308,8 @@ export class MockGlobalSpec {
 
   private static readonly groupByBase: GroupBySpec = {
     id: 'groupBy',
-    chartType: ChartTypes.Global,
-    specType: SpecTypes.IndexOrder,
+    chartType: ChartType.Global,
+    specType: SpecType.IndexOrder,
     by: ({ id }: Spec) => id,
     sort: Predicate.DataIndex,
   };
@@ -346,19 +346,19 @@ export class MockAnnotationSpec {
   private static readonly lineBase: LineAnnotationSpec = {
     id: 'line_annotation_1',
     groupId: DEFAULT_GLOBAL_ID,
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Annotation,
-    annotationType: AnnotationTypes.Line,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Annotation,
+    annotationType: AnnotationType.Line,
     dataValues: [],
-    domainType: AnnotationDomainTypes.XDomain,
+    domainType: AnnotationDomainType.XDomain,
   };
 
   private static readonly rectBase: RectAnnotationSpec = {
     id: 'rect_annotation_1',
     groupId: DEFAULT_GLOBAL_ID,
-    chartType: ChartTypes.XYAxis,
-    specType: SpecTypes.Annotation,
-    annotationType: AnnotationTypes.Rectangle,
+    chartType: ChartType.XYAxis,
+    specType: SpecType.Annotation,
+    annotationType: AnnotationType.Rectangle,
     dataValues: [],
   };
 

--- a/src/specs/constants.ts
+++ b/src/specs/constants.ts
@@ -19,12 +19,12 @@
 
 import { $Values } from 'utility-types';
 
-import { ChartTypes } from '../chart_types';
+import { ChartType } from '../chart_types';
 import { Position } from '../utils/common';
 import { LIGHT_THEME } from '../utils/themes/light_theme';
 import { SettingsSpec } from './settings';
 
-export const SpecTypes = Object.freeze({
+export const SpecType = Object.freeze({
   Series: 'series' as const,
   Axis: 'axis' as const,
   Annotation: 'annotation' as const,
@@ -33,7 +33,7 @@ export const SpecTypes = Object.freeze({
   SmallMultiples: 'small_multiples' as const,
 });
 /** @public */
-export type SpecTypes = $Values<typeof SpecTypes>;
+export type SpecType = $Values<typeof SpecType>;
 
 /**
  * Type of bin aggregations
@@ -129,8 +129,8 @@ export const DEFAULT_LEGEND_CONFIG = {
 
 export const DEFAULT_SETTINGS_SPEC: SettingsSpec = {
   id: '__global__settings___',
-  chartType: ChartTypes.Global,
-  specType: SpecTypes.Settings,
+  chartType: ChartType.Global,
+  specType: SpecType.Settings,
   rendering: 'canvas' as const,
   rotation: 0 as const,
   animateData: true,

--- a/src/specs/group_by.ts
+++ b/src/specs/group_by.ts
@@ -19,10 +19,10 @@
 import React from 'react';
 
 import { Spec } from '.';
-import { ChartTypes } from '../chart_types';
+import { ChartType } from '../chart_types';
 import { Predicate } from '../common/predicate';
 import { getConnect, specComponentFactory } from '../state/spec_factory';
-import { SpecTypes } from './constants';
+import { SpecType } from './constants';
 
 /** @alpha */
 export type GroupByAccessor = (spec: Spec, datum: any) => string | number;
@@ -53,8 +53,8 @@ export interface GroupBySpec extends Spec {
   format?: GroupByFormatter;
 }
 const DEFAULT_GROUP_BY_PROPS = {
-  chartType: ChartTypes.Global,
-  specType: SpecTypes.IndexOrder,
+  chartType: ChartType.Global,
+  specType: SpecType.IndexOrder,
 };
 
 type DefaultGroupByProps = 'chartType' | 'specType';

--- a/src/specs/index.ts
+++ b/src/specs/index.ts
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-import { ChartTypes } from '../chart_types';
+import { ChartType } from '../chart_types';
 
 export interface Spec {
   /** unique Spec identifier */
   id: string;
   /** Chart type define the type of chart that use this spec */
-  chartType: ChartTypes;
+  chartType: ChartType;
   /** The type of spec, can be series, axis, annotation, settings etc */
   specType: string;
 }

--- a/src/specs/small_multiples.ts
+++ b/src/specs/small_multiples.ts
@@ -19,10 +19,10 @@
 import React from 'react';
 
 import { Spec } from '.';
-import { ChartTypes } from '../chart_types';
+import { ChartType } from '../chart_types';
 import { Ratio } from '../common/geometry';
 import { getConnect, specComponentFactory } from '../state/spec_factory';
-import { SpecTypes } from './constants';
+import { SpecType } from './constants';
 
 /**
  * Can be used for margin or padding start/end (eg. left/right or top/bottom)
@@ -82,8 +82,8 @@ export interface SmallMultiplesSpec extends Spec {
 
 const DEFAULT_SMALL_MULTIPLES_PROPS = {
   id: '__global__small_multiples___',
-  chartType: ChartTypes.Global,
-  specType: SpecTypes.SmallMultiples,
+  chartType: ChartType.Global,
+  specType: SpecType.SmallMultiples,
 };
 
 /** @alpha */

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -19,7 +19,7 @@
 
 import React, { RefObject } from 'react';
 
-import { ChartTypes } from '../chart_types';
+import { ChartType } from '../chart_types';
 import { GoalState } from '../chart_types/goal_chart/state/chart_state';
 import { HeatmapState } from '../chart_types/heatmap/state/chart_state';
 import { PartitionState } from '../chart_types/partition_chart/state/chart_state';
@@ -60,7 +60,7 @@ export interface InternalChartState {
   /**
    * The chart type
    */
-  chartType: ChartTypes;
+  chartType: ChartType;
   isInitialized(globalState: GlobalChartState): InitStatus;
   /**
    * Returns a JSX element with the chart rendered (lenged excluded)
@@ -234,7 +234,7 @@ export interface GlobalChartState {
   /**
    * the chart type depending on the used specs
    */
-  chartType: ChartTypes | null;
+  chartType: ChartType | null;
   /**
    * a chart-type-dependant class that is used to render and share chart-type dependant functions
    */
@@ -406,10 +406,10 @@ export const chartStoreReducer = (chartId: string) => {
   };
 };
 
-function chartTypeFromSpecs(specs: SpecList): ChartTypes | null {
+function chartTypeFromSpecs(specs: SpecList): ChartType | null {
   const nonGlobalTypes = Object.values(specs)
     .map((s) => s.chartType)
-    .filter((type) => type !== ChartTypes.Global)
+    .filter((type) => type !== ChartType.Global)
     .filter(keepDistinct);
   if (nonGlobalTypes.length !== 1) {
     Logger.warn(`${nonGlobalTypes.length === 0 ? 'Zero' : 'Multiple'} chart types in the same configuration`);
@@ -418,15 +418,15 @@ function chartTypeFromSpecs(specs: SpecList): ChartTypes | null {
   return nonGlobalTypes[0];
 }
 
-const constructors: Record<ChartTypes, () => InternalChartState | null> = {
-  [ChartTypes.Goal]: () => new GoalState(),
-  [ChartTypes.Partition]: () => new PartitionState(),
-  [ChartTypes.XYAxis]: () => new XYAxisChartState(),
-  [ChartTypes.Heatmap]: () => new HeatmapState(),
-  [ChartTypes.Wordcloud]: () => new WordcloudState(),
-  [ChartTypes.Global]: () => null,
+const constructors: Record<ChartType, () => InternalChartState | null> = {
+  [ChartType.Goal]: () => new GoalState(),
+  [ChartType.Partition]: () => new PartitionState(),
+  [ChartType.XYAxis]: () => new XYAxisChartState(),
+  [ChartType.Heatmap]: () => new HeatmapState(),
+  [ChartType.Wordcloud]: () => new WordcloudState(),
+  [ChartType.Global]: () => null,
 }; // with no default, TS signals if a new chart type isn't added here too
 
-function newInternalState(chartType: ChartTypes | null): InternalChartState | null {
+function newInternalState(chartType: ChartType | null): InternalChartState | null {
   return chartType ? constructors[chartType]() : null;
 }

--- a/src/state/reducers/interactions.ts
+++ b/src/state/reducers/interactions.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ChartTypes } from '../../chart_types';
+import { ChartType } from '../../chart_types';
 import { drilldownActive } from '../../chart_types/partition_chart/state/selectors/drilldown_active';
 import { getPickedShapesLayerValues } from '../../chart_types/partition_chart/state/selectors/picked_shapes';
 import { LegendItem } from '../../common/legend';
@@ -206,7 +206,7 @@ function toggleDeselectedDataSeries(
 }
 
 function getDrilldownData(globalState: GlobalChartState) {
-  if (globalState.chartType !== ChartTypes.Partition || !drilldownActive(globalState)) {
+  if (globalState.chartType !== ChartType.Partition || !drilldownActive(globalState)) {
     return [];
   }
   const layerValues: LayerValue[] = getPickedShapesLayerValues(globalState)[0];

--- a/src/state/selectors/get_settings_specs.ts
+++ b/src/state/selectors/get_settings_specs.ts
@@ -19,8 +19,8 @@
 
 import createCachedSelector from 're-reselect';
 
-import { ChartTypes } from '../../chart_types';
-import { SpecTypes, DEFAULT_SETTINGS_SPEC } from '../../specs/constants';
+import { ChartType } from '../../chart_types';
+import { SpecType, DEFAULT_SETTINGS_SPEC } from '../../specs/constants';
 import { SettingsSpec } from '../../specs/settings';
 import { GlobalChartState } from '../chart_state';
 import { getSpecsFromStore } from '../utils';
@@ -33,7 +33,7 @@ export const getSpecs = (state: GlobalChartState) => state.specs;
 export const getSettingsSpecSelector = createCachedSelector(
   [getSpecs],
   (specs): SettingsSpec => {
-    const settingsSpecs = getSpecsFromStore<SettingsSpec>(specs, ChartTypes.Global, SpecTypes.Settings);
+    const settingsSpecs = getSpecsFromStore<SettingsSpec>(specs, ChartType.Global, SpecType.Settings);
     if (settingsSpecs.length === 1) {
       return settingsSpecs[0];
     }

--- a/src/state/selectors/get_small_multiples_spec.ts
+++ b/src/state/selectors/get_small_multiples_spec.ts
@@ -18,8 +18,8 @@
  */
 import createCachedSelector from 're-reselect';
 
-import { ChartTypes } from '../../chart_types';
-import { SpecTypes } from '../../specs/constants';
+import { ChartType } from '../../chart_types';
+import { SpecType } from '../../specs/constants';
 import { SmallMultiplesSpec } from '../../specs/small_multiples';
 import { getSpecsFromStore } from '../utils';
 import { getChartIdSelector } from './get_chart_id';
@@ -30,7 +30,7 @@ import { getSpecs } from './get_settings_specs';
  * @internal
  */
 export const getSmallMultiplesSpecs = createCachedSelector([getSpecs], (specs) =>
-  getSpecsFromStore<SmallMultiplesSpec>(specs, ChartTypes.Global, SpecTypes.SmallMultiples),
+  getSpecsFromStore<SmallMultiplesSpec>(specs, ChartType.Global, SpecType.SmallMultiples),
 )(getChartIdSelector);
 
 /**

--- a/src/state/utils.test.ts
+++ b/src/state/utils.test.ts
@@ -17,14 +17,14 @@
  * under the License.
  */
 
-import { ChartTypes } from '../chart_types';
-import { SpecTypes } from '../specs/constants';
+import { ChartType } from '../chart_types';
+import { SpecType } from '../specs/constants';
 import { getSpecsFromStore } from './utils';
 
 describe('State utils', () => {
   it('getSpecsFromStore shall return always the same object reference excluding the array', () => {
-    const spec1 = { id: 'id1', chartType: ChartTypes.XYAxis, specType: SpecTypes.Series };
-    const specs = getSpecsFromStore({ id1: spec1 }, ChartTypes.XYAxis, SpecTypes.Series);
+    const spec1 = { id: 'id1', chartType: ChartType.XYAxis, specType: SpecType.Series };
+    const specs = getSpecsFromStore({ id1: spec1 }, ChartType.XYAxis, SpecType.Series);
     expect(specs[0]).toBe(spec1);
   });
 });

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-import { ChartTypes } from '../chart_types';
+import { ChartType } from '../chart_types';
 import { Spec } from '../specs';
 import { SpecList, PointerState } from './chart_state';
 
 /** @internal */
-export function getSpecsFromStore<U extends Spec>(specs: SpecList, chartType: ChartTypes, specType?: string): U[] {
+export function getSpecsFromStore<U extends Spec>(specs: SpecList, chartType: ChartType, specType?: string): U[] {
   return Object.keys(specs)
     .filter((specId) => {
       const currentSpec = specs[specId];

--- a/stories/annotations/lines/1_x_continuous.tsx
+++ b/stories/annotations/lines/1_x_continuous.tsx
@@ -21,7 +21,7 @@ import { boolean, select } from '@storybook/addon-knobs';
 import React from 'react';
 
 import {
-  AnnotationDomainTypes,
+  AnnotationDomainType,
   Axis,
   BarSeries,
   Chart,
@@ -72,7 +72,7 @@ export const Example = () => {
       <Settings showLegend showLegendExtra debug={debug} rotation={rotation} />
       <LineAnnotation
         id="annotation_1"
-        domainType={AnnotationDomainTypes.XDomain}
+        domainType={AnnotationDomainType.XDomain}
         dataValues={dataValues}
         style={style}
         marker={<Icon type="alert" />}

--- a/stories/annotations/lines/2_x_ordinal.tsx
+++ b/stories/annotations/lines/2_x_ordinal.tsx
@@ -21,7 +21,7 @@ import { boolean, select } from '@storybook/addon-knobs';
 import React from 'react';
 
 import {
-  AnnotationDomainTypes,
+  AnnotationDomainType,
   Axis,
   BarSeries,
   Chart,
@@ -52,7 +52,7 @@ export const Example = () => {
       <Settings debug={debug} rotation={rotation} />
       <LineAnnotation
         id="annotation_1"
-        domainType={AnnotationDomainTypes.XDomain}
+        domainType={AnnotationDomainType.XDomain}
         dataValues={dataValues}
         marker={<Icon type="alert" />}
         markerPosition={markerPosition === 'undefined' ? undefined : markerPosition}

--- a/stories/annotations/lines/3_x_time.tsx
+++ b/stories/annotations/lines/3_x_time.tsx
@@ -21,7 +21,7 @@ import { boolean, select } from '@storybook/addon-knobs';
 import React from 'react';
 
 import {
-  AnnotationDomainTypes,
+  AnnotationDomainType,
   Axis,
   BarSeries,
   Chart,
@@ -68,7 +68,7 @@ export const Example = () => {
       <Settings debug={debug} rotation={rotation} />
       <LineAnnotation
         id="annotation_1"
-        domainType={AnnotationDomainTypes.XDomain}
+        domainType={AnnotationDomainType.XDomain}
         dataValues={dataValues}
         marker={<Icon type="alert" />}
         markerPosition={markerPosition === 'undefined' ? undefined : markerPosition}

--- a/stories/annotations/lines/4_y_domain.tsx
+++ b/stories/annotations/lines/4_y_domain.tsx
@@ -21,7 +21,7 @@ import { boolean, select } from '@storybook/addon-knobs';
 import React from 'react';
 
 import {
-  AnnotationDomainTypes,
+  AnnotationDomainType,
   Axis,
   BarSeries,
   Chart,
@@ -58,7 +58,7 @@ export const Example = () => {
       <Settings debug={debug} rotation={rotation} />
       <LineAnnotation
         id="annotation_1"
-        domainType={AnnotationDomainTypes.YDomain}
+        domainType={AnnotationDomainType.YDomain}
         dataValues={dataValues}
         marker={<Icon type="alert" />}
         markerPosition={markerPosition === 'undefined' ? undefined : markerPosition}

--- a/stories/annotations/lines/5_styling.tsx
+++ b/stories/annotations/lines/5_styling.tsx
@@ -21,7 +21,7 @@ import { boolean, color, number, select } from '@storybook/addon-knobs';
 import React from 'react';
 
 import {
-  AnnotationDomainTypes,
+  AnnotationDomainType,
   Axis,
   BarSeries,
   Chart,
@@ -83,7 +83,7 @@ export const Example = () => {
       <Settings debug={debug} rotation={rotation} />
       <LineAnnotation
         id="annotation_1"
-        domainType={AnnotationDomainTypes.XDomain}
+        domainType={AnnotationDomainType.XDomain}
         dataValues={dataValues}
         style={style}
         marker={<Icon type={marker} />}

--- a/stories/annotations/lines/6_test_single_bar_histogram.tsx
+++ b/stories/annotations/lines/6_test_single_bar_histogram.tsx
@@ -20,7 +20,7 @@
 import { boolean } from '@storybook/addon-knobs';
 import React from 'react';
 
-import { AnnotationDomainTypes, Axis, BarSeries, Chart, LineAnnotation, ScaleType, Settings } from '../../../src';
+import { AnnotationDomainType, Axis, BarSeries, Chart, LineAnnotation, ScaleType, Settings } from '../../../src';
 import { Position } from '../../../src/utils/common';
 import { getChartRotationKnob } from '../../utils/knobs';
 
@@ -58,7 +58,7 @@ export const Example = () => {
       <Settings debug={debug} rotation={rotation} xDomain={xDomain} />
       <LineAnnotation
         id="annotation_1"
-        domainType={AnnotationDomainTypes.XDomain}
+        domainType={AnnotationDomainType.XDomain}
         dataValues={dataValues}
         style={style}
       />

--- a/stories/annotations/lines/7_tooltip_options.tsx
+++ b/stories/annotations/lines/7_tooltip_options.tsx
@@ -28,7 +28,7 @@ import {
   ScaleType,
   Settings,
   LineAnnotation,
-  AnnotationDomainTypes,
+  AnnotationDomainType,
   LineAnnotationDatum,
 } from '../../../src';
 import { CustomAnnotationTooltip } from '../../../src/chart_types/xy_chart/annotations/types';
@@ -79,7 +79,7 @@ export const Example = () => {
       <Settings rotation={rotation} />
       <LineAnnotation
         id="annotation_1"
-        domainType={AnnotationDomainTypes.XDomain}
+        domainType={AnnotationDomainType.XDomain}
         offset={offset}
         dataValues={dataValues}
         boundary={boundary}

--- a/stories/bar/41_test_histogram_linear.tsx
+++ b/stories/bar/41_test_histogram_linear.tsx
@@ -21,7 +21,7 @@ import { boolean, number, select } from '@storybook/addon-knobs';
 import React from 'react';
 
 import {
-  AnnotationDomainTypes,
+  AnnotationDomainType,
   AreaSeries,
   Axis,
   BarSeries,
@@ -109,7 +109,7 @@ export const Example = () => {
       <Settings rotation={getChartRotationKnob()} theme={theme} debug={boolean('debug', true)} />
       <LineAnnotation
         id="line-annotation"
-        domainType={AnnotationDomainTypes.XDomain}
+        domainType={AnnotationDomainType.XDomain}
         dataValues={[{ dataValue: 2 }, { dataValue: 2.5 }, { dataValue: 3.5 }]}
         style={lineAnnotationStyle}
         marker={<div style={{ background: 'red', width: 10, height: 10 }} />}

--- a/stories/interactions/17_png_export.tsx
+++ b/stories/interactions/17_png_export.tsx
@@ -31,7 +31,7 @@ import {
   Partition,
   Datum,
   Goal,
-  ChartTypes,
+  ChartType,
 } from '../../src';
 import { BandFillColorAccessorInput } from '../../src/chart_types/goal_chart/specs';
 import { GoalSubtype } from '../../src/chart_types/goal_chart/specs/constants';
@@ -74,18 +74,14 @@ export const Example = () => {
     }
   };
   button('Export PNG', handler);
-  const selectedChart = select(
-    'chart type',
-    [ChartTypes.XYAxis, ChartTypes.Partition, ChartTypes.Goal],
-    ChartTypes.XYAxis,
-  );
+  const selectedChart = select('chart type', [ChartType.XYAxis, ChartType.Partition, ChartType.Goal], ChartType.XYAxis);
 
   switch (selectedChart) {
-    case ChartTypes.Partition:
+    case ChartType.Partition:
       return renderPartitionChart(chartRef);
-    case ChartTypes.Goal:
+    case ChartType.Goal:
       return renderGoalchart(chartRef);
-    case ChartTypes.XYAxis:
+    case ChartType.XYAxis:
     default:
       return renderXYAxisChart(chartRef);
   }

--- a/stories/mixed/6_fitting.tsx
+++ b/stories/mixed/6_fitting.tsx
@@ -30,7 +30,7 @@ import {
   ScaleType,
   Settings,
   Fit,
-  SeriesTypes,
+  SeriesType,
 } from '../../src';
 import { SB_KNOBS_PANEL } from '../utils/storybook';
 
@@ -103,10 +103,10 @@ export const Example = () => {
   const seriesType = select<string>(
     'seriesType',
     {
-      Area: SeriesTypes.Area,
-      Line: SeriesTypes.Line,
+      Area: SeriesType.Area,
+      Line: SeriesType.Line,
     },
-    SeriesTypes.Area,
+    SeriesType.Area,
   );
   const dataKey = select<keyof typeof dataTypes>(
     'dataset',
@@ -179,7 +179,7 @@ export const Example = () => {
       />
       <Axis id="bottom" position={Position.Bottom} title="Bottom axis" showOverlappingTicks />
       <Axis id="left" title="Left axis" position={Position.Left} />
-      {seriesType === SeriesTypes.Area ? (
+      {seriesType === SeriesType.Area ? (
         <AreaSeries
           id="test"
           xScaleType={xScaleType}

--- a/stories/small_multiples/1_grid.tsx
+++ b/stories/small_multiples/1_grid.tsx
@@ -34,7 +34,7 @@ import {
   Fit,
   LineAnnotation,
   BubbleSeries,
-  AnnotationDomainTypes,
+  AnnotationDomainType,
   Rotation,
   RectAnnotation,
 } from '../../src';
@@ -144,7 +144,7 @@ export const Example = () => {
         <LineAnnotation
           dataValues={[{ dataValue: 4 }]}
           id="test"
-          domainType={AnnotationDomainTypes.XDomain}
+          domainType={AnnotationDomainType.XDomain}
           marker={<div style={{ width: 10, height: 10, background: 'red' }} />}
           style={{
             line: {
@@ -159,7 +159,7 @@ export const Example = () => {
         <LineAnnotation
           dataValues={[{ dataValue: 5 }]}
           id="test2"
-          domainType={AnnotationDomainTypes.YDomain}
+          domainType={AnnotationDomainType.YDomain}
           marker={<div style={{ width: 10, height: 10, background: 'blue' }} />}
           style={{
             line: {

--- a/stories/small_multiples/4_horizontal_bars.tsx
+++ b/stories/small_multiples/4_horizontal_bars.tsx
@@ -31,7 +31,7 @@ import {
   Settings,
   BarSeries,
   LineAnnotation,
-  AnnotationDomainTypes,
+  AnnotationDomainType,
 } from '../../src';
 import { SeededDataGenerator } from '../../src/mocks/utils';
 import { SB_SOURCE_PANEL } from '../utils/storybook';
@@ -94,7 +94,7 @@ export const Example = () => {
           },
         ]}
         id="threshold"
-        domainType={AnnotationDomainTypes.YDomain}
+        domainType={AnnotationDomainType.YDomain}
         marker={marker}
         style={{
           line: {

--- a/stories/small_multiples/4_vertical_bars.tsx
+++ b/stories/small_multiples/4_vertical_bars.tsx
@@ -31,7 +31,7 @@ import {
   Settings,
   BarSeries,
   LineAnnotation,
-  AnnotationDomainTypes,
+  AnnotationDomainType,
   LIGHT_THEME,
   LineSeries,
 } from '../../src';
@@ -104,7 +104,7 @@ export const Example = () => {
           },
         ]}
         id="threshold"
-        domainType={AnnotationDomainTypes.YDomain}
+        domainType={AnnotationDomainType.YDomain}
         marker={marker}
         style={{
           line: {

--- a/stories/small_multiples/6_heterogeneous_cartesians.tsx
+++ b/stories/small_multiples/6_heterogeneous_cartesians.tsx
@@ -31,7 +31,7 @@ import {
   Settings,
   BarSeries,
   LineAnnotation,
-  AnnotationDomainTypes,
+  AnnotationDomainType,
   LIGHT_THEME,
   LineSeries,
   AreaSeries,
@@ -97,7 +97,7 @@ export const Example = () => {
           },
         ]}
         id="threshold"
-        domainType={AnnotationDomainTypes.YDomain}
+        domainType={AnnotationDomainType.YDomain}
         marker={marker}
         style={{
           line: {

--- a/wiki/overview.md
+++ b/wiki/overview.md
@@ -125,7 +125,7 @@ export interface SeriesSpec {
   /** An array of data */
   data: Datum[];
   /** The type of series you are looking to render */
-  seriesType: SeriesTypes;
+  seriesType: SeriesType;
   /** Set colors for specific series */
   color?: SeriesColorAccessor;
   /** If the series should appear in the legend
@@ -178,7 +178,7 @@ A `BarSeriesSpec` for example is the following intersection type:
 export type BarSeriesSpec = SeriesSpec &
   SeriesAccessors &
   SeriesScales & {
-    seriesType: SeriesTypes.Bar;
+    seriesType: SeriesType.Bar;
   };
 ```
 


### PR DESCRIPTION
Simple search and replace...low hanging fruit.
Also, not sure if the markdown files should be included in this refactor?

fix https://github.com/elastic/elastic-charts/issues/767
## Summary

I was searching for an easy pr to start understanding this repo.


I think there are still more enums to fixup, such as:
https://github.com/elastic/elastic-charts/blob/dce139a1e72b2ad136cb09dc4c705dcfff1720e6/src/specs/constants.ts#L27

