### PR TITLE
chore: always use offset with flip modifier

### DIFF
--- a/src/components/portal/tooltip_portal.tsx
+++ b/src/components/portal/tooltip_portal.tsx
@@ -57,8 +57,7 @@ type PortalTooltipProps = {
   chartId: string;
 };
 
-function addToPadding(padding?: Partial<Padding> | number, extra: number = 0): Padding | number | undefined {
-  if (!padding) return undefined;
+function addToPadding(padding: Partial<Padding> | number = 0, extra: number = 0): Padding | number | undefined {
   if (typeof padding === 'number') return padding + extra;
 
   const { top = 0, right = 0, bottom = 0, left = 0 } = padding;


### PR DESCRIPTION
## Summary

Adds `offset` back to `flip` modifier regardless of `padding`.

### Checklist

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility
