### PR TITLE
build: fix types in vscode tsconfigs

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -42,6 +42,7 @@ declare global {
        * Including:
        * - disabling animations
        * - preloading icons
+       * - setting rng seed
        */
       STORYBOOK_VRT: string;
       /**

--- a/integration/tsconfig.json
+++ b/integration/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig",
-  "include": ["./**/*"]
+  "include": ["./**/*", "../**/*.d.ts", "../scripts/custom_matchers.ts"]
 }

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -5,6 +5,6 @@
     "target": "es5",
     "resolveJsonModule": true
   },
-  "include": ["../src/**/*", "./**/*"],
+  "include": ["../src/**/*", "./**/*", "../**/*.d.ts", "../scripts/custom_matchers.ts"],
   "exclude": ["../**/*.test.*"]
 }

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -1,5 +1,12 @@
 {
   "extends": "../tsconfig",
-  "include": ["../src/**/*", "../stories/**/*", "./**/*", "../storybook-docs/config.docs.ts"],
+  "include": [
+    "../src/**/*",
+    "../stories/**/*",
+    "./**/*",
+    "../storybook-docs/config.docs.ts",
+    "../**/*.d.ts",
+    "../scripts/custom_matchers.ts"
+  ],
   "exclude": ["../**/*.test.*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
     "downlevelIteration": true,
     "stripInternal": true,
     "resolveJsonModule": true,
-    "typeRoots": ["./node_modules/@types", "./global.d.ts"]
-  },
-  "files": ["./global.d.ts", "./scripts/custom_matchers.ts"]
+    "typeRoots": ["./node_modules/@types", "./**/*.d.ts", "./scripts/custom_matchers.ts"]
+  }
 }


### PR DESCRIPTION
## Summary

Fix issue with custom jest matchers and global types not registering in vscode.

![image](https://user-images.githubusercontent.com/19007109/115914889-258c2f00-a438-11eb-8f21-61fadb6d43d4.png)
