### PR TITLE
fix(brush): force brush tool per panel

### DIFF
--- a/src/chart_types/xy_chart/state/selectors/get_brush_area.test.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_brush_area.test.ts
@@ -17,62 +17,301 @@
  * under the License.
  */
 
-import { Dimensions } from '../../../../utils/dimensions';
-import { getBrushForXAxis, getBrushForYAxis, getBrushForBothAxis } from './get_brush_area';
+import { MockGlobalSpec, MockSeriesSpec } from '../../../../mocks/specs/specs';
+import { MockStore } from '../../../../mocks/store/store';
+import { ScaleType } from '../../../../scales/constants';
+import { BrushAxis } from '../../../../specs/constants';
+import { onMouseDown, onMouseUp, onPointerMove } from '../../../../state/actions/mouse';
+import { getBrushAreaSelector } from './get_brush_area';
 
-describe('getBrushArea Selector', () => {
-  it('should return the brush area', () => {
-    const chartDimensions: Dimensions = { left: 0, top: 0, width: 100, height: 110 };
+describe('getBrushArea selector', () => {
+  describe('compute brush', () => {
+    it('along the X axis', () => {
+      const store = MockStore.default({ left: 0, top: 0, width: 100, height: 100 });
+      const onBrushEnd = jest.fn();
+      MockStore.addSpecs(
+        [
+          MockGlobalSpec.settingsNoMargins({ onBrushEnd }),
+          MockSeriesSpec.line({
+            xAccessor: 0,
+            yAccessors: [1],
+            xScaleType: ScaleType.Linear,
+            data: [
+              [0, 10],
+              [0.5, 5],
+              [1, 3],
+            ],
+          }),
+        ],
+        store,
+      );
+      store.dispatch(onMouseDown({ x: 10, y: 10 }, 0));
+      store.dispatch(onPointerMove({ x: 30, y: 30 }, 1000));
+      const xBrushArea = getBrushAreaSelector(store.getState());
+      store.dispatch(onMouseUp({ x: 30, y: 30 }, 1100));
+      store.getState().internalChartState?.eventCallbacks(store.getState());
 
-    const xBrushArea = getBrushForXAxis(chartDimensions, 0, { x: 10, y: 10 }, { x: 30, y: 30 });
-    expect(xBrushArea).toEqual({
-      top: 0,
-      left: 10,
-      width: 20,
-      height: 110,
+      expect(onBrushEnd).toHaveBeenCalled();
+      expect(onBrushEnd.mock.calls[0][0].x[0]).toBeCloseTo(0.1);
+      expect(onBrushEnd.mock.calls[0][0].x[1]).toBeCloseTo(0.3);
+
+      expect(xBrushArea).toEqual({
+        top: 0,
+        left: 10,
+        width: 20,
+        height: 100,
+      });
     });
-    const yBrushArea = getBrushForYAxis(chartDimensions, 0, { x: 10, y: 10 }, { x: 30, y: 30 });
-    expect(yBrushArea).toEqual({
-      top: 10,
-      left: 0,
-      width: 100,
-      height: 20,
+
+    it('along the Y axis', () => {
+      const store = MockStore.default({ left: 0, top: 0, width: 100, height: 100 });
+      const onBrushEnd = jest.fn();
+      MockStore.addSpecs(
+        [
+          MockGlobalSpec.settingsNoMargins({ onBrushEnd, brushAxis: BrushAxis.Y }),
+          MockSeriesSpec.line({
+            xAccessor: 0,
+            yAccessors: [1],
+            xScaleType: ScaleType.Linear,
+            data: [
+              [0, 10],
+              [0.5, 5],
+              [1, 3],
+            ],
+          }),
+        ],
+        store,
+      );
+      store.dispatch(onMouseDown({ x: 10, y: 10 }, 0));
+      store.dispatch(onPointerMove({ x: 30, y: 30 }, 1000));
+      const yBrushArea = getBrushAreaSelector(store.getState());
+      store.dispatch(onMouseUp({ x: 30, y: 30 }, 1100));
+      store.getState().internalChartState?.eventCallbacks(store.getState());
+
+      expect(onBrushEnd).toHaveBeenCalled();
+      const brushData = onBrushEnd.mock.calls[0][0].y;
+
+      expect(brushData[0].extent[0]).toBeCloseTo(7);
+      expect(brushData[0].extent[1]).toBeCloseTo(9);
+
+      expect(yBrushArea).toEqual({
+        top: 10,
+        left: 0,
+        width: 100,
+        height: 20,
+      });
     });
 
-    const bothBrushArea = getBrushForBothAxis(chartDimensions, { x: 10, y: 10 }, { x: 30, y: 30 });
-    expect(bothBrushArea).toEqual({
-      top: 10,
-      left: 10,
-      width: 20,
-      height: 20,
+    it('along both axis', () => {
+      const store = MockStore.default({ left: 0, top: 0, width: 100, height: 100 });
+      const onBrushEnd = jest.fn();
+      MockStore.addSpecs(
+        [
+          MockGlobalSpec.settingsNoMargins({ onBrushEnd, brushAxis: BrushAxis.Both }),
+          MockSeriesSpec.line({
+            xAccessor: 0,
+            yAccessors: [1],
+            xScaleType: ScaleType.Linear,
+            data: [
+              [0, 10],
+              [0.5, 5],
+              [1, 3],
+            ],
+          }),
+        ],
+        store,
+      );
+      store.dispatch(onMouseDown({ x: 10, y: 10 }, 0));
+      store.dispatch(onPointerMove({ x: 30, y: 30 }, 1000));
+      const bothBrushArea = getBrushAreaSelector(store.getState());
+      store.dispatch(onMouseUp({ x: 30, y: 30 }, 1100));
+      store.getState().internalChartState?.eventCallbacks(store.getState());
+
+      expect(onBrushEnd).toHaveBeenCalled();
+
+      expect(onBrushEnd.mock.calls[0][0].x[0]).toBeCloseTo(0.1);
+      expect(onBrushEnd.mock.calls[0][0].x[1]).toBeCloseTo(0.3);
+      expect(onBrushEnd.mock.calls[0][0].y[0].extent[0]).toBeCloseTo(7);
+      expect(onBrushEnd.mock.calls[0][0].y[0].extent[1]).toBeCloseTo(9);
+
+      expect(bothBrushArea).toEqual({
+        top: 10,
+        left: 10,
+        width: 20,
+        height: 20,
+      });
     });
   });
 
-  it('should return the brush area on rotated chart', () => {
-    const chartDimensions: Dimensions = { left: 0, top: 0, width: 100, height: 110 };
+  describe('compute brush on a rotated chart', () => {
+    it('along the X axis', () => {
+      const store = MockStore.default({ left: 0, top: 0, width: 100, height: 100 });
+      const onBrushEnd = jest.fn();
+      MockStore.addSpecs(
+        [
+          MockGlobalSpec.settingsNoMargins({ onBrushEnd, rotation: 90 }),
+          MockSeriesSpec.line({
+            xAccessor: 0,
+            yAccessors: [1],
+            xScaleType: ScaleType.Linear,
+            data: [
+              [0, 10],
+              [0.5, 5],
+              [1, 3],
+            ],
+          }),
+        ],
+        store,
+      );
+      store.dispatch(onMouseDown({ x: 10, y: 10 }, 0));
+      store.dispatch(onPointerMove({ x: 30, y: 30 }, 1000));
+      const xBrushArea = getBrushAreaSelector(store.getState());
+      store.dispatch(onMouseUp({ x: 30, y: 30 }, 1100));
+      store.getState().internalChartState?.eventCallbacks(store.getState());
 
-    const brushArea = getBrushForXAxis(chartDimensions, 90, { x: 10, y: 10 }, { x: 30, y: 30 });
-    expect(brushArea).toEqual({
-      top: 10,
-      left: 0,
-      width: 100,
-      height: 20,
+      expect(onBrushEnd).toHaveBeenCalled();
+      expect(onBrushEnd.mock.calls[0][0].x[0]).toBeCloseTo(0.1);
+      expect(onBrushEnd.mock.calls[0][0].x[1]).toBeCloseTo(0.3);
+
+      expect(xBrushArea).toEqual({
+        top: 10,
+        left: 0,
+        width: 100,
+        height: 20,
+      });
     });
 
-    const yBrushArea = getBrushForYAxis(chartDimensions, 90, { x: 10, y: 10 }, { x: 30, y: 30 });
-    expect(yBrushArea).toEqual({
-      top: 0,
-      left: 10,
-      width: 20,
-      height: 110,
+    it('along the Y axis', () => {
+      const store = MockStore.default({ left: 0, top: 0, width: 100, height: 100 });
+      const onBrushEnd = jest.fn();
+      MockStore.addSpecs(
+        [
+          MockGlobalSpec.settingsNoMargins({ onBrushEnd, brushAxis: BrushAxis.Y, rotation: 90 }),
+          MockSeriesSpec.line({
+            xAccessor: 0,
+            yAccessors: [1],
+            xScaleType: ScaleType.Linear,
+            data: [
+              [0, 10],
+              [0.5, 5],
+              [1, 3],
+            ],
+          }),
+        ],
+        store,
+      );
+      store.dispatch(onMouseDown({ x: 10, y: 10 }, 0));
+      store.dispatch(onPointerMove({ x: 30, y: 30 }, 1000));
+      const yBrushArea = getBrushAreaSelector(store.getState());
+      store.dispatch(onMouseUp({ x: 30, y: 30 }, 1100));
+      store.getState().internalChartState?.eventCallbacks(store.getState());
+
+      expect(onBrushEnd).toHaveBeenCalled();
+      const brushData = onBrushEnd.mock.calls[0][0].y;
+
+      expect(brushData[0].extent[0]).toBeCloseTo(1);
+      expect(brushData[0].extent[1]).toBeCloseTo(3);
+
+      expect(yBrushArea).toEqual({
+        top: 0,
+        left: 10,
+        width: 20,
+        height: 100,
+      });
     });
 
-    const bothBrushArea = getBrushForBothAxis(chartDimensions, { x: 10, y: 10 }, { x: 30, y: 30 });
+    it('along both axis', () => {
+      const store = MockStore.default({ left: 0, top: 0, width: 100, height: 100 });
+      const onBrushEnd = jest.fn();
+      MockStore.addSpecs(
+        [
+          MockGlobalSpec.settingsNoMargins({ onBrushEnd, brushAxis: BrushAxis.Both, rotation: 90 }),
+          MockSeriesSpec.line({
+            xAccessor: 0,
+            yAccessors: [1],
+            xScaleType: ScaleType.Linear,
+            data: [
+              [0, 10],
+              [0.5, 5],
+              [1, 3],
+            ],
+          }),
+        ],
+        store,
+      );
+      store.dispatch(onMouseDown({ x: 10, y: 10 }, 0));
+      store.dispatch(onPointerMove({ x: 30, y: 30 }, 1000));
+      const bothBrushArea = getBrushAreaSelector(store.getState());
+      store.dispatch(onMouseUp({ x: 30, y: 30 }, 1100));
+      store.getState().internalChartState?.eventCallbacks(store.getState());
+
+      expect(onBrushEnd).toHaveBeenCalled();
+
+      expect(onBrushEnd.mock.calls[0][0].x[0]).toBeCloseTo(0.1);
+      expect(onBrushEnd.mock.calls[0][0].x[1]).toBeCloseTo(0.3);
+      expect(onBrushEnd.mock.calls[0][0].y[0].extent[0]).toBeCloseTo(1);
+      expect(onBrushEnd.mock.calls[0][0].y[0].extent[1]).toBeCloseTo(3);
+
+      expect(bothBrushArea).toEqual({
+        top: 10,
+        left: 10,
+        width: 20,
+        height: 20,
+      });
+    });
+  });
+
+  describe('limit brush to single panel w/small multiples', () => {
+    const store = MockStore.default({ left: 0, top: 0, width: 200, height: 200 });
+    const onBrushEnd = jest.fn();
+    MockStore.addSpecs(
+      [
+        MockGlobalSpec.settingsNoMargins({ onBrushEnd }),
+        MockGlobalSpec.groupBy({ id: 'hSplit' }),
+        MockGlobalSpec.groupBy({ id: 'vSplit' }),
+        MockGlobalSpec.smallMultiple({ splitHorizontally: 'hSplit', splitVertically: 'vSplit' }),
+        MockSeriesSpec.line({
+          id: '1',
+          xAccessor: 0,
+          yAccessors: [1],
+          xScaleType: ScaleType.Linear,
+          data: [
+            [0, 10],
+            [0.5, 5],
+            [1, 3],
+          ],
+        }),
+        MockSeriesSpec.line({
+          id: '2',
+          xAccessor: 0,
+          yAccessors: [1],
+          xScaleType: ScaleType.Linear,
+          data: [
+            [0, 5],
+            [0.5, 2],
+            [1, 6],
+          ],
+        }),
+      ],
+      store,
+    );
+
+    store.dispatch(onMouseDown({ x: 150, y: 10 }, 0));
+    store.dispatch(onPointerMove({ x: 10, y: 150 }, 1000));
+    const bothBrushArea = getBrushAreaSelector(store.getState());
     expect(bothBrushArea).toEqual({
-      top: 10,
-      left: 10,
-      width: 20,
-      height: 20,
+      top: 0,
+      left: 150,
+      width: -50,
+      height: 100,
     });
+
+    store.dispatch(onMouseUp({ x: 10, y: 150 }, 1100));
+    store.getState().internalChartState?.eventCallbacks(store.getState());
+
+    expect(onBrushEnd).toHaveBeenCalled();
+
+    expect(onBrushEnd.mock.calls[0][0].x[0]).toBeCloseTo(0);
+    expect(onBrushEnd.mock.calls[0][0].x[1]).toBeCloseTo(0.5);
   });
 });

--- a/src/chart_types/xy_chart/state/selectors/get_brush_area.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_brush_area.ts
@@ -66,6 +66,7 @@ export const getBrushAreaSelector = createCachedSelector(
   },
 )(getChartIdSelector);
 
+/** @internal */
 export type PanelPoints = {
   start: Point;
   end: Point;
@@ -75,6 +76,7 @@ export type PanelPoints = {
   vPanelHeight: number;
 };
 
+/** @internal */
 export function getPointsConstraintToSinglePanel(
   startPlotPoint: Point,
   endPlotPoint: Point,

--- a/src/chart_types/xy_chart/state/selectors/get_brush_area.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_brush_area.ts
@@ -89,11 +89,18 @@ export function getPointsConstraintToSinglePanel(
   const vPanelStart = vertical.scale(vPanel) ?? 0;
   const vPanelEnd = vPanelStart + vertical.bandwidth;
 
-  const x = clamp(endPlotPoint.x, hPanelStart, hPanelEnd);
-  const y = clamp(endPlotPoint.y, vPanelStart, vPanelEnd);
+  const start = {
+    x: clamp(startPlotPoint.x, hPanelStart, hPanelEnd),
+    y: clamp(startPlotPoint.y, vPanelStart, vPanelEnd),
+  };
+  const end = {
+    x: clamp(endPlotPoint.x, hPanelStart, hPanelEnd),
+    y: clamp(endPlotPoint.y, vPanelStart, vPanelEnd),
+  };
+
   return {
-    start: startPlotPoint,
-    end: { x, y },
+    start,
+    end,
     hPanelStart,
     hPanelWidth: horizontal.bandwidth,
     vPanelStart,

--- a/src/chart_types/xy_chart/state/selectors/get_brush_area.ts
+++ b/src/chart_types/xy_chart/state/selectors/get_brush_area.ts
@@ -24,15 +24,16 @@ import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getChartRotationSelector } from '../../../../state/selectors/get_chart_rotation';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
-import { Rotation } from '../../../../utils/common';
+import { clamp, Rotation } from '../../../../utils/common';
 import { Dimensions } from '../../../../utils/dimensions';
 import { Point } from '../../../../utils/point';
 import { isVerticalRotation } from '../utils/common';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
+import { computeSmallMultipleScalesSelector, SmallMultipleScales } from './compute_small_multiple_scales';
 
 const MIN_AREA_SIZE = 1;
 
-const getMouseDownPosition = (state: GlobalChartState) => state.interactions.pointer.down;
+const getMouseDownPosition = (state: GlobalChartState) => state.interactions.pointer.down?.position;
 const getCurrentPointerPosition = (state: GlobalChartState) => state.interactions.pointer.current.position;
 
 /** @internal */
@@ -43,81 +44,115 @@ export const getBrushAreaSelector = createCachedSelector(
     getChartRotationSelector,
     computeChartDimensionsSelector,
     getSettingsSpecSelector,
+    computeSmallMultipleScalesSelector,
   ],
-  (mouseDownPosition, end, chartRotation, { chartDimensions }, { brushAxis }): Dimensions | null => {
-    if (!mouseDownPosition) {
+  (start, end, chartRotation, { chartDimensions }, { brushAxis }, smallMultipleScales): Dimensions | null => {
+    if (!start) {
       return null;
     }
-    const start = {
-      x: mouseDownPosition.position.x,
-      y: mouseDownPosition.position.y,
-    };
+    const plotStartPointPx = getPlotAreaRestrictedPoint(start, chartDimensions);
+    const plotEndPointPx = getPlotAreaRestrictedPoint(end, chartDimensions);
+    const panelPoints = getPointsConstraintToSinglePanel(plotStartPointPx, plotEndPointPx, smallMultipleScales);
+
     switch (brushAxis) {
       case BrushAxis.Y:
-        return getBrushForYAxis(chartDimensions, chartRotation, start, end);
+        return getBrushForYAxis(chartRotation, panelPoints);
       case BrushAxis.Both:
-        return getBrushForBothAxis(chartDimensions, start, end);
+        return getBrushForBothAxis(panelPoints);
       case BrushAxis.X:
       default:
-        return getBrushForXAxis(chartDimensions, chartRotation, start, end);
+        return getBrushForXAxis(chartRotation, panelPoints);
     }
   },
 )(getChartIdSelector);
 
+export type PanelPoints = {
+  start: Point;
+  end: Point;
+  hPanelStart: number;
+  hPanelWidth: number;
+  vPanelStart: number;
+  vPanelHeight: number;
+};
+
+export function getPointsConstraintToSinglePanel(
+  startPlotPoint: Point,
+  endPlotPoint: Point,
+  { horizontal, vertical }: SmallMultipleScales,
+): PanelPoints {
+  const hPanel = horizontal.invert(startPlotPoint.x);
+  const vPanel = vertical.invert(startPlotPoint.y);
+
+  const hPanelStart = horizontal.scale(hPanel) ?? 0;
+  const hPanelEnd = hPanelStart + horizontal.bandwidth;
+
+  const vPanelStart = vertical.scale(vPanel) ?? 0;
+  const vPanelEnd = vPanelStart + vertical.bandwidth;
+
+  const x = clamp(endPlotPoint.x, hPanelStart, hPanelEnd);
+  const y = clamp(endPlotPoint.y, vPanelStart, vPanelEnd);
+  return {
+    start: startPlotPoint,
+    end: { x, y },
+    hPanelStart,
+    hPanelWidth: horizontal.bandwidth,
+    vPanelStart,
+    vPanelHeight: vertical.bandwidth,
+  };
+}
+
 /** @internal */
-export function getBrushForXAxis(chartDimensions: Dimensions, chartRotation: Rotation, start: Point, end: Point) {
+export function getPlotAreaRestrictedPoint({ x, y }: Point, { left, top }: Dimensions) {
+  return {
+    x: x - left,
+    y: y - top,
+  };
+}
+
+/** @internal */
+export function getBrushForXAxis(
+  chartRotation: Rotation,
+  { hPanelStart, vPanelStart, hPanelWidth, vPanelHeight, start, end }: PanelPoints,
+) {
   const rotated = isVerticalRotation(chartRotation);
+
   return {
-    left: rotated ? 0 : getLeftPoint(chartDimensions, start),
-    top: rotated ? getTopPoint(chartDimensions, start) : 0,
-    height: rotated ? getMinimalHeight(start, end) : chartDimensions.height,
-    width: rotated ? chartDimensions.width : getMinimalWidth(start, end),
+    left: rotated ? hPanelStart : start.x,
+    top: rotated ? start.y : vPanelStart,
+    height: rotated ? getMinSize(start.y, end.y) : vPanelHeight,
+    width: rotated ? hPanelWidth : getMinSize(start.x, end.x),
   };
 }
 
 /** @internal */
-export function getBrushForYAxis(chartDimensions: Dimensions, chartRotation: Rotation, start: Point, end: Point) {
+export function getBrushForYAxis(
+  chartRotation: Rotation,
+  { hPanelStart, vPanelStart, hPanelWidth, vPanelHeight, start, end }: PanelPoints,
+) {
   const rotated = isVerticalRotation(chartRotation);
+
   return {
-    left: rotated ? getLeftPoint(chartDimensions, start) : 0,
-    top: rotated ? 0 : getTopPoint(chartDimensions, start),
-    height: rotated ? chartDimensions.height : getMinimalHeight(start, end),
-    width: rotated ? getMinimalWidth(start, end) : chartDimensions.width,
+    left: rotated ? start.x : hPanelStart,
+    top: rotated ? vPanelStart : start.y,
+    height: rotated ? vPanelHeight : getMinSize(start.y, end.y),
+    width: rotated ? getMinSize(start.x, end.x) : hPanelWidth,
   };
 }
 
 /** @internal */
-export function getBrushForBothAxis(chartDimensions: Dimensions, start: Point, end: Point) {
+export function getBrushForBothAxis({ start, end }: PanelPoints) {
   return {
-    left: getLeftPoint(chartDimensions, start),
-    top: getTopPoint(chartDimensions, start),
-    height: getMinimalHeight(start, end),
-    width: getMinimalWidth(start, end),
+    left: start.x,
+    top: start.y,
+    height: getMinSize(start.y, end.y),
+    width: getMinSize(start.x, end.x),
   };
 }
 
-/** @internal */
-export function getLeftPoint({ left }: Dimensions, { x }: Point) {
-  return x - left;
-}
-
-/** @internal */
-export function getTopPoint({ top }: Dimensions, { y }: Point) {
-  return y - top;
-}
-
-function getMinimalHeight(start: Point, end: Point, min = MIN_AREA_SIZE) {
-  const height = end.y - start.y;
-  if (Math.abs(height) < min) {
-    return min;
+function getMinSize(a: number, b: number, minSize = MIN_AREA_SIZE) {
+  const size = b - a;
+  if (Math.abs(size) < minSize) {
+    return minSize;
   }
-  return height;
-}
-
-function getMinimalWidth(start: Point, end: Point, min = MIN_AREA_SIZE) {
-  const width = end.x - start.x;
-  if (Math.abs(width) < min) {
-    return min;
-  }
-  return width;
+  return size;
 }

--- a/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
+++ b/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
@@ -85,7 +85,6 @@ export function createOnBrushEndCaller(): (state: GlobalChartState) => void {
             lastDrag,
             onBrushEnd,
           };
-
           if (lastDrag !== null && hasDragged(prevProps, nextProps) && onBrushEnd) {
             const brushArea: XYBrushArea = {};
             const { yScales, xScale } = computedScales;

--- a/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
+++ b/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
@@ -25,6 +25,7 @@ import { Scale } from '../../../../scales';
 import { GroupBrushExtent, XYBrushArea } from '../../../../specs';
 import { BrushAxis } from '../../../../specs/constants';
 import { DragState, GlobalChartState } from '../../../../state/chart_state';
+import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { maxValueWithUpperLimit, minValueWithLowerLimit, Rotation } from '../../../../utils/common';
 import { Dimensions } from '../../../../utils/dimensions';
@@ -32,7 +33,8 @@ import { hasDragged, DragCheckProps } from '../../../../utils/events';
 import { GroupId } from '../../../../utils/ids';
 import { isVerticalRotation } from '../utils/common';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
-import { getLeftPoint, getTopPoint } from './get_brush_area';
+import { computeSmallMultipleScalesSelector, SmallMultipleScales } from './compute_small_multiple_scales';
+import { getPlotAreaRestrictedPoint, getPointsConstraintToSinglePanel, PanelPoints } from './get_brush_area';
 import { getComputedScalesSelector } from './get_computed_scales';
 import { isBrushAvailableSelector } from './is_brush_available';
 import { isHistogramModeEnabledSelector } from './is_histogram_mode_enabled';
@@ -62,6 +64,7 @@ export function createOnBrushEndCaller(): (state: GlobalChartState) => void {
           getComputedScalesSelector,
           computeChartDimensionsSelector,
           isHistogramModeEnabledSelector,
+          computeSmallMultipleScalesSelector,
         ],
         (
           lastDrag,
@@ -76,6 +79,7 @@ export function createOnBrushEndCaller(): (state: GlobalChartState) => void {
           computedScales,
           { chartDimensions },
           histogramMode,
+          smallMultipleScales,
         ): void => {
           const nextProps = {
             lastDrag,
@@ -93,13 +97,21 @@ export function createOnBrushEndCaller(): (state: GlobalChartState) => void {
                 rotation,
                 histogramMode,
                 xScale,
+                smallMultipleScales,
                 minBrushDelta,
                 roundHistogramBrushValues,
                 allowBrushingLastHistogramBucket,
               );
             }
             if (brushAxis === BrushAxis.Y || brushAxis === BrushAxis.Both) {
-              brushArea.y = getYBrushExtents(chartDimensions, lastDrag, rotation, yScales, minBrushDelta);
+              brushArea.y = getYBrushExtents(
+                chartDimensions,
+                lastDrag,
+                rotation,
+                yScales,
+                smallMultipleScales,
+                minBrushDelta,
+              );
             }
             if (brushArea.x !== undefined || brushArea.y !== undefined) {
               onBrushEnd(brushArea);
@@ -107,13 +119,26 @@ export function createOnBrushEndCaller(): (state: GlobalChartState) => void {
           }
           prevProps = nextProps;
         },
-      )({
-        keySelector: (state: GlobalChartState) => state.chartId,
-      });
+      )(getChartIdSelector);
     }
     if (selector) {
       selector(state);
     }
+  };
+}
+
+function scalePanelPointsToPanelCoordinates(
+  scaleXPoint: boolean,
+  { start, end, vPanelStart, hPanelStart, vPanelHeight, hPanelWidth }: PanelPoints,
+) {
+  // scale screen coordinates down to panel scale
+  const startPos = scaleXPoint ? start.x - hPanelStart : start.y - vPanelStart;
+  const endPos = scaleXPoint ? end.x - hPanelStart : end.y - vPanelStart;
+  const panelMax = scaleXPoint ? hPanelWidth : vPanelHeight;
+  return {
+    minPos: Math.min(startPos, endPos),
+    maxPos: Math.max(startPos, endPos),
+    panelMax,
   };
 }
 
@@ -123,25 +148,19 @@ function getXBrushExtent(
   rotation: Rotation,
   histogramMode: boolean,
   xScale: Scale,
+  smallMultipleScales: SmallMultipleScales,
   minBrushDelta?: number,
   roundHistogramBrushValues?: boolean,
   allowBrushingLastHistogramBucket?: boolean,
 ): [number, number] | undefined {
-  let startPos = getLeftPoint(chartDimensions, lastDrag.start.position);
-  let endPos = getLeftPoint(chartDimensions, lastDrag.end.position);
-  let chartMax = chartDimensions.width;
-
-  if (isVerticalRotation(rotation)) {
-    startPos = getTopPoint(chartDimensions, lastDrag.start.position);
-    endPos = getTopPoint(chartDimensions, lastDrag.end.position);
-    chartMax = chartDimensions.height;
-  }
-
-  let minPos = minValueWithLowerLimit(startPos, endPos, 0);
-  let maxPos = maxValueWithUpperLimit(startPos, endPos, chartMax);
+  const isXHorizontal = !isVerticalRotation(rotation);
+  // scale screen coordinates down to panel scale
+  const scaledPanelPoints = getMinMaxPos(chartDimensions, lastDrag, smallMultipleScales, isXHorizontal);
+  let { minPos, maxPos } = scaledPanelPoints;
+  // reverse the positions if chart is mirrored
   if (rotation === -90 || rotation === 180) {
-    minPos = chartMax - minPos;
-    maxPos = chartMax - maxPos;
+    minPos = scaledPanelPoints.panelMax - minPos;
+    maxPos = scaledPanelPoints.panelMax - maxPos;
   }
   if (minBrushDelta !== undefined ? Math.abs(maxPos - minPos) < minBrushDelta : maxPos === minPos) {
     // if 0 size brush, avoid computing the value
@@ -163,28 +182,41 @@ function getXBrushExtent(
   return [minValue, maxValue];
 }
 
+function getMinMaxPos(
+  chartDimensions: Dimensions,
+  lastDrag: DragState,
+  smallMultipleScales: SmallMultipleScales,
+  scaleXPoint: boolean,
+) {
+  const panelPoints = getPanelPoints(chartDimensions, lastDrag, smallMultipleScales);
+  // scale screen coordinates down to panel scale
+  return scalePanelPointsToPanelCoordinates(scaleXPoint, panelPoints);
+}
+
+function getPanelPoints(chartDimensions: Dimensions, lastDrag: DragState, smallMultipleScales: SmallMultipleScales) {
+  const plotStartPointPx = getPlotAreaRestrictedPoint(lastDrag.start.position, chartDimensions);
+  const plotEndPointPx = getPlotAreaRestrictedPoint(lastDrag.end.position, chartDimensions);
+  return getPointsConstraintToSinglePanel(plotStartPointPx, plotEndPointPx, smallMultipleScales);
+}
+
 function getYBrushExtents(
   chartDimensions: Dimensions,
   lastDrag: DragState,
   rotation: Rotation,
   yScales: Map<GroupId, Scale>,
+  smallMultipleScales: SmallMultipleScales,
   minBrushDelta?: number,
 ): GroupBrushExtent[] | undefined {
   const yValues: GroupBrushExtent[] = [];
   yScales.forEach((yScale, groupId) => {
-    let startPos = getTopPoint(chartDimensions, lastDrag.start.position);
-    let endPos = getTopPoint(chartDimensions, lastDrag.end.position);
-    let chartMax = chartDimensions.height;
-    if (isVerticalRotation(rotation)) {
-      startPos = getLeftPoint(chartDimensions, lastDrag.start.position);
-      endPos = getLeftPoint(chartDimensions, lastDrag.end.position);
-      chartMax = chartDimensions.width;
-    }
-    let minPos = minValueWithLowerLimit(startPos, endPos, 0);
-    let maxPos = maxValueWithUpperLimit(startPos, endPos, chartMax);
-    if (rotation === -90 || rotation === 180) {
-      minPos = chartMax - minPos;
-      maxPos = chartMax - maxPos;
+    const isXVertical = isVerticalRotation(rotation);
+    // scale screen coordinates down to panel scale
+    const scaledPanelPoints = getMinMaxPos(chartDimensions, lastDrag, smallMultipleScales, isXVertical);
+    let { minPos, maxPos } = scaledPanelPoints;
+
+    if (rotation === 90 || rotation === 180) {
+      minPos = scaledPanelPoints.panelMax - minPos;
+      maxPos = scaledPanelPoints.panelMax - maxPos;
     }
     if (minBrushDelta !== undefined ? Math.abs(maxPos - minPos) < minBrushDelta : maxPos === minPos) {
       // if 0 size brush, avoid computing the value

--- a/src/mocks/specs/specs.ts
+++ b/src/mocks/specs/specs.ts
@@ -18,6 +18,7 @@
  */
 
 import { ChartTypes } from '../../chart_types';
+import { Predicate } from '../../chart_types/heatmap/utils/common';
 import { config, percentFormatter } from '../../chart_types/partition_chart/layout/config';
 import { PartitionLayout } from '../../chart_types/partition_chart/layout/types/config_types';
 import { ShapeTreeNode } from '../../chart_types/partition_chart/layout/types/viewmodel_types';
@@ -41,7 +42,7 @@ import {
   AxisSpec,
 } from '../../chart_types/xy_chart/utils/specs';
 import { ScaleType } from '../../scales/constants';
-import { SettingsSpec, SpecTypes, DEFAULT_SETTINGS_SPEC } from '../../specs';
+import { SettingsSpec, SpecTypes, DEFAULT_SETTINGS_SPEC, SmallMultiplesSpec, GroupBySpec, Spec } from '../../specs';
 import { Datum, mergePartial, Position, RecursivePartial } from '../../utils/common';
 import { LIGHT_THEME } from '../../utils/themes/light_theme';
 
@@ -293,6 +294,24 @@ export class MockGlobalSpec {
     },
   };
 
+  private static readonly smallMultipleBase: SmallMultiplesSpec = {
+    id: 'smallMultiple',
+    chartType: ChartTypes.Global,
+    specType: SpecTypes.SmallMultiples,
+    style: {
+      verticalPanelPadding: [0, 0],
+      horizontalPanelPadding: [0, 0],
+    },
+  };
+
+  private static readonly groupByBase: GroupBySpec = {
+    id: 'groupBy',
+    chartType: ChartTypes.Global,
+    specType: SpecTypes.IndexOrder,
+    by: ({ id }: Spec) => id,
+    sort: Predicate.DataIndex,
+  };
+
   static settings(partial?: Partial<SettingsSpec>): SettingsSpec {
     return mergePartial<SettingsSpec>(MockGlobalSpec.settingsBase, partial, { mergeOptionalPartialValues: true });
   }
@@ -305,6 +324,18 @@ export class MockGlobalSpec {
 
   static axis(partial?: Partial<AxisSpec>): AxisSpec {
     return mergePartial<AxisSpec>(MockGlobalSpec.axisBase, partial, { mergeOptionalPartialValues: true });
+  }
+
+  static smallMultiple(partial?: Partial<SmallMultiplesSpec>): SmallMultiplesSpec {
+    return mergePartial<SmallMultiplesSpec>(MockGlobalSpec.smallMultipleBase, partial, {
+      mergeOptionalPartialValues: true,
+    });
+  }
+
+  static groupBy(partial?: Partial<GroupBySpec>): GroupBySpec {
+    return mergePartial<GroupBySpec>(MockGlobalSpec.groupByBase, partial, {
+      mergeOptionalPartialValues: true,
+    });
   }
 }
 

--- a/stories/interactions/9a_brush_selection_linear.tsx
+++ b/stories/interactions/9a_brush_selection_linear.tsx
@@ -36,7 +36,7 @@ export const Example = () => {
   );
   return (
     <Chart className="story-chart">
-      <Settings onBrushEnd={action('onBrushEnd')} rotation={getChartRotationKnob()} brushAxis={brushAxisSelect} />
+      <Settings rotation={getChartRotationKnob()} brushAxis={brushAxisSelect} onBrushEnd={action('brush')} />
       <Axis id="bottom" position={Position.Bottom} title="bottom" showOverlappingTicks />
       <Axis id="left" title="left" position={Position.Left} tickFormat={(d) => Number(d).toFixed(2)} />
       <Axis id="top" position={Position.Top} title="top" showOverlappingTicks />

--- a/stories/small_multiples/1_grid.tsx
+++ b/stories/small_multiples/1_grid.tsx
@@ -91,6 +91,7 @@ export const Example = () => {
               },
             },
           }}
+          onBrushEnd={(d) => console.log(d)}
         />
         <Axis id="time" title="horizontal" position={Position.Bottom} gridLine={{ visible: false }} />
         <Axis

--- a/stories/small_multiples/1_grid.tsx
+++ b/stories/small_multiples/1_grid.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
 import React, { useState } from 'react';
 
@@ -91,7 +92,7 @@ export const Example = () => {
               },
             },
           }}
-          onBrushEnd={(d) => console.log(d)}
+          onBrushEnd={action('brushEvent')}
         />
         <Axis id="time" title="horizontal" position={Position.Bottom} gridLine={{ visible: false }} />
         <Axis

--- a/stories/small_multiples/2_vertical_areas.tsx
+++ b/stories/small_multiples/2_vertical_areas.tsx
@@ -85,11 +85,7 @@ export const Example = () => {
         }}
         sort="alphaDesc"
       />
-      <SmallMultiples
-        splitHorizontally="v_split"
-        // splitVertically="v_split"
-        style={{ verticalPanelPadding: [0, 0.3] }}
-      />
+      <SmallMultiples splitVertically="v_split" style={{ verticalPanelPadding: [0, 0.3] }} />
       <AreaSeries
         id="line"
         xScaleType={ScaleType.Time}

--- a/stories/small_multiples/2_vertical_areas.tsx
+++ b/stories/small_multiples/2_vertical_areas.tsx
@@ -33,8 +33,10 @@ import {
   LIGHT_THEME,
   niceTimeFormatByDay,
   timeFormatter,
+  BrushAxis,
 } from '../../src';
 import { SeededDataGenerator } from '../../src/mocks/utils';
+import { getChartRotationKnob } from '../utils/knobs';
 import { SB_SOURCE_PANEL } from '../utils/storybook';
 
 const dg = new SeededDataGenerator();
@@ -51,7 +53,21 @@ export const Example = () => {
   const onElementClick = action('onElementClick');
   return (
     <Chart className="story-chart">
-      <Settings onElementClick={onElementClick} showLegend={showLegend} />
+      <Settings
+        onElementClick={onElementClick}
+        showLegend={showLegend}
+        onBrushEnd={(d) => {
+          if (d.x) {
+            console.log(new Date(d.x[0]).toISOString());
+            console.log(new Date(d.x[1]).toISOString());
+          }
+          if (d.y) {
+            console.log(d.y);
+          }
+        }}
+        brushAxis={BrushAxis.X}
+        // rotation={getChartRotationKnob()}
+      />
       <Axis
         id="time"
         title="Timestamp"
@@ -74,7 +90,11 @@ export const Example = () => {
         }}
         sort="alphaDesc"
       />
-      <SmallMultiples splitVertically="v_split" style={{ verticalPanelPadding: [0, 0.3] }} />
+      <SmallMultiples
+        splitHorizontally="v_split"
+        // splitVertically="v_split"
+        style={{ verticalPanelPadding: [0, 0.3] }}
+      />
       <AreaSeries
         id="line"
         xScaleType={ScaleType.Time}

--- a/stories/small_multiples/2_vertical_areas.tsx
+++ b/stories/small_multiples/2_vertical_areas.tsx
@@ -36,7 +36,6 @@ import {
   BrushAxis,
 } from '../../src';
 import { SeededDataGenerator } from '../../src/mocks/utils';
-import { getChartRotationKnob } from '../utils/knobs';
 import { SB_SOURCE_PANEL } from '../utils/storybook';
 
 const dg = new SeededDataGenerator();
@@ -51,6 +50,7 @@ const data = dg.generateGroupedSeries(numOfDays, 6, 'metric ').map((d) => {
 export const Example = () => {
   const showLegend = boolean('Show Legend', true);
   const onElementClick = action('onElementClick');
+  const tickTimeFormatter = timeFormatter(niceTimeFormatByDay(numOfDays));
   return (
     <Chart className="story-chart">
       <Settings
@@ -58,22 +58,17 @@ export const Example = () => {
         showLegend={showLegend}
         onBrushEnd={(d) => {
           if (d.x) {
-            console.log(new Date(d.x[0]).toISOString());
-            console.log(new Date(d.x[1]).toISOString());
-          }
-          if (d.y) {
-            console.log(d.y);
+            action('brushEventX')(tickTimeFormatter(d.x[0] ?? 0), tickTimeFormatter(d.x[1] ?? 0), d.y);
           }
         }}
         brushAxis={BrushAxis.X}
-        // rotation={getChartRotationKnob()}
       />
       <Axis
         id="time"
         title="Timestamp"
         position={Position.Bottom}
         gridLine={{ visible: false }}
-        tickFormat={timeFormatter(niceTimeFormatByDay(numOfDays))}
+        tickFormat={tickTimeFormatter}
       />
       <Axis
         id="y"

--- a/stories/small_multiples/3_grid_lines.tsx
+++ b/stories/small_multiples/3_grid_lines.tsx
@@ -67,6 +67,7 @@ const getAxisStyle = (position: Position): AxisSpec['style'] => ({
     visible: false,
   },
 });
+const tickTimeFormatter = timeFormatter(niceTimeFormatByDay(numOfDays));
 
 const getAxisOptions = (
   position: Position,
@@ -77,7 +78,7 @@ const getAxisOptions = (
     id: position,
     position,
     ticks: isVertical ? 2 : undefined,
-    tickFormat: isVertical ? (d) => d.toFixed(2) : timeFormatter(niceTimeFormatByDay(numOfDays)),
+    tickFormat: isVertical ? (d) => d.toFixed(2) : tickTimeFormatter,
     domain: isVertical
       ? {
           max: 10,
@@ -113,6 +114,11 @@ export const Example = () => {
               visible: false,
             },
           },
+        }}
+        onBrushEnd={(d) => {
+          if (d.x) {
+            action('brushEvent')(tickTimeFormatter(d.x[0] ?? 0), tickTimeFormatter(d.x[1] ?? 0));
+          }
         }}
       />
       <Axis {...getAxisOptions(Position.Left)} />


### PR DESCRIPTION
## Summary

This PR forced the brush tool to work per panel when using small multiples. This behavior is built to works independently from the presence or absence of a small multiples configuration.
It works by forcing the brushable area to be constraint between the boundaries of the panel where the brushing event started. The brush selection doesn't move between panels and the coordinate of the mouse down event determines the limiting panel.

I've cleaned up the code to compute the brush area and also updated the unit test by mocking the SmallMultiple specs

fixes #1070


https://user-images.githubusercontent.com/1421091/110787477-a66adf00-826d-11eb-9f4e-15f0b89c857a.mp4

