### PR TITLE
chore(wordcloud): improvements

### DIFF
--- a/api/charts.api.md
+++ b/api/charts.api.md
@@ -2444,10 +2444,10 @@ export interface WordcloudSpec extends Spec {
     spiral: string;
     // (undocumented)
     startAngle: number;
-    // Warning: (ae-forgotten-export) The symbol "weightFn" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "WeightFn" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    weightFn: weightFn;
+    weightFn: WeightFn;
 }
 
 // Warning: (ae-missing-release-tag) "XScaleType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api/charts.api.md
+++ b/api/charts.api.md
@@ -2444,10 +2444,10 @@ export interface WordcloudSpec extends Spec {
     spiral: string;
     // (undocumented)
     startAngle: number;
-    // Warning: (ae-forgotten-export) The symbol "WeightFun" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "weightFn" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    weightFun: WeightFun;
+    weightFn: weightFn;
 }
 
 // Warning: (ae-missing-release-tag) "XScaleType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api/charts.api.md
+++ b/api/charts.api.md
@@ -707,7 +707,7 @@ export const DEFAULT_TOOLTIP_TYPE: "vertical";
 // Warning: (ae-missing-release-tag) "DefaultSettingsProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type DefaultSettingsProps = 'id' | 'chartType' | 'specType' | 'rendering' | 'rotation' | 'resizeDebounce' | 'animateData' | 'showLegend' | 'debug' | 'tooltip' | 'showLegendExtra' | 'theme' | 'legendPosition' | 'legendMaxDepth' | 'hideDuplicateAxes' | 'brushAxis' | 'minBrushDelta' | 'externalPointerEvents';
+export type DefaultSettingsProps = 'id' | 'chartType' | 'specType' | 'rendering' | 'rotation' | 'resizeDebounce' | 'animateData' | 'debug' | 'tooltip' | 'theme' | 'hideDuplicateAxes' | 'brushAxis' | 'minBrushDelta' | 'externalPointerEvents' | 'showLegend' | 'showLegendExtra' | 'legendPosition' | 'legendMaxDepth';
 
 // Warning: (ae-missing-release-tag) "DEPTH_KEY" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1221,6 +1221,17 @@ export interface LayerValue {
     value: number;
 }
 
+// Warning: (ae-missing-release-tag) "LayoutDirection" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const LayoutDirection: Readonly<{
+    Horizontal: "horizontal";
+    Vertical: "vertical";
+}>;
+
+// @public (undocumented)
+export type LayoutDirection = $Values<typeof LayoutDirection>;
+
 // @public
 export type LegendAction = ComponentType<LegendActionProps>;
 
@@ -1260,6 +1271,37 @@ export type LegendPathElement = {
     index: number;
     value: CategoryKey;
 };
