### PR TITLE
feat: expose NaN values to tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:tz-ny": "TZ=America/New_York jest --verbose --config=jest.tz.config.js",
     "test:tz-jp": "TZ=Asia/Tokyo jest --verbose --config=jest.tz.config.js",
     "test:integration": "./scripts/vrt.sh",
-    "test:integration:local": "LOCAL_VRT_SERVER=true PORT=9001 yarn test:integration",
+    "test:integration:local": "LOCAL_VRT_SERVER=true PORT=9002 yarn test:integration",
     "test:integration:debug": "DEBUG=true yarn test:integration:local",
     "test:integration:legacy": "LEGACY_VRT_SERVER=true yarn test:integration",
     "test:integration:local:legacy": "LOCAL_VRT_SERVER=true PORT=9002 yarn test:integration:legacy",

--- a/packages/charts/src/chart_types/xy_chart/annotations/line/dimensions.ts
+++ b/packages/charts/src/chart_types/xy_chart/annotations/line/dimensions.ts
@@ -79,8 +79,8 @@ function computeYDomainLineAnnotationDimensions(
 
     vertical.domain.forEach((verticalValue) => {
       horizontal.domain.forEach((horizontalValue) => {
-        const top = vertical.scaleOrThrow(verticalValue);
-        const left = horizontal.scaleOrThrow(horizontalValue);
+        const top = vertical.scale(verticalValue);
+        const left = horizontal.scale(horizontalValue);
 
         const width = isHorizontalChartRotation ? horizontal.bandwidth : vertical.bandwidth;
         const height = isHorizontalChartRotation ? vertical.bandwidth : horizontal.bandwidth;
@@ -193,8 +193,8 @@ function computeXDomainLineAnnotationDimensions(
           return;
         }
 
-        const top = vertical.scaleOrThrow(verticalValue);
-        const left = horizontal.scaleOrThrow(horizontalValue);
+        const top = vertical.scale(verticalValue);
+        const left = horizontal.scale(horizontalValue);
         const width = isHorizontalChartRotation ? horizontal.bandwidth : vertical.bandwidth;
         const height = isHorizontalChartRotation ? vertical.bandwidth : horizontal.bandwidth;
 

--- a/packages/charts/src/chart_types/xy_chart/annotations/rect/dimensions.ts
+++ b/packages/charts/src/chart_types/xy_chart/annotations/rect/dimensions.ts
@@ -129,8 +129,8 @@ export function computeRectAnnotationDimensions(
       smallMultiplesScales.horizontal.domain.forEach((hDomainValue) => {
         const panel = {
           ...panelSize,
-          top: smallMultiplesScales.vertical.scaleOrThrow(vDomainValue),
-          left: smallMultiplesScales.horizontal.scaleOrThrow(hDomainValue),
+          top: smallMultiplesScales.vertical.scale(vDomainValue),
+          left: smallMultiplesScales.horizontal.scale(hDomainValue),
         };
         duplicated.push({ ...props, panel });
       });

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/areas.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/areas.ts
@@ -88,7 +88,7 @@ export function renderAreas(ctx: CanvasRenderingContext2D, imgCanvas: HTMLCanvas
         (ctx) => {
           renderPoints(ctx, visiblePoints, geometryStateStyle);
         },
-        { area: clippings, shouldClip: points[0]?.value.mark !== null },
+        { area: clippings, shouldClip: points.length > 0 && !isNaN(points[0].value.mark) },
       );
     });
   });

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/lines.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/lines.ts
@@ -65,6 +65,7 @@ export function renderLines(ctx: CanvasRenderingContext2D, props: LineGeometries
       if (visiblePoints.length === 0) {
         return;
       }
+
       const geometryStyle = getGeometryStateStyle(line.seriesIdentifier, sharedStyle, highlightedLegendItem);
       withPanelTransform(
         ctx,
@@ -75,7 +76,7 @@ export function renderLines(ctx: CanvasRenderingContext2D, props: LineGeometries
           renderPoints(ctx, visiblePoints, geometryStyle);
         },
         // TODO: add padding over clipping
-        { area: clippings, shouldClip: line.points[0]?.value.mark !== null },
+        { area: clippings, shouldClip: points.length > 0 && !isNaN(points[0].value.mark) },
       );
     });
   });

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/points.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/points.ts
@@ -34,6 +34,7 @@ import { withPanelTransform } from './utils/panel_transform';
  */
 export function renderPoints(ctx: CanvasRenderingContext2D, points: PointGeometry[], { opacity }: GeometryStateStyle) {
   points
+    .filter(({ value, y }) => !value.isFilled && isFinite(y))
     .map<[Circle, Fill, Stroke, PointShape]>(({ x, y, radius, transform, style }) => {
       const fill: Fill = {
         color: applyOpacity(style.fill.color, opacity),
@@ -49,7 +50,6 @@ export function renderPoints(ctx: CanvasRenderingContext2D, points: PointGeometr
         y: y + transform.y,
         radius,
       };
-
       return [coordinates, fill, stroke, style.shape];
     })
     .sort(([{ radius: a }], [{ radius: b }]) => b - a)

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/path.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/path.ts
@@ -108,7 +108,7 @@ function renderPathFill(ctx: CanvasRenderingContext2D, path: string, fill: Fill)
 
     ctx.fillStyle = fill.texture.pattern;
 
-    // Use oversized rect to fill rotation/offset beyond path
+    // Use oversize rect to fill rotation/offset beyond path
     const rotationRectFillSize = ctx.canvas.clientWidth * ctx.canvas.clientHeight;
     ctx.translate(-rotationRectFillSize / 2, -rotationRectFillSize / 2);
     ctx.fillRect(0, 0, rotationRectFillSize, rotationRectFillSize);

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/shapes.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/shapes.ts
@@ -38,6 +38,9 @@ export function renderShape(
   withContext(ctx, (ctx) => {
     const [pathFn, rotation] = ShapeRendererFn[shape];
     const { x, y, radius } = coordinates;
+    if (isNaN(x) || isNaN(y)) {
+      return;
+    }
     ctx.translate(x, y);
     ctx.rotate(getRadians(rotation));
     ctx.beginPath();

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/values/bar.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/values/bar.ts
@@ -78,6 +78,9 @@ export function renderBarValues(ctx: CanvasRenderingContext2D, props: BarValuesP
       barSeriesStyle.displayValue,
       alignment,
     );
+    if (isNaN(bars[i].value.y)) {
+      continue;
+    }
 
     if (displayValue.isValueContainedInElement) {
       const width = rotation === 0 || rotation === 180 ? bars[i].width : bars[i].height;

--- a/packages/charts/src/chart_types/xy_chart/rendering/area.ts
+++ b/packages/charts/src/chart_types/xy_chart/rendering/area.ts
@@ -31,8 +31,8 @@ import { PointStyleAccessor } from '../utils/specs';
 import { renderPoints } from './points';
 import {
   getClippedRanges,
-  getY0ScaledValueOrThrowFn,
-  getY1ScaledValueOrThrowFn,
+  getY0ScaledValue,
+  getY1ScaledValue,
   getYDatumValueFn,
   isYValueDefinedFn,
   MarkSizeOptions,
@@ -58,13 +58,14 @@ export function renderArea(
   areaGeometry: AreaGeometry;
   indexedGeometryMap: IndexedGeometryMap;
 } {
-  const y1Fn = getY1ScaledValueOrThrowFn(yScale);
-  const y0Fn = getY0ScaledValueOrThrowFn(yScale);
+  const y1Fn = getY1ScaledValue(yScale);
+  const y0Fn = getY0ScaledValue(yScale);
   const definedFn = isYValueDefinedFn(yScale, xScale);
   const y1DatumAccessor = getYDatumValueFn();
   const y0DatumAccessor = getYDatumValueFn('y0');
+  console.log(dataSeries);
   const pathGenerator = area<DataSeriesDatum>()
-    .x(({ x }) => xScale.scaleOrThrow(x) - xScaleOffset)
+    .x(({ x }) => xScale.scale(x) - xScaleOffset)
     .y1(y1Fn)
     .y0(y0Fn)
     .defined((datum) => {
@@ -77,7 +78,7 @@ export function renderArea(
   let y1Line: string | null;
 
   try {
-    y1Line = pathGenerator.lineY1()(dataSeries.data);
+    y1Line = pathGenerator.lineY1()(dataSeries.data.filter((d) => isFinite(d.y1)));
   } catch {
     // When values are not scalable
     y1Line = null;
@@ -91,7 +92,7 @@ export function renderArea(
     let y0Line: string | null;
 
     try {
-      y0Line = pathGenerator.lineY0()(dataSeries.data);
+      y0Line = pathGenerator.lineY0()(dataSeries.data.filter((d) => isFinite(d.y1)));
     } catch {
       // When values are not scalable
       y0Line = null;
@@ -118,7 +119,7 @@ export function renderArea(
   let areaPath: string;
 
   try {
-    areaPath = pathGenerator(dataSeries.data) || '';
+    areaPath = pathGenerator(dataSeries.data.filter((d) => isFinite(d.y1))) || '';
   } catch {
     // When values are not scalable
     areaPath = '';

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_highlighted_values.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_highlighted_values.ts
@@ -22,11 +22,11 @@ import createCachedSelector from 're-reselect';
 import { LegendItemExtraValues } from '../../../../common/legend';
 import { SeriesKey } from '../../../../common/series_id';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
-import { getHighligthedValues } from '../../tooltip/tooltip';
+import { getHighlightedValues } from '../../tooltip/tooltip';
 import { getTooltipInfoSelector } from './get_tooltip_values_highlighted_geoms';
 
 /** @internal */
 export const getHighlightedValuesSelector = createCachedSelector(
   [getTooltipInfoSelector],
-  ({ values }): Map<SeriesKey, LegendItemExtraValues> => getHighligthedValues(values),
+  ({ values }): Map<SeriesKey, LegendItemExtraValues> => getHighlightedValues(values),
 )(getChartIdSelector);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_position.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_position.ts
@@ -49,14 +49,14 @@ export const getTooltipAnchorPositionSelector = createCachedSelector(
       return null;
     }
 
-    const topPos = vertical.scale(projectedPointerPosition.verticalPanelValue) ?? 0;
-    const leftPos = horizontal.scale(projectedPointerPosition.horizontalPanelValue) ?? 0;
+    const topPos = vertical.scale(projectedPointerPosition.verticalPanelValue);
+    const leftPos = horizontal.scale(projectedPointerPosition.horizontalPanelValue);
 
     const panel = {
       width: horizontal.bandwidth,
       height: vertical.bandwidth,
-      top: chartDimensions.chartDimensions.top + topPos,
-      left: chartDimensions.chartDimensions.left + leftPos,
+      top: chartDimensions.chartDimensions.top + (isFinite(topPos) ? topPos : 0),
+      left: chartDimensions.chartDimensions.left + (isFinite(leftPos) ? leftPos : 0),
     };
 
     return getTooltipAnchorPosition(

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_snap.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_snap.ts
@@ -33,7 +33,7 @@ export const getTooltipSnapSelector = createCachedSelector(
 function getTooltipSnap(settings: SettingsSpec): boolean {
   const { tooltip } = settings;
   if (tooltip && isTooltipProps(tooltip)) {
-    return tooltip.snap || false;
+    return tooltip.snap ?? DEFAULT_TOOLTIP_SNAP;
   }
   return DEFAULT_TOOLTIP_SNAP;
 }

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
@@ -28,6 +28,8 @@ import {
   isFollowTooltipType,
   SettingsSpec,
   getTooltipType,
+  getShowTooltipOnNullValues,
+  getShowTooltipOnFittedValues,
 } from '../../../../specs';
 import { TooltipType } from '../../../../specs/constants';
 import { GlobalChartState } from '../../../../state/chart_state';
@@ -136,9 +138,12 @@ function getTooltipAndHighlightFromValue(
   let header: TooltipValue | null = null;
   const highlightedGeometries: IndexedGeometry[] = [];
   const xValues = new Set<any>();
-
+  const showTooltipOnNullValues = getShowTooltipOnNullValues(settings);
+  const showTooltipOnFittedValues = getShowTooltipOnFittedValues(settings);
   const values = matchingGeoms
-    .filter(({ value: { y } }) => y !== null)
+    .filter(({ value: { y, isFilled } }) => {
+      return (showTooltipOnNullValues && isNaN(y)) || (showTooltipOnFittedValues && isFilled) || !isNaN(y);
+    })
     .reduce<TooltipValue[]>((acc, indexedGeometry) => {
       const {
         seriesIdentifier: { specId },

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/is_tooltip_visible.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/is_tooltip_visible.ts
@@ -20,18 +20,15 @@
 import createCachedSelector from 're-reselect';
 
 import { TooltipInfo } from '../../../../components/tooltip/types';
-import { getTooltipType } from '../../../../specs';
 import { TooltipType } from '../../../../specs/constants';
 import { GlobalChartState, PointerStates } from '../../../../state/chart_state';
 import { getChartIdSelector } from '../../../../state/selectors/get_chart_id';
-import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { isExternalTooltipVisibleSelector } from '../../../../state/selectors/is_external_tooltip_visible';
 import { Point } from '../../../../utils/point';
 import { getProjectedPointerPositionSelector } from './get_projected_pointer_position';
+import { getTooltipTypeSelector } from './get_tooltip_type';
 import { getTooltipInfoSelector } from './get_tooltip_values_highlighted_geoms';
 import { isAnnotationTooltipVisibleSelector } from './is_annotation_tooltip_visible';
-
-const getTooltipTypeSelector = (state: GlobalChartState): TooltipType => getTooltipType(getSettingsSpecSelector(state));
 
 const getPointerSelector = (state: GlobalChartState) => state.interactions.pointer;
 

--- a/packages/charts/src/chart_types/xy_chart/state/utils/get_last_value.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/utils/get_last_value.ts
@@ -56,12 +56,12 @@ export function getLastValues(dataSeries: DataSeries[], xDomain: XDomain): Map<S
     const { y0, y1, initialY0, initialY1 } = last;
     const seriesKey = getSeriesKey(series as XYChartSeriesIdentifier, series.groupId);
 
-    if (series.stackMode === StackMode.Percentage) {
-      const y1InPercentage = y1 === null || y0 === null ? null : y1 - y0;
+    if (series.stackMode === StackMode.Percentage && !isNaN(y1 - y0)) {
+      const y1InPercentage = y1 - y0;
       lastValues.set(seriesKey, { y0, y1: y1InPercentage });
       return;
     }
-    if (initialY0 !== null || initialY1 !== null) {
+    if (!isNaN(initialY0) || !isNaN(initialY1)) {
       lastValues.set(seriesKey, { y0: initialY0, y1: initialY1 });
     }
   });

--- a/packages/charts/src/chart_types/xy_chart/state/utils/types.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/utils/types.ts
@@ -85,6 +85,6 @@ export interface SeriesDomainsAndData {
 
 /** @internal */
 export interface LastValues {
-  y0: number | null;
-  y1: number | null;
+  y0: number;
+  y1: number;
 }

--- a/packages/charts/src/chart_types/xy_chart/tooltip/tooltip.ts
+++ b/packages/charts/src/chart_types/xy_chart/tooltip/tooltip.ts
@@ -40,7 +40,7 @@ export const Y0_ACCESSOR_POSTFIX = ' - lower';
 export const Y1_ACCESSOR_POSTFIX = ' - upper';
 
 /** @internal */
-export function getHighligthedValues(
+export function getHighlightedValues(
   tooltipValues: TooltipValue[],
   defaultValue?: string,
 ): Map<SeriesKey, LegendItemExtraValues> {

--- a/packages/charts/src/chart_types/xy_chart/utils/fill_series.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/fill_series.ts
@@ -55,12 +55,12 @@ export function fillSeries(
 
       filledData.splice(index, 0, {
         x: missingValue,
-        y1: null,
-        y0: null,
-        initialY1: null,
-        initialY0: null,
-        mark: null,
-        datum: undefined,
+        y1: NaN,
+        y0: NaN,
+        initialY1: NaN,
+        initialY0: NaN,
+        mark: NaN,
+        datum: NaN,
         filled: {
           x: missingValue,
         },

--- a/packages/charts/src/chart_types/xy_chart/utils/fit_function.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/fit_function.ts
@@ -197,10 +197,10 @@ export const fitFunction = (
   if (type === Fit.Zero) {
     return data.map((datum) => ({
       ...datum,
-      y1: datum.y1 === null ? 0 : datum.y1,
+      y1: isNaN(datum.y1) ? 0 : datum.y1,
       filled: {
         ...datum.filled,
-        y1: datum.y1 === null ? 0 : undefined,
+        y1: isNaN(datum.y1) ? 0 : undefined,
       },
     }));
   }
@@ -212,10 +212,10 @@ export const fitFunction = (
 
     return data.map((datum) => ({
       ...datum,
-      y1: datum.y1 === null ? value : datum.y1,
+      y1: isNaN(datum.y1) ? value : datum.y1,
       filled: {
         ...datum.filled,
-        y1: datum.y1 === null ? value : undefined,
+        y1: isNaN(datum.y1) ? value : undefined,
       },
     }));
   }
@@ -231,7 +231,7 @@ export const fitFunction = (
     const currentValue = sortedData[i];
 
     if (
-      currentValue.y1 === null &&
+      isNaN(currentValue.y1) &&
       nextNonNullDatum === null &&
       (type === Fit.Lookahead ||
         type === Fit.Nearest ||
@@ -243,7 +243,7 @@ export const fitFunction = (
       for (j = i + 1; j < sortedData.length; j++) {
         const nextValue = sortedData[j];
 
-        if (nextValue.y1 !== null && nextValue.x !== null) {
+        if (!isNaN(nextValue.y1) && nextValue.x !== null) {
           nextNonNullDatum = {
             ...(nextValue as FullDataSeriesDatum),
             fittingIndex: j,
@@ -253,14 +253,13 @@ export const fitFunction = (
       }
     }
 
-    const newValue =
-      currentValue.y1 === null
-        ? getValue(currentValue, i, previousNonNullDatum, nextNonNullDatum, type, endValue)
-        : currentValue;
+    const newValue = isNaN(currentValue.y1)
+      ? getValue(currentValue, i, previousNonNullDatum, nextNonNullDatum, type, endValue)
+      : currentValue;
 
     newData[i] = newValue;
 
-    if (currentValue.y1 !== null && currentValue.x !== null) {
+    if (!isNaN(currentValue.y1)) {
       previousNonNullDatum = {
         ...(currentValue as FullDataSeriesDatum),
         fittingIndex: i,

--- a/packages/charts/src/chart_types/xy_chart/utils/indexed_geometry_spatial_map.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/indexed_geometry_spatial_map.ts
@@ -46,10 +46,6 @@ export class IndexedGeometrySpatialMap {
     return this.points.length;
   }
 
-  isSpatial() {
-    return this.pointGeometries.length > 0;
-  }
-
   set(points: PointGeometry[]) {
     this.maxRadius = Math.max(this.maxRadius, ...points.map(({ radius }) => radius));
     this.pointGeometries.push(...points);
@@ -57,10 +53,10 @@ export class IndexedGeometrySpatialMap {
       ...points.map<IndexedGeometrySpatialMapPoint>(({ x, y }) => {
         // TODO: handle coincident points better
         // This nonce is used to slightly offset every point such that each point
-        // has a unique poition in the index. This number is only used in the index.
+        // has a unique position in the index. This number is only used in the index.
         // The other option would be to find the point(s) near a Point and add logic
         // to account for multiple values in the pointGeometries array. This would be
-        // a very comutationally expensive approach having to repeat for every point.
+        // a very computationally expensive approach having to repeat for every point.
         const nonce = Math.random() * 0.000001;
         return [x + nonce, y];
       }),
@@ -78,7 +74,7 @@ export class IndexedGeometrySpatialMap {
     return [...this.pointGeometries];
   }
 
-  keys(): Array<number> {
+  keys(): Array<number | string> {
     return this.pointGeometries.map(({ value: { x } }) => x);
   }
 

--- a/packages/charts/src/chart_types/xy_chart/utils/series.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/series.test.ts
@@ -200,10 +200,10 @@ describe('Series', () => {
         seriesKeys: ['a'],
         key: 'a',
         data: [
-          { x: 1, y1: 1, mark: null, y0: null, initialY1: 1, initialY0: null, datum: undefined },
-          { x: 2, y1: 2, mark: null, y0: null, initialY1: 2, initialY0: null, datum: undefined },
-          { x: 3, y1: 3, mark: null, y0: null, initialY1: 3, initialY0: null, datum: undefined },
-          { x: 4, y1: 4, mark: null, y0: null, initialY1: 4, initialY0: null, datum: undefined },
+          { x: 1, y1: 1, mark: NaN, y0: NaN, initialY1: 1, initialY0: NaN, datum: undefined },
+          { x: 2, y1: 2, mark: NaN, y0: NaN, initialY1: 2, initialY0: NaN, datum: undefined },
+          { x: 3, y1: 3, mark: NaN, y0: NaN, initialY1: 3, initialY0: NaN, datum: undefined },
+          { x: 4, y1: 4, mark: NaN, y0: NaN, initialY1: 4, initialY0: NaN, datum: undefined },
         ],
       }),
       MockDataSeries.default({
@@ -213,10 +213,10 @@ describe('Series', () => {
         seriesKeys: ['b'],
         key: 'b',
         data: [
-          { x: 1, y1: 1, mark: null, y0: null, initialY1: 1, initialY0: null, datum: undefined },
-          { x: 2, y1: 2, mark: null, y0: null, initialY1: 2, initialY0: null, datum: undefined },
-          { x: 3, y1: 3, mark: null, y0: null, initialY1: 3, initialY0: null, datum: undefined },
-          { x: 4, y1: 4, mark: null, y0: null, initialY1: 4, initialY0: null, datum: undefined },
+          { x: 1, y1: 1, mark: NaN, y0: NaN, initialY1: 1, initialY0: NaN, datum: undefined },
+          { x: 2, y1: 2, mark: NaN, y0: NaN, initialY1: 2, initialY0: NaN, datum: undefined },
+          { x: 3, y1: 3, mark: NaN, y0: NaN, initialY1: 3, initialY0: NaN, datum: undefined },
+          { x: 4, y1: 4, mark: NaN, y0: NaN, initialY1: 4, initialY0: NaN, datum: undefined },
         ],
       }),
       MockDataSeries.default({
@@ -226,10 +226,10 @@ describe('Series', () => {
         seriesKeys: ['b'],
         key: 'b',
         data: [
-          { x: 1, y1: 1, mark: null, y0: null, initialY1: 1, initialY0: null, datum: undefined },
-          { x: 2, y1: 2, mark: null, y0: null, initialY1: 2, initialY0: null, datum: undefined },
-          { x: 3, y1: 3, mark: null, y0: null, initialY1: 3, initialY0: null, datum: undefined },
-          { x: 4, y1: 4, mark: null, y0: null, initialY1: 4, initialY0: null, datum: undefined },
+          { x: 1, y1: 1, mark: NaN, y0: NaN, initialY1: 1, initialY0: NaN, datum: undefined },
+          { x: 2, y1: 2, mark: NaN, y0: NaN, initialY1: 2, initialY0: NaN, datum: undefined },
+          { x: 3, y1: 3, mark: NaN, y0: NaN, initialY1: 3, initialY0: NaN, datum: undefined },
+          { x: 4, y1: 4, mark: NaN, y0: NaN, initialY1: 4, initialY0: NaN, datum: undefined },
         ],
       }),
       MockDataSeries.default({
@@ -239,10 +239,10 @@ describe('Series', () => {
         seriesKeys: ['b'],
         key: 'b',
         data: [
-          { x: 1, y1: 1, mark: null, y0: null, initialY1: 1, initialY0: null, datum: undefined },
-          { x: 2, y1: 2, mark: null, y0: null, initialY1: 2, initialY0: null, datum: undefined },
-          { x: 3, y1: 3, mark: null, y0: null, initialY1: 3, initialY0: null, datum: undefined },
-          { x: 4, y1: 4, mark: null, y0: null, initialY1: 4, initialY0: null, datum: undefined },
+          { x: 1, y1: 1, mark: NaN, y0: NaN, initialY1: 1, initialY0: NaN, datum: undefined },
+          { x: 2, y1: 2, mark: NaN, y0: NaN, initialY1: 2, initialY0: NaN, datum: undefined },
+          { x: 3, y1: 3, mark: NaN, y0: NaN, initialY1: 3, initialY0: NaN, datum: undefined },
+          { x: 4, y1: 4, mark: NaN, y0: NaN, initialY1: 4, initialY0: NaN, datum: undefined },
         ],
       }),
     ];
@@ -284,7 +284,7 @@ describe('Series', () => {
         key: 'a',
         data: new Array(maxArrayItems)
           .fill(0)
-          .map((d, i) => ({ x: i, y1: i, mark: null, y0: null, initialY1: i, initialY0: null, datum: undefined })),
+          .map((d, i) => ({ x: i, y1: i, mark: NaN, y0: NaN, initialY1: i, initialY0: NaN, datum: undefined })),
       }),
       MockDataSeries.default({
         specId: 'spec1',
@@ -294,7 +294,7 @@ describe('Series', () => {
         key: 'b',
         data: new Array(maxArrayItems)
           .fill(0)
-          .map((d, i) => ({ x: i, y1: i, mark: null, y0: null, initialY1: i, initialY0: null, datum: undefined })),
+          .map((d, i) => ({ x: i, y1: i, mark: NaN, y0: NaN, initialY1: i, initialY0: NaN, datum: undefined })),
       }),
     ];
     const xValues = new Set(new Array(maxArrayItems).fill(0).map((d, i) => i));

--- a/packages/charts/src/chart_types/xy_chart/utils/stacked_series_utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/stacked_series_utils.ts
@@ -88,10 +88,10 @@ export function formatStackedDataSeriesValues(
         reorderedArray[xIndex] = { x };
       }
       // y0 can be considered as always present
-      reorderedArray[xIndex][`${key}-y0`] = y0;
+      reorderedArray[xIndex][`${key}-y0`] = isNaN(y0) ? 0 : y0;
       // if y0 is available, we have to count y1 as the different of y1 and y0
       // to correctly stack them when stacking banded charts
-      reorderedArray[xIndex][`${key}-y1`] = (y1 ?? 0) - (y0 ?? 0);
+      reorderedArray[xIndex][`${key}-y1`] = (!isNaN(y1) ? y1 : 0) - (!isNaN(y0) ? y0 : 0);
       dsMap.set(x, d);
     });
     xValueMap.set(key, dsMap);

--- a/packages/charts/src/components/tooltip/tooltip.tsx
+++ b/packages/charts/src/components/tooltip/tooltip.tsx
@@ -142,7 +142,10 @@ const TooltipComponent = ({
               <div className="echTooltip__item--container">
                 <span className="echTooltip__label">{label}</span>
                 <span className="echTooltip__value">{formattedValue}</span>
-                {isDefined(markValue) && <span className="echTooltip__markValue">&nbsp;({formattedMarkValue})</span>}
+                {/* TODO move mark definition as part of the data property */}
+                {isDefined(markValue) && !isNaN(markValue) && (
+                  <span className="echTooltip__markValue">&nbsp;({formattedMarkValue})</span>
+                )}
               </div>
             </div>
           );

--- a/packages/charts/src/mocks/scale/scale.ts
+++ b/packages/charts/src/mocks/scale/scale.ts
@@ -24,7 +24,6 @@ import { mergePartial } from '../../utils/common';
 /** @internal */
 export class MockScale {
   private static readonly base: Scale = {
-    scaleOrThrow: jest.fn().mockImplementation((x) => x),
     scale: jest.fn().mockImplementation((x) => x),
     type: ScaleType.Linear,
     step: 0,

--- a/packages/charts/src/mocks/series/data.ts
+++ b/packages/charts/src/mocks/series/data.ts
@@ -23,11 +23,11 @@ import { DataSeriesDatum } from '../../chart_types/xy_chart/utils/series';
 export const fitFunctionData: DataSeriesDatum[] = [
   {
     x: 0,
-    y1: null,
-    y0: null,
-    initialY1: null,
-    initialY0: null,
-    mark: null,
+    y1: NaN,
+    y0: NaN,
+    initialY1: NaN,
+    initialY0: NaN,
+    mark: NaN,
     datum: {
       x: 0,
       y: null,
@@ -39,7 +39,7 @@ export const fitFunctionData: DataSeriesDatum[] = [
     y0: 0,
     initialY1: 3,
     initialY0: 0,
-    mark: null,
+    mark: NaN,
     datum: {
       x: 1,
       y: 3,
@@ -51,7 +51,7 @@ export const fitFunctionData: DataSeriesDatum[] = [
     y0: 0,
     initialY1: 5,
     initialY0: 0,
-    mark: null,
+    mark: NaN,
     datum: {
       x: 2,
       y: 5,
@@ -59,11 +59,11 @@ export const fitFunctionData: DataSeriesDatum[] = [
   },
   {
     x: 3,
-    y1: null,
-    y0: null,
-    initialY1: null,
-    initialY0: null,
-    mark: null,
+    y1: NaN,
+    y0: NaN,
+    initialY1: NaN,
+    initialY0: NaN,
+    mark: NaN,
     datum: {
       x: 3,
       y: null,
@@ -75,7 +75,7 @@ export const fitFunctionData: DataSeriesDatum[] = [
     y0: 0,
     initialY1: 4,
     initialY0: 0,
-    mark: null,
+    mark: NaN,
     datum: {
       x: 4,
       y: 4,
@@ -83,11 +83,11 @@ export const fitFunctionData: DataSeriesDatum[] = [
   },
   {
     x: 5,
-    y1: null,
-    y0: null,
-    initialY1: null,
-    initialY0: null,
-    mark: null,
+    y1: NaN,
+    y0: NaN,
+    initialY1: NaN,
+    initialY0: NaN,
+    mark: NaN,
     datum: {
       x: 5,
       y: null,
@@ -111,7 +111,7 @@ export const fitFunctionData: DataSeriesDatum[] = [
     y0: 0,
     initialY1: 6,
     initialY0: 0,
-    mark: null,
+    mark: NaN,
     datum: {
       x: 7,
       y: 6,
@@ -119,11 +119,11 @@ export const fitFunctionData: DataSeriesDatum[] = [
   },
   {
     x: 8,
-    y1: null,
-    y0: null,
-    initialY1: null,
-    initialY0: null,
-    mark: null,
+    y1: NaN,
+    y0: NaN,
+    initialY1: NaN,
+    initialY0: NaN,
+    mark: NaN,
     datum: {
       x: 8,
       y: null,
@@ -131,11 +131,11 @@ export const fitFunctionData: DataSeriesDatum[] = [
   },
   {
     x: 9,
-    y1: null,
-    y0: null,
-    initialY1: null,
-    initialY0: null,
-    mark: null,
+    y1: NaN,
+    y0: NaN,
+    initialY1: NaN,
+    initialY0: NaN,
+    mark: NaN,
     datum: {
       x: 9,
       y: null,
@@ -143,11 +143,11 @@ export const fitFunctionData: DataSeriesDatum[] = [
   },
   {
     x: 10,
-    y1: null,
-    y0: null,
-    initialY1: null,
-    initialY0: null,
-    mark: null,
+    y1: NaN,
+    y0: NaN,
+    initialY1: NaN,
+    initialY0: NaN,
+    mark: NaN,
     datum: {
       x: 10,
       y: null,
@@ -159,7 +159,7 @@ export const fitFunctionData: DataSeriesDatum[] = [
     y0: 0,
     initialY1: 12,
     initialY0: 0,
-    mark: null,
+    mark: NaN,
     datum: {
       x: 11,
       y: 12,
@@ -167,11 +167,11 @@ export const fitFunctionData: DataSeriesDatum[] = [
   },
   {
     x: 12,
-    y1: null,
-    y0: null,
-    initialY1: null,
-    initialY0: null,
-    mark: null,
+    y1: NaN,
+    y0: NaN,
+    initialY1: NaN,
+    initialY0: NaN,
+    mark: NaN,
     datum: {
       x: 12,
       y: null,

--- a/packages/charts/src/mocks/series/series.ts
+++ b/packages/charts/src/mocks/series/series.ts
@@ -102,10 +102,10 @@ export class MockDataSeriesDatum {
   private static readonly base: DataSeriesDatum = {
     x: 1,
     y1: 1,
-    y0: null,
-    mark: null,
-    initialY1: null,
-    initialY0: null,
+    y0: NaN,
+    mark: NaN,
+    initialY1: NaN,
+    initialY0: NaN,
     datum: undefined,
   };
 
@@ -128,9 +128,9 @@ export class MockDataSeriesDatum {
    */
   static simple({
     x,
-    y1 = null,
-    y0 = null,
-    mark = null,
+    y1 = NaN,
+    y0 = NaN,
+    mark = NaN,
     filled,
   }: Partial<DataSeriesDatum> & Pick<DataSeriesDatum, 'x'>): DataSeriesDatum {
     return {

--- a/packages/charts/src/scales/index.ts
+++ b/packages/charts/src/scales/index.ts
@@ -47,9 +47,8 @@ export interface Scale {
    */
   step: number;
   ticks: () => any[];
-  scale: (value?: PrimitiveValue) => number | null;
-  scaleOrThrow(value?: PrimitiveValue): number;
-  pureScale: (value?: PrimitiveValue) => number | null;
+  scale: (value?: PrimitiveValue) => number;
+  pureScale: (value?: PrimitiveValue) => number;
   invert: (value: number) => any;
   invertWithStep: (
     value: number,

--- a/packages/charts/src/scales/scale_band.test.ts
+++ b/packages/charts/src/scales/scale_band.test.ts
@@ -134,16 +134,4 @@ describe('Scale Band', () => {
       expect(scale.isSingleValue()).toBe(false);
     });
   });
-
-  describe('#scaleOrThrow', () => {
-    const scale = new ScaleBand(['a', 'b'], [0, 100]);
-
-    it('should NOT throw for values in domain', () => {
-      expect(() => scale.scaleOrThrow('a')).not.toThrow();
-    });
-
-    it('should throw for values not in domain', () => {
-      expect(() => scale.scaleOrThrow('c')).toThrow();
-    });
-  });
 });

--- a/packages/charts/src/scales/scale_band.ts
+++ b/packages/charts/src/scales/scale_band.ts
@@ -23,7 +23,7 @@ import { Scale, ScaleBandType } from '.';
 import { PrimitiveValue } from '../chart_types/partition_chart/layout/utils/group_by_rollup';
 import { Ratio } from '../common/geometry';
 import { RelativeBandsPadding } from '../specs';
-import { maxValueWithUpperLimit, stringifyNullsUndefined } from '../utils/common';
+import { isNil, maxValueWithUpperLimit, stringifyNullsUndefined } from '../utils/common';
 import { Range } from '../utils/domain';
 import { ScaleType } from './constants';
 
@@ -104,21 +104,11 @@ export class ScaleBand implements Scale {
     this.minInterval = 0;
   }
 
-  private getScaledValue(value?: PrimitiveValue): number | null {
+  private getScaledValue(value?: PrimitiveValue): number {
     const scaleValue = this.d3Scale(stringifyNullsUndefined(value));
 
-    if (scaleValue === undefined || isNaN(scaleValue)) {
-      return null;
-    }
-
-    return scaleValue;
-  }
-
-  scaleOrThrow(value?: PrimitiveValue): number {
-    const scaleValue = this.scale(value);
-
-    if (scaleValue === null) {
-      throw new Error(`Unable to scale value: ${scaleValue})`);
+    if (isNil(scaleValue)) {
+      return NaN;
     }
 
     return scaleValue;

--- a/packages/charts/src/scales/scale_continuous.test.ts
+++ b/packages/charts/src/scales/scale_continuous.test.ts
@@ -501,32 +501,6 @@ describe('Scale Continuous', () => {
     });
   });
 
-  describe('#scaleOrThrow', () => {
-    const scale = new ScaleContinuous({ type: ScaleType.Linear, domain: [0, 100], range: [0, 100] });
-
-    it('should NOT throw for values in domain', () => {
-      expect(() => scale.scaleOrThrow(10)).not.toThrow();
-    });
-
-    it('should throw for NaN values', () => {
-      // @ts-ignore
-      jest.spyOn(scale, 'd3Scale').mockImplementationOnce(() => NaN);
-      expect(() => scale.scaleOrThrow(1)).toThrow();
-    });
-
-    it('should throw for string values', () => {
-      expect(() => scale.scaleOrThrow('c')).toThrow();
-    });
-
-    it('should throw for null values', () => {
-      expect(() => scale.scaleOrThrow(null)).toThrow();
-    });
-
-    it('should throw for undefined values', () => {
-      expect(() => scale.scaleOrThrow()).toThrow();
-    });
-  });
-
   describe('#limitLogScaleDomain', () => {
     const LIMIT = 2;
     const ZERO_LIMIT = 0;

--- a/packages/charts/src/scales/scale_continuous.ts
+++ b/packages/charts/src/scales/scale_continuous.ts
@@ -419,14 +419,8 @@ export class ScaleContinuous implements Scale {
     }
   }
 
-  private getScaledValue(value?: PrimitiveValue): number | null {
-    if (typeof value !== 'number' || isNaN(value)) {
-      return null;
-    }
-
-    const scaledValue = this.d3Scale(value);
-
-    return isNaN(scaledValue) ? null : scaledValue;
+  private getScaledValue(value?: PrimitiveValue): number {
+    return typeof value === 'number' ? this.d3Scale(value) : NaN;
   }
 
   getTicks(ticks: number, integersOnly: boolean) {
@@ -440,20 +434,8 @@ export class ScaleContinuous implements Scale {
       : (this.d3Scale as D3ScaleNonTime).ticks(ticks);
   }
 
-  scaleOrThrow(value?: PrimitiveValue): number {
-    const scaleValue = this.scale(value);
-
-    if (scaleValue === null) {
-      throw new Error(`Unable to scale value: ${scaleValue})`);
-    }
-
-    return scaleValue;
-  }
-
   scale(value?: PrimitiveValue) {
-    const scaledValue = this.getScaledValue(value);
-
-    return scaledValue === null ? null : scaledValue + (this.bandwidthPadding / 2) * this.totalBarsInCluster;
+    return this.getScaledValue(value) + (this.bandwidthPadding / 2) * this.totalBarsInCluster;
   }
 
   pureScale(value?: PrimitiveValue) {
@@ -461,11 +443,7 @@ export class ScaleContinuous implements Scale {
       return this.getScaledValue(value);
     }
 
-    if (typeof value !== 'number' || isNaN(value)) {
-      return null;
-    }
-
-    return this.getScaledValue(value + this.minInterval / 2);
+    return typeof value === 'number' ? this.d3Scale(value + this.minInterval / 2) : NaN;
   }
 
   ticks() {

--- a/packages/charts/src/specs/constants.ts
+++ b/packages/charts/src/specs/constants.ts
@@ -23,7 +23,6 @@ import { ChartType } from '../chart_types';
 import { BOTTOM, CENTER, LEFT, MIDDLE, RIGHT, TOP } from '../common/constants';
 import { Position } from '../utils/common';
 import { LIGHT_THEME } from '../utils/themes/light_theme';
-import { SettingsSpec } from './settings';
 
 /** @public */
 export const SpecType = Object.freeze({
@@ -149,7 +148,7 @@ export const DEFAULT_LEGEND_CONFIG = {
 };
 
 /** @public */
-export const DEFAULT_SETTINGS_SPEC: SettingsSpec = {
+export const DEFAULT_SETTINGS_SPEC = {
   id: '__global__settings___',
   chartType: ChartType.Global,
   specType: SpecType.Settings,
@@ -161,6 +160,8 @@ export const DEFAULT_SETTINGS_SPEC: SettingsSpec = {
   tooltip: {
     type: DEFAULT_TOOLTIP_TYPE,
     snap: DEFAULT_TOOLTIP_SNAP,
+    showOnNullValues: false,
+    showOnFittedValues: false,
   },
   externalPointerEvents: {
     tooltip: {
@@ -172,6 +173,6 @@ export const DEFAULT_SETTINGS_SPEC: SettingsSpec = {
   brushAxis: BrushAxis.X,
   minBrushDelta: 2,
   ariaUseDefaultSummary: true,
-  ariaLabelHeadingLevel: 'p',
+  ariaLabelHeadingLevel: 'p' as const,
   ...DEFAULT_LEGEND_CONFIG,
 };

--- a/packages/charts/src/specs/settings.tsx
+++ b/packages/charts/src/specs/settings.tsx
@@ -277,6 +277,16 @@ export type TooltipProps = TooltipPortalSettings<'chart'> & {
    * @defaultValue mousePosition
    */
   stickTo?: TooltipStickTo;
+  /**
+   * Display tooltip on null values
+   * @defaultValue false
+   */
+  showOnNullValues?: boolean;
+  /**
+   * Display tooltip on fitted values
+   * @defaultValue false
+   */
+  showOnFittedValues?: boolean;
 };
 
 /**
@@ -707,9 +717,25 @@ export function getTooltipType(settings: SettingsSpec, externalTooltip = false):
     return tooltip;
   }
   if (isTooltipProps(tooltip)) {
-    return tooltip.type || defaultType;
+    return tooltip.type ?? defaultType;
   }
   return defaultType;
+}
+
+/** @internal */
+export function getShowTooltipOnNullValues({ tooltip }: SettingsSpec): boolean {
+  if (isTooltipProps(tooltip)) {
+    return tooltip.showOnNullValues ?? DEFAULT_SETTINGS_SPEC.tooltip.showOnNullValues;
+  }
+  return DEFAULT_SETTINGS_SPEC.tooltip.showOnNullValues;
+}
+
+/** @internal */
+export function getShowTooltipOnFittedValues({ tooltip }: SettingsSpec): boolean {
+  if (isTooltipProps(tooltip)) {
+    return tooltip.showOnFittedValues ?? DEFAULT_SETTINGS_SPEC.tooltip.showOnFittedValues;
+  }
+  return DEFAULT_SETTINGS_SPEC.tooltip.showOnFittedValues;
 }
 
 /**

--- a/packages/charts/src/utils/geometry.ts
+++ b/packages/charts/src/utils/geometry.ts
@@ -39,14 +39,15 @@ export type BandedAccessorType = $Values<typeof BandedAccessorType>;
 
 /** @public */
 export interface GeometryValue {
-  y: any;
-  x: any;
-  mark: number | null;
+  x: number | string;
+  y: number;
+  mark: number;
   accessor: BandedAccessorType;
   /**
    * The original datum used for this geometry
    */
-  datum: any;
+  datum: unknown;
+  isFilled: boolean;
 }
 
 /** @internal */

--- a/stories/annotations/lines/1_x_continuous.tsx
+++ b/stories/annotations/lines/1_x_continuous.tsx
@@ -69,7 +69,13 @@ export const Example = () => {
 
   return (
     <Chart className="story-chart">
-      <Settings showLegend showLegendExtra debug={debug} rotation={rotation} />
+      <Settings
+        showLegend
+        showLegendExtra
+        debug={debug}
+        rotation={rotation}
+        tooltip={{ showOnNullValues: false, showOnFittedValues: true }}
+      />
       <LineAnnotation
         id="annotation_1"
         domainType={AnnotationDomainType.XDomain}
@@ -86,9 +92,13 @@ export const Example = () => {
         yScaleType={ScaleType.Linear}
         xAccessor="x"
         yAccessors={['y']}
+        tickFormat={(v) => {
+          return v ?? 'n/a';
+        }}
         data={[
           { x: 0, y: 2 },
           { x: 1, y: 7 },
+          { x: 2, y: null },
           { x: 3, y: 6 },
         ]}
       />

--- a/stories/bubble/3_multiple.tsx
+++ b/stories/bubble/3_multiple.tsx
@@ -46,7 +46,7 @@ export const Example = () => {
     step: 5,
   });
   const data = dg.generateRandomGroupedSeries(size, 4);
-
+  console.log(data);
   return (
     <Chart className="story-chart">
       <Settings

--- a/stories/interactions/16_cursor_update_action.tsx
+++ b/stories/interactions/16_cursor_update_action.tsx
@@ -99,7 +99,7 @@ export const Example = () => {
           externalPointerEvents={{
             tooltip: { visible: topVisible, placement: topPlacement },
           }}
-          tooltip={{ type: topType }}
+          tooltip={{ type: topType, showOnNullValues: true, showOnFittedValues: true }}
         />
         <Axis
           id="bottom"
@@ -107,7 +107,11 @@ export const Example = () => {
           title={`External tooltip visible: ${topVisible} - boundary: scroll parent`}
           tickFormat={niceTimeFormatter([data[0][0], data[data.length - 1][0]])}
         />
-        <Axis id="left2" position={Position.Left} tickFormat={(d: any) => Number(d).toFixed(2)} />
+        <Axis
+          id="left2"
+          position={Position.Left}
+          tickFormat={(d: any) => (isFinite(d) ? Number(d).toFixed(2) : 'n/a')}
+        />
 
         <TopSeries
           id="Top"
@@ -115,7 +119,12 @@ export const Example = () => {
           yScaleType={ScaleType.Linear}
           xAccessor={0}
           yAccessors={[1]}
-          data={data1.slice(3, 60)}
+          data={data1.slice(3, 60).map((d, i) => {
+            if ([3, 10, 12, 15].includes(i)) {
+              return [d[0], null];
+            }
+            return d;
+          })}
         />
       </Chart>
       <Chart className="story-chart" ref={ref2} size={{ height: '50%' }} id="chart2">

--- a/stories/mixed/6_fitting.tsx
+++ b/stories/mixed/6_fitting.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { select, number } from '@storybook/addon-knobs';
+import { select, number, boolean } from '@storybook/addon-knobs';
 import React from 'react';
 
 import {
@@ -175,6 +175,10 @@ export const Example = () => {
               visible: true,
             },
           },
+        }}
+        tooltip={{
+          showOnFittedValues: boolean('Show tooltip on filled values', true),
+          showOnNullValues: boolean('Show tooltip on null values', true),
         }}
       />
       <Axis id="bottom" position={Position.Bottom} title="Bottom axis" showOverlappingTicks />


### PR DESCRIPTION
## Summary

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [ ] The proper chart type label was added (e.g. :xy, :partition) if the PR involves a specific chart type
- [ ] The proper feature label was added (e.g. :interactions, :axis) if the PR involves a specific chart feature
- [ ] Whenever possible, please check if the closing issue is connected to a running GH project
- [ ] Any consumer-facing exports were added to `packages/charts/src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [ ] This was checked for cross-browser compatibility
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
