### PR TITLE
chore: use LF as new line configuration on API-extractor

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,6 @@
   "singleQuote": true,
   "trailingComma": "all",
   "printWidth": 120,
-  "arrowParens": "always"
+  "arrowParens": "always",
+  "endOfLine": "lf"
 }

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -3,6 +3,7 @@
  */
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "newlineKind": "lf",
 
   /**
    * Optionally specifies another JSON config file that this file extends from.  This provides a way for


### PR DESCRIPTION
## Summary

By default, `api-extractor` uses `CRLF` as line-ending configuration.
Since our code uses `LF`, as specified in the `.editorconf` file, it's better to align to that configuration for every file.
I'm using a configuration introduced here: https://github.com/microsoft/rushstack/pull/1626

I've noticed multiple situations where the generated export is interpreted in github/diff viewer as completely new due to this different line endings configuration. I hope with that to avoid completely this issue in the future

