### PR TITLE
fix: memory leak related to re-reselect cache

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,7 +75,7 @@ module.exports = {
     'import/no-cycle': [0, { maxDepth: 3, ignoreExternal: true }], // TODO: should error when this is fixed https://github.com/benmosher/eslint-plugin-import/issues/1453
     'no-use-before-define': 0,
     'no-restricted-properties': 0, // need to find and filter desired options
-    'class-methods-use-this': 1,
+    'class-methods-use-this': 0,
     'unicorn/prefer-number-properties': 0,
     'global-require': 1,
     'import/no-dynamic-require': 1,
@@ -360,6 +360,14 @@ module.exports = {
               ]
             : 0,
 
+        'no-restricted-imports': [
+          'error',
+          {
+            name: 're-reselect',
+            importNames: ['default'],
+            message: 'Please use `createCustomCachedSelector` instead.',
+          },
+        ],
         'no-underscore-dangle': 2,
         'import/no-unresolved': 'error',
         'import/no-extraneous-dependencies': 2,

--- a/packages/charts/src/chart_types/goal_chart/state/selectors/geometries.ts
+++ b/packages/charts/src/chart_types/goal_chart/state/selectors/geometries.ts
@@ -17,12 +17,10 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ChartType } from '../../..';
 import { SpecType } from '../../../../specs/constants';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSpecs } from '../../../../state/selectors/get_settings_specs';
 import { getSpecsFromStore } from '../../../../state/utils';
 import { nullShapeViewModel, ShapeViewModel } from '../../layout/types/viewmodel_types';
@@ -32,10 +30,10 @@ import { render } from './scenegraph';
 const getParentDimensions = (state: GlobalChartState) => state.parentDimensions;
 
 /** @internal */
-export const geometries = createCachedSelector(
+export const geometries = createCustomCachedSelector(
   [getSpecs, getParentDimensions],
   (specs, parentDimensions): ShapeViewModel => {
     const goalSpecs = getSpecsFromStore<GoalSpec>(specs, ChartType.Goal, SpecType.Series);
     return goalSpecs.length === 1 ? render(goalSpecs[0], parentDimensions) : nullShapeViewModel();
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/goal_chart/state/selectors/get_chart_type_description.ts
+++ b/packages/charts/src/chart_types/goal_chart/state/selectors/get_chart_type_description.ts
@@ -17,12 +17,10 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSpecOrNull } from './goal_spec';
 
 /** @internal */
-export const getChartTypeDescriptionSelector = createCachedSelector([getSpecOrNull], (spec) => {
+export const getChartTypeDescriptionSelector = createCustomCachedSelector([getSpecOrNull], (spec) => {
   return `${spec?.subtype ?? 'goal'} chart`;
-})(getChartIdSelector);
+});

--- a/packages/charts/src/chart_types/goal_chart/state/selectors/is_tooltip_visible.ts
+++ b/packages/charts/src/chart_types/goal_chart/state/selectors/is_tooltip_visible.ts
@@ -17,16 +17,14 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { getTooltipType } from '../../../../specs';
 import { TooltipType } from '../../../../specs/constants';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getTooltipInfoSelector } from './tooltip';
 
 /** @internal */
-export const isTooltipVisibleSelector = createCachedSelector(
+export const isTooltipVisibleSelector = createCustomCachedSelector(
   [getSettingsSpecSelector, getTooltipInfoSelector],
   (settingsSpec, tooltipInfo): boolean => {
     if (getTooltipType(settingsSpec) === TooltipType.None) {
@@ -34,4 +32,4 @@ export const isTooltipVisibleSelector = createCachedSelector(
     }
     return tooltipInfo.values.length > 0;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/goal_chart/state/selectors/on_element_click_caller.ts
+++ b/packages/charts/src/chart_types/goal_chart/state/selectors/on_element_click_caller.ts
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
 import { ChartType } from '../../..';
 import { getOnElementClickSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState, PointerStates } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getLastClickSelector } from '../../../../state/selectors/get_last_click';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getSpecOrNull } from './goal_spec';
@@ -41,10 +40,10 @@ export function createOnElementClickCaller(): (state: GlobalChartState) => void 
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.Goal) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getSpecOrNull, getLastClickSelector, getSettingsSpecSelector, getPickedShapesLayerValues],
         getOnElementClickSelector(prev),
-      )(getChartIdSelector);
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/goal_chart/state/selectors/on_element_out_caller.ts
+++ b/packages/charts/src/chart_types/goal_chart/state/selectors/on_element_out_caller.ts
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartType } from '../../..';
 import { getOnElementOutSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getSpecOrNull } from './goal_spec';
 import { getPickedShapesLayerValues } from './picked_shapes';
@@ -39,10 +38,10 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.Goal) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getSpecOrNull, getPickedShapesLayerValues, getSettingsSpecSelector],
         getOnElementOutSelector(prev),
-      )(getChartIdSelector);
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/goal_chart/state/selectors/on_element_over_caller.ts
+++ b/packages/charts/src/chart_types/goal_chart/state/selectors/on_element_over_caller.ts
@@ -17,14 +17,13 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartType } from '../../..';
 import { getOnElementOverSelector } from '../../../../common/event_handler_selectors';
 import { LayerValue } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getSpecOrNull } from './goal_spec';
 import { getPickedShapesLayerValues } from './picked_shapes';
@@ -40,12 +39,10 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.Goal) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getSpecOrNull, getPickedShapesLayerValues, getSettingsSpecSelector],
         getOnElementOverSelector(prev),
-      )({
-        keySelector: getChartIdSelector,
-      });
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/goal_chart/state/selectors/picked_shapes.ts
+++ b/packages/charts/src/chart_types/goal_chart/state/selectors/picked_shapes.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { LayerValue } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { BulletViewModel } from '../../layout/types/viewmodel_types';
 import { geometries } from './geometries';
 
@@ -30,7 +28,7 @@ function getCurrentPointerPosition(state: GlobalChartState) {
 }
 
 /** @internal */
-export const getPickedShapes = createCachedSelector(
+export const getPickedShapes = createCustomCachedSelector(
   [geometries, getCurrentPointerPosition],
   (geoms, pointerPosition): BulletViewModel[] => {
     const picker = geoms.pickQuads;
@@ -39,10 +37,10 @@ export const getPickedShapes = createCachedSelector(
     const y = pointerPosition.y - chartCenter.y;
     return picker(x, y);
   },
-)(getChartIdSelector);
+);
 
 /** @internal */
-export const getPickedShapesLayerValues = createCachedSelector(
+export const getPickedShapesLayerValues = createCustomCachedSelector(
   [getPickedShapes],
   (pickedShapes): Array<Array<LayerValue>> => {
     const elements = pickedShapes.map<Array<LayerValue>>((model) => {
@@ -59,4 +57,4 @@ export const getPickedShapesLayerValues = createCachedSelector(
     });
     return elements;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/goal_chart/state/selectors/tooltip.ts
+++ b/packages/charts/src/chart_types/goal_chart/state/selectors/tooltip.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { TooltipInfo } from '../../../../components/tooltip/types';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSpecOrNull } from './goal_spec';
 import { getPickedShapes } from './picked_shapes';
 
@@ -30,7 +28,7 @@ const EMPTY_TOOLTIP = Object.freeze({
 });
 
 /** @internal */
-export const getTooltipInfoSelector = createCachedSelector(
+export const getTooltipInfoSelector = createCustomCachedSelector(
   [getSpecOrNull, getPickedShapes],
   (spec, pickedShapes): TooltipInfo => {
     if (!spec) {
@@ -60,4 +58,4 @@ export const getTooltipInfoSelector = createCachedSelector(
 
     return tooltipInfo;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/compute_chart_dimensions.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/compute_chart_dimensions.ts
@@ -18,11 +18,10 @@
  */
 
 import { max as d3Max } from 'd3-array';
-import createCachedSelector from 're-reselect';
 
 import { Box, measureText } from '../../../../common/text_utils';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getLegendSizeSelector } from '../../../../state/selectors/get_legend_size';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { Position } from '../../../../utils/common';
@@ -50,7 +49,7 @@ const getParentDimension = (state: GlobalChartState) => state.parentDimensions;
  * Gets charts grid area excluding legend and X,Y axis labels and paddings.
  * @internal
  */
-export const computeChartDimensionsSelector = createCachedSelector(
+export const computeChartDimensionsSelector = createCustomCachedSelector(
   [
     getParentDimension,
     getLegendSizeSelector,
@@ -114,4 +113,4 @@ export const computeChartDimensionsSelector = createCachedSelector(
       left,
     };
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/compute_legend.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/compute_legend.ts
@@ -17,16 +17,14 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { LegendItem } from '../../../../common/legend';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getDeselectedSeriesSelector } from '../../../../state/selectors/get_deselected_data_series';
 import { getColorScale } from './get_color_scale';
 import { getSpecOrNull } from './heatmap_spec';
 
 /** @internal */
-export const computeLegendSelector = createCachedSelector(
+export const computeLegendSelector = createCustomCachedSelector(
   [getSpecOrNull, getColorScale, getDeselectedSeriesSelector],
   (spec, colorScale, deselectedDataSeries): LegendItem[] => {
     const legendItems: LegendItem[] = [];
@@ -53,4 +51,4 @@ export const computeLegendSelector = createCachedSelector(
       };
     });
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/geometries.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/geometries.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { nullShapeViewModel, ShapeViewModel } from '../../layout/types/viewmodel_types';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
@@ -34,7 +32,7 @@ import { render } from './scenegraph';
 const getDeselectedSeriesSelector = (state: GlobalChartState) => state.interactions.deselectedDataSeries;
 
 /** @internal */
-export const geometries = createCachedSelector(
+export const geometries = createCustomCachedSelector(
   [
     getHeatmapSpecSelector,
     computeChartDimensionsSelector,
@@ -73,4 +71,4 @@ export const geometries = createCachedSelector(
       ? render(heatmapSpec, settingSpec, chartDimensions, heatmapTable, colorScale, ranges, gridHeightParams)
       : nullShapeViewModel();
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_brush_area.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_brush_area.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { BrushAxis } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartRotationSelector } from '../../../../state/selectors/get_chart_rotation';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { Dimensions } from '../../../../utils/dimensions';
@@ -32,7 +30,7 @@ const getIsDragging = (state: GlobalChartState) => state.interactions.pointer.dr
 const getCurrentPointerPosition = (state: GlobalChartState) => state.interactions.pointer.current.position;
 
 /** @internal */
-export const getBrushAreaSelector = createCachedSelector(
+export const getBrushAreaSelector = createCustomCachedSelector(
   [
     getIsDragging,
     getMouseDownPosition,
@@ -55,4 +53,4 @@ export const getBrushAreaSelector = createCachedSelector(
         return { top: start.y, left: start.x, width: end.x - start.x - chartDimensions.left, height: end.y - start.y };
     }
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_brushed_highlighted_shapes.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_brushed_highlighted_shapes.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { DragShape } from '../../layout/types/viewmodel_types';
 import { geometries } from './geometries';
 
@@ -29,7 +27,7 @@ function getCurrentPointerStates(state: GlobalChartState) {
 }
 
 /** @internal */
-export const getBrushedHighlightedShapesSelector = createCachedSelector(
+export const getBrushedHighlightedShapesSelector = createCustomCachedSelector(
   [geometries, getCurrentPointerStates],
   (geoms, pointerStates): DragShape | null => {
     if (!pointerStates.dragging || !pointerStates.down) {
@@ -51,4 +49,4 @@ export const getBrushedHighlightedShapesSelector = createCachedSelector(
     ]);
     return shape;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_color_scale.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_color_scale.ts
@@ -29,10 +29,9 @@ import {
   ScaleThreshold,
   scaleThreshold,
 } from 'd3-scale';
-import createCachedSelector from 're-reselect';
 
 import { ScaleType } from '../../../../scales/constants';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getHeatmapSpecSelector } from './get_heatmap_spec';
 import { getHeatmapTableSelector } from './get_heatmap_table';
 
@@ -52,7 +51,7 @@ export type ColorScaleType = ScaleLinearType | ScaleQuantizeType | ScaleQuantile
  * @internal
  * Gets color scale based on specification and values range.
  */
-export const getColorScale = createCachedSelector(
+export const getColorScale = createCustomCachedSelector(
   [getHeatmapSpecSelector, getHeatmapTableSelector],
   (spec, heatmapTable) => {
     const { colors, colorScale: colorScaleSpec } = spec;
@@ -81,7 +80,7 @@ export const getColorScale = createCachedSelector(
     }
     return colorScale;
   },
-)(getChartIdSelector);
+);
 
 function addBaselineOnLinearScale(min: number, max: number, ticks: Array<number>): Array<number> {
   if (min < 0 && max < 0) {

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_cursor_pointer.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_cursor_pointer.ts
@@ -17,17 +17,15 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { DEFAULT_CSS_CURSOR } from '../../../../common/constants';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { isBrushingSelector } from './is_brushing';
 import { getPickedShapes } from './picked_shapes';
 
 /** @internal */
-export const getPointerCursorSelector = createCachedSelector(
+export const getPointerCursorSelector = createCustomCachedSelector(
   [getPickedShapes, isBrushingSelector],
   (pickedShapes, isBrushing) => {
     return isBrushing || (Array.isArray(pickedShapes) && pickedShapes.length > 0) ? 'pointer' : DEFAULT_CSS_CURSOR;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_debug_state.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_debug_state.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { RGBtoString } from '../../../../common/color_library_wrappers';
 import { LegendItem } from '../../../../common/legend';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { DebugState, DebugStateLegend } from '../../../../state/types';
 import { Position } from '../../../../utils/common';
 import { computeLegendSelector } from './compute_legend';
@@ -33,7 +31,7 @@ import { getPickedCells } from './get_picked_cells';
  * Returns a stringified version of the `debugState`
  * @internal
  */
-export const getDebugStateSelector = createCachedSelector(
+export const getDebugStateSelector = createCustomCachedSelector(
   [geometries, computeLegendSelector, getHighlightedAreaSelector, getPickedCells, getHighlightedDataSelector],
   (geoms, legend, pickedArea, pickedCells, highlightedData): DebugState => {
     return {
@@ -77,7 +75,7 @@ export const getDebugStateSelector = createCachedSelector(
       },
     };
   },
-)(getChartIdSelector);
+);
 
 function getLegendState(legendItems: LegendItem[]): DebugStateLegend {
   const items = legendItems

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_grid_full_height.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_grid_full_height.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getLegendSizeSelector } from '../../../../state/selectors/get_legend_size';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { isHorizontalLegend } from '../../../../utils/legend';
@@ -37,7 +35,7 @@ export interface GridHeightParams {
 const getParentDimension = (state: GlobalChartState) => state.parentDimensions;
 
 /** @internal */
-export const getGridHeightParamsSelector = createCachedSelector(
+export const getGridHeightParamsSelector = createCustomCachedSelector(
   [
     getLegendSizeSelector,
     getSettingsSpecSelector,
@@ -74,7 +72,7 @@ export const getGridHeightParamsSelector = createCachedSelector(
       pageSize,
     };
   },
-)(getChartIdSelector);
+);
 
 function getGridCellHeight(yValues: Array<string | number>, grid: Config['grid'], height: number): number {
   if (yValues.length === 0) {

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_heatmap_config.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_heatmap_config.ts
@@ -17,18 +17,16 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { mergePartial } from '../../../../utils/common';
 import { config as defaultConfig } from '../../layout/config/config';
 import { Config } from '../../layout/types/config_types';
 import { getHeatmapSpecSelector } from './get_heatmap_spec';
 
 /** @internal */
-export const getHeatmapConfigSelector = createCachedSelector(
+export const getHeatmapConfigSelector = createCustomCachedSelector(
   [getHeatmapSpecSelector],
   (spec): Config => {
     return mergePartial<Config>(defaultConfig, spec.config, { mergeOptionalPartialValues: true });
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_heatmap_container_size.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_heatmap_container_size.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getLegendConfigSelector } from '../../../../state/selectors/get_legend_config_selector';
 import { getLegendSizeSelector } from '../../../../state/selectors/get_legend_size';
 import { LayoutDirection } from '../../../../utils/common';
@@ -33,7 +31,7 @@ const getParentDimension = (state: GlobalChartState) => state.parentDimensions;
  * Gets charts grid area excluding legend and X,Y axis labels and paddings.
  * @internal
  */
-export const getHeatmapContainerSizeSelector = createCachedSelector(
+export const getHeatmapContainerSizeSelector = createCustomCachedSelector(
   [getParentDimension, getLegendSizeSelector, getHeatmapConfigSelector, getLegendConfigSelector],
   (parentDimensions, legendSize, { maxLegendHeight }, { showLegend, legendPosition }): Dimensions => {
     if (!showLegend || legendPosition.floating) {
@@ -57,4 +55,4 @@ export const getHeatmapContainerSizeSelector = createCachedSelector(
       height: parentDimensions.height - legendHeight,
     };
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_heatmap_spec.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_heatmap_spec.ts
@@ -17,17 +17,15 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ChartType } from '../../..';
 import { SpecType } from '../../../../specs';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSpecs } from '../../../../state/selectors/get_settings_specs';
 import { getSpecsFromStore } from '../../../../state/utils';
 import { HeatmapSpec } from '../../specs';
 
 /** @internal */
-export const getHeatmapSpecSelector = createCachedSelector([getSpecs], (specs) => {
+export const getHeatmapSpecSelector = createCustomCachedSelector([getSpecs], (specs) => {
   const spec = getSpecsFromStore<HeatmapSpec>(specs, ChartType.Heatmap, SpecType.Series);
   return spec[0];
-})(getChartIdSelector);
+});

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_heatmap_table.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_heatmap_table.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { getPredicateFn } from '../../../../common/predicate';
 import { ScaleType } from '../../../../scales/constants';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getAccessorValue } from '../../../../utils/accessor';
 import { mergeXDomain } from '../../../xy_chart/domains/x_domain';
@@ -34,7 +32,7 @@ import { getHeatmapSpecSelector } from './get_heatmap_spec';
  * Extracts axis and cell values from the input data.
  * @internal
  */
-export const getHeatmapTableSelector = createCachedSelector(
+export const getHeatmapTableSelector = createCustomCachedSelector(
   [getHeatmapSpecSelector, getSettingsSpecSelector],
   (spec, settingsSpec): HeatmapTable => {
     const { data, valueAccessor, xAccessor, yAccessor, xSortPredicate, ySortPredicate } = spec;
@@ -94,4 +92,4 @@ export const getHeatmapTableSelector = createCachedSelector(
 
     return resultData;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_highlighted_area.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_highlighted_area.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { geometries } from './geometries';
 import { getHeatmapSpecSelector } from './get_heatmap_spec';
 import { isBrushingSelector } from './is_brushing';
@@ -27,7 +25,7 @@ import { isBrushingSelector } from './is_brushing';
 /**
  * @internal
  */
-export const getHighlightedDataSelector = createCachedSelector(
+export const getHighlightedDataSelector = createCustomCachedSelector(
   [getHeatmapSpecSelector, isBrushingSelector],
   (spec, isBrushing) => {
     if (!spec.highlightedData || isBrushing) {
@@ -35,13 +33,13 @@ export const getHighlightedDataSelector = createCachedSelector(
     }
     return spec.highlightedData;
   },
-)(getChartIdSelector);
+);
 
 /**
  * Returns rect position of the highlighted selection.
  * @internal
  */
-export const getHighlightedAreaSelector = createCachedSelector(
+export const getHighlightedAreaSelector = createCustomCachedSelector(
   [geometries, getHeatmapSpecSelector, isBrushingSelector],
   (geoms, spec, isBrushing) => {
     if (!spec.highlightedData || isBrushing) {
@@ -49,4 +47,4 @@ export const getHighlightedAreaSelector = createCachedSelector(
     }
     return geoms.pickHighlightedArea(spec.highlightedData.x, spec.highlightedData.y);
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_legend_items_labels.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_legend_items_labels.ts
@@ -17,15 +17,13 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { LegendItemLabel } from '../../../../state/selectors/get_legend_items_labels';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { computeLegendSelector } from './compute_legend';
 
 /** @internal */
-export const getLegendItemsLabelsSelector = createCachedSelector(
+export const getLegendItemsLabelsSelector = createCustomCachedSelector(
   [computeLegendSelector, getSettingsSpecSelector],
   (legendItems, { showLegendExtra }): LegendItemLabel[] =>
     legendItems.map(({ label, defaultExtra }) => {
@@ -34,4 +32,4 @@ export const getLegendItemsLabelsSelector = createCachedSelector(
       }
       return { label, depth: 0 };
     }),
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_picked_cells.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_picked_cells.ts
@@ -17,15 +17,13 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getLastDragSelector } from '../../../../state/selectors/get_last_drag';
 import { PickDragFunction } from '../../layout/types/viewmodel_types';
 import { geometries } from './geometries';
 
 /** @internal */
-export const getPickedCells = createCachedSelector(
+export const getPickedCells = createCustomCachedSelector(
   [geometries, getLastDragSelector],
   (geoms, dragState): ReturnType<PickDragFunction> | null => {
     if (!dragState) {
@@ -46,4 +44,4 @@ export const getPickedCells = createCachedSelector(
       { x: endX, y: endY },
     ]);
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_tooltip_anchor.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_tooltip_anchor.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { AnchorPosition } from '../../../../components/portal/types';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
 import { getPickedShapes } from './picked_shapes';
 
@@ -30,7 +28,7 @@ function getCurrentPointerPosition(state: GlobalChartState) {
 }
 
 /** @internal */
-export const getTooltipAnchorSelector = createCachedSelector(
+export const getTooltipAnchorSelector = createCustomCachedSelector(
   [getPickedShapes, computeChartDimensionsSelector, getCurrentPointerPosition],
   (shapes, chartDimensions, position): AnchorPosition => {
     if (Array.isArray(shapes) && shapes.length > 0) {
@@ -49,4 +47,4 @@ export const getTooltipAnchorSelector = createCachedSelector(
       height: 0,
     };
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_x_axis_right_overflow.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_x_axis_right_overflow.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ScaleContinuous } from '../../../../scales';
 import { ScaleType } from '../../../../scales/constants';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { CanvasTextBBoxCalculator } from '../../../../utils/bbox/canvas_text_bbox_calculator';
 import { getHeatmapConfigSelector } from './get_heatmap_config';
 import { getHeatmapTableSelector } from './get_heatmap_table';
@@ -30,7 +28,7 @@ import { getHeatmapTableSelector } from './get_heatmap_table';
  * @internal
  * Gets color scale based on specification and values range.
  */
-export const getXAxisRightOverflow = createCachedSelector(
+export const getXAxisRightOverflow = createCustomCachedSelector(
   [getHeatmapConfigSelector, getHeatmapTableSelector],
   ({ xAxisLabel: { fontSize, fontFamily, padding, formatter, width }, timeZone }, { xDomain }): number => {
     if (xDomain.type !== ScaleType.Time) {
@@ -59,4 +57,4 @@ export const getXAxisRightOverflow = createCachedSelector(
     bboxCompute.destroy();
     return maxTextWidth / 2;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/is_brush_available.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/is_brush_available.ts
@@ -17,20 +17,18 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getHeatmapConfigSelector } from './get_heatmap_config';
 
 /**
  * The brush is available only if a onBrushEnd listener is configured
  * @internal
  */
-export const isBrushAvailableSelector = createCachedSelector([getHeatmapConfigSelector], (config): boolean => {
+export const isBrushAvailableSelector = createCustomCachedSelector([getHeatmapConfigSelector], (config): boolean => {
   return Boolean(config.onBrushEnd) && config.brushTool.visible;
-})(getChartIdSelector);
+});
 
 /** @internal */
-export const isBrushEndProvided = createCachedSelector([getHeatmapConfigSelector], (config): boolean => {
+export const isBrushEndProvided = createCustomCachedSelector([getHeatmapConfigSelector], (config): boolean => {
   return Boolean(config.onBrushEnd);
-})(getChartIdSelector);
+});

--- a/packages/charts/src/chart_types/heatmap/state/selectors/is_brushing.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/is_brushing.ts
@@ -17,14 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 
 const getPointerSelector = (state: GlobalChartState) => state.interactions.pointer;
 
 /** @internal */
-export const isBrushingSelector = createCachedSelector([getPointerSelector], (pointer): boolean => {
+export const isBrushingSelector = createCustomCachedSelector([getPointerSelector], (pointer): boolean => {
   return pointer.dragging;
-})(getChartIdSelector);
+});

--- a/packages/charts/src/chart_types/heatmap/state/selectors/is_tooltip_visible.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/is_tooltip_visible.ts
@@ -17,16 +17,14 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { getTooltipType } from '../../../../specs';
 import { TooltipType } from '../../../../specs/constants';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getTooltipInfoSelector } from './tooltip';
 
 /** @internal */
-export const isTooltipVisibleSelector = createCachedSelector(
+export const isTooltipVisibleSelector = createCustomCachedSelector(
   [getSettingsSpecSelector, getTooltipInfoSelector],
   (settingsSpec, tooltipInfo): boolean => {
     if (getTooltipType(settingsSpec) === TooltipType.None) {
@@ -34,4 +32,4 @@ export const isTooltipVisibleSelector = createCachedSelector(
     }
     return tooltipInfo.values.length > 0;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/on_brush_end_caller.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/on_brush_end_caller.ts
@@ -17,12 +17,11 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
 import { ChartType } from '../../..';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getLastDragSelector } from '../../../../state/selectors/get_last_drag';
 import { DragCheckProps, hasDragged } from '../../../../utils/events';
 import { getHeatmapConfigSelector } from './get_heatmap_config';
@@ -46,7 +45,7 @@ export function createOnBrushEndCaller(): (state: GlobalChartState) => void {
         prevProps = null;
         return;
       }
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getLastDragSelector, getSpecOrNull, getHeatmapConfigSelector, getPickedCells],
         (lastDrag, spec, { onBrushEnd }, pickedCells): void => {
           const nextProps: DragCheckProps = {
@@ -61,9 +60,7 @@ export function createOnBrushEndCaller(): (state: GlobalChartState) => void {
           }
           prevProps = nextProps;
         },
-      )({
-        keySelector: getChartIdSelector,
-      });
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/on_element_click_caller.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/on_element_click_caller.ts
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
 import { ChartType } from '../../..';
 import { SeriesIdentifier } from '../../../../common/series_id';
 import { SettingsSpec } from '../../../../specs';
 import { GlobalChartState, PointerState } from '../../../../state/chart_state';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getLastClickSelector } from '../../../../state/selectors/get_last_click';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { isClicking } from '../../../../state/utils';
@@ -43,7 +43,7 @@ export function createOnElementClickCaller(): (state: GlobalChartState) => void 
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.Heatmap) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getSpecOrNull, getLastClickSelector, getSettingsSpecSelector, getPickedShapes],
         (spec, lastClick: PointerState | null, settings: SettingsSpec, pickedShapes): void => {
           if (!spec) {
@@ -68,9 +68,7 @@ export function createOnElementClickCaller(): (state: GlobalChartState) => void 
           }
           prevClick = lastClick;
         },
-      )({
-        keySelector: (state: GlobalChartState) => state.chartId,
-      });
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/on_element_out_caller.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/on_element_out_caller.ts
@@ -17,12 +17,11 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartType } from '../../..';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { isPickedCells } from '../../layout/types/viewmodel_types';
 import { getSpecOrNull } from './heatmap_spec';
@@ -39,7 +38,7 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.Heatmap) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getSpecOrNull, getPickedShapes, getSettingsSpecSelector],
         (spec, pickedShapes, settings): void => {
           if (!spec) {
@@ -55,9 +54,7 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
           }
           prevPickedShapes = nextPickedShapes;
         },
-      )({
-        keySelector: getChartIdSelector,
-      });
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/on_element_over_caller.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/on_element_over_caller.ts
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartType } from '../../..';
 import { SeriesIdentifier } from '../../../../common/series_id';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { Cell, isPickedCells } from '../../layout/types/viewmodel_types';
 import { getSpecOrNull } from './heatmap_spec';
@@ -56,7 +55,7 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.Heatmap) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getSpecOrNull, getPickedShapes, getSettingsSpecSelector],
         (spec, nextPickedShapes, settings): void => {
           if (!spec) {
@@ -81,9 +80,7 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
           }
           prevPickedShapes = nextPickedShapes;
         },
-      )({
-        keySelector: getChartIdSelector,
-      });
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/picked_shapes.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/picked_shapes.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { Cell } from '../../layout/types/viewmodel_types';
 import { TextBox } from '../../layout/viewmodel/viewmodel';
 import { geometries } from './geometries';
@@ -30,10 +28,11 @@ function getCurrentPointerPosition(state: GlobalChartState) {
 }
 
 /** @internal */
-export const getPickedShapes = createCachedSelector([geometries, getCurrentPointerPosition], (geoms, pointerPosition):
-  | Cell[]
-  | TextBox => {
-  const picker = geoms.pickQuads;
-  const { x, y } = pointerPosition;
-  return picker(x, y);
-})(getChartIdSelector);
+export const getPickedShapes = createCustomCachedSelector(
+  [geometries, getCurrentPointerPosition],
+  (geoms, pointerPosition): Cell[] | TextBox => {
+    const picker = geoms.pickQuads;
+    const { x, y } = pointerPosition;
+    return picker(x, y);
+  },
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/tooltip.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/tooltip.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { RGBtoString } from '../../../../common/color_library_wrappers';
 import { TooltipInfo } from '../../../../components/tooltip/types';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getHeatmapConfigSelector } from './get_heatmap_config';
 import { getSpecOrNull } from './heatmap_spec';
 import { getPickedShapes } from './picked_shapes';
@@ -32,7 +30,7 @@ const EMPTY_TOOLTIP = Object.freeze({
 });
 
 /** @internal */
-export const getTooltipInfoSelector = createCachedSelector(
+export const getTooltipInfoSelector = createCustomCachedSelector(
   [getSpecOrNull, getHeatmapConfigSelector, getPickedShapes],
   (spec, config, pickedShapes): TooltipInfo => {
     if (!spec) {
@@ -111,4 +109,4 @@ export const getTooltipInfoSelector = createCachedSelector(
 
     return tooltipInfo;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/compute_legend.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/compute_legend.ts
@@ -17,17 +17,15 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { LegendItem } from '../../../../common/legend';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getLegendConfigSelector } from '../../../../state/selectors/get_legend_config_selector';
 import { getLegendItems } from '../../layout/utils/legend';
 import { partitionMultiGeometries } from './geometries';
 import { getPartitionSpecs } from './get_partition_specs';
 
 /** @internal */
-export const computeLegendSelector = createCachedSelector(
+export const computeLegendSelector = createCustomCachedSelector(
   [getPartitionSpecs, getLegendConfigSelector, partitionMultiGeometries],
   (specs, { flatLegend, legendMaxDepth, legendPosition }, geometries): LegendItem[] =>
     specs.flatMap((partitionSpec, i) => {
@@ -41,4 +39,4 @@ export const computeLegendSelector = createCachedSelector(
         quadViewModel,
       );
     }),
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/drilldown_active.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/drilldown_active.ts
@@ -17,12 +17,11 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { isSimpleLinear } from '../../layout/viewmodel/viewmodel';
 import { getPartitionSpecs } from './partition_spec';
 
 /** @internal */
-export const drilldownActive = createCachedSelector([getPartitionSpecs], (specs) => {
+export const drilldownActive = createCustomCachedSelector([getPartitionSpecs], (specs) => {
   return specs.length === 1 && isSimpleLinear(specs[0].config, specs[0].layers); // singleton!
-})((state) => state.chartId);
+});

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/geometries.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/geometries.ts
@@ -17,14 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ChartType } from '../../..';
 import { CategoryKey } from '../../../../common/category';
 import { Pixels, Ratio } from '../../../../common/geometry';
 import { RelativeBandsPadding, SmallMultiplesSpec, SpecType } from '../../../../specs';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartContainerDimensionsSelector } from '../../../../state/selectors/get_chart_container_dimensions';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { getSpecs } from '../../../../state/selectors/get_settings_specs';
 import { getSpecsFromStore } from '../../../../state/utils';
@@ -49,7 +47,7 @@ function bandwidth(range: Pixels, bandCount: number, { outer, inner }: RelativeB
 }
 
 /** @internal */
-export const partitionMultiGeometries = createCachedSelector(
+export const partitionMultiGeometries = createCustomCachedSelector(
   [getSpecs, getPartitionSpecs, getChartContainerDimensionsSelector, getTrees, getChartThemeSelector],
   (specs, partitionSpecs, parentDimensions, trees, { background }): ShapeViewModel[] => {
     const smallMultiplesSpecs = getSpecsFromStore<SmallMultiplesSpec>(specs, ChartType.Global, SpecType.SmallMultiples);
@@ -208,7 +206,7 @@ export const partitionMultiGeometries = createCachedSelector(
 
     return result.length === 0 ? [nullShapeViewModel(config, { x: outerWidthRatio, y: outerHeightRatio })] : result;
   },
-)(getChartIdSelector);
+);
 
 function focusRect(quadViewModel: QuadViewModel[], { left, width }: Dimensions, drilldown: CategoryKey[]) {
   return drilldown.length === 0
@@ -219,7 +217,7 @@ function focusRect(quadViewModel: QuadViewModel[], { left, width }: Dimensions, 
 }
 
 /** @internal */
-export const partitionDrilldownFocus = createCachedSelector(
+export const partitionDrilldownFocus = createCustomCachedSelector(
   [
     partitionMultiGeometries,
     getChartContainerDimensionsSelector,
@@ -232,4 +230,4 @@ export const partitionDrilldownFocus = createCachedSelector(
       const { x0: prevFocusX0, x1: prevFocusX1 } = focusRect(quadViewModel, chartDimensions, prevDrilldown);
       return { currentFocusX0, currentFocusX1, prevFocusX0, prevFocusX1, smAccessorValue, index, innerIndex };
     }),
-)((state) => state.chartId);
+);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/get_chart_type_description.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/get_chart_type_description.ts
@@ -17,12 +17,13 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getPartitionSpec } from './partition_spec';
 
 /** @internal */
-export const getChartTypeDescriptionSelector = createCachedSelector([getPartitionSpec], (partitionSpec): string => {
-  return `${partitionSpec?.config.partitionLayout} chart` ?? 'Partition chart';
-})(getChartIdSelector);
+export const getChartTypeDescriptionSelector = createCustomCachedSelector(
+  [getPartitionSpec],
+  (partitionSpec): string => {
+    return `${partitionSpec?.config.partitionLayout} chart` ?? 'Partition chart';
+  },
+);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/get_debug_state.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/get_debug_state.ts
@@ -17,18 +17,16 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { TAU } from '../../../../common/constants';
 import { Pixels, PointObject } from '../../../../common/geometry';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { DebugState, PartitionDebugState } from '../../../../state/types';
 import { QuadViewModel } from '../../layout/types/viewmodel_types';
 import { isSunburst } from '../../layout/viewmodel/viewmodel';
 import { partitionMultiGeometries } from './geometries';
 
 /** @internal */
-export const getDebugStateSelector = createCachedSelector(
+export const getDebugStateSelector = createCustomCachedSelector(
   [partitionMultiGeometries],
   (geoms): DebugState => {
     return {
@@ -53,7 +51,7 @@ export const getDebugStateSelector = createCachedSelector(
       }, []),
     };
   },
-)(getChartIdSelector);
+);
 
 function getCoordsForSector({ x0, x1, y1px, y0px }: QuadViewModel, diskCenter: PointObject): [Pixels, Pixels] {
   const X0 = x0 - TAU / 4;

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/get_highlighted_shapes.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/get_highlighted_shapes.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { QuadViewModel } from '../../layout/types/viewmodel_types';
 import { highlightedGeoms } from '../../layout/utils/highlighted_geoms';
@@ -29,7 +27,7 @@ import { partitionMultiGeometries } from './geometries';
 const getHighlightedLegendItemPath = (state: GlobalChartState) => state.interactions.highlightedLegendPath;
 
 /** @internal */
-export const legendHoverHighlightNodes = createCachedSelector(
+export const legendHoverHighlightNodes = createCustomCachedSelector(
   [getSettingsSpecSelector, getHighlightedLegendItemPath, partitionMultiGeometries],
   ({ legendStrategy, flatLegend }, highlightedLegendItemPath, geometries): QuadViewModel[] => {
     if (highlightedLegendItemPath.length === 0) return [];
@@ -37,4 +35,4 @@ export const legendHoverHighlightNodes = createCachedSelector(
       highlightedGeoms(legendStrategy, flatLegend, quadViewModel, highlightedLegendItemPath),
     );
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/get_legend_items_extra.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/get_legend_items_extra.ts
@@ -17,22 +17,20 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { LegendItemExtraValues } from '../../../../common/legend';
 import { SeriesKey } from '../../../../common/series_id';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getExtraValueMap } from '../../layout/viewmodel/hierarchy_of_arrays';
 import { getPartitionSpec } from './partition_spec';
 import { getTrees } from './tree';
 
 /** @internal */
-export const getLegendItemsExtra = createCachedSelector(
+export const getLegendItemsExtra = createCustomCachedSelector(
   [getPartitionSpec, getSettingsSpecSelector, getTrees],
   (spec, { legendMaxDepth }, trees): Map<SeriesKey, LegendItemExtraValues> => {
     return spec && !Number.isNaN(legendMaxDepth) && legendMaxDepth > 0
       ? getExtraValueMap(spec.layers, spec.valueFormatter, trees[0].tree, legendMaxDepth) // singleton! wrt inner small multiples
       : new Map<SeriesKey, LegendItemExtraValues>();
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/get_legend_items_labels.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/get_legend_items_labels.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { LegendItemLabel } from '../../../../state/selectors/get_legend_items_labels';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getLegendLabels } from '../../layout/utils/legend_labels';
@@ -27,10 +25,10 @@ import { getPartitionSpecs } from './get_partition_specs';
 import { getTrees } from './tree';
 
 /** @internal */
-export const getLegendItemsLabels = createCachedSelector(
+export const getLegendItemsLabels = createCustomCachedSelector(
   [getPartitionSpecs, getSettingsSpecSelector, getTrees],
   (specs, { legendMaxDepth, showLegend }, trees): LegendItemLabel[] =>
-    specs.flatMap((spec) =>
-      showLegend ? trees.flatMap(({ tree }) => getLegendLabels(spec.layers, tree, legendMaxDepth)) : [],
+    specs.flatMap(({ layers }) =>
+      showLegend ? trees.flatMap(({ tree }) => getLegendLabels(layers, tree, legendMaxDepth)) : [],
     ),
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/get_partition_specs.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/get_partition_specs.ts
@@ -17,16 +17,14 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ChartType } from '../../..';
 import { SpecType } from '../../../../specs';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSpecs } from '../../../../state/selectors/get_settings_specs';
 import { getSpecsFromStore } from '../../../../state/utils';
 import { PartitionSpec } from '../../specs';
 
 /** @internal */
-export const getPartitionSpecs = createCachedSelector([getSpecs], (specs) => {
+export const getPartitionSpecs = createCustomCachedSelector([getSpecs], (specs) => {
   return getSpecsFromStore<PartitionSpec>(specs, ChartType.Partition, SpecType.Series);
-})(getChartIdSelector);
+});

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/get_screen_reader_data.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/get_screen_reader_data.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { ShapeViewModel } from '../../layout/types/viewmodel_types';
 import { STATISTICS_KEY } from '../../layout/utils/group_by_rollup';
 import { PartitionSpec } from '../../specs';
@@ -72,7 +70,7 @@ const getScreenReaderDataForPartitions = (
 };
 
 /** @internal */
-export const getScreenReaderDataSelector = createCachedSelector(
+export const getScreenReaderDataSelector = createCustomCachedSelector(
   [getPartitionSpecs, partitionMultiGeometries],
   (specs, shapeViewModel): PartitionData => {
     if (specs.length === 0) {
@@ -88,4 +86,4 @@ export const getScreenReaderDataSelector = createCachedSelector(
       data: getScreenReaderDataForPartitions(specs, shapeViewModel),
     };
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/is_tooltip_visible.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/is_tooltip_visible.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { getTooltipType } from '../../../../specs';
 import { TooltipType } from '../../../../specs/constants';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getTooltipInfoSelector } from './tooltip';
 
@@ -30,9 +28,9 @@ import { getTooltipInfoSelector } from './tooltip';
  * if we have configured an onBrushEnd listener
  * @internal
  */
-export const isTooltipVisibleSelector = createCachedSelector(
+export const isTooltipVisibleSelector = createCustomCachedSelector(
   [getSettingsSpecSelector, getTooltipInfoSelector],
   (settingsSpec, tooltipInfo): boolean => {
     return getTooltipType(settingsSpec) !== TooltipType.None && tooltipInfo.values.length > 0;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/on_element_click_caller.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/on_element_click_caller.ts
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
 import { ChartType } from '../../..';
 import { getOnElementClickSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState, PointerStates } from '../../../../state/chart_state';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getLastClickSelector } from '../../../../state/selectors/get_last_click';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getPartitionSpec } from './partition_spec';
@@ -40,12 +40,10 @@ export function createOnElementClickCaller(): (state: GlobalChartState) => void 
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.Partition) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getPartitionSpec, getLastClickSelector, getSettingsSpecSelector, getPickedShapesLayerValues],
         getOnElementClickSelector(prev),
-      )({
-        keySelector: (s: GlobalChartState) => s.chartId,
-      });
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/on_element_out_caller.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/on_element_out_caller.ts
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartType } from '../../..';
 import { getOnElementOutSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getPartitionSpec } from './partition_spec';
 import { getPickedShapesLayerValues } from './picked_shapes';
@@ -39,12 +38,10 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.Partition) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getPartitionSpec, getPickedShapesLayerValues, getSettingsSpecSelector],
         getOnElementOutSelector(prev),
-      )({
-        keySelector: getChartIdSelector,
-      });
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/on_element_over_caller.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/on_element_over_caller.ts
@@ -17,14 +17,13 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartType } from '../../..';
 import { getOnElementOverSelector } from '../../../../common/event_handler_selectors';
 import { LayerValue } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getPartitionSpec } from './partition_spec';
 import { getPickedShapesLayerValues } from './picked_shapes';
@@ -40,12 +39,10 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.Partition) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getPartitionSpec, getPickedShapesLayerValues, getSettingsSpecSelector],
         getOnElementOverSelector(prev),
-      )({
-        keySelector: getChartIdSelector,
-      });
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/picked_shapes.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/picked_shapes.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { pickedShapes, pickShapesLayerValues } from '../../layout/viewmodel/picked_shapes';
 import { partitionDrilldownFocus, partitionMultiGeometries } from './geometries';
 
@@ -29,13 +27,10 @@ function getCurrentPointerPosition(state: GlobalChartState) {
 }
 
 /** @internal */
-export const getPickedShapes = createCachedSelector(
+export const getPickedShapes = createCustomCachedSelector(
   [partitionMultiGeometries, getCurrentPointerPosition, partitionDrilldownFocus],
   pickedShapes,
-)(getChartIdSelector);
+);
 
 /** @internal */
-export const getPickedShapesLayerValues = createCachedSelector(
-  [getPickedShapes],
-  pickShapesLayerValues,
-)(getChartIdSelector);
+export const getPickedShapesLayerValues = createCustomCachedSelector([getPickedShapes], pickShapesLayerValues);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/tooltip.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/tooltip.ts
@@ -17,16 +17,14 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { TooltipInfo } from '../../../../components/tooltip/types';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { EMPTY_TOOLTIP, getTooltipInfo } from '../../layout/viewmodel/tooltip_info';
 import { getPartitionSpec } from './partition_spec';
 import { getPickedShapes } from './picked_shapes';
 
 /** @internal */
-export const getTooltipInfoSelector = createCachedSelector(
+export const getTooltipInfoSelector = createCustomCachedSelector(
   [getPartitionSpec, getPickedShapes],
   (spec, pickedShapes): TooltipInfo => {
     return spec
@@ -40,4 +38,4 @@ export const getTooltipInfoSelector = createCachedSelector(
         )
       : EMPTY_TOOLTIP;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/tree.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/tree.ts
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ChartType } from '../../..';
 import { getPredicateFn } from '../../../../common/predicate';
 import {
@@ -29,7 +27,7 @@ import {
   SmallMultiplesStyle,
   SpecType,
 } from '../../../../specs';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSpecs } from '../../../../state/selectors/get_settings_specs';
 import { getSmallMultiplesSpecs } from '../../../../state/selectors/get_small_multiples_spec';
 import { getSpecsFromStore } from '../../../../state/utils';
@@ -40,9 +38,9 @@ import { partitionTree } from '../../layout/viewmodel/hierarchy_of_arrays';
 import { PartitionSpec } from '../../specs';
 import { getPartitionSpecs } from './get_partition_specs';
 
-const getGroupBySpecs = createCachedSelector([getSpecs], (specs) =>
+const getGroupBySpecs = createCustomCachedSelector([getSpecs], (specs) =>
   getSpecsFromStore<GroupBySpec>(specs, ChartType.Global, SpecType.IndexOrder),
-)(getChartIdSelector);
+);
 
 /** @internal */
 export type StyledTree = {
@@ -109,8 +107,8 @@ function getTreesForSpec(
 }
 
 /** @internal */
-export const getTrees = createCachedSelector(
+export const getTrees = createCustomCachedSelector(
   [getPartitionSpecs, getSmallMultiplesSpecs, getGroupBySpecs],
   (partitionSpecs, smallMultiplesSpecs, groupBySpecs): StyledTree[] =>
     partitionSpecs.length > 0 ? getTreesForSpec(partitionSpecs[0], smallMultiplesSpecs, groupBySpecs) : [], // singleton!
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/wordcloud/state/selectors/geometries.ts
+++ b/packages/charts/src/chart_types/wordcloud/state/selectors/geometries.ts
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ChartType } from '../../..';
 import { SpecType } from '../../../../specs/constants';
 import { GlobalChartState } from '../../../../state/chart_state';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSpecsFromStore } from '../../../../state/utils';
 import { nullShapeViewModel, ShapeViewModel } from '../../layout/types/viewmodel_types';
 import { WordcloudSpec } from '../../specs';
@@ -32,10 +31,10 @@ const getSpecs = (state: GlobalChartState) => state.specs;
 const getParentDimensions = (state: GlobalChartState) => state.parentDimensions;
 
 /** @internal */
-export const geometries = createCachedSelector(
+export const geometries = createCustomCachedSelector(
   [getSpecs, getParentDimensions],
   (specs, parentDimensions): ShapeViewModel => {
     const wordcloudSpecs = getSpecsFromStore<WordcloudSpec>(specs, ChartType.Wordcloud, SpecType.Series);
     return wordcloudSpecs.length === 1 ? render(wordcloudSpecs[0], parentDimensions) : nullShapeViewModel();
   },
-)((state) => state.chartId);
+);

--- a/packages/charts/src/chart_types/wordcloud/state/selectors/on_element_click_caller.ts
+++ b/packages/charts/src/chart_types/wordcloud/state/selectors/on_element_click_caller.ts
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
 import { ChartType } from '../../..';
 import { getOnElementClickSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState, PointerStates } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getLastClickSelector } from '../../../../state/selectors/get_last_click';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getPickedShapesLayerValues } from './picked_shapes';
@@ -41,10 +40,10 @@ export function createOnElementClickCaller(): (state: GlobalChartState) => void 
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.Wordcloud) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getSpecOrNull, getLastClickSelector, getSettingsSpecSelector, getPickedShapesLayerValues],
         getOnElementClickSelector(prev),
-      )(getChartIdSelector);
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/wordcloud/state/selectors/on_element_out_caller.ts
+++ b/packages/charts/src/chart_types/wordcloud/state/selectors/on_element_out_caller.ts
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartType } from '../../..';
 import { getOnElementOutSelector } from '../../../../common/event_handler_selectors';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getPickedShapesLayerValues } from './picked_shapes';
 import { getSpecOrNull } from './wordcloud_spec';
@@ -39,10 +38,10 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.Wordcloud) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getSpecOrNull, getPickedShapesLayerValues, getSettingsSpecSelector],
         getOnElementOutSelector(prev),
-      )(getChartIdSelector);
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/wordcloud/state/selectors/on_element_over_caller.ts
+++ b/packages/charts/src/chart_types/wordcloud/state/selectors/on_element_over_caller.ts
@@ -17,14 +17,13 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartType } from '../../..';
 import { getOnElementOverSelector } from '../../../../common/event_handler_selectors';
 import { LayerValue } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getPickedShapesLayerValues } from './picked_shapes';
 import { getSpecOrNull } from './wordcloud_spec';
@@ -40,12 +39,10 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.Wordcloud) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getSpecOrNull, getPickedShapesLayerValues, getSettingsSpecSelector],
         getOnElementOverSelector(prev),
-      )({
-        keySelector: getChartIdSelector,
-      });
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/wordcloud/state/selectors/picked_shapes.ts
+++ b/packages/charts/src/chart_types/wordcloud/state/selectors/picked_shapes.ts
@@ -17,10 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { LayerValue } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { WordcloudViewModel } from '../../layout/types/viewmodel_types';
 import { geometries } from './geometries';
 
@@ -29,7 +28,7 @@ function getCurrentPointerPosition(state: GlobalChartState) {
 }
 
 /** @internal */
-export const getPickedShapes = createCachedSelector(
+export const getPickedShapes = createCustomCachedSelector(
   [geometries, getCurrentPointerPosition],
   (geoms, pointerPosition): WordcloudViewModel[] => {
     const picker = geoms.pickQuads;
@@ -38,10 +37,10 @@ export const getPickedShapes = createCachedSelector(
     const y = pointerPosition.y - chartCenter.y;
     return picker(x, y);
   },
-)((state) => state.chartId);
+);
 
 /** @internal */
-export const getPickedShapesLayerValues = createCachedSelector(
+export const getPickedShapesLayerValues = createCustomCachedSelector(
   [getPickedShapes],
   (pickedShapes): Array<Array<LayerValue>> => {
     const elements = pickedShapes.map<Array<LayerValue>>((model) => {
@@ -58,4 +57,4 @@ export const getPickedShapesLayerValues = createCachedSelector(
     });
     return elements;
   },
-)((state) => state.chartId);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_annotations.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_annotations.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { AnnotationId } from '../../../../utils/ids';
 import { AnnotationDimensions } from '../../annotations/types';
@@ -31,7 +29,7 @@ import { getAxisSpecsSelector, getAnnotationSpecsSelector } from './get_specs';
 import { isHistogramModeEnabledSelector } from './is_histogram_mode_enabled';
 
 /** @internal */
-export const computeAnnotationDimensionsSelector = createCachedSelector(
+export const computeAnnotationDimensionsSelector = createCustomCachedSelector(
   [
     getAnnotationSpecsSelector,
     computeChartDimensionsSelector,
@@ -60,4 +58,4 @@ export const computeAnnotationDimensionsSelector = createCachedSelector(
       isHistogramMode,
       smallMultipleScales,
     ),
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_axes_geometries.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_axes_geometries.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getAxesGeometries, AxisGeometry, defaultTickFormatter } from '../../utils/axis_utils';
@@ -34,7 +32,7 @@ import { getAxisSpecsSelector, getSeriesSpecsSelector } from './get_specs';
 import { isHistogramModeEnabledSelector } from './is_histogram_mode_enabled';
 
 /** @internal */
-export const computeAxesGeometriesSelector = createCachedSelector(
+export const computeAxesGeometriesSelector = createCustomCachedSelector(
   [
     computeChartDimensionsSelector,
     getChartThemeSelector,
@@ -82,4 +80,4 @@ export const computeAxesGeometriesSelector = createCachedSelector(
       barsPadding,
     );
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_axis_ticks_dimensions.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_axis_ticks_dimensions.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { CanvasTextBBoxCalculator } from '../../../../utils/bbox/canvas_text_bbox_calculator';
@@ -38,7 +36,7 @@ import { getAxisSpecsSelector, getSeriesSpecsSelector } from './get_specs';
 import { isHistogramModeEnabledSelector } from './is_histogram_mode_enabled';
 
 /** @internal */
-export const computeAxisTicksDimensionsSelector = createCachedSelector(
+export const computeAxisTicksDimensionsSelector = createCustomCachedSelector(
   [
     getBarPaddingsSelector,
     isHistogramModeEnabledSelector,
@@ -90,4 +88,4 @@ export const computeAxisTicksDimensionsSelector = createCachedSelector(
     bboxCalculator.destroy();
     return axesTicksDimensions;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_chart_dimensions.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_chart_dimensions.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartContainerDimensionsSelector } from '../../../../state/selectors/get_chart_container_dimensions';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { getSmallMultiplesSpec } from '../../../../state/selectors/get_small_multiples_spec';
 import { computeChartDimensions, ChartDimensions } from '../../utils/dimensions';
@@ -29,7 +27,7 @@ import { getAxesStylesSelector } from './get_axis_styles';
 import { getAxisSpecsSelector } from './get_specs';
 
 /** @internal */
-export const computeChartDimensionsSelector = createCachedSelector(
+export const computeChartDimensionsSelector = createCustomCachedSelector(
   [
     getChartContainerDimensionsSelector,
     getChartThemeSelector,
@@ -47,4 +45,4 @@ export const computeChartDimensionsSelector = createCachedSelector(
       axesSpecs,
       smSpec && smSpec[0],
     ),
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_chart_transform.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_chart_transform.ts
@@ -17,17 +17,15 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { Transform } from '../utils/types';
 import { computeChartTransform } from '../utils/utils';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
 
 /** @internal */
-export const computeChartTransformSelector = createCachedSelector(
+export const computeChartTransformSelector = createCustomCachedSelector(
   [computeChartDimensionsSelector, getSettingsSpecSelector],
   (chartDimensions, settingsSpecs): Transform =>
     computeChartTransform(chartDimensions.chartDimensions, settingsSpecs.rotation),
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_grid_lines.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_grid_lines.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { getGridLines, LinesGrid } from '../../utils/grid_lines';
 import { computeAxesGeometriesSelector } from './compute_axes_geometries';
@@ -27,9 +25,9 @@ import { computeSmallMultipleScalesSelector } from './compute_small_multiple_sca
 import { getAxisSpecsSelector } from './get_specs';
 
 /** @internal */
-export const computePerPanelGridLinesSelector = createCachedSelector(
+export const computePerPanelGridLinesSelector = createCustomCachedSelector(
   [getAxisSpecsSelector, getChartThemeSelector, computeAxesGeometriesSelector, computeSmallMultipleScalesSelector],
   (axesSpecs, chartTheme, axesGeoms, scales): Array<LinesGrid> => {
     return getGridLines(axesSpecs, axesGeoms, chartTheme.axes, scales);
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_legend.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_legend.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { LegendItem } from '../../../../common/legend';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { getDeselectedSeriesSelector } from '../../../../state/selectors/get_deselected_data_series';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
@@ -33,7 +31,7 @@ import { getSiDataSeriesMapSelector } from './get_si_dataseries_map';
 import { getSeriesSpecsSelector, getAxisSpecsSelector } from './get_specs';
 
 /** @internal */
-export const computeLegendSelector = createCachedSelector(
+export const computeLegendSelector = createCustomCachedSelector(
   [
     getSeriesSpecsSelector,
     computeSeriesDomainsSelector,
@@ -69,4 +67,4 @@ export const computeLegendSelector = createCachedSelector(
       settings.sortSeriesBy,
     );
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_panels.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_panels.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { Size } from '../../../../utils/dimensions';
 import { getPanelSize } from '../../utils/panel';
 import { PerPanelMap, getPerPanelMap } from '../../utils/panel_utils';
@@ -29,10 +27,10 @@ import { computeSmallMultipleScalesSelector } from './compute_small_multiple_sca
 export type PanelGeoms = Array<Size & PerPanelMap>;
 
 /** @internal */
-export const computePanelsSelectors = createCachedSelector(
+export const computePanelsSelectors = createCustomCachedSelector(
   [computeSmallMultipleScalesSelector],
   (scales): PanelGeoms => {
     const panelSize = getPanelSize(scales);
     return getPerPanelMap(scales, () => panelSize);
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_per_panel_axes_geoms.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_per_panel_axes_geoms.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { Position, safeFormat } from '../../../../utils/common';
 import { isHorizontalAxis, isVerticalAxis } from '../../utils/axis_type_utils';
 import { AxisGeometry } from '../../utils/axis_utils';
@@ -55,7 +53,7 @@ const isPrimaryRowFn = ({ vertical: { domain } }: SmallMultipleScales) => (posit
   isHorizontalAxis(position) && domain[0] === verticalValue;
 
 /** @internal */
-export const computePerPanelAxesGeomsSelector = createCachedSelector(
+export const computePerPanelAxesGeomsSelector = createCustomCachedSelector(
   [computeAxesGeometriesSelector, computeSmallMultipleScalesSelector, getSmallMultiplesIndexOrderSelector],
   (axesGeoms, scales, groupBySpec): Array<PerPanelAxisGeoms> => {
     const { horizontal, vertical } = scales;
@@ -83,4 +81,4 @@ export const computePerPanelAxesGeomsSelector = createCachedSelector(
       }),
     }));
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_series_domains.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_series_domains.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { SeriesDomainsAndData } from '../utils/types';
 import { computeSeriesDomains } from '../utils/utils';
@@ -30,7 +28,7 @@ import { getSeriesSpecsSelector, getSmallMultiplesIndexOrderSelector } from './g
 const getDeselectedSeriesSelector = (state: GlobalChartState) => state.interactions.deselectedDataSeries;
 
 /** @internal */
-export const computeSeriesDomainsSelector = createCachedSelector(
+export const computeSeriesDomainsSelector = createCustomCachedSelector(
   [
     getSeriesSpecsSelector,
     getDeselectedSeriesSelector,
@@ -49,4 +47,4 @@ export const computeSeriesDomainsSelector = createCachedSelector(
       settingsSpec.sortSeriesBy,
     );
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_series_geometries.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_series_geometries.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { ComputedGeometries } from '../utils/types';
@@ -31,7 +29,7 @@ import { getSeriesSpecsSelector, getAxisSpecsSelector } from './get_specs';
 import { isHistogramModeEnabledSelector } from './is_histogram_mode_enabled';
 
 /** @internal */
-export const computeSeriesGeometriesSelector = createCachedSelector(
+export const computeSeriesGeometriesSelector = createCustomCachedSelector(
   [
     getSettingsSpecSelector,
     getSeriesSpecsSelector,
@@ -63,4 +61,4 @@ export const computeSeriesGeometriesSelector = createCachedSelector(
       isHistogramMode,
     );
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_small_multiple_scales.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_small_multiple_scales.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ScaleBand } from '../../../../scales';
 import { DEFAULT_SM_PANEL_PADDING, RelativeBandsPadding } from '../../../../specs/small_multiples';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSmallMultiplesSpec } from '../../../../state/selectors/get_small_multiples_spec';
 import { OrdinalDomain } from '../../../../utils/domain';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
@@ -37,7 +35,7 @@ export interface SmallMultipleScales {
  * Return the small multiple scales for horizontal and vertical grids
  * @internal
  */
-export const computeSmallMultipleScalesSelector = createCachedSelector(
+export const computeSmallMultipleScalesSelector = createCustomCachedSelector(
   [computeSeriesDomainsSelector, computeChartDimensionsSelector, getSmallMultiplesSpec],
   ({ smHDomain, smVDomain }, { chartDimensions: { width, height } }, smSpec): SmallMultipleScales => {
     return {
@@ -45,7 +43,7 @@ export const computeSmallMultipleScalesSelector = createCachedSelector(
       vertical: getScale(smVDomain, height, smSpec && smSpec[0].style?.verticalPanelPadding),
     };
   },
-)(getChartIdSelector);
+);
 
 /**
  * @internal

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/count_bars_in_cluster.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/count_bars_in_cluster.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { SeriesType } from '../../../../specs';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { groupBy } from '../../utils/group_data_series';
 import { SeriesDomainsAndData } from '../utils/types';
 import { getBarIndexKey } from '../utils/utils';
@@ -28,10 +26,10 @@ import { computeSeriesDomainsSelector } from './compute_series_domains';
 import { isHistogramModeEnabledSelector } from './is_histogram_mode_enabled';
 
 /** @internal */
-export const countBarsInClusterSelector = createCachedSelector(
+export const countBarsInClusterSelector = createCustomCachedSelector(
   [computeSeriesDomainsSelector, isHistogramModeEnabledSelector],
   countBarsInCluster,
-)(getChartIdSelector);
+);
 
 /** @internal */
 export function countBarsInCluster({ formattedDataSeries }: SeriesDomainsAndData, isHistogramEnabled: boolean): number {

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_annotation_tooltip_state.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_annotation_tooltip_state.ts
@@ -17,13 +17,11 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { TooltipPortalSettings } from '../../../../components/portal/types';
 import { TooltipInfo } from '../../../../components/tooltip/types';
 import { DOMElement } from '../../../../state/actions/dom_element';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartRotationSelector } from '../../../../state/selectors/get_chart_rotation';
 import { Rotation } from '../../../../utils/common';
 import { Dimensions } from '../../../../utils/dimensions';
@@ -45,7 +43,7 @@ const getCurrentPointerPosition = (state: GlobalChartState) => state.interaction
 const getHoveredDOMElement = (state: GlobalChartState) => state.interactions.hoveredDOMElement;
 
 /** @internal */
-export const getAnnotationTooltipStateSelector = createCachedSelector(
+export const getAnnotationTooltipStateSelector = createCustomCachedSelector(
   [
     getCurrentPointerPosition,
     computeChartDimensionsSelector,
@@ -58,7 +56,7 @@ export const getAnnotationTooltipStateSelector = createCachedSelector(
     getHoveredDOMElement,
   ],
   getAnnotationTooltipState,
-)(getChartIdSelector);
+);
 
 function getAnnotationTooltipState(
   cursorPosition: Point,

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_api_scale_configs.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_api_scale_configs.ts
@@ -17,12 +17,10 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ScaleContinuousType } from '../../../../scales';
 import { ScaleType } from '../../../../scales/constants';
 import { SettingsSpec } from '../../../../specs/settings';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { GroupId } from '../../../../utils/ids';
 import { convertXScaleTypes } from '../../domains/x_domain';
@@ -57,10 +55,10 @@ export interface ScaleConfigs {
 }
 
 /** @internal */
-export const getScaleConfigsFromSpecsSelector = createCachedSelector(
+export const getScaleConfigsFromSpecsSelector = createCustomCachedSelector(
   [getAxisSpecsSelector, getSeriesSpecsSelector, getSettingsSpecSelector],
   getScaleConfigsFromSpecs,
-)(getChartIdSelector);
+);
 
 /** @internal */
 export function getScaleConfigsFromSpecs(

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_axis_styles.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_axis_styles.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { mergePartial, RecursivePartial } from '../../../../utils/common';
 import { AxisId } from '../../../../utils/ids';
@@ -32,7 +30,7 @@ import { getAxisSpecsSelector } from './get_specs';
  *
  * @internal
  */
-export const getAxesStylesSelector = createCachedSelector(
+export const getAxesStylesSelector = createCustomCachedSelector(
   [getAxisSpecsSelector, getChartThemeSelector],
   (axesSpecs, { axes: sharedAxesStyle }): Map<AxisId, AxisStyle | null> => {
     const axesStyles = new Map<AxisId, AxisStyle | null>();
@@ -53,4 +51,4 @@ export const getAxesStylesSelector = createCachedSelector(
     });
     return axesStyles;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_bar_paddings.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_bar_paddings.ts
@@ -17,15 +17,13 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { isHistogramModeEnabledSelector } from './is_histogram_mode_enabled';
 
 /** @internal */
-export const getBarPaddingsSelector = createCachedSelector(
+export const getBarPaddingsSelector = createCustomCachedSelector(
   [isHistogramModeEnabledSelector, getChartThemeSelector],
   (isHistogramMode, chartTheme): number =>
     isHistogramMode ? chartTheme.scales.histogramPadding : chartTheme.scales.barsPadding,
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_brush_area.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_brush_area.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { BrushAxis } from '../../../../specs/constants';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartRotationSelector } from '../../../../state/selectors/get_chart_rotation';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { clamp, Rotation } from '../../../../utils/common';
@@ -37,7 +35,7 @@ const getMouseDownPosition = (state: GlobalChartState) => state.interactions.poi
 const getCurrentPointerPosition = (state: GlobalChartState) => state.interactions.pointer.current.position;
 
 /** @internal */
-export const getBrushAreaSelector = createCachedSelector(
+export const getBrushAreaSelector = createCustomCachedSelector(
   [
     getMouseDownPosition,
     getCurrentPointerPosition,
@@ -64,7 +62,7 @@ export const getBrushAreaSelector = createCachedSelector(
         return getBrushForXAxis(chartRotation, panelPoints);
     }
   },
-)(getChartIdSelector);
+);
 
 /** @internal */
 export type PanelPoints = {

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_chart_type_description.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_chart_type_description.ts
@@ -17,17 +17,15 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { SeriesType } from '../../utils/specs';
 import { getSeriesSpecsSelector } from './get_specs';
 
 /** @internal */
-export const getChartTypeDescriptionSelector = createCachedSelector([getSeriesSpecsSelector], (specs): string => {
+export const getChartTypeDescriptionSelector = createCustomCachedSelector([getSeriesSpecsSelector], (specs): string => {
   const seriesTypes = new Set<SeriesType>();
   specs.forEach((value) => seriesTypes.add(value.seriesType));
   const chartSeriesTypes =
     seriesTypes.size > 1 ? `Mixed chart: ${[...seriesTypes].join(' and ')} chart` : `${[...seriesTypes]} chart`;
   return chartSeriesTypes;
-})(getChartIdSelector);
+});

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_computed_scales.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_computed_scales.ts
@@ -17,14 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { ComputedScales } from '../utils/types';
 import { computeSeriesGeometriesSelector } from './compute_series_geometries';
 
 /** @internal */
-export const getComputedScalesSelector = createCachedSelector(
+export const getComputedScalesSelector = createCustomCachedSelector(
   [computeSeriesGeometriesSelector],
   ({ scales }): ComputedScales => scales,
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_cursor_band.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_cursor_band.ts
@@ -17,13 +17,11 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { Rect } from '../../../../geoms/types';
 import { Scale } from '../../../../scales';
 import { SettingsSpec, PointerEvent } from '../../../../specs/settings';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { Dimensions } from '../../../../utils/dimensions';
 import { isValidPointerOverEvent } from '../../../../utils/events';
@@ -43,7 +41,7 @@ import { isTooltipSnapEnableSelector } from './is_tooltip_snap_enabled';
 const getExternalPointerEventStateSelector = (state: GlobalChartState) => state.externalEvents.pointer;
 
 /** @internal */
-export const getCursorBandPositionSelector = createCachedSelector(
+export const getCursorBandPositionSelector = createCustomCachedSelector(
   [
     getOrientedProjectedPointerPositionSelector,
     getExternalPointerEventStateSelector,
@@ -80,7 +78,7 @@ export const getCursorBandPositionSelector = createCachedSelector(
       geometriesIndexKeys,
       smallMultipleScales,
     ),
-)(getChartIdSelector);
+);
 
 function getCursorBand(
   orientedProjectedPointerPosition: PointerPosition,

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_cursor_line.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_cursor_line.ts
@@ -17,18 +17,16 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { Line } from '../../../../geoms/types';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getCursorLinePosition } from '../../crosshair/crosshair_utils';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
 import { getProjectedPointerPositionSelector } from './get_projected_pointer_position';
 
 /** @internal */
-export const getCursorLinePositionSelector = createCachedSelector(
+export const getCursorLinePositionSelector = createCustomCachedSelector(
   [computeChartDimensionsSelector, getSettingsSpecSelector, getProjectedPointerPositionSelector],
   (chartDimensions, settingsSpec, projectedPointerPosition): Line | undefined =>
     getCursorLinePosition(settingsSpec.rotation, chartDimensions.chartDimensions, projectedPointerPosition),
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_cursor_pointer.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_cursor_pointer.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { DEFAULT_CSS_CURSOR } from '../../../../common/constants';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
 import { getProjectedScaledValues } from './get_projected_scaled_values';
@@ -31,7 +29,7 @@ import { isBrushAvailableSelector } from './is_brush_available';
 const getCurrentPointerPositionSelector = (state: GlobalChartState) => state.interactions.pointer.current.position;
 
 /** @internal */
-export const getPointerCursorSelector = createCachedSelector(
+export const getPointerCursorSelector = createCustomCachedSelector(
   [
     getHighlightedGeomsSelector,
     getSettingsSpecSelector,
@@ -65,4 +63,4 @@ export const getPointerCursorSelector = createCachedSelector(
     }
     return isBrushAvailable ? 'crosshair' : DEFAULT_CSS_CURSOR;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_debug_state.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_debug_state.ts
@@ -17,12 +17,10 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { LegendItem } from '../../../../common/legend';
 import { Line } from '../../../../geoms/types';
 import { AxisSpec } from '../../../../specs';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import {
   DebugState,
   DebugStateValue,
@@ -47,7 +45,7 @@ import { getAxisSpecsSelector } from './get_specs';
  * Returns a stringified version of the `debugState`
  * @internal
  */
-export const getDebugStateSelector = createCachedSelector(
+export const getDebugStateSelector = createCustomCachedSelector(
   [
     computeSeriesGeometriesSelector,
     computeLegendSelector,
@@ -66,7 +64,7 @@ export const getDebugStateSelector = createCachedSelector(
       bars: getBarsState(seriesNameMap, geometries.bars),
     };
   },
-)(getChartIdSelector);
+);
 
 function getAxes(axesGeoms: AxisGeometry[], axesSpecs: AxisSpec[], gridLines: LinesGrid[]): DebugStateAxes | undefined {
   if (axesSpecs.length === 0) {

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_elements_at_cursor_pos.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_elements_at_cursor_pos.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { PointerEvent } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { isValidPointerOverEvent } from '../../../../utils/events';
 import { IndexedGeometry } from '../../../../utils/geometry';
 import { ChartDimensions } from '../../utils/dimensions';
@@ -38,7 +36,7 @@ import { PointerPosition } from './get_projected_pointer_position';
 const getExternalPointerEventStateSelector = (state: GlobalChartState) => state.externalEvents.pointer;
 
 /** @internal */
-export const getElementAtCursorPositionSelector = createCachedSelector(
+export const getElementAtCursorPositionSelector = createCustomCachedSelector(
   [
     getOrientedProjectedPointerPositionSelector,
     getComputedScalesSelector,
@@ -48,7 +46,7 @@ export const getElementAtCursorPositionSelector = createCachedSelector(
     computeChartDimensionsSelector,
   ],
   getElementAtCursorPosition,
-)(getChartIdSelector);
+);
 
 function getElementAtCursorPosition(
   orientedProjectedPointerPosition: PointerPosition,

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_geometries_index.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_geometries_index.ts
@@ -17,14 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { IndexedGeometryMap } from '../../utils/indexed_geometry_map';
 import { computeSeriesGeometriesSelector } from './compute_series_geometries';
 
 /** @internal */
-export const getGeometriesIndexSelector = createCachedSelector(
+export const getGeometriesIndexSelector = createCustomCachedSelector(
   [computeSeriesGeometriesSelector],
   ({ geometriesIndex }): IndexedGeometryMap => geometriesIndex,
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_geometries_index_keys.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_geometries_index_keys.ts
@@ -17,14 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { compareByValueAsc } from '../../../../utils/common';
 import { computeSeriesGeometriesSelector } from './compute_series_geometries';
 
 /** @internal */
-export const getGeometriesIndexKeysSelector = createCachedSelector(
+export const getGeometriesIndexKeysSelector = createCustomCachedSelector(
   [computeSeriesGeometriesSelector],
   (seriesGeometries): (number | string)[] => seriesGeometries.geometriesIndex.keys().sort(compareByValueAsc),
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_grid_lines.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_grid_lines.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { getGridLines, LinesGrid } from '../../utils/grid_lines';
 import { computeAxesGeometriesSelector } from './compute_axes_geometries';
@@ -27,9 +25,9 @@ import { computeSmallMultipleScalesSelector } from './compute_small_multiple_sca
 import { getAxisSpecsSelector } from './get_specs';
 
 /** @internal */
-export const computeGridLinesSelector = createCachedSelector(
+export const computeGridLinesSelector = createCustomCachedSelector(
   [getChartThemeSelector, getAxisSpecsSelector, computeAxesGeometriesSelector, computeSmallMultipleScalesSelector],
   (chartTheme, axesSpecs, axesGeoms, scales): LinesGrid[] => {
     return getGridLines(axesSpecs, axesGeoms, chartTheme.axes, scales);
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_highlighted_series.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_highlighted_series.ts
@@ -17,17 +17,15 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { LegendItem } from '../../../../common/legend';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { computeLegendSelector } from './compute_legend';
 
 const getHighlightedLegendPath = (state: GlobalChartState) => state.interactions.highlightedLegendPath;
 
 /** @internal */
-export const getHighlightedSeriesSelector = createCachedSelector(
+export const getHighlightedSeriesSelector = createCustomCachedSelector(
   [getHighlightedLegendPath, computeLegendSelector],
   (highlightedLegendPaths, legendItems): LegendItem | undefined => {
     if (highlightedLegendPaths.length === 0) {
@@ -38,4 +36,4 @@ export const getHighlightedSeriesSelector = createCachedSelector(
       seriesIdentifiers.some(({ key }) => highlightedSeriesKeys.some((hKey) => hKey === key)),
     );
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_highlighted_values.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_highlighted_values.ts
@@ -17,16 +17,14 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { LegendItemExtraValues } from '../../../../common/legend';
 import { SeriesKey } from '../../../../common/series_id';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getHighligthedValues } from '../../tooltip/tooltip';
 import { getTooltipInfoSelector } from './get_tooltip_values_highlighted_geoms';
 
 /** @internal */
-export const getHighlightedValuesSelector = createCachedSelector(
+export const getHighlightedValuesSelector = createCustomCachedSelector(
   [getTooltipInfoSelector],
   ({ values }): Map<SeriesKey, LegendItemExtraValues> => getHighligthedValues(values),
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_legend_items_labels.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_legend_items_labels.ts
@@ -17,15 +17,13 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { LegendItemLabel } from '../../../../state/selectors/get_legend_items_labels';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { computeLegendSelector } from './compute_legend';
 
 /** @internal */
-export const getLegendItemsLabelsSelector = createCachedSelector(
+export const getLegendItemsLabelsSelector = createCustomCachedSelector(
   [computeLegendSelector, getSettingsSpecSelector],
   (legendItems, { showLegendExtra }): LegendItemLabel[] =>
     legendItems.map(({ label, defaultExtra }) => {
@@ -34,4 +32,4 @@ export const getLegendItemsLabelsSelector = createCachedSelector(
       }
       return { label, depth: 0 };
     }),
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_oriented_projected_pointer_position.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_oriented_projected_pointer_position.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { SettingsSpec } from '../../../../specs/settings';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getOrientedXPosition, getOrientedYPosition } from '../../utils/interactions';
 import { getPanelSize } from '../../utils/panel';
@@ -28,10 +26,10 @@ import { computeSmallMultipleScalesSelector, SmallMultipleScales } from './compu
 import { getProjectedPointerPositionSelector, PointerPosition } from './get_projected_pointer_position';
 
 /** @internal */
-export const getOrientedProjectedPointerPositionSelector = createCachedSelector(
+export const getOrientedProjectedPointerPositionSelector = createCustomCachedSelector(
   [getProjectedPointerPositionSelector, getSettingsSpecSelector, computeSmallMultipleScalesSelector],
   getOrientedProjectedPointerPosition,
-)(getChartIdSelector);
+);
 
 function getOrientedProjectedPointerPosition(
   { x, y, horizontalPanelValue, verticalPanelValue }: PointerPosition,

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_projected_pointer_position.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_projected_pointer_position.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ScaleBand } from '../../../../scales/scale_band';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { Dimensions } from '../../../../utils/dimensions';
 import { Point } from '../../../../utils/point';
 import { PrimitiveValue } from '../../../partition_chart/layout/utils/group_by_rollup';
@@ -36,11 +34,11 @@ export type PointerPosition = Point & { horizontalPanelValue: PrimitiveValue; ve
  * Get the x and y pointer position relative to the chart projection area
  * @internal
  */
-export const getProjectedPointerPositionSelector = createCachedSelector(
+export const getProjectedPointerPositionSelector = createCustomCachedSelector(
   [getCurrentPointerPosition, computeChartDimensionsSelector, computeSmallMultipleScalesSelector],
   (currentPointerPosition, { chartDimensions }, smallMultipleScales): PointerPosition =>
     getProjectedPointerPosition(currentPointerPosition, chartDimensions, smallMultipleScales),
-)(getChartIdSelector);
+);
 
 /**
  * Get the x and y pointer position relative to the chart projection area

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_projected_scaled_values.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_projected_scaled_values.ts
@@ -17,16 +17,14 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ProjectedValues } from '../../../../specs/settings';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { computeSeriesGeometriesSelector } from './compute_series_geometries';
 import { getGeometriesIndexKeysSelector } from './get_geometries_index_keys';
 import { getOrientedProjectedPointerPositionSelector } from './get_oriented_projected_pointer_position';
 
 /** @internal */
-export const getProjectedScaledValues = createCachedSelector(
+export const getProjectedScaledValues = createCustomCachedSelector(
   [getOrientedProjectedPointerPositionSelector, computeSeriesGeometriesSelector, getGeometriesIndexKeysSelector],
   (
     { x, y, verticalPanelValue, horizontalPanelValue },
@@ -51,4 +49,4 @@ export const getProjectedScaledValues = createCachedSelector(
       smHorizontalValue: horizontalPanelValue,
     };
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_series_color_map.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_series_color_map.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { SeriesKey } from '../../../../common/series_id';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { Color } from '../../../../utils/common';
 import { getSeriesColors } from '../../utils/series';
@@ -33,7 +31,7 @@ function getColorOverrides({ colors }: GlobalChartState) {
 }
 
 /** @internal */
-export const getSeriesColorsSelector = createCachedSelector(
+export const getSeriesColorsSelector = createCustomCachedSelector(
   [computeSeriesDomainsSelector, getChartThemeSelector, getColorOverrides],
   (seriesDomainsAndData, chartTheme, colorOverrides): Map<SeriesKey, Color> => {
     const updatedCustomSeriesColors = getCustomSeriesColors(seriesDomainsAndData.formattedDataSeries);
@@ -45,4 +43,4 @@ export const getSeriesColorsSelector = createCachedSelector(
       colorOverrides,
     );
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_si_dataseries_map.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_si_dataseries_map.ts
@@ -17,14 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { DataSeries, getSeriesKey } from '../../utils/series';
 import { computeSeriesDomainsSelector } from './compute_series_domains';
 
 /** @internal */
-export const getSiDataSeriesMapSelector = createCachedSelector(
+export const getSiDataSeriesMapSelector = createCustomCachedSelector(
   [computeSeriesDomainsSelector],
   ({ formattedDataSeries }) => {
     return formattedDataSeries.reduce<Record<string, DataSeries>>((acc, dataSeries) => {
@@ -33,4 +31,4 @@ export const getSiDataSeriesMapSelector = createCachedSelector(
       return acc;
     }, {});
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_specs.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_specs.ts
@@ -17,12 +17,10 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ChartType } from '../../..';
 import { GroupBySpec, SmallMultiplesSpec } from '../../../../specs';
 import { SpecType } from '../../../../specs/constants';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSpecs } from '../../../../state/selectors/get_settings_specs';
 import { getSpecsFromStore } from '../../../../state/utils';
 import { AnnotationSpec, AxisSpec, BasicSeriesSpec } from '../../utils/specs';
@@ -34,22 +32,22 @@ export interface SmallMultiplesGroupBy {
 }
 
 /** @internal */
-export const getAxisSpecsSelector = createCachedSelector([getSpecs], (specs): AxisSpec[] =>
+export const getAxisSpecsSelector = createCustomCachedSelector([getSpecs], (specs): AxisSpec[] =>
   getSpecsFromStore<AxisSpec>(specs, ChartType.XYAxis, SpecType.Axis),
-)(getChartIdSelector);
+);
 
 /** @internal */
-export const getSeriesSpecsSelector = createCachedSelector([getSpecs], (specs) => {
+export const getSeriesSpecsSelector = createCustomCachedSelector([getSpecs], (specs) => {
   return getSpecsFromStore<BasicSeriesSpec>(specs, ChartType.XYAxis, SpecType.Series);
-})(getChartIdSelector);
+});
 
 /** @internal */
-export const getAnnotationSpecsSelector = createCachedSelector([getSpecs], (specs) =>
+export const getAnnotationSpecsSelector = createCustomCachedSelector([getSpecs], (specs) =>
   getSpecsFromStore<AnnotationSpec>(specs, ChartType.XYAxis, SpecType.Annotation),
-)(getChartIdSelector);
+);
 
 /** @internal */
-export const getSmallMultiplesIndexOrderSelector = createCachedSelector([getSpecs], (specs):
+export const getSmallMultiplesIndexOrderSelector = createCustomCachedSelector([getSpecs], (specs):
   | SmallMultiplesGroupBy
   | undefined => {
   const [smallMultiples] = getSpecsFromStore<SmallMultiplesSpec>(specs, ChartType.Global, SpecType.SmallMultiples);
@@ -58,4 +56,4 @@ export const getSmallMultiplesIndexOrderSelector = createCachedSelector([getSpec
     horizontal: groupBySpecs.find((s) => s.id === smallMultiples?.splitHorizontally),
     vertical: groupBySpecs.find((s) => s.id === smallMultiples?.splitVertically),
   };
-})(getChartIdSelector);
+});

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_position.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_position.ts
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { AnchorPosition } from '../../../../components/portal/types';
 import { isTooltipType } from '../../../../specs/settings';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getTooltipAnchorPosition } from '../../crosshair/crosshair_utils';
 import { computeChartDimensionsSelector } from './compute_chart_dimensions';
@@ -30,7 +28,7 @@ import { getCursorBandPositionSelector } from './get_cursor_band';
 import { getProjectedPointerPositionSelector } from './get_projected_pointer_position';
 
 /** @internal */
-export const getTooltipAnchorPositionSelector = createCachedSelector(
+export const getTooltipAnchorPositionSelector = createCustomCachedSelector(
   [
     computeChartDimensionsSelector,
     getSettingsSpecSelector,
@@ -67,4 +65,4 @@ export const getTooltipAnchorPositionSelector = createCachedSelector(
       isTooltipType(settings.tooltip) ? undefined : settings.tooltip.stickTo,
     );
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_snap.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_snap.ts
@@ -17,18 +17,13 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { DEFAULT_TOOLTIP_SNAP } from '../../../../specs/constants';
 import { SettingsSpec, isTooltipProps } from '../../../../specs/settings';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 
 /** @internal */
-export const getTooltipSnapSelector = createCachedSelector(
-  [getSettingsSpecSelector],
-  getTooltipSnap,
-)(getChartIdSelector);
+export const getTooltipSnapSelector = createCustomCachedSelector([getSettingsSpecSelector], getTooltipSnap);
 
 function getTooltipSnap(settings: SettingsSpec): boolean {
   const { tooltip } = settings;

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_type.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_type.ts
@@ -17,14 +17,9 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { getTooltipType } from '../../../../specs/settings';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 
 /** @internal */
-export const getTooltipTypeSelector = createCachedSelector(
-  [getSettingsSpecSelector],
-  getTooltipType,
-)(getChartIdSelector);
+export const getTooltipTypeSelector = createCustomCachedSelector([getSettingsSpecSelector], getTooltipType);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { TooltipInfo } from '../../../../components/tooltip/types';
 import {
   PointerEvent,
@@ -31,7 +29,7 @@ import {
 } from '../../../../specs';
 import { TooltipType } from '../../../../specs/constants';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartRotationSelector } from '../../../../state/selectors/get_chart_rotation';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getTooltipHeaderFormatterSelector } from '../../../../state/selectors/get_tooltip_header_formatter';
@@ -72,7 +70,7 @@ export interface TooltipAndHighlightedGeoms {
 const getExternalPointerEventStateSelector = (state: GlobalChartState) => state.externalEvents.pointer;
 
 /** @internal */
-export const getTooltipInfoAndGeometriesSelector = createCachedSelector(
+export const getTooltipInfoAndGeometriesSelector = createCustomCachedSelector(
   [
     getSeriesSpecsSelector,
     getAxisSpecsSelector,
@@ -88,7 +86,7 @@ export const getTooltipInfoAndGeometriesSelector = createCachedSelector(
     getTooltipHeaderFormatterSelector,
   ],
   getTooltipAndHighlightFromValue,
-)(({ chartId }) => chartId);
+);
 
 function getTooltipAndHighlightFromValue(
   seriesSpecs: BasicSeriesSpec[],
@@ -222,13 +220,13 @@ function getTooltipAndHighlightFromValue(
 }
 
 /** @internal */
-export const getTooltipInfoSelector = createCachedSelector(
+export const getTooltipInfoSelector = createCustomCachedSelector(
   [getTooltipInfoAndGeometriesSelector],
   ({ tooltip }): TooltipInfo => tooltip,
-)(getChartIdSelector);
+);
 
 /** @internal */
-export const getHighlightedGeomsSelector = createCachedSelector(
+export const getHighlightedGeomsSelector = createCustomCachedSelector(
   [getTooltipInfoAndGeometriesSelector],
   ({ highlightedGeometries }): IndexedGeometry[] => highlightedGeometries,
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/has_single_series.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/has_single_series.ts
@@ -17,14 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { computeSeriesDomainsSelector } from './compute_series_domains';
 
 /** @internal */
-export const hasSingleSeriesSelector = createCachedSelector(
+export const hasSingleSeriesSelector = createCustomCachedSelector(
   [computeSeriesDomainsSelector],
   (seriesDomainsAndData): boolean =>
     Boolean(seriesDomainsAndData) && seriesDomainsAndData.formattedDataSeries.length > 1,
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/is_annotation_tooltip_visible.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/is_annotation_tooltip_visible.ts
@@ -17,13 +17,11 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getAnnotationTooltipStateSelector } from './get_annotation_tooltip_state';
 
 /** @internal */
-export const isAnnotationTooltipVisibleSelector = createCachedSelector(
+export const isAnnotationTooltipVisibleSelector = createCustomCachedSelector(
   [getAnnotationTooltipStateSelector],
   (annotationTooltipState): boolean => annotationTooltipState !== null && annotationTooltipState.isVisible,
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/is_brush_available.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/is_brush_available.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ScaleType } from '../../../../scales/constants';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { getComputedScalesSelector } from './get_computed_scales';
 
@@ -29,7 +27,7 @@ import { getComputedScalesSelector } from './get_computed_scales';
  * if we have configured an onBrushEnd listener
  * @internal
  */
-export const isBrushAvailableSelector = createCachedSelector(
+export const isBrushAvailableSelector = createCustomCachedSelector(
   [getSettingsSpecSelector, getComputedScalesSelector],
   (settingsSpec, scales): boolean => {
     if (!scales.xScale) {
@@ -37,4 +35,4 @@ export const isBrushAvailableSelector = createCachedSelector(
     }
     return scales.xScale.type !== ScaleType.Ordinal && Boolean(settingsSpec.onBrushEnd);
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/is_brushing.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/is_brushing.ts
@@ -17,16 +17,14 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { isBrushAvailableSelector } from './is_brush_available';
 
 const getPointerSelector = (state: GlobalChartState) => state.interactions.pointer;
 
 /** @internal */
-export const isBrushingSelector = createCachedSelector(
+export const isBrushingSelector = createCustomCachedSelector(
   [isBrushAvailableSelector, getPointerSelector],
   (isBrushAvailable, pointer): boolean => {
     if (!isBrushAvailable) {
@@ -35,4 +33,4 @@ export const isBrushingSelector = createCachedSelector(
 
     return pointer.dragging;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/is_chart_animatable.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/is_chart_animatable.ts
@@ -17,15 +17,13 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { computeSeriesGeometriesSelector } from './compute_series_geometries';
 // import { isChartAnimatable } from '../utils';
 
 /** @internal */
-export const isChartAnimatableSelector = createCachedSelector(
+export const isChartAnimatableSelector = createCustomCachedSelector(
   [computeSeriesGeometriesSelector, getSettingsSpecSelector],
   // eslint-disable-next-line arrow-body-style
   () => {
@@ -35,4 +33,4 @@ export const isChartAnimatableSelector = createCachedSelector(
     // return isChartAnimatable(geometriesCounts, settingsSpec.animateData);
     return false;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/is_chart_empty.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/is_chart_empty.ts
@@ -17,13 +17,11 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { isAllSeriesDeselected } from '../utils/common';
 import { computeLegendSelector } from './compute_legend';
 
 /** @internal */
-export const isChartEmptySelector = createCachedSelector([computeLegendSelector], (legendItems): boolean =>
+export const isChartEmptySelector = createCustomCachedSelector([computeLegendSelector], (legendItems): boolean =>
   isAllSeriesDeselected(legendItems),
-)(getChartIdSelector);
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/is_histogram_mode_enabled.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/is_histogram_mode_enabled.ts
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { isHistogramModeEnabled } from '../utils/utils';
 import { getSeriesSpecsSelector } from './get_specs';
 
 /** @internal */
-export const isHistogramModeEnabledSelector = createCachedSelector([getSeriesSpecsSelector], (seriesSpecs): boolean =>
-  isHistogramModeEnabled(seriesSpecs),
-)(getChartIdSelector);
+export const isHistogramModeEnabledSelector = createCustomCachedSelector(
+  [getSeriesSpecsSelector],
+  (seriesSpecs): boolean => isHistogramModeEnabled(seriesSpecs),
+);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/is_tooltip_snap_enabled.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/is_tooltip_snap_enabled.ts
@@ -17,18 +17,16 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { Scale } from '../../../../scales';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { computeSeriesGeometriesSelector } from './compute_series_geometries';
 import { getTooltipSnapSelector } from './get_tooltip_snap';
 
 /** @internal */
-export const isTooltipSnapEnableSelector = createCachedSelector(
+export const isTooltipSnapEnableSelector = createCustomCachedSelector(
   [computeSeriesGeometriesSelector, getTooltipSnapSelector],
   (seriesGeometries, snap) => isTooltipSnapEnabled(seriesGeometries.scales.xScale, snap),
-)(getChartIdSelector);
+);
 
 function isTooltipSnapEnabled(xScale: Scale, snap: boolean) {
   return (xScale && xScale.bandwidth > 0) || snap;

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/is_tooltip_visible.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/is_tooltip_visible.ts
@@ -17,13 +17,11 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { TooltipInfo } from '../../../../components/tooltip/types';
 import { getTooltipType } from '../../../../specs';
 import { TooltipType } from '../../../../specs/constants';
 import { GlobalChartState, PointerStates } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { isExternalTooltipVisibleSelector } from '../../../../state/selectors/is_external_tooltip_visible';
 import { Point } from '../../../../utils/point';
@@ -36,7 +34,7 @@ const getTooltipTypeSelector = (state: GlobalChartState): TooltipType => getTool
 const getPointerSelector = (state: GlobalChartState) => state.interactions.pointer;
 
 /** @internal */
-export const isTooltipVisibleSelector = createCachedSelector(
+export const isTooltipVisibleSelector = createCustomCachedSelector(
   [
     getTooltipTypeSelector,
     getPointerSelector,
@@ -46,7 +44,7 @@ export const isTooltipVisibleSelector = createCachedSelector(
     isExternalTooltipVisibleSelector,
   ],
   isTooltipVisible,
-)(getChartIdSelector);
+);
 
 function isTooltipVisible(
   tooltipType: TooltipType,

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
 import { ChartType } from '../../..';
@@ -25,7 +24,7 @@ import { Scale } from '../../../../scales';
 import { GroupBrushExtent, XYBrushArea } from '../../../../specs';
 import { BrushAxis } from '../../../../specs/constants';
 import { DragState, GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { maxValueWithUpperLimit, minValueWithLowerLimit, Rotation } from '../../../../utils/common';
 import { Dimensions } from '../../../../utils/dimensions';
@@ -57,7 +56,7 @@ export function createOnBrushEndCaller(): (state: GlobalChartState) => void {
         prevProps = null;
         return;
       }
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [
           getLastDragSelector,
           getSettingsSpecSelector,
@@ -118,7 +117,7 @@ export function createOnBrushEndCaller(): (state: GlobalChartState) => void {
           }
           prevProps = nextProps;
         },
-      )(getChartIdSelector);
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/on_click_caller.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/on_click_caller.ts
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
 import { ChartType } from '../../..';
 import { ProjectedValues, SettingsSpec } from '../../../../specs';
 import { GlobalChartState, PointerState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getLastClickSelector } from '../../../../state/selectors/get_last_click';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { isClicking } from '../../../../state/utils';
@@ -49,7 +48,7 @@ export function createOnClickCaller(): (state: GlobalChartState) => void {
     if (state.chartType !== ChartType.XYAxis) {
       return;
     }
-    selector = createCachedSelector(
+    selector = createCustomCachedSelector(
       [getLastClickSelector, getSettingsSpecSelector, getHighlightedGeomsSelector, getProjectedScaledValues],
       (
         lastClick: PointerState | null,
@@ -66,9 +65,7 @@ export function createOnClickCaller(): (state: GlobalChartState) => void {
         }
         prevClick = lastClick;
       },
-    )({
-      keySelector: getChartIdSelector,
-    });
+    );
   };
 }
 

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/on_element_out_caller.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/on_element_out_caller.ts
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartType } from '../../..';
 import { SettingsSpec } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { IndexedGeometry } from '../../../../utils/geometry';
 import {
@@ -60,7 +59,7 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.XYAxis) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getTooltipInfoAndGeometriesSelector, getSettingsSpecSelector],
         ({ highlightedGeometries }: TooltipAndHighlightedGeoms, settings: SettingsSpec): void => {
           const nextProps = {
@@ -73,9 +72,7 @@ export function createOnElementOutCaller(): (state: GlobalChartState) => void {
           }
           prevProps = nextProps;
         },
-      )({
-        keySelector: getChartIdSelector,
-      });
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/on_element_over_caller.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/on_element_over_caller.ts
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'react-redux';
 
 import { ChartType } from '../../..';
 import { SettingsSpec } from '../../../../specs';
 import { GlobalChartState } from '../../../../state/chart_state';
-import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { IndexedGeometry, GeometryValue } from '../../../../utils/geometry';
 import { XYChartSeriesIdentifier } from '../../utils/series';
@@ -70,7 +69,7 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.XYAxis) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getTooltipInfoAndGeometriesSelector, getSettingsSpecSelector],
         ({ highlightedGeometries }: TooltipAndHighlightedGeoms, settings: SettingsSpec): void => {
           const nextProps = {
@@ -86,9 +85,7 @@ export function createOnElementOverCaller(): (state: GlobalChartState) => void {
           }
           prevProps = nextProps;
         },
-      )({
-        keySelector: getChartIdSelector,
-      });
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/on_pointer_move_caller.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/on_pointer_move_caller.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
 import { Selector } from 'reselect';
 
 import { ChartType } from '../../..';
@@ -25,6 +24,7 @@ import { Scale } from '../../../../scales';
 import { SettingsSpec, PointerEvent } from '../../../../specs';
 import { PointerEventType } from '../../../../specs/constants';
 import { GlobalChartState } from '../../../../state/chart_state';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { computeSeriesGeometriesSelector } from './compute_series_geometries';
@@ -32,7 +32,7 @@ import { getGeometriesIndexKeysSelector } from './get_geometries_index_keys';
 import { getOrientedProjectedPointerPositionSelector } from './get_oriented_projected_pointer_position';
 import { PointerPosition } from './get_projected_pointer_position';
 
-const getPointerEventSelector = createCachedSelector(
+const getPointerEventSelector = createCustomCachedSelector(
   [
     getChartIdSelector,
     getOrientedProjectedPointerPositionSelector,
@@ -41,7 +41,7 @@ const getPointerEventSelector = createCachedSelector(
   ],
   (chartId, orientedProjectedPointerPosition, seriesGeometries, geometriesIndexKeys): PointerEvent =>
     getPointerEvent(chartId, orientedProjectedPointerPosition, seriesGeometries.scales.xScale, geometriesIndexKeys),
-)(getChartIdSelector);
+);
 
 function getPointerEvent(
   chartId: string,
@@ -110,7 +110,7 @@ export function createOnPointerMoveCaller(): (state: GlobalChartState) => void {
   let selector: Selector<GlobalChartState, void> | null = null;
   return (state: GlobalChartState) => {
     if (selector === null && state.chartType === ChartType.XYAxis) {
-      selector = createCachedSelector(
+      selector = createCustomCachedSelector(
         [getSettingsSpecSelector, getPointerEventSelector, getChartIdSelector],
         (settings: SettingsSpec, nextPointerEvent: PointerEvent, chartId: string): void => {
           if (prevPointerEvent === null) {
@@ -129,9 +129,7 @@ export function createOnPointerMoveCaller(): (state: GlobalChartState) => void {
             settings.onPointerUpdate(nextPointerEvent);
           }
         },
-      )({
-        keySelector: getChartIdSelector,
-      });
+      );
     }
     if (selector) {
       selector(state);

--- a/packages/charts/src/components/__snapshots__/chart.test.tsx.snap
+++ b/packages/charts/src/components/__snapshots__/chart.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Chart should render the legend name test 1`] = `
         </ChartBackground>
       </Connect(ChartBackground)>
       <Connect(ChartStatusComponent)>
-        <ChartStatusComponent rendered={true} renderedCount={1} onRenderChange={[undefined]} debugState={{...}} dispatch={[Function: dispatch]}>
+        <ChartStatusComponent chartId=\\"chart1\\" rendered={true} renderedCount={1} onRenderChange={[undefined]} debugState={{...}} dispatch={[Function: dispatch]}>
           <div className=\\"echChartStatus\\" data-ech-render-complete={true} data-ech-render-count={1} data-ech-debug-state={{...}} />
         </ChartStatusComponent>
       </Connect(ChartStatusComponent)>

--- a/packages/charts/src/components/chart_status.tsx
+++ b/packages/charts/src/components/chart_status.tsx
@@ -35,9 +35,7 @@ interface ChartStatusStateProps {
   debugState: DebugState | null;
 }
 
-type Props = ChartStatusStateProps;
-
-class ChartStatusComponent extends React.Component<Props> {
+class ChartStatusComponent extends React.Component<ChartStatusStateProps> {
   componentDidMount() {
     this.dispatchRenderChange();
   }

--- a/packages/charts/src/components/chart_status.tsx
+++ b/packages/charts/src/components/chart_status.tsx
@@ -22,23 +22,32 @@ import { connect } from 'react-redux';
 
 import { RenderChangeListener } from '../specs';
 import { GlobalChartState } from '../state/chart_state';
+import { globalSelectorCache } from '../state/create_selector';
 import { getDebugStateSelector } from '../state/selectors/get_debug_state';
 import { getSettingsSpecSelector } from '../state/selectors/get_settings_specs';
 import { DebugState } from '../state/types';
 
 interface ChartStatusStateProps {
+  chartId: string;
   rendered: boolean;
   renderedCount: number;
   onRenderChange?: RenderChangeListener;
   debugState: DebugState | null;
 }
-class ChartStatusComponent extends React.Component<ChartStatusStateProps> {
+
+type Props = ChartStatusStateProps;
+
+class ChartStatusComponent extends React.Component<Props> {
   componentDidMount() {
     this.dispatchRenderChange();
   }
 
   componentDidUpdate() {
     this.dispatchRenderChange();
+  }
+
+  componentWillUnmount() {
+    globalSelectorCache.removeKeyFromAll(this.props.chartId);
   }
 
   dispatchRenderChange = () => {
@@ -69,6 +78,7 @@ const mapStateToProps = (state: GlobalChartState): ChartStatusStateProps => {
   const { onRenderChange, debugState } = getSettingsSpecSelector(state);
 
   return {
+    chartId: state.chartId,
     rendered: state.chartRendered,
     renderedCount: state.chartRenderedCount,
     onRenderChange,

--- a/packages/charts/src/state/create_selector.ts
+++ b/packages/charts/src/state/create_selector.ts
@@ -28,12 +28,7 @@ import { GlobalChartState } from './chart_state';
  * see https://github.com/toomuchdesign/re-reselect/tree/master/src/cache#write-your-custom-cache-object
  */
 class CustomMapCache implements ICacheObject {
-  debug: boolean;
   private cache: any = {};
-
-  constructor(debug: boolean = false) {
-    this.debug = debug;
-  }
 
   set(key: string, selectorFn: () => any) {
     this.cache[key] = selectorFn;
@@ -67,10 +62,10 @@ class GlobalSelectorCache {
     return chartId;
   }
 
-  getNewOptions(debug?: boolean): Options<GlobalChartState, unknown, unknown> {
+  getNewOptions(): Options<GlobalChartState, unknown, unknown> {
     return {
       keySelector: GlobalSelectorCache.keySelector,
-      cacheObject: this.getCacheObject(debug),
+      cacheObject: this.getCacheObject(),
     };
   }
 
@@ -80,8 +75,8 @@ class GlobalSelectorCache {
     });
   }
 
-  private getCacheObject(debug?: boolean): CustomMapCache {
-    const cache = new CustomMapCache(debug);
+  private getCacheObject(): CustomMapCache {
+    const cache = new CustomMapCache();
     this.selectorCaches.push(cache);
 
     return cache;

--- a/packages/charts/src/state/create_selector.ts
+++ b/packages/charts/src/state/create_selector.ts
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// eslint-disable-next-line no-restricted-imports
+import createCachedSelector, { ICacheObject, Options } from 're-reselect';
+import type { createSelector } from 'reselect';
+
+import { GlobalChartState } from './chart_state';
+
+/**
+ * Custom object cache
+ * see https://github.com/toomuchdesign/re-reselect/tree/master/src/cache#write-your-custom-cache-object
+ */
+class CustomMapCache implements ICacheObject {
+  debug: boolean;
+  private cache: any = {};
+
+  constructor(debug: boolean = false) {
+    this.debug = debug;
+  }
+
+  set(key: string, selectorFn: () => any) {
+    this.cache[key] = selectorFn;
+  }
+
+  get(key: string) {
+    return this.cache[key];
+  }
+
+  remove(key: string) {
+    delete this.cache[key];
+  }
+
+  clear() {
+    this.cache = {};
+  }
+
+  isEmpty() {
+    return Object.keys(this.cache).length === 0;
+  }
+
+  isValidCacheKey(key: string) {
+    return typeof key === 'string';
+  }
+}
+
+class GlobalSelectorCache {
+  private selectorCaches: CustomMapCache[] = [];
+
+  static keySelector({ chartId }: GlobalChartState) {
+    return chartId;
+  }
+
+  getNewOptions(debug?: boolean): Options<GlobalChartState, unknown, unknown> {
+    return {
+      keySelector: GlobalSelectorCache.keySelector,
+      cacheObject: this.getCacheObject(debug),
+    };
+  }
+
+  removeKeyFromAll(key: string) {
+    this.selectorCaches.forEach((cache) => {
+      cache.remove(key);
+    });
+  }
+
+  private getCacheObject(debug?: boolean): CustomMapCache {
+    const cache = new CustomMapCache(debug);
+    this.selectorCaches.push(cache);
+
+    return cache;
+  }
+}
+
+/**
+ * Global singleton to manage state of selector caches
+ *
+ * @internal
+ */
+export const globalSelectorCache = new GlobalSelectorCache();
+
+/**
+ * Wrapper around `createCachedSelector` to provide `keySelector` and `cacheObject`
+ * for all selector instances in on place. This should be used in place of `createCachedSelector`.
+ *
+ * The types defining `createCachedSelector` are very complex and essentially hardcoded overloads for having any
+ * number of selector inputs up to about 20 with genetic types. Thus the types are extremely hard to duplciate.
+ * To fix this I used the type of `createSelector` which is what is the same as that of `createCachedSelector`
+ * method with the added curring for the cached options which this wrapper handles.
+ *
+ * @internal
+ */
+export const createCustomCachedSelector: typeof createSelector = (...args: any[]) => {
+  // @ts-ignore - forced types to simplify usage. All types align correctly
+  return createCachedSelector(...args)(globalSelectorCache.getNewOptions());
+};

--- a/packages/charts/src/state/selectors/get_accessibility_config.ts
+++ b/packages/charts/src/state/selectors/get_accessibility_config.ts
@@ -17,12 +17,11 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { DEFAULT_SETTINGS_SPEC } from '../../specs/constants';
 import { SettingsSpec } from '../../specs/settings';
 import { isDefined } from '../../utils/common';
 import { GlobalChartState } from '../chart_state';
+import { createCustomCachedSelector } from '../create_selector';
 import { getChartIdSelector } from './get_chart_id';
 import { getSettingsSpecSelector } from './get_settings_specs';
 
@@ -46,7 +45,7 @@ export const DEFAULT_A11Y_SETTINGS: A11ySettings = {
 };
 
 /** @internal */
-export const getA11ySettingsSelector = createCachedSelector(
+export const getA11ySettingsSelector = createCustomCachedSelector(
   [getSettingsSpecSelector, getChartIdSelector],
   (
     {
@@ -81,7 +80,7 @@ export const getA11ySettingsSelector = createCachedSelector(
       tableCaption: ariaTableCaption,
     };
   },
-)(getChartIdSelector);
+);
 
 function isValidHeadingLevel(ariaLabelHeadingLevel: SettingsSpec['ariaLabelHeadingLevel']): boolean {
   return ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p'].includes(ariaLabelHeadingLevel);

--- a/packages/charts/src/state/selectors/get_chart_container_dimensions.ts
+++ b/packages/charts/src/state/selectors/get_chart_container_dimensions.ts
@@ -17,19 +17,17 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { LayoutDirection } from '../../utils/common';
 import { Dimensions } from '../../utils/dimensions';
 import { GlobalChartState } from '../chart_state';
-import { getChartIdSelector } from './get_chart_id';
+import { createCustomCachedSelector } from '../create_selector';
 import { getLegendConfigSelector } from './get_legend_config_selector';
 import { getLegendSizeSelector } from './get_legend_size';
 
 const getParentDimension = (state: GlobalChartState) => state.parentDimensions;
 
 /** @internal */
-export const getChartContainerDimensionsSelector = createCachedSelector(
+export const getChartContainerDimensionsSelector = createCustomCachedSelector(
   [getLegendConfigSelector, getLegendSizeSelector, getParentDimension],
   ({ showLegend, legendPosition: { floating, direction } }, legendSize, parentDimensions): Dimensions => {
     if (!showLegend || floating) {
@@ -50,4 +48,4 @@ export const getChartContainerDimensionsSelector = createCachedSelector(
       height: parentDimensions.height - legendSize.height - legendSize.margin * 2,
     };
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/state/selectors/get_chart_rotation.ts
+++ b/packages/charts/src/state/selectors/get_chart_rotation.ts
@@ -17,14 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { Rotation } from '../../utils/common';
-import { getChartIdSelector } from './get_chart_id';
+import { createCustomCachedSelector } from '../create_selector';
 import { getSettingsSpecSelector } from './get_settings_specs';
 
 /** @internal */
-export const getChartRotationSelector = createCachedSelector(
+export const getChartRotationSelector = createCustomCachedSelector(
   [getSettingsSpecSelector],
   (settingsSpec): Rotation => settingsSpec.rotation,
-)(getChartIdSelector);
+);

--- a/packages/charts/src/state/selectors/get_chart_theme.ts
+++ b/packages/charts/src/state/selectors/get_chart_theme.ts
@@ -17,19 +17,17 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { LIGHT_THEME } from '../../utils/themes/light_theme';
 import { mergeWithDefaultTheme } from '../../utils/themes/merge_utils';
 import { PartialTheme, Theme } from '../../utils/themes/theme';
-import { getChartIdSelector } from './get_chart_id';
+import { createCustomCachedSelector } from '../create_selector';
 import { getSettingsSpecSelector } from './get_settings_specs';
 
 /** @internal */
-export const getChartThemeSelector = createCachedSelector(
+export const getChartThemeSelector = createCustomCachedSelector(
   [getSettingsSpecSelector],
   (settingsSpec): Theme => getTheme(settingsSpec.baseTheme, settingsSpec.theme),
-)(getChartIdSelector);
+);
 
 function getTheme(baseTheme?: Theme, theme?: PartialTheme | PartialTheme[]): Theme {
   const base = baseTheme || LIGHT_THEME;

--- a/packages/charts/src/state/selectors/get_legend_config_selector.ts
+++ b/packages/charts/src/state/selectors/get_legend_config_selector.ts
@@ -17,14 +17,12 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { getLegendPositionConfig } from '../../components/legend/position_style';
-import { getChartIdSelector } from './get_chart_id';
+import { createCustomCachedSelector } from '../create_selector';
 import { getSettingsSpecSelector } from './get_settings_specs';
 
 /** @internal */
-export const getLegendConfigSelector = createCachedSelector(
+export const getLegendConfigSelector = createCustomCachedSelector(
   [getSettingsSpecSelector],
   ({
     flatLegend,
@@ -57,4 +55,4 @@ export const getLegendConfigSelector = createCachedSelector(
       showLegendExtra,
     };
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/state/selectors/get_legend_size.ts
+++ b/packages/charts/src/state/selectors/get_legend_size.ts
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { LEGEND_HIERARCHY_MARGIN } from '../../components/legend/legend_item';
 import { LEGEND_TO_FULL_CONFIG } from '../../components/legend/position_style';
 import { LegendPositionConfig } from '../../specs/settings';
@@ -26,7 +24,7 @@ import { BBox } from '../../utils/bbox/bbox_calculator';
 import { CanvasTextBBoxCalculator } from '../../utils/bbox/canvas_text_bbox_calculator';
 import { Position, isDefined, LayoutDirection } from '../../utils/common';
 import { GlobalChartState } from '../chart_state';
-import { getChartIdSelector } from './get_chart_id';
+import { createCustomCachedSelector } from '../create_selector';
 import { getChartThemeSelector } from './get_chart_theme';
 import { getLegendConfigSelector } from './get_legend_config_selector';
 import { getLegendItemsLabelsSelector } from './get_legend_items_labels';
@@ -46,7 +44,7 @@ export type LegendSizing = BBox & {
 };
 
 /** @internal */
-export const getLegendSizeSelector = createCachedSelector(
+export const getLegendSizeSelector = createCustomCachedSelector(
   [getLegendConfigSelector, getChartThemeSelector, getParentDimensionSelector, getLegendItemsLabelsSelector],
   (legendConfig, theme, parentDimensions, labels): LegendSizing => {
     if (!legendConfig.showLegend) {
@@ -107,4 +105,4 @@ export const getLegendSizeSelector = createCachedSelector(
       position: legendPosition,
     };
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/state/selectors/get_settings_specs.ts
+++ b/packages/charts/src/state/selectors/get_settings_specs.ts
@@ -17,20 +17,20 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ChartType } from '../../chart_types';
 import { SpecType, DEFAULT_SETTINGS_SPEC } from '../../specs/constants';
 import { SettingsSpec } from '../../specs/settings';
 import { GlobalChartState } from '../chart_state';
+import { createCustomCachedSelector } from '../create_selector';
 import { getSpecsFromStore } from '../utils';
-import { getChartIdSelector } from './get_chart_id';
 
 /** @internal */
 export const getSpecs = (state: GlobalChartState) => state.specs;
 
-/** @internal */
-export const getSettingsSpecSelector = createCachedSelector(
+/**
+ * @internal
+ */
+export const getSettingsSpecSelector = createCustomCachedSelector(
   [getSpecs],
   (specs): SettingsSpec => {
     const settingsSpecs = getSpecsFromStore<SettingsSpec>(specs, ChartType.Global, SpecType.Settings);
@@ -39,4 +39,4 @@ export const getSettingsSpecSelector = createCachedSelector(
     }
     return DEFAULT_SETTINGS_SPEC;
   },
-)(getChartIdSelector);
+);

--- a/packages/charts/src/state/selectors/get_small_multiples_spec.ts
+++ b/packages/charts/src/state/selectors/get_small_multiples_spec.ts
@@ -17,27 +17,25 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { ChartType } from '../../chart_types';
 import { SpecType } from '../../specs/constants';
 import { SmallMultiplesSpec } from '../../specs/small_multiples';
+import { createCustomCachedSelector } from '../create_selector';
 import { getSpecsFromStore } from '../utils';
-import { getChartIdSelector } from './get_chart_id';
 import { getSpecs } from './get_settings_specs';
 
 /**
  * Return the small multiple specs
  * @internal
  */
-export const getSmallMultiplesSpecs = createCachedSelector([getSpecs], (specs) =>
+export const getSmallMultiplesSpecs = createCustomCachedSelector([getSpecs], (specs) =>
   getSpecsFromStore<SmallMultiplesSpec>(specs, ChartType.Global, SpecType.SmallMultiples),
-)(getChartIdSelector);
+);
 
 /**
  * Return the small multiple spec
  * @internal
  */
-export const getSmallMultiplesSpec = createCachedSelector([getSmallMultiplesSpecs], (smallMultiples) =>
+export const getSmallMultiplesSpec = createCustomCachedSelector([getSmallMultiplesSpecs], (smallMultiples) =>
   smallMultiples.length === 1 ? smallMultiples : undefined,
-)(getChartIdSelector);
+);

--- a/packages/charts/src/state/selectors/get_tooltip_header_formatter.ts
+++ b/packages/charts/src/state/selectors/get_tooltip_header_formatter.ts
@@ -17,17 +17,15 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { SettingsSpec, TooltipValueFormatter, isTooltipProps } from '../../specs/settings';
-import { getChartIdSelector } from './get_chart_id';
+import { createCustomCachedSelector } from '../create_selector';
 import { getSettingsSpecSelector } from './get_settings_specs';
 
 /** @internal */
-export const getTooltipHeaderFormatterSelector = createCachedSelector(
+export const getTooltipHeaderFormatterSelector = createCustomCachedSelector(
   [getSettingsSpecSelector],
   getTooltipHeaderFormatter,
-)(getChartIdSelector);
+);
 
 function getTooltipHeaderFormatter(settings: SettingsSpec): TooltipValueFormatter | undefined {
   const { tooltip } = settings;

--- a/packages/charts/src/state/selectors/is_external_tooltip_visible.ts
+++ b/packages/charts/src/state/selectors/is_external_tooltip_visible.ts
@@ -17,20 +17,18 @@
  * under the License.
  */
 
-import createCachedSelector from 're-reselect';
-
 import { computeChartDimensionsSelector } from '../../chart_types/xy_chart/state/selectors/compute_chart_dimensions';
 import { getComputedScalesSelector } from '../../chart_types/xy_chart/state/selectors/get_computed_scales';
 import { PointerEventType } from '../../specs';
 import { GlobalChartState } from '../chart_state';
-import { getChartIdSelector } from './get_chart_id';
+import { createCustomCachedSelector } from '../create_selector';
 import { getSettingsSpecSelector } from './get_settings_specs';
 import { hasExternalEventSelector } from './has_external_pointer_event';
 
 const getExternalEventPointer = ({ externalEvents: { pointer } }: GlobalChartState) => pointer;
 
 /** @internal */
-export const isExternalTooltipVisibleSelector = createCachedSelector(
+export const isExternalTooltipVisibleSelector = createCustomCachedSelector(
   [
     getSettingsSpecSelector,
     hasExternalEventSelector,
@@ -49,4 +47,4 @@ export const isExternalTooltipVisibleSelector = createCachedSelector(
     }
     return hasExternalEvent && externalPointerEvents.tooltip?.visible === true;
   },
-)(getChartIdSelector);
+);


### PR DESCRIPTION
## Summary

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->

Fixes memory leak related to re-reselect cache holding onto old chart store references.

<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

Now selectors are creeated using a centralized method `createCustomCachedSelector` to facilitate `keySelector` and `objectCache` for all selectors in one place.

```diff
- selector = createCachedSelector(
+ selector = createCustomCachedSelector(
  [getSpecOrNull, getPickedShapesLayerValues, getSettingsSpecSelector],
  getOnElementOverSelector(prev),
- )({
-  keySelector: getChartIdSelector,
-});
+);

// Or similarly 
- selector = createCachedSelector(
+ selector = createCustomCachedSelector(
  [getSpecOrNull, getPickedShapesLayerValues, getSettingsSpecSelector],
  getOnElementOverSelector(prev),
- )((state) => state.chartId);
+);
```

> There is an added lint rule to prevent importing `createCachedSelector` from `re-reselect`.

The types for the new `createCustomCachedSelector` method are `@ts-ignored` in order to facilitate this central method for creating selectors as the [`createCachedSelector` type](https://github.com/toomuchdesign/re-reselect/blob/6e870b7352fae16f470f1d77358e91158e0f4609/src/index.d.ts#L75-L4252) uses over 90 overrides with generics to type the function.

### Before

Detached nodes in memory heap snapshot point to chart id in `FlatObjectCache` in `re-reselect`. The `FlatObjectCache` keeps around chart states based on ids that have since been randomized and recreated, thus the `_cache` grows proportional to the count of remounted charts.👇🏼 

https://user-images.githubusercontent.com/19007109/121589848-2b949a00-c9fd-11eb-8ffb-509557d5cf2d.mp4

Dom elements are much higher and continue to grow after charts are mounted and unmounted repeatedly, even after forced garbage collection. 👇🏼 

https://user-images.githubusercontent.com/19007109/121589503-c17bf500-c9fc-11eb-9087-8115dab8f74c.mp4

### After

Detached nodes in memory heap snapshot no longer point to chart id in `FlatObjectCache` in `re-reselect`. 👇🏼 

https://user-images.githubusercontent.com/19007109/121588010-043ccd80-c9fb-11eb-9571-7bed2abc9293.mp4

Dom elements are now being garbage collected after charts are mounted and unmounted repeatedly. 👇🏼 

https://user-images.githubusercontent.com/19007109/121588218-47973c00-c9fb-11eb-9a74-32e1c772fa30.mp4


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->

Related to #1148, still need to address `tooltip_portal` memory leaks

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [ ] The proper chart type label was added (e.g. :xy, :partition) if the PR involves a specific chart type
- [ ] The proper feature label was added (e.g. :interactions, :axis) if the PR involves a specific chart feature
- [ ] Whenever possible, please check if the closing issue is connected to a running GH project
- [ ] Any consumer-facing exports were added to `packages/charts/src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [ ] This was checked for cross-browser compatibility
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
