### PR TITLE
test(partition): mosaic plot story knob for alternatives selector

### DIFF
--- a/stories/mosaic/10_mosaic_simple.tsx
+++ b/stories/mosaic/10_mosaic_simple.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, radios } from '@storybook/addon-knobs';
 import React from 'react';
 
 import {
@@ -62,6 +62,15 @@ const productToColor = new Map(
 );
 
 export const Example = () => {
+  const partitionLayout = radios(
+    'Partition layout',
+    {
+      [PartitionLayout.mosaic]: PartitionLayout.mosaic,
+      [PartitionLayout.treemap]: PartitionLayout.treemap,
+      [PartitionLayout.sunburst]: PartitionLayout.sunburst,
+    },
+    PartitionLayout.mosaic,
+  );
   return (
     <Chart className="story-chart">
       <Settings showLegend={boolean('Show legend', true)} showLegendExtra={boolean('Show legend values', true)} />
@@ -78,7 +87,7 @@ export const Example = () => {
               fontWeight: 400,
             },
             shape: {
-              fillColor: () => 'white',
+              fillColor: partitionLayout === PartitionLayout.sunburst ? 'lightgrey' : 'white',
             },
           },
           {
@@ -103,7 +112,9 @@ export const Example = () => {
           },
         ]}
         config={{
-          partitionLayout: PartitionLayout.mosaic,
+          partitionLayout,
+          linkLabel: { maxCount: 0 }, // relevant for sunburst only
+          outerSizeRatio: 0.9, // relevant for sunburst only
         }}
       />
     </Chart>


### PR DESCRIPTION
## Summary

Comparison radio buttons in the mosaic story that got added by https://github.com/elastic/elastic-charts/pull/1113

![alternatives](https://user-images.githubusercontent.com/1548516/114773251-1ab60800-9d6f-11eb-95df-167f522e8596.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [X] This was checked for cross-browser compatibility
- [X] Proper documentation or storybook story was added for features that require explanation or tutorials