+
+// @public
+export type LegendPositionConfig = {
+    vAlign: typeof VerticalAlignment.Top | typeof VerticalAlignment.Bottom;
+    hAlign: typeof HorizontalAlignment.Left | typeof HorizontalAlignment.Right;
+    direction: LayoutDirection;
+    floating: boolean;
+};
+
+// @public
+export interface LegendSpec {
+    flatLegend?: boolean;
+    legendAction?: LegendAction;
+    // (undocumented)
+    legendColorPicker?: LegendColorPicker;
+    legendMaxDepth: number;
+    legendPosition: Position | LegendPositionConfig;
+    legendStrategy?: LegendStrategy;
+    // (undocumented)
+    onLegendItemClick?: LegendItemListener;
+    // (undocumented)
+    onLegendItemMinusClick?: LegendItemListener;
+    // (undocumented)
+    onLegendItemOut?: BasicListener;
+    // (undocumented)
+    onLegendItemOver?: LegendItemListener;
+    // (undocumented)
+    onLegendItemPlusClick?: LegendItemListener;
+    showLegend: boolean;
+    showLegendExtra: boolean;
+}
 
 // @public (undocumented)
 export const LegendStrategy: Readonly<{
@@ -1942,7 +1984,7 @@ export type SeriesTypes = $Values<typeof SeriesTypes>;
 export const Settings: React_2.FunctionComponent<SettingsSpecProps>;
 
 // @public
-export interface SettingsSpec extends Spec {
+export interface SettingsSpec extends Spec, LegendSpec {
     allowBrushingLastHistogramBucket?: boolean;
     // (undocumented)
     animateData: boolean;
@@ -1953,14 +1995,7 @@ export interface SettingsSpec extends Spec {
     debugState?: boolean;
     // @alpha
     externalPointerEvents: ExternalPointerEventsSettings;
-    flatLegend?: boolean;
     hideDuplicateAxes: boolean;
-    legendAction?: LegendAction;
-    // (undocumented)
-    legendColorPicker?: LegendColorPicker;
-    legendMaxDepth: number;
-    legendPosition: Position;
-    legendStrategy?: LegendStrategy;
     minBrushDelta?: number;
     noResults?: ComponentType | ReactChild;
     // (undocumented)
@@ -1971,16 +2006,6 @@ export interface SettingsSpec extends Spec {
     onElementOut?: BasicListener;
     // (undocumented)
     onElementOver?: ElementOverListener;
-    // (undocumented)
-    onLegendItemClick?: LegendItemListener;
-    // (undocumented)
-    onLegendItemMinusClick?: LegendItemListener;
-    // (undocumented)
-    onLegendItemOut?: BasicListener;
-    // (undocumented)
-    onLegendItemOver?: LegendItemListener;
-    // (undocumented)
-    onLegendItemPlusClick?: LegendItemListener;
     // (undocumented)
     onPointerUpdate?: PointerUpdateListener;
     onProjectionClick?: ProjectionClickListener;
@@ -1996,9 +2021,6 @@ export interface SettingsSpec extends Spec {
     // (undocumented)
     rotation: Rotation;
     roundHistogramBrushValues?: boolean;
-    // (undocumented)
-    showLegend: boolean;
-    showLegendExtra: boolean;
     theme?: PartialTheme | PartialTheme[];
     tooltip: TooltipSettings;
     // (undocumented)
@@ -2422,10 +2444,10 @@ export interface WordcloudSpec extends Spec {
     spiral: string;
     // (undocumented)
     startAngle: number;
-    // Warning: (ae-forgotten-export) The symbol "WeightFun" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "WeightFn" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    weightFun: WeightFun;
+    weightFn: WeightFn;
 }
 
 // Warning: (ae-missing-release-tag) "XScaleType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api/charts.api.md
+++ b/api/charts.api.md
@@ -707,7 +707,7 @@ export const DEFAULT_TOOLTIP_TYPE: "vertical";
 // Warning: (ae-missing-release-tag) "DefaultSettingsProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type DefaultSettingsProps = 'id' | 'chartType' | 'specType' | 'rendering' | 'rotation' | 'resizeDebounce' | 'animateData' | 'debug' | 'tooltip' | 'theme' | 'hideDuplicateAxes' | 'brushAxis' | 'minBrushDelta' | 'externalPointerEvents' | 'showLegend' | 'showLegendExtra' | 'legendPosition' | 'legendMaxDepth';
+export type DefaultSettingsProps = 'id' | 'chartType' | 'specType' | 'rendering' | 'rotation' | 'resizeDebounce' | 'animateData' | 'showLegend' | 'debug' | 'tooltip' | 'showLegendExtra' | 'theme' | 'legendPosition' | 'legendMaxDepth' | 'hideDuplicateAxes' | 'brushAxis' | 'minBrushDelta' | 'externalPointerEvents';
 
 // Warning: (ae-missing-release-tag) "DEPTH_KEY" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1221,17 +1221,6 @@ export interface LayerValue {
     value: number;
 }
 
-// Warning: (ae-missing-release-tag) "LayoutDirection" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export const LayoutDirection: Readonly<{
-    Horizontal: "horizontal";
-    Vertical: "vertical";
-}>;
-
-// @public (undocumented)
-export type LayoutDirection = $Values<typeof LayoutDirection>;
-
 // @public
 export type LegendAction = ComponentType<LegendActionProps>;
 
@@ -1271,37 +1260,6 @@ export type LegendPathElement = {
     index: number;
     value: CategoryKey;
 };
-
-// @public
-export type LegendPositionConfig = {
-    vAlign: typeof VerticalAlignment.Top | typeof VerticalAlignment.Bottom;
-    hAlign: typeof HorizontalAlignment.Left | typeof HorizontalAlignment.Right;
-    direction: LayoutDirection;
-    floating: boolean;
-};
-
-// @public
-export interface LegendSpec {
-    flatLegend?: boolean;
-    legendAction?: LegendAction;
-    // (undocumented)
-    legendColorPicker?: LegendColorPicker;
-    legendMaxDepth: number;
-    legendPosition: Position | LegendPositionConfig;
-    legendStrategy?: LegendStrategy;
-    // (undocumented)
-    onLegendItemClick?: LegendItemListener;
-    // (undocumented)
-    onLegendItemMinusClick?: LegendItemListener;
-    // (undocumented)
-    onLegendItemOut?: BasicListener;
-    // (undocumented)
-    onLegendItemOver?: LegendItemListener;
-    // (undocumented)
-    onLegendItemPlusClick?: LegendItemListener;
-    showLegend: boolean;
-    showLegendExtra: boolean;
-}
 
 // @public (undocumented)
 export const LegendStrategy: Readonly<{
@@ -1984,7 +1942,7 @@ export type SeriesTypes = $Values<typeof SeriesTypes>;
 export const Settings: React_2.FunctionComponent<SettingsSpecProps>;
 
 // @public
-export interface SettingsSpec extends Spec, LegendSpec {
+export interface SettingsSpec extends Spec {
     allowBrushingLastHistogramBucket?: boolean;
     // (undocumented)
     animateData: boolean;
@@ -1995,7 +1953,14 @@ export interface SettingsSpec extends Spec, LegendSpec {
     debugState?: boolean;
     // @alpha
     externalPointerEvents: ExternalPointerEventsSettings;
+    flatLegend?: boolean;
     hideDuplicateAxes: boolean;
+    legendAction?: LegendAction;
+    // (undocumented)
+    legendColorPicker?: LegendColorPicker;
+    legendMaxDepth: number;
+    legendPosition: Position;
+    legendStrategy?: LegendStrategy;
     minBrushDelta?: number;
     noResults?: ComponentType | ReactChild;
     // (undocumented)
@@ -2006,6 +1971,16 @@ export interface SettingsSpec extends Spec, LegendSpec {
     onElementOut?: BasicListener;
     // (undocumented)
     onElementOver?: ElementOverListener;
+    // (undocumented)
+    onLegendItemClick?: LegendItemListener;
+    // (undocumented)
+    onLegendItemMinusClick?: LegendItemListener;
+    // (undocumented)
+    onLegendItemOut?: BasicListener;
+    // (undocumented)
+    onLegendItemOver?: LegendItemListener;
+    // (undocumented)
+    onLegendItemPlusClick?: LegendItemListener;
     // (undocumented)
     onPointerUpdate?: PointerUpdateListener;
     onProjectionClick?: ProjectionClickListener;
@@ -2021,6 +1996,9 @@ export interface SettingsSpec extends Spec, LegendSpec {
     // (undocumented)
     rotation: Rotation;
     roundHistogramBrushValues?: boolean;
+    // (undocumented)
+    showLegend: boolean;
+    showLegendExtra: boolean;
     theme?: PartialTheme | PartialTheme[];
     tooltip: TooltipSettings;
     // (undocumented)
@@ -2444,10 +2422,10 @@ export interface WordcloudSpec extends Spec {
     spiral: string;
     // (undocumented)
     startAngle: number;
-    // Warning: (ae-forgotten-export) The symbol "WeightFn" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "WeightFun" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    weightFn: WeightFn;
+    weightFun: WeightFun;
 }
 
 // Warning: (ae-missing-release-tag) "XScaleType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/chart_types/wordcloud/layout/types/viewmodel_types.ts
+++ b/src/chart_types/wordcloud/layout/types/viewmodel_types.ts
@@ -21,7 +21,6 @@ import { $Values as Values } from 'utility-types';
 
 import { Pixels, PointObject } from '../../../../common/geometry';
 import { Color } from '../../../../utils/common';
-import { Logger } from '../../../../utils/logger';
 import { config } from '../config/config';
 import { Config } from './config_types';
 
@@ -137,9 +136,7 @@ const commonDefaults: WordcloudViewModel = {
   exponent: 3,
   data: [],
   weightFn: 'exponential',
-  outOfRoomCallback: (wordCount, renderedWordCount) => {
-    Logger.warn(`Not all words have been placed: ${renderedWordCount} words rendered out of ${wordCount}`);
-  },
+  outOfRoomCallback: () => {},
 };
 
 /** @internal */

--- a/src/chart_types/wordcloud/layout/types/viewmodel_types.ts
+++ b/src/chart_types/wordcloud/layout/types/viewmodel_types.ts
@@ -32,7 +32,7 @@ export interface WordModel {
   color: Color;
 }
 
-export const WeightFun = Object.freeze({
+export const WeightFn = Object.freeze({
   log: 'log' as const,
   linear: 'linear' as const,
   exponential: 'exponential' as const,
@@ -40,7 +40,7 @@ export const WeightFun = Object.freeze({
 });
 
 /** @public */
-export type WeightFun = Values<typeof WeightFun>;
+export type WeightFn = Values<typeof WeightFn>;
 
 /** @internal */
 export interface Word {
@@ -80,7 +80,7 @@ export interface Configs {
   padding: number;
   spiral: string;
   startAngle: number;
-  weightFun: WeightFun;
+  weightFn: WeightFn;
   width: number;
 }
 
@@ -100,7 +100,7 @@ export interface WordcloudViewModel {
   spiral: string;
   exponent: number;
   data: WordModel[];
-  weightFun: WeightFun;
+  weightFn: WeightFn;
   outOfRoomCallback: OutOfRoomCallback;
   // specType: string;
 }
@@ -136,7 +136,7 @@ const commonDefaults: WordcloudViewModel = {
   spiral: 'archimedean',
   exponent: 3,
   data: [],
-  weightFun: 'exponential',
+  weightFn: 'exponential',
   outOfRoomCallback: (wordCount, renderedWordCount) => {
     Logger.warn(`Not all words have been placed: ${renderedWordCount} words rendered out of ${wordCount}`);
   },

--- a/src/chart_types/wordcloud/layout/viewmodel/viewmodel.ts
+++ b/src/chart_types/wordcloud/layout/viewmodel/viewmodel.ts
@@ -46,7 +46,7 @@ export function shapeViewModel(spec: WordcloudSpec, config: Config): ShapeViewMo
     spiral,
     exponent,
     data,
-    weightFun,
+    weightFn,
     outOfRoomCallback,
   } = spec;
 
@@ -63,7 +63,7 @@ export function shapeViewModel(spec: WordcloudSpec, config: Config): ShapeViewMo
     spiral,
     exponent,
     data,
-    weightFun,
+    weightFn,
     outOfRoomCallback,
   };
 

--- a/src/chart_types/wordcloud/renderer/svg/connected_component.tsx
+++ b/src/chart_types/wordcloud/renderer/svg/connected_component.tsx
@@ -92,18 +92,18 @@ function log(minFontSize: number, maxFontSize: number, _exponent: number, weight
   return minFontSize + (maxFontSize - minFontSize) * Math.log2(weight + 1);
 }
 
-const weightFunLookup = { linear, exponential, log, squareRoot };
+const weightFnLookup = { linear, exponential, log, squareRoot };
 
 function layoutMaker(config: Configs, data: Datum[]) {
   const words = data.map((d) => {
-    const weightFun = weightFunLookup[config.weightFun];
+    const weightFn = weightFnLookup[config.weightFn];
     return {
       text: d.text,
       color: d.color,
       fontFamily: config.fontFamily,
       style: config.fontStyle,
       fontWeight: config.fontWeight,
-      size: weightFun(config.minFontSize, config.maxFontSize, config.exponent, d.weight),
+      size: weightFn(config.minFontSize, config.maxFontSize, config.exponent, d.weight),
     };
   });
   return d3TagCloud()
@@ -240,7 +240,7 @@ class Component extends React.Component<Props> {
       maxFontSize: wordcloudViewModel.maxFontSize,
       spiral: wordcloudViewModel.spiral,
       exponent: wordcloudViewModel.exponent,
-      weightFun: wordcloudViewModel.weightFun,
+      weightFn: wordcloudViewModel.weightFn,
     };
 
     const layout = layoutMaker(conf1, wordcloudViewModel.data);

--- a/src/chart_types/wordcloud/renderer/svg/connected_component.tsx
+++ b/src/chart_types/wordcloud/renderer/svg/connected_component.tsx
@@ -127,7 +127,6 @@ const View = ({ words, conf }: { words: Word[]; conf: Configs }) => (
           <text
             key={String(i)}
             style={{
-              transform: `translate(${d.x}, ${d.y}) rotate(${d.rotate})`,
               fontSize: getFontSize(d),
               fontStyle: getFontStyle(d),
               fontFamily: getFont(d),

--- a/src/chart_types/wordcloud/renderer/svg/connected_component.tsx
+++ b/src/chart_types/wordcloud/renderer/svg/connected_component.tsx
@@ -19,7 +19,7 @@
 
 // @ts-ignore
 import d3TagCloud from 'd3-cloud';
-import React, { MouseEvent, RefObject } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
@@ -154,72 +154,27 @@ interface ReactiveChartDispatchProps {
   onChartRendered: typeof onChartRendered;
 }
 
-interface ReactiveChartOwnProps {
-  forwardStageRef: RefObject<HTMLCanvasElement>;
-}
-
-type Props = ReactiveChartStateProps & ReactiveChartDispatchProps & ReactiveChartOwnProps;
+type Props = ReactiveChartStateProps & ReactiveChartDispatchProps;
 
 class Component extends React.Component<Props> {
   static displayName = 'Wordcloud';
 
-  // firstRender = true; // this'll be useful for stable resizing of treemaps
-  private ctx: CanvasRenderingContext2D | null;
-
-  // see example https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#Example
-  private readonly devicePixelRatio: number; // fixme this be no constant: multi-monitor window drag may necessitate modifying the `<canvas>` dimensions
-
-  constructor(props: Readonly<Props>) {
-    super(props);
-    this.ctx = null;
-    this.devicePixelRatio = window.devicePixelRatio;
-  }
-
   componentDidMount() {
-    /*
-     * the DOM element has just been appended, and getContext('2d') is always non-null,
-     * so we could use a couple of ! non-null assertions but no big plus
-     */
-    this.tryCanvasContext();
     if (this.props.initialized) {
-      this.drawCanvas();
       this.props.onChartRendered();
     }
   }
 
   componentDidUpdate() {
-    if (!this.ctx) {
-      this.tryCanvasContext();
-    }
     if (this.props.initialized) {
-      this.drawCanvas();
       this.props.onChartRendered();
     }
-  }
-
-  handleMouseMove(e: MouseEvent<HTMLCanvasElement>) {
-    const {
-      initialized,
-      chartContainerDimensions: { width, height },
-      forwardStageRef,
-      geometries,
-    } = this.props;
-    if (!forwardStageRef.current || !this.ctx || !initialized || width === 0 || height === 0) {
-      return;
-    }
-    const picker = geometries.pickQuads;
-    const box = forwardStageRef.current.getBoundingClientRect();
-    const { chartCenter } = geometries;
-    const x = e.clientX - box.left - chartCenter.x;
-    const y = e.clientY - box.top - chartCenter.y;
-    return picker(x, y);
   }
 
   render() {
     const {
       initialized,
       chartContainerDimensions: { width, height },
-      forwardStageRef,
       geometries: { wordcloudViewModel },
     } = this.props;
     if (!initialized || width === 0 || height === 0) {
@@ -259,38 +214,7 @@ class Component extends React.Component<Props> {
       );
     }
 
-    return (
-      <>
-        <canvas
-          ref={forwardStageRef}
-          className="echCanvasRenderer"
-          width={width * this.devicePixelRatio}
-          height={height * this.devicePixelRatio}
-          onMouseMove={this.handleMouseMove.bind(this)}
-          style={{
-            width,
-            height,
-          }}
-        />
-        <View words={renderedWordObjects} conf={conf1} />
-      </>
-    );
-  }
-
-  private tryCanvasContext() {
-    const canvas = this.props.forwardStageRef.current;
-    this.ctx = canvas && canvas.getContext('2d');
-  }
-
-  private drawCanvas() {
-    if (this.ctx) {
-      /*      const { width, height }: Dimensions = this.props.chartContainerDimensions;
-                renderCanvas2d(this.ctx, this.devicePixelRatio, {
-             ...this.props.geometries,
-             config: { ...this.props.geometries.config, width, height },
-           });
-      */
-    }
+    return <View words={renderedWordObjects} conf={conf1} />;
   }
 }
 

--- a/src/chart_types/wordcloud/specs/index.ts
+++ b/src/chart_types/wordcloud/specs/index.ts
@@ -26,7 +26,7 @@ import { getConnect, specComponentFactory } from '../../../state/spec_factory';
 import { RecursivePartial } from '../../../utils/common';
 import { Config } from '../../partition_chart/layout/types/config_types';
 import { config } from '../layout/config/config';
-import { WordModel, defaultWordcloudSpec, WeightFun, OutOfRoomCallback } from '../layout/types/viewmodel_types';
+import { WordModel, defaultWordcloudSpec, WeightFn, OutOfRoomCallback } from '../layout/types/viewmodel_types';
 
 const defaultProps = {
   chartType: ChartTypes.Wordcloud,
@@ -52,7 +52,7 @@ export interface WordcloudSpec extends Spec {
   spiral: string;
   exponent: number;
   data: WordModel[];
-  weightFun: WeightFun;
+  weightFn: WeightFn;
   outOfRoomCallback: OutOfRoomCallback;
 }
 
@@ -77,7 +77,7 @@ export const Wordcloud: React.FunctionComponent<SpecRequiredProps & SpecOptional
     | 'spiral'
     | 'exponent'
     | 'data'
-    | 'weightFun'
+    | 'weightFn'
     | 'outOfRoomCallback'
   >(defaultProps),
 );

--- a/src/chart_types/wordcloud/state/chart_state.tsx
+++ b/src/chart_types/wordcloud/state/chart_state.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { RefObject } from 'react';
+import React from 'react';
 
 import { ChartTypes } from '../..';
 import { DEFAULT_CSS_CURSOR } from '../../../common/constants';
@@ -84,11 +84,11 @@ export class WordcloudState implements InternalChartState {
     return EMPTY_MAP;
   }
 
-  chartRenderer(containerRef: BackwardRef, forwardStageRef: RefObject<HTMLCanvasElement>) {
+  chartRenderer(containerRef: BackwardRef) {
     return (
       <>
         <Tooltip getChartContainerRef={containerRef} />
-        <Wordcloud forwardStageRef={forwardStageRef} />
+        <Wordcloud />
       </>
     );
   }

--- a/stories/wordcloud/1_wordcloud.tsx
+++ b/stories/wordcloud/1_wordcloud.tsx
@@ -21,7 +21,7 @@ import { color, number, select } from '@storybook/addon-knobs';
 import React from 'react';
 
 import { Chart, Settings, Wordcloud } from '../../src';
-import { WeightFun, WordModel } from '../../src/chart_types/wordcloud/layout/types/viewmodel_types';
+import { WeightFn, WordModel } from '../../src/chart_types/wordcloud/layout/types/viewmodel_types';
 import { getRandomNumberGenerator } from '../../src/mocks/utils';
 import { palettes as euiPalettes } from '../../src/utils/themes/colors';
 
@@ -77,7 +77,7 @@ const configs = {
     shape: 'archimedean',
     palette: 'turquoise',
     backgroundColor: '#1c1c24',
-    weightFun: WeightFun.exponential,
+    weightFn: WeightFn.exponential,
   },
   single: {
     startAngle: 0,
@@ -93,7 +93,7 @@ const configs = {
     shape: 'rectangular',
     palette: 'greyScale',
     backgroundColor: '#9fa714',
-    weightFun: WeightFun.exponential,
+    weightFn: WeightFn.exponential,
   },
   rightAngled: {
     startAngle: 0,
@@ -109,7 +109,7 @@ const configs = {
     shape: 'rectangular',
     palette: 'euiLight',
     backgroundColor: '#ffffff',
-    weightFun: WeightFun.exponential,
+    weightFn: WeightFn.exponential,
   },
   multiple: {
     startAngle: -90,
@@ -125,7 +125,7 @@ const configs = {
     shape: 'archimedean',
     palette: 'redBlue',
     backgroundColor: '#1c1c24',
-    weightFun: WeightFun.exponential,
+    weightFn: WeightFn.exponential,
   },
   squareWords: {
     startAngle: -45,
@@ -141,7 +141,7 @@ const configs = {
     shape: 'archimedean',
     palette: 'weight',
     backgroundColor: '#4a6960',
-    weightFun: WeightFun.exponential,
+    weightFn: WeightFn.exponential,
   },
   smallWaves: {
     startAngle: -15,
@@ -157,7 +157,7 @@ const configs = {
     shape: 'rectangular',
     palette: 'euiColorBlind',
     backgroundColor: '#ffffff',
-    weightFun: WeightFun.exponential,
+    weightFn: WeightFn.exponential,
   },
   sparse: {
     startAngle: 0,
@@ -173,7 +173,7 @@ const configs = {
     shape: 'rectangular',
     palette: 'vivid',
     backgroundColor: '#1c1c24',
-    weightFun: WeightFun.exponential,
+    weightFn: WeightFn.exponential,
   },
 };
 
@@ -263,17 +263,17 @@ export const Example = () => {
         Object.keys(palettes).reduce((p, k) => ({ ...p, [k]: k }), {}),
         startConfig.palette,
       );
-  const weightFun = template
-    ? startConfig.weightFun
+  const weightFn = template
+    ? startConfig.weightFn
     : select(
-        'weightFun',
+        'weightFn',
         {
-          linear: WeightFun.linear,
-          exponential: WeightFun.exponential,
-          squareRoot: WeightFun.squareRoot,
-          log: WeightFun.log,
+          linear: WeightFn.linear,
+          exponential: WeightFn.exponential,
+          squareRoot: WeightFn.squareRoot,
+          log: WeightFn.log,
         },
-        startConfig.weightFun,
+        startConfig.weightFn,
       );
 
   return (
@@ -300,7 +300,7 @@ export const Example = () => {
         spiral={spiral}
         exponent={exponent}
         data={sampleData(text, palette as keyof typeof palettes)}
-        weightFun={weightFun}
+        weightFn={weightFn}
         outOfRoomCallback={(wordCount: number, renderedWordCount: number, renderedWords: string[]) => {
           // eslint-disable-next-line no-console
           console.log(


### PR DESCRIPTION
## Summary

Partially addresses #1083 

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility
