### PR TITLE
refactor(xy): prepare for time axis improvements

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/axes/axes_sizes.ts
+++ b/packages/charts/src/chart_types/xy_chart/axes/axes_sizes.ts
@@ -19,7 +19,7 @@
 
 import { SmallMultiplesSpec } from '../../../specs';
 import { Position } from '../../../utils/common';
-import { getSimplePadding } from '../../../utils/dimensions';
+import { getSimplePadding, PerSideDistance } from '../../../utils/dimensions';
 import { AxisId } from '../../../utils/ids';
 import { AxisStyle, Theme } from '../../../utils/themes/theme';
 import { getSpecsById } from '../state/utils/spec';
@@ -27,9 +27,9 @@ import { isVerticalAxis } from '../utils/axis_type_utils';
 import { AxisTicksDimensions, getTitleDimension, shouldShowTicks } from '../utils/axis_utils';
 import { AxisSpec } from '../utils/specs';
 
-/**
- * @internal
- */
+const nullPadding = (): PerSideDistance => ({ left: 0, right: 0, top: 0, bottom: 0 });
+
+/** @internal */
 export function computeAxesSizes(
   { axes: sharedAxesStyles, chartMargins }: Theme,
   axisDimensions: Map<AxisId, AxisTicksDimensions>,
@@ -37,18 +37,8 @@ export function computeAxesSizes(
   axisSpecs: AxisSpec[],
   smSpec?: SmallMultiplesSpec,
 ): { left: number; right: number; top: number; bottom: number; margin: { left: number } } {
-  const axisMainSize = {
-    left: 0,
-    right: 0,
-    top: 0,
-    bottom: 0,
-  };
-  const axisLabelOverflow = {
-    left: 0,
-    right: 0,
-    top: 0,
-    bottom: 0,
-  };
+  const axisMainSize = nullPadding();
+  const axisLabelOverflow = nullPadding();
 
   axisDimensions.forEach(({ maxLabelBboxWidth = 0, maxLabelBboxHeight = 0, isHidden }, id) => {
     const axisSpec = getSpecsById<AxisSpec>(axisSpecs, id);

--- a/packages/charts/src/chart_types/xy_chart/axes/axes_sizes.ts
+++ b/packages/charts/src/chart_types/xy_chart/axes/axes_sizes.ts
@@ -58,34 +58,36 @@ export function computeAxesSizes(
     const axisDimension = labelPaddingSum + tickDimension + titleDimension + panelTitleDimension;
     const maxAxisHeight = tickLabel.visible ? maxLabelBboxHeight + axisDimension : axisDimension;
     const maxAxisWidth = tickLabel.visible ? maxLabelBboxWidth + axisDimension : axisDimension;
+    const labelHalfWidth = maxLabelBboxWidth / 2;
+    const labelHalfHeight = maxLabelBboxHeight / 2;
 
     switch (position) {
       case Position.Top:
         axisMainSize.top += maxAxisHeight + chartMargins.top;
         // find the max half label size to accommodate the left/right labels
         // TODO use first and last labels
-        axisLabelOverflow.left = Math.max(axisLabelOverflow.left, maxLabelBboxWidth / 2);
-        axisLabelOverflow.right = Math.max(axisLabelOverflow.right, maxLabelBboxWidth / 2);
+        axisLabelOverflow.left = Math.max(axisLabelOverflow.left, labelHalfWidth);
+        axisLabelOverflow.right = Math.max(axisLabelOverflow.right, labelHalfWidth);
         break;
       case Position.Bottom:
         axisMainSize.bottom += maxAxisHeight + chartMargins.bottom;
         // find the max half label size to accommodate the left/right labels
         // TODO use first and last labels
-        axisLabelOverflow.left = Math.max(axisLabelOverflow.left, maxLabelBboxWidth / 2);
-        axisLabelOverflow.right = Math.max(axisLabelOverflow.right, maxLabelBboxWidth / 2);
+        axisLabelOverflow.left = Math.max(axisLabelOverflow.left, labelHalfWidth);
+        axisLabelOverflow.right = Math.max(axisLabelOverflow.right, labelHalfWidth);
         break;
       case Position.Right:
         axisMainSize.right += maxAxisWidth + chartMargins.right;
         // TODO use first and last labels
-        axisLabelOverflow.top = Math.max(axisLabelOverflow.top, maxLabelBboxHeight / 2);
-        axisLabelOverflow.bottom = Math.max(axisLabelOverflow.bottom, maxLabelBboxHeight / 2);
+        axisLabelOverflow.top = Math.max(axisLabelOverflow.top, labelHalfHeight);
+        axisLabelOverflow.bottom = Math.max(axisLabelOverflow.bottom, labelHalfHeight);
         break;
       case Position.Left:
       default:
         axisMainSize.left += maxAxisWidth + chartMargins.left;
         // TODO use first and last labels
-        axisLabelOverflow.top = Math.max(axisLabelOverflow.top, maxLabelBboxHeight / 2);
-        axisLabelOverflow.bottom = Math.max(axisLabelOverflow.bottom, maxLabelBboxHeight / 2);
+        axisLabelOverflow.top = Math.max(axisLabelOverflow.top, labelHalfHeight);
+        axisLabelOverflow.bottom = Math.max(axisLabelOverflow.bottom, labelHalfHeight);
     }
   });
   const left = Math.max(axisLabelOverflow.left + chartMargins.left, axisMainSize.left);

--- a/packages/charts/src/chart_types/xy_chart/axes/axes_sizes.ts
+++ b/packages/charts/src/chart_types/xy_chart/axes/axes_sizes.ts
@@ -24,7 +24,7 @@ import { AxisId } from '../../../utils/ids';
 import { AxisStyle, Theme } from '../../../utils/themes/theme';
 import { getSpecsById } from '../state/utils/spec';
 import { isVerticalAxis } from '../utils/axis_type_utils';
-import { AxisTicksDimensions, getTitleDimension, shouldShowTicks } from '../utils/axis_utils';
+import { AxisViewModel, getTitleDimension, shouldShowTicks } from '../utils/axis_utils';
 import { AxisSpec } from '../utils/specs';
 
 const nullPadding = (): PerSideDistance => ({ left: 0, right: 0, top: 0, bottom: 0 });
@@ -32,7 +32,7 @@ const nullPadding = (): PerSideDistance => ({ left: 0, right: 0, top: 0, bottom:
 /** @internal */
 export function computeAxesSizes(
   { axes: sharedAxesStyles, chartMargins }: Theme,
-  axisDimensions: Map<AxisId, AxisTicksDimensions>,
+  axisDimensions: Map<AxisId, AxisViewModel>,
   axesStyles: Map<AxisId, AxisStyle | null>,
   axisSpecs: AxisSpec[],
   smSpec?: SmallMultiplesSpec,

--- a/packages/charts/src/chart_types/xy_chart/axes/axes_sizes.ts
+++ b/packages/charts/src/chart_types/xy_chart/axes/axes_sizes.ts
@@ -36,7 +36,7 @@ export function computeAxesSizes(
   axesStyles: Map<AxisId, AxisStyle | null>,
   axisSpecs: AxisSpec[],
   smSpec?: SmallMultiplesSpec,
-): { left: number; right: number; top: number; bottom: number; margin: { left: number } } {
+): PerSideDistance & { margin: { left: number } } {
   const axisMainSize = nullPadding();
   const axisLabelOverflow = nullPadding();
 

--- a/packages/charts/src/chart_types/xy_chart/axes/axes_sizes.ts
+++ b/packages/charts/src/chart_types/xy_chart/axes/axes_sizes.ts
@@ -58,36 +58,34 @@ export function computeAxesSizes(
     const axisDimension = labelPaddingSum + tickDimension + titleDimension + panelTitleDimension;
     const maxAxisHeight = tickLabel.visible ? maxLabelBboxHeight + axisDimension : axisDimension;
     const maxAxisWidth = tickLabel.visible ? maxLabelBboxWidth + axisDimension : axisDimension;
-    const labelHalfWidth = maxLabelBboxWidth / 2;
-    const labelHalfHeight = maxLabelBboxHeight / 2;
 
     switch (position) {
       case Position.Top:
         axisMainSize.top += maxAxisHeight + chartMargins.top;
         // find the max half label size to accommodate the left/right labels
         // TODO use first and last labels
-        axisLabelOverflow.left = Math.max(axisLabelOverflow.left, labelHalfWidth);
-        axisLabelOverflow.right = Math.max(axisLabelOverflow.right, labelHalfWidth);
+        axisLabelOverflow.left = Math.max(axisLabelOverflow.left, maxLabelBboxWidth / 2);
+        axisLabelOverflow.right = Math.max(axisLabelOverflow.right, maxLabelBboxWidth / 2);
         break;
       case Position.Bottom:
         axisMainSize.bottom += maxAxisHeight + chartMargins.bottom;
         // find the max half label size to accommodate the left/right labels
         // TODO use first and last labels
-        axisLabelOverflow.left = Math.max(axisLabelOverflow.left, labelHalfWidth);
-        axisLabelOverflow.right = Math.max(axisLabelOverflow.right, labelHalfWidth);
+        axisLabelOverflow.left = Math.max(axisLabelOverflow.left, maxLabelBboxWidth / 2);
+        axisLabelOverflow.right = Math.max(axisLabelOverflow.right, maxLabelBboxWidth / 2);
         break;
       case Position.Right:
         axisMainSize.right += maxAxisWidth + chartMargins.right;
         // TODO use first and last labels
-        axisLabelOverflow.top = Math.max(axisLabelOverflow.top, labelHalfHeight);
-        axisLabelOverflow.bottom = Math.max(axisLabelOverflow.bottom, labelHalfHeight);
+        axisLabelOverflow.top = Math.max(axisLabelOverflow.top, maxLabelBboxHeight / 2);
+        axisLabelOverflow.bottom = Math.max(axisLabelOverflow.bottom, maxLabelBboxHeight / 2);
         break;
       case Position.Left:
       default:
         axisMainSize.left += maxAxisWidth + chartMargins.left;
         // TODO use first and last labels
-        axisLabelOverflow.top = Math.max(axisLabelOverflow.top, labelHalfHeight);
-        axisLabelOverflow.bottom = Math.max(axisLabelOverflow.bottom, labelHalfHeight);
+        axisLabelOverflow.top = Math.max(axisLabelOverflow.top, maxLabelBboxHeight / 2);
+        axisLabelOverflow.bottom = Math.max(axisLabelOverflow.bottom, maxLabelBboxHeight / 2);
     }
   });
   const left = Math.max(axisLabelOverflow.left + chartMargins.left, axisMainSize.left);

--- a/packages/charts/src/chart_types/xy_chart/axes/axes_sizes.ts
+++ b/packages/charts/src/chart_types/xy_chart/axes/axes_sizes.ts
@@ -28,11 +28,6 @@ import { AxisTicksDimensions, getTitleDimension, shouldShowTicks } from '../util
 import { AxisSpec } from '../utils/specs';
 
 /**
- * Compute the axes required size around the chart
- * @param chartTheme the theme style of the chart
- * @param axisDimensions the axis dimensions
- * @param axesStyles a map with all the custom axis styles
- * @param axisSpecs the axis specs
  * @internal
  */
 export function computeAxesSizes(

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/annotations/lines.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/annotations/lines.ts
@@ -23,7 +23,7 @@ import { Rotation } from '../../../../../utils/common';
 import { Dimensions } from '../../../../../utils/dimensions';
 import { LineAnnotationStyle } from '../../../../../utils/themes/theme';
 import { AnnotationLineProps } from '../../../annotations/line/types';
-import { renderLine } from '../primitives/line';
+import { renderMultiLine } from '../primitives/line';
 import { withPanelTransform } from '../utils/panel_transform';
 
 /** @internal */
@@ -44,7 +44,7 @@ export function renderLineAnnotations(
 
   annotations.forEach(({ linePathPoints, panel }) => {
     withPanelTransform(ctx, panel, rotation, renderingArea, (ctx) => {
-      renderLine(ctx, linePathPoints, stroke);
+      renderMultiLine(ctx, [linePathPoints], stroke);
     });
   });
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/global_title.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/global_title.ts
@@ -33,12 +33,11 @@ type TitleProps = Pick<AxisProps, 'panelTitle' | 'axisSpec' | 'axisStyle' | 'siz
 
 /** @internal */
 export function renderTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
-  if (props.axisSpec.title && props.axisStyle.axisTitle.visible) {
-    renderWhateverTitle(ctx, isHorizontalAxis(props.axisSpec.position), props);
+  if (!props.axisSpec.title || !props.axisStyle.axisTitle.visible) {
+    return;
   }
-}
 
-function renderWhateverTitle(ctx: CanvasRenderingContext2D, horizontal: boolean, props: TitleProps) {
+  const horizontal = isHorizontalAxis(props.axisSpec.position);
   const {
     size: { width, height },
     axisSpec: { position, hide: hideAxis, title },
@@ -80,7 +79,7 @@ function renderWhateverTitle(ctx: CanvasRenderingContext2D, horizontal: boolean,
 
   renderText(
     ctx,
-    { x: left + (horizontal ? width : font.fontSize) / 2, y: top + (horizontal ? height : font.fontSize) / 2 },
+    { x: left + (horizontal ? width : font.fontSize) / 2, y: top + (horizontal ? font.fontSize : -height) / 2 },
     title ?? '', // title is always a string due to caller; consider turning `title` to be obligate string upstream
     font,
     horizontal ? 0 : -90,

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/global_title.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/global_title.ts
@@ -37,7 +37,6 @@ export function renderTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
     return;
   }
 
-  const horizontal = isHorizontalAxis(props.axisSpec.position);
   const {
     size: { width, height },
     axisSpec: { position, hide: hideAxis, title },
@@ -53,6 +52,7 @@ export function renderTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
   const panelTitleDimension = panelTitle ? getTitleDimension(axisPanelTitle) : 0;
   const tickDimension = shouldShowTicks(tickLine, hideAxis) ? tickLine.size + tickLine.padding : 0;
   const labelPadding = getSimplePadding(tickLabel.padding);
+  const horizontal = isHorizontalAxis(props.axisSpec.position);
   const maxLabelBoxSize = horizontal ? maxLabelBboxHeight : maxLabelBboxWidth;
   const labelSize = tickLabel.visible ? maxLabelBoxSize + labelPadding.outer + labelPadding.inner : 0;
   const offset =

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/global_title.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/global_title.ts
@@ -33,17 +33,10 @@ type TitleProps = Pick<AxisProps, 'panelTitle' | 'axisSpec' | 'axisStyle' | 'siz
 
 /** @internal */
 export function renderTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
-  const {
-    axisSpec: { position, title },
-    axisStyle: { axisTitle },
-  } = props;
-  if (!title || !axisTitle.visible) {
-    return null;
+  if (props.axisSpec.title && props.axisStyle.axisTitle.visible) {
+    const render = isHorizontalAxis(props.axisSpec.position) ? renderHorizontalTitle : renderVerticalTitle;
+    render(ctx, props);
   }
-  if (isHorizontalAxis(position)) {
-    return renderHorizontalTitle(ctx, props);
-  }
-  return renderVerticalTitle(ctx, props);
 }
 
 function renderVerticalTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
@@ -68,26 +61,17 @@ function renderVerticalTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
   const labelPadding = getSimplePadding(tickLabel.padding);
   const labelWidth = tickLabel.visible ? labelPadding.outer + maxLabelBboxWidth + labelPadding.inner : 0;
 
-  const top = height + anchorPoint.y;
   const left =
-    (position === Position.Left
-      ? titlePadding.outer
-      : tickDimension + labelWidth + titlePadding.inner + panelTitleDimension) + anchorPoint.x;
+    position === Position.Left
+      ? anchorPoint.x + titlePadding.outer
+      : anchorPoint.x + tickDimension + labelWidth + titlePadding.inner + panelTitleDimension;
+  const top = anchorPoint.y + height;
 
   if (debug) {
     renderDebugRect(ctx, { x: left, y: top, width: height, height: font.fontSize }, undefined, undefined, -90);
   }
 
-  renderText(
-    ctx,
-    {
-      x: left + font.fontSize / 2,
-      y: top - height / 2,
-    },
-    title,
-    font,
-    -90,
-  );
+  renderText(ctx, { x: left + font.fontSize / 2, y: top - height / 2 }, title, font, -90);
 }
 
 function renderHorizontalTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
@@ -101,10 +85,6 @@ function renderHorizontalTitle(ctx: CanvasRenderingContext2D, props: TitleProps)
     panelTitle,
   } = props;
 
-  if (!title) {
-    return;
-  }
-
   const font = getFontStyle(axisTitle);
   const titlePadding = getSimplePadding(axisTitle.visible && title ? axisTitle.padding : 0);
   const panelTitleDimension = panelTitle ? getTitleDimension(axisPanelTitle) : 0;
@@ -112,11 +92,11 @@ function renderHorizontalTitle(ctx: CanvasRenderingContext2D, props: TitleProps)
   const labelPadding = getSimplePadding(tickLabel.padding);
   const labelHeight = tickLabel.visible ? maxLabelBboxHeight + labelPadding.outer + labelPadding.inner : 0;
 
-  const top =
-    (position === Position.Top
-      ? titlePadding.outer
-      : labelHeight + tickDimension + titlePadding.inner + panelTitleDimension) + anchorPoint.y;
   const left = anchorPoint.x;
+  const top =
+    position === Position.Top
+      ? anchorPoint.y + titlePadding.outer
+      : anchorPoint.y + labelHeight + tickDimension + titlePadding.inner + panelTitleDimension;
 
   if (debug) {
     renderDebugRect(ctx, { x: left, y: top, width, height: font.fontSize });
@@ -124,11 +104,8 @@ function renderHorizontalTitle(ctx: CanvasRenderingContext2D, props: TitleProps)
 
   renderText(
     ctx,
-    {
-      x: left + width / 2,
-      y: top + font.fontSize / 2,
-    },
-    title,
+    { x: left + width / 2, y: top + font.fontSize / 2 },
+    title ?? '', // title is always a string due to caller; consider turning `title` to be obligate string upstream
     font,
   );
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/global_title.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/global_title.ts
@@ -53,19 +53,15 @@ export function renderTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
   const panelTitleDimension = panelTitle ? getTitleDimension(axisPanelTitle) : 0;
   const tickDimension = shouldShowTicks(tickLine, hideAxis) ? tickLine.size + tickLine.padding : 0;
   const labelPadding = getSimplePadding(tickLabel.padding);
-  const labelWidth = tickLabel.visible ? maxLabelBboxWidth + labelPadding.outer + labelPadding.inner : 0;
-  const labelHeight = tickLabel.visible ? maxLabelBboxHeight + labelPadding.outer + labelPadding.inner : 0;
+  const maxLabelBoxSize = horizontal ? maxLabelBboxHeight : maxLabelBboxWidth;
+  const labelSize = tickLabel.visible ? maxLabelBoxSize + labelPadding.outer + labelPadding.inner : 0;
+  const offset =
+    position === Position.Left || position === Position.Top
+      ? titlePadding.outer
+      : labelSize + tickDimension + titlePadding.inner + panelTitleDimension;
 
-  const left = horizontal
-    ? anchorPoint.x
-    : position === Position.Left
-    ? anchorPoint.x + titlePadding.outer
-    : anchorPoint.x + tickDimension + labelWidth + titlePadding.inner + panelTitleDimension;
-  const top = horizontal
-    ? position === Position.Top
-      ? anchorPoint.y + titlePadding.outer
-      : anchorPoint.y + labelHeight + tickDimension + titlePadding.inner + panelTitleDimension
-    : anchorPoint.y + height;
+  const left = anchorPoint.x + (horizontal ? 0 : offset);
+  const top = anchorPoint.y + (horizontal ? offset : height);
 
   if (debug) {
     renderDebugRect(
@@ -85,74 +81,3 @@ export function renderTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
     horizontal ? 0 : -90,
   );
 }
-
-/*
-function renderVerticalTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
-  const {
-    size: { height },
-    axisSpec: { position, hide: hideAxis, title },
-    dimension: { maxLabelBboxWidth },
-    axisStyle: { axisTitle, axisPanelTitle, tickLine, tickLabel },
-    anchorPoint,
-    debug,
-    panelTitle,
-  } = props;
-
-  const font = getFontStyle(axisTitle);
-  const titlePadding = getSimplePadding(axisTitle.visible && title ? axisTitle.padding : 0);
-  const panelTitleDimension = panelTitle ? getTitleDimension(axisPanelTitle) : 0;
-  const tickDimension = shouldShowTicks(tickLine, hideAxis) ? tickLine.size + tickLine.padding : 0;
-  const labelPadding = getSimplePadding(tickLabel.padding);
-  const labelWidth = tickLabel.visible ? labelPadding.outer + maxLabelBboxWidth + labelPadding.inner : 0;
-
-  const left =
-    position === Position.Left
-      ? anchorPoint.x + titlePadding.outer
-      : anchorPoint.x + tickDimension + labelWidth + titlePadding.inner + panelTitleDimension;
-  const top = anchorPoint.y + height;
-
-  if (debug) {
-    renderDebugRect(ctx, { x: left, y: top, width: height, height: font.fontSize }, undefined, undefined, -90);
-  }
-
-  renderText(ctx, { x: left + font.fontSize / 2, y: top - height / 2 }, title, font, -90);
-}
-*/
-
-/*
-function renderHorizontalTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
-  const {
-    size: { width },
-    axisSpec: { position, hide: hideAxis, title },
-    dimension: { maxLabelBboxHeight },
-    axisStyle: { axisTitle, axisPanelTitle, tickLine, tickLabel },
-    anchorPoint,
-    debug,
-    panelTitle,
-  } = props;
-
-  const font = getFontStyle(axisTitle);
-  const titlePadding = getSimplePadding(axisTitle.visible && title ? axisTitle.padding : 0);
-  const panelTitleDimension = panelTitle ? getTitleDimension(axisPanelTitle) : 0;
-  const tickDimension = shouldShowTicks(tickLine, hideAxis) ? tickLine.size + tickLine.padding : 0;
-  const labelPadding = getSimplePadding(tickLabel.padding);
-  const labelHeight = tickLabel.visible ? maxLabelBboxHeight + labelPadding.outer + labelPadding.inner : 0;
-
-  const left = anchorPoint.x;
-  const top =
-    position === Position.Top
-      ? anchorPoint.y + titlePadding.outer
-      : anchorPoint.y + labelHeight + tickDimension + titlePadding.inner + panelTitleDimension;
-
-  if (debug) {
-    renderDebugRect(ctx, { x: left, y: top, width, height: font.fontSize });
-  }
-
-  renderText(
-    ctx,
-    { x: left + width / 2, y: top + font.fontSize / 2 },
-    title ?? '', // title is always a string due to caller; consider turning `title` to be obligate string upstream
-    font,
-  );
-}
-*/

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/global_title.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/global_title.ts
@@ -34,11 +34,60 @@ type TitleProps = Pick<AxisProps, 'panelTitle' | 'axisSpec' | 'axisStyle' | 'siz
 /** @internal */
 export function renderTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
   if (props.axisSpec.title && props.axisStyle.axisTitle.visible) {
-    const render = isHorizontalAxis(props.axisSpec.position) ? renderHorizontalTitle : renderVerticalTitle;
-    render(ctx, props);
+    renderWhateverTitle(ctx, isHorizontalAxis(props.axisSpec.position), props);
   }
 }
 
+function renderWhateverTitle(ctx: CanvasRenderingContext2D, horizontal: boolean, props: TitleProps) {
+  const {
+    size: { width, height },
+    axisSpec: { position, hide: hideAxis, title },
+    dimension: { maxLabelBboxWidth, maxLabelBboxHeight },
+    axisStyle: { axisTitle, axisPanelTitle, tickLine, tickLabel },
+    anchorPoint,
+    debug,
+    panelTitle,
+  } = props;
+
+  const font = getFontStyle(axisTitle);
+  const titlePadding = getSimplePadding(axisTitle.visible && title ? axisTitle.padding : 0);
+  const panelTitleDimension = panelTitle ? getTitleDimension(axisPanelTitle) : 0;
+  const tickDimension = shouldShowTicks(tickLine, hideAxis) ? tickLine.size + tickLine.padding : 0;
+  const labelPadding = getSimplePadding(tickLabel.padding);
+  const labelWidth = tickLabel.visible ? maxLabelBboxWidth + labelPadding.outer + labelPadding.inner : 0;
+  const labelHeight = tickLabel.visible ? maxLabelBboxHeight + labelPadding.outer + labelPadding.inner : 0;
+
+  const left = horizontal
+    ? anchorPoint.x
+    : position === Position.Left
+    ? anchorPoint.x + titlePadding.outer
+    : anchorPoint.x + tickDimension + labelWidth + titlePadding.inner + panelTitleDimension;
+  const top = horizontal
+    ? position === Position.Top
+      ? anchorPoint.y + titlePadding.outer
+      : anchorPoint.y + labelHeight + tickDimension + titlePadding.inner + panelTitleDimension
+    : anchorPoint.y + height;
+
+  if (debug) {
+    renderDebugRect(
+      ctx,
+      { x: left, y: top, width: horizontal ? width : height, height: font.fontSize },
+      undefined,
+      undefined,
+      horizontal ? 0 : -90,
+    );
+  }
+
+  renderText(
+    ctx,
+    { x: left + (horizontal ? width : font.fontSize) / 2, y: top + (horizontal ? height : font.fontSize) / 2 },
+    title ?? '', // title is always a string due to caller; consider turning `title` to be obligate string upstream
+    font,
+    horizontal ? 0 : -90,
+  );
+}
+
+/*
 function renderVerticalTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
   const {
     size: { height },
@@ -49,10 +98,6 @@ function renderVerticalTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
     debug,
     panelTitle,
   } = props;
-
-  if (!title) {
-    return null;
-  }
 
   const font = getFontStyle(axisTitle);
   const titlePadding = getSimplePadding(axisTitle.visible && title ? axisTitle.padding : 0);
@@ -73,7 +118,9 @@ function renderVerticalTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
 
   renderText(ctx, { x: left + font.fontSize / 2, y: top - height / 2 }, title, font, -90);
 }
+*/
 
+/*
 function renderHorizontalTitle(ctx: CanvasRenderingContext2D, props: TitleProps) {
   const {
     size: { width },
@@ -109,3 +156,4 @@ function renderHorizontalTitle(ctx: CanvasRenderingContext2D, props: TitleProps)
     font,
   );
 }
+*/

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
@@ -66,42 +66,40 @@ export function renderAxes(ctx: CanvasRenderingContext2D, props: AxesProps) {
   const seenAxesTitleIds = new Set<AxisId>();
 
   perPanelAxisGeoms.forEach(({ axesGeoms, panelAnchor }) => {
-    withContext(ctx, (ctx) => {
-      axesGeoms.forEach((geometry) => {
-        const {
-          axis: { panelTitle, id, position, secondary },
-          anchorPoint,
-          size,
-          dimension,
-          visibleTicks: ticks,
-          parentSize,
-        } = geometry;
-        const axisSpec = getSpecsById<AxisSpec>(axesSpecs, id);
+    axesGeoms.forEach((geometry) => {
+      const {
+        axis: { panelTitle, id, position, secondary },
+        anchorPoint,
+        size,
+        dimension,
+        visibleTicks: ticks,
+        parentSize,
+      } = geometry;
+      const axisSpec = getSpecsById<AxisSpec>(axesSpecs, id);
 
-        if (!axisSpec || !dimension || !position || axisSpec.hide) {
-          return;
-        }
+      if (!axisSpec || !dimension || !position || axisSpec.hide) {
+        return;
+      }
 
-        const axisStyle = axesStyles.get(axisSpec.id) ?? sharedAxesStyle;
+      const axisStyle = axesStyles.get(axisSpec.id) ?? sharedAxesStyle;
 
-        if (!seenAxesTitleIds.has(id)) {
-          seenAxesTitleIds.add(id);
-          renderTitle(ctx, { size: parentSize, debug, panelTitle, anchorPoint, dimension, axisStyle, axisSpec });
-        }
+      if (!seenAxesTitleIds.has(id)) {
+        seenAxesTitleIds.add(id);
+        renderTitle(ctx, { size: parentSize, debug, panelTitle, anchorPoint, dimension, axisStyle, axisSpec });
+      }
 
-        renderAxis(ctx, {
-          panelTitle,
-          secondary,
-          panelAnchor,
-          axisSpec,
-          anchorPoint,
-          size,
-          dimension,
-          ticks,
-          axisStyle,
-          debug,
-          renderingArea,
-        });
+      renderAxis(ctx, {
+        panelTitle,
+        secondary,
+        panelAnchor,
+        axisSpec,
+        anchorPoint,
+        size,
+        dimension,
+        ticks,
+        axisStyle,
+        debug,
+        renderingArea,
       });
     });
   });

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
@@ -106,26 +106,25 @@ export function renderAxes(ctx: CanvasRenderingContext2D, props: AxesProps) {
 }
 
 function renderAxis(ctx: CanvasRenderingContext2D, props: AxisProps) {
-  withContext(ctx, (ctx) => {
-    const { ticks, size, anchorPoint, debug, axisStyle, axisSpec, panelAnchor, secondary } = props;
-    const showTicks = shouldShowTicks(axisStyle.tickLine, axisSpec.hide);
-    const { position } = axisSpec;
-    const isVertical = isVerticalAxis(position);
-    const y = isVertical
-      ? anchorPoint.y + panelAnchor.y
-      : anchorPoint.y + (position === Position.Top ? 1 : -1) * panelAnchor.y;
-    const x = isVertical
-      ? anchorPoint.x + (position === Position.Right ? -1 : 1) * panelAnchor.x
-      : anchorPoint.x + panelAnchor.x;
-    const translate = { y, x };
+  const { ticks, size, anchorPoint, debug, axisStyle, axisSpec, panelAnchor, secondary } = props;
+  const showTicks = shouldShowTicks(axisStyle.tickLine, axisSpec.hide);
+  const { position } = axisSpec;
+  const isVertical = isVerticalAxis(position);
+  const y = isVertical
+    ? anchorPoint.y + panelAnchor.y
+    : anchorPoint.y + (position === Position.Top ? 1 : -1) * panelAnchor.y;
+  const x = isVertical
+    ? anchorPoint.x + (position === Position.Right ? -1 : 1) * panelAnchor.x
+    : anchorPoint.x + panelAnchor.x;
 
-    ctx.translate(translate.x, translate.y);
+  withContext(ctx, (ctx) => {
+    ctx.translate(x, y);
 
     if (debug && !secondary) {
       renderDebugRect(ctx, { x: 0, y: 0, ...size });
     }
 
-    renderLine(ctx, props);
+    renderLine(ctx, props); // render the axis line
 
     // TODO: compute axis dimensions per panels
     // For now just rendering axis line

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
@@ -25,7 +25,7 @@ import { Point } from '../../../../../utils/point';
 import { AxisStyle } from '../../../../../utils/themes/theme';
 import { PerPanelAxisGeoms } from '../../../state/selectors/compute_per_panel_axes_geoms';
 import { getSpecsById } from '../../../state/utils/spec';
-import { isVerticalAxis } from '../../../utils/axis_type_utils';
+import { isHorizontalAxis } from '../../../utils/axis_type_utils';
 import { AxisTick, AxisViewModel, shouldShowTicks } from '../../../utils/axis_utils';
 import { AxisSpec } from '../../../utils/specs';
 import { renderDebugRect } from '../utils/debug';
@@ -109,13 +109,13 @@ function renderAxis(ctx: CanvasRenderingContext2D, props: AxisProps) {
   const { ticks, size, anchorPoint, debug, axisStyle, axisSpec, panelAnchor, secondary } = props;
   const showTicks = shouldShowTicks(axisStyle.tickLine, axisSpec.hide);
   const { position } = axisSpec;
-  const isVertical = isVerticalAxis(position);
-  const y = isVertical
-    ? anchorPoint.y + panelAnchor.y
-    : anchorPoint.y + (position === Position.Top ? 1 : -1) * panelAnchor.y;
-  const x = isVertical
-    ? anchorPoint.x + (position === Position.Right ? -1 : 1) * panelAnchor.x
-    : anchorPoint.x + panelAnchor.x;
+  const isHorizontal = isHorizontalAxis(position);
+  const x = isHorizontal
+    ? anchorPoint.x + panelAnchor.x
+    : anchorPoint.x + (position === Position.Right ? -1 : 1) * panelAnchor.x;
+  const y = isHorizontal
+    ? anchorPoint.y + (position === Position.Top ? 1 : -1) * panelAnchor.y
+    : anchorPoint.y + panelAnchor.y;
 
   withContext(ctx, (ctx) => {
     ctx.translate(x, y);

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
@@ -21,8 +21,11 @@ import { Dimensions, Size } from '../../../../../utils/dimensions';
 import { Point } from '../../../../../utils/point';
 import { AxisStyle } from '../../../../../utils/themes/theme';
 import { PerPanelAxisGeoms } from '../../../state/selectors/compute_per_panel_axes_geoms';
-import { AxisTick, AxisViewModel } from '../../../utils/axis_utils';
+import { AxisTick, AxisViewModel, shouldShowTicks } from '../../../utils/axis_utils';
 import { AxisSpec } from '../../../utils/specs';
+import { renderAxisLine } from './line';
+import { renderTick } from './tick';
+import { renderTickLabel } from './tick_label';
 
 /** @internal */
 export interface AxisProps {
@@ -47,4 +50,14 @@ export interface AxesProps {
   sharedAxesStyle: AxisStyle;
   debug: boolean;
   renderingArea: Dimensions;
+}
+
+/** @internal */
+export function renderAxis(ctx: CanvasRenderingContext2D, props: AxisProps) {
+  const { ticks, axisStyle, axisSpec, secondary } = props;
+  const showTicks = shouldShowTicks(axisStyle.tickLine, axisSpec.hide);
+
+  renderAxisLine(ctx, props); // render the axis line
+  if (!secondary && showTicks) ticks.forEach((tick) => renderTick(ctx, tick, props));
+  if (!secondary && axisStyle.tickLabel.visible) ticks.forEach((tick) => renderTickLabel(ctx, tick, showTicks, props));
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
@@ -119,19 +119,12 @@ function renderAxis(ctx: CanvasRenderingContext2D, props: AxisProps) {
     const x = isVertical
       ? anchorPoint.x + (position === Position.Right ? -1 : 1) * panelAnchor.x
       : anchorPoint.x + panelAnchor.x;
-    const translate = {
-      y,
-      x,
-    };
+    const translate = { y, x };
 
     ctx.translate(translate.x, translate.y);
 
     if (debug && !secondary) {
-      renderDebugRect(ctx, {
-        x: 0,
-        y: 0,
-        ...size,
-      });
+      renderDebugRect(ctx, { x: 0, y: 0, ...size });
     }
 
     withContext(ctx, (ctx) => {
@@ -144,19 +137,13 @@ function renderAxis(ctx: CanvasRenderingContext2D, props: AxisProps) {
 
     if (showTicks) {
       withContext(ctx, (ctx) => {
-        ticks.forEach((tick) => {
-          renderTick(ctx, tick, props);
-        });
+        ticks.forEach((tick) => renderTick(ctx, tick, props));
       });
     }
 
     if (axisStyle.tickLabel.visible) {
       withContext(ctx, (ctx) => {
-        ticks
-          .filter((tick) => tick.label !== null)
-          .forEach((tick) => {
-            renderTickLabel(ctx, tick, showTicks, props);
-          });
+        ticks.forEach((tick) => renderTickLabel(ctx, tick, showTicks, props));
       });
     }
 

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
@@ -37,7 +37,7 @@ import { renderTickLabel } from './tick_label';
 
 /** @internal */
 export interface AxisProps {
-  panelTitle?: string;
+  panelTitle?: string | undefined;
   secondary?: boolean;
   panelAnchor: Point;
   axisStyle: AxisStyle;
@@ -86,16 +86,7 @@ export function renderAxes(ctx: CanvasRenderingContext2D, props: AxesProps) {
 
         if (!seenAxesTitleIds.has(id)) {
           seenAxesTitleIds.add(id);
-
-          renderTitle(ctx, {
-            ...props,
-            panelTitle,
-            size: parentSize,
-            anchorPoint,
-            dimension,
-            axisStyle,
-            axisSpec,
-          });
+          renderTitle(ctx, { size: parentSize, debug, panelTitle, anchorPoint, dimension, axisStyle, axisSpec });
         }
 
         renderAxis(ctx, {
@@ -170,7 +161,8 @@ function renderAxis(ctx: CanvasRenderingContext2D, props: AxisProps) {
     }
 
     withContext(ctx, (ctx) => {
-      renderPanelTitle(ctx, props);
+      const { panelTitle, dimension } = props;
+      renderPanelTitle(ctx, { panelTitle, axisSpec, axisStyle, size, dimension, debug });
     });
   });
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
@@ -26,7 +26,7 @@ import { AxisStyle } from '../../../../../utils/themes/theme';
 import { PerPanelAxisGeoms } from '../../../state/selectors/compute_per_panel_axes_geoms';
 import { getSpecsById } from '../../../state/utils/spec';
 import { isVerticalAxis } from '../../../utils/axis_type_utils';
-import { AxisTick, AxisTicksDimensions, shouldShowTicks } from '../../../utils/axis_utils';
+import { AxisTick, AxisViewModel, shouldShowTicks } from '../../../utils/axis_utils';
 import { AxisSpec } from '../../../utils/specs';
 import { renderDebugRect } from '../utils/debug';
 import { renderTitle } from './global_title';
@@ -44,7 +44,7 @@ export interface AxisProps {
   axisSpec: AxisSpec;
   size: Size;
   anchorPoint: Point;
-  dimension: AxisTicksDimensions;
+  dimension: AxisViewModel;
   ticks: AxisTick[];
   debug: boolean;
   renderingArea: Dimensions;

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
@@ -25,7 +25,6 @@ import { Point } from '../../../../../utils/point';
 import { AxisStyle } from '../../../../../utils/themes/theme';
 import { PerPanelAxisGeoms } from '../../../state/selectors/compute_per_panel_axes_geoms';
 import { getSpecsById } from '../../../state/utils/spec';
-import { isHorizontalAxis } from '../../../utils/axis_type_utils';
 import { AxisTick, AxisViewModel, shouldShowTicks } from '../../../utils/axis_utils';
 import { AxisSpec } from '../../../utils/specs';
 import { renderDebugRect } from '../utils/debug';
@@ -109,13 +108,8 @@ function renderAxis(ctx: CanvasRenderingContext2D, props: AxisProps) {
   const { ticks, size, anchorPoint, debug, axisStyle, axisSpec, panelAnchor, secondary } = props;
   const showTicks = shouldShowTicks(axisStyle.tickLine, axisSpec.hide);
   const { position } = axisSpec;
-  const isHorizontal = isHorizontalAxis(position);
-  const x = isHorizontal
-    ? anchorPoint.x + panelAnchor.x
-    : anchorPoint.x + (position === Position.Right ? -1 : 1) * panelAnchor.x;
-  const y = isHorizontal
-    ? anchorPoint.y + (position === Position.Top ? 1 : -1) * panelAnchor.y
-    : anchorPoint.y + panelAnchor.y;
+  const x = anchorPoint.x + (position === Position.Right ? -1 : 1) * panelAnchor.x;
+  const y = anchorPoint.y + (position === Position.Bottom ? -1 : 1) * panelAnchor.y;
 
   withContext(ctx, (ctx) => {
     ctx.translate(x, y);
@@ -127,8 +121,7 @@ function renderAxis(ctx: CanvasRenderingContext2D, props: AxisProps) {
     renderLine(ctx, props); // render the axis line
 
     // TODO: compute axis dimensions per panels
-    // For now just rendering axis line
-    if (secondary) return;
+    if (secondary) return; // For now, just render the axis line
 
     if (showTicks) {
       ticks.forEach((tick) => renderTick(ctx, tick, props));

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/index.ts
@@ -127,29 +127,21 @@ function renderAxis(ctx: CanvasRenderingContext2D, props: AxisProps) {
       renderDebugRect(ctx, { x: 0, y: 0, ...size });
     }
 
-    withContext(ctx, (ctx) => {
-      renderLine(ctx, props);
-    });
+    renderLine(ctx, props);
 
     // TODO: compute axis dimensions per panels
     // For now just rendering axis line
     if (secondary) return;
 
     if (showTicks) {
-      withContext(ctx, (ctx) => {
-        ticks.forEach((tick) => renderTick(ctx, tick, props));
-      });
+      ticks.forEach((tick) => renderTick(ctx, tick, props));
     }
 
     if (axisStyle.tickLabel.visible) {
-      withContext(ctx, (ctx) => {
-        ticks.forEach((tick) => renderTickLabel(ctx, tick, showTicks, props));
-      });
+      ticks.forEach((tick) => renderTickLabel(ctx, tick, showTicks, props));
     }
 
-    withContext(ctx, (ctx) => {
-      const { panelTitle, dimension } = props;
-      renderPanelTitle(ctx, { panelTitle, axisSpec, axisStyle, size, dimension, debug });
-    });
+    const { panelTitle, dimension } = props;
+    renderPanelTitle(ctx, { panelTitle, axisSpec, axisStyle, size, dimension, debug });
   });
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/line.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/line.ts
@@ -23,12 +23,12 @@ import { Position as P } from '../../../../../utils/common';
 /** @internal */
 export function renderAxisLine(
   ctx: CanvasRenderingContext2D,
-  { axisSpec: { position: p }, size: { width: w, height: h }, axisStyle: { axisLine } }: AxisProps,
+  { axisSpec: { position: p }, size: { width, height }, axisStyle: { axisLine } }: AxisProps,
 ) {
   if (!axisLine.visible) return;
   ctx.beginPath();
-  ctx.moveTo(p === P.Left ? w : 0, p === P.Top ? h : 0);
-  ctx.lineTo(p !== P.Right ? w : 0, p !== P.Bottom ? h : 0);
+  ctx.moveTo(p === P.Left ? width : 0, p === P.Top ? height : 0);
+  ctx.lineTo(p !== P.Right ? width : 0, p !== P.Bottom ? height : 0);
   ctx.strokeStyle = axisLine.stroke;
   ctx.lineWidth = axisLine.strokeWidth;
   ctx.stroke();

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/line.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/line.ts
@@ -19,32 +19,16 @@
 
 import { AxisProps } from '.';
 import { Position } from '../../../../../utils/common';
-import { isVerticalAxis } from '../../../utils/axis_type_utils';
 
 /** @internal */
-export function renderLine(
+export function renderAxisLine(
   ctx: CanvasRenderingContext2D,
-  { axisSpec: { position }, size, axisStyle: { axisLine } }: AxisProps,
+  { axisSpec: { position }, size: { width, height }, axisStyle: { axisLine } }: AxisProps,
 ) {
-  if (!axisLine.visible) {
-    return;
-  }
-
-  const lineProps: number[] = [];
-  if (isVerticalAxis(position)) {
-    lineProps[0] = position === Position.Left ? size.width : 0;
-    lineProps[2] = position === Position.Left ? size.width : 0;
-    lineProps[1] = 0;
-    lineProps[3] = size.height;
-  } else {
-    lineProps[0] = 0;
-    lineProps[2] = size.width;
-    lineProps[1] = position === Position.Top ? size.height : 0;
-    lineProps[3] = position === Position.Top ? size.height : 0;
-  }
+  if (!axisLine.visible) return;
   ctx.beginPath();
-  ctx.moveTo(lineProps[0], lineProps[1]);
-  ctx.lineTo(lineProps[2], lineProps[3]);
+  ctx.moveTo(position === Position.Left ? width : 0, position === Position.Top ? height : 0);
+  ctx.lineTo(position === Position.Right ? 0 : width, position === Position.Bottom ? 0 : height);
   ctx.strokeStyle = axisLine.stroke;
   ctx.lineWidth = axisLine.strokeWidth;
   ctx.stroke();

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/line.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/line.ts
@@ -18,17 +18,17 @@
  */
 
 import { AxisProps } from '.';
-import { Position } from '../../../../../utils/common';
+import { Position as P } from '../../../../../utils/common';
 
 /** @internal */
 export function renderAxisLine(
   ctx: CanvasRenderingContext2D,
-  { axisSpec: { position }, size: { width, height }, axisStyle: { axisLine } }: AxisProps,
+  { axisSpec: { position: p }, size: { width: w, height: h }, axisStyle: { axisLine } }: AxisProps,
 ) {
   if (!axisLine.visible) return;
   ctx.beginPath();
-  ctx.moveTo(position === Position.Left ? width : 0, position === Position.Top ? height : 0);
-  ctx.lineTo(position === Position.Right ? 0 : width, position === Position.Bottom ? 0 : height);
+  ctx.moveTo(p === P.Left ? w : 0, p === P.Top ? h : 0);
+  ctx.lineTo(p !== P.Right ? w : 0, p !== P.Bottom ? h : 0);
   ctx.strokeStyle = axisLine.stroke;
   ctx.lineWidth = axisLine.strokeWidth;
   ctx.stroke();

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
@@ -35,19 +35,18 @@ export function renderTick(
   const tickSize = tickLine.size;
   const tickPosition = tick.position;
   const isTopOrLeftAxis = position === Position.Top || position === Position.Left;
-  if (horizontal) {
-    const y1 = isTopOrLeftAxis ? axisGirth - tickSize : 0;
-    const y2 = isTopOrLeftAxis ? axisGirth : tickSize;
-    renderMultiLine(ctx, [{ x1: tickPosition, y1, x2: tickPosition, y2 }], {
-      color: stringToRGB(tickLine.stroke),
-      width: tickLine.strokeWidth,
-    });
-  } else {
-    const x1 = isTopOrLeftAxis ? axisGirth : 0;
-    const x2 = isTopOrLeftAxis ? axisGirth - tickSize : tickSize;
-    renderMultiLine(ctx, [{ x1, y1: tickPosition, x2, y2: tickPosition }], {
-      color: stringToRGB(tickLine.stroke),
-      width: tickLine.strokeWidth,
-    });
-  }
+  const xy = horizontal
+    ? {
+        x1: tickPosition,
+        y1: isTopOrLeftAxis ? axisGirth - tickSize : 0,
+        x2: tickPosition,
+        y2: isTopOrLeftAxis ? axisGirth : tickSize,
+      }
+    : {
+        x1: isTopOrLeftAxis ? axisGirth : 0,
+        y1: tickPosition,
+        x2: isTopOrLeftAxis ? axisGirth - tickSize : tickSize,
+        y2: tickPosition,
+      };
+  renderMultiLine(ctx, [xy], { color: stringToRGB(tickLine.stroke), width: tickLine.strokeWidth });
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
@@ -27,26 +27,19 @@ import { renderMultiLine } from '../primitives/line';
 /** @internal */
 export function renderTick(
   ctx: CanvasRenderingContext2D,
-  tick: AxisTick,
-  { axisSpec: { position }, size: { width, height }, axisStyle: { tickLine } }: AxisProps,
+  { position: tickPosition }: AxisTick,
+  { axisSpec: { position: axisPosition }, size: { width, height }, axisStyle: { tickLine } }: AxisProps,
 ) {
-  const horizontal = isHorizontalAxis(position); // todo avoid checking it per tick in the future
-  const axisGirth = horizontal ? height : width;
-  const tickSize = tickLine.size;
-  const tickPosition = tick.position;
-  const isTopOrLeftAxis = position === Position.Top || position === Position.Left;
-  const xy = horizontal
+  const xy = isHorizontalAxis(axisPosition)
     ? {
         x1: tickPosition,
         x2: tickPosition,
-        y1: isTopOrLeftAxis ? axisGirth - tickSize : 0,
-        y2: isTopOrLeftAxis ? axisGirth : tickSize,
+        ...(axisPosition === Position.Top ? { y1: height - tickLine.size, y2: height } : { y1: 0, y2: tickLine.size }),
       }
     : {
         y1: tickPosition,
         y2: tickPosition,
-        x1: isTopOrLeftAxis ? axisGirth : 0,
-        x2: isTopOrLeftAxis ? axisGirth - tickSize : tickSize,
+        ...(axisPosition === Position.Left ? { x1: width, x2: width - tickLine.size } : { x1: 0, x2: tickLine.size }),
       };
   renderMultiLine(ctx, [xy], { color: stringToRGB(tickLine.stroke), width: tickLine.strokeWidth });
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
@@ -23,7 +23,7 @@ import { Position } from '../../../../../utils/common';
 import { TickStyle } from '../../../../../utils/themes/theme';
 import { isVerticalAxis } from '../../../utils/axis_type_utils';
 import { AxisTick } from '../../../utils/axis_utils';
-import { renderLine } from '../primitives/line';
+import { renderMultiLine } from '../primitives/line';
 
 /** @internal */
 export function renderTick(ctx: CanvasRenderingContext2D, tick: AxisTick, props: AxisProps) {
@@ -50,14 +50,10 @@ function renderVerticalTick(
   const isLeftAxis = position === Position.Left;
   const x1 = isLeftAxis ? axisWidth : 0;
   const x2 = isLeftAxis ? axisWidth - tickSize : tickSize;
-  renderLine(
-    ctx,
-    { x1, y1: tickPosition, x2, y2: tickPosition },
-    {
-      color: stringToRGB(tickStyle.stroke),
-      width: tickStyle.strokeWidth,
-    },
-  );
+  renderMultiLine(ctx, [{ x1, y1: tickPosition, x2, y2: tickPosition }], {
+    color: stringToRGB(tickStyle.stroke),
+    width: tickStyle.strokeWidth,
+  });
 }
 
 function renderHorizontalTick(
@@ -72,12 +68,8 @@ function renderHorizontalTick(
   const y1 = isTopAxis ? axisHeight - tickSize : 0;
   const y2 = isTopAxis ? axisHeight : tickSize;
 
-  renderLine(
-    ctx,
-    { x1: tickPosition, y1, x2: tickPosition, y2 },
-    {
-      color: stringToRGB(tickStyle.stroke),
-      width: tickStyle.strokeWidth,
-    },
-  );
+  renderMultiLine(ctx, [{ x1: tickPosition, y1, x2: tickPosition, y2 }], {
+    color: stringToRGB(tickStyle.stroke),
+    width: tickStyle.strokeWidth,
+  });
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
@@ -21,7 +21,7 @@ import { AxisProps } from '.';
 import { stringToRGB } from '../../../../../common/color_library_wrappers';
 import { Position } from '../../../../../utils/common';
 import { TickStyle } from '../../../../../utils/themes/theme';
-import { isVerticalAxis } from '../../../utils/axis_type_utils';
+import { isHorizontalAxis } from '../../../utils/axis_type_utils';
 import { AxisTick } from '../../../utils/axis_utils';
 import { renderMultiLine } from '../primitives/line';
 
@@ -31,42 +31,45 @@ export function renderTick(
   tick: AxisTick,
   { axisSpec: { position }, size: { width, height }, axisStyle: { tickLine } }: AxisProps,
 ) {
-  const vertical = isVerticalAxis(position); // todo avoid checking it per tick in the future
-  const render = vertical ? renderVerticalTick : renderHorizontalTick;
-  render(ctx, position, vertical ? width : height, tickLine.size, tick.position, tickLine);
+  const horizontal = isHorizontalAxis(position); // todo avoid checking it per tick in the future
+  const axisGirth = horizontal ? height : width;
+  const tickSize = tickLine.size;
+  const tickPosition = tick.position;
+  const render = horizontal ? renderHorizontalTick : renderVerticalTick;
+  render(ctx, position, axisGirth, tickSize, tickPosition, tickLine);
 }
 
 function renderVerticalTick(
   ctx: CanvasRenderingContext2D,
   position: Position,
-  axisLength: number,
+  axisGirth: number,
   tickSize: number,
   tickPosition: number,
-  tickStyle: TickStyle,
+  tickLine: TickStyle,
 ) {
   const isLeftAxis = position === Position.Left;
-  const x1 = isLeftAxis ? axisLength : 0;
-  const x2 = isLeftAxis ? axisLength - tickSize : tickSize;
+  const x1 = isLeftAxis ? axisGirth : 0;
+  const x2 = isLeftAxis ? axisGirth - tickSize : tickSize;
   renderMultiLine(ctx, [{ x1, y1: tickPosition, x2, y2: tickPosition }], {
-    color: stringToRGB(tickStyle.stroke),
-    width: tickStyle.strokeWidth,
+    color: stringToRGB(tickLine.stroke),
+    width: tickLine.strokeWidth,
   });
 }
 
 function renderHorizontalTick(
   ctx: CanvasRenderingContext2D,
   position: Position,
-  axisLength: number,
+  axisGirth: number,
   tickSize: number,
   tickPosition: number,
-  tickStyle: TickStyle,
+  tickLine: TickStyle,
 ) {
   const isTopAxis = position === Position.Top;
-  const y1 = isTopAxis ? axisLength - tickSize : 0;
-  const y2 = isTopAxis ? axisLength : tickSize;
+  const y1 = isTopAxis ? axisGirth - tickSize : 0;
+  const y2 = isTopAxis ? axisGirth : tickSize;
 
   renderMultiLine(ctx, [{ x1: tickPosition, y1, x2: tickPosition, y2 }], {
-    color: stringToRGB(tickStyle.stroke),
-    width: tickStyle.strokeWidth,
+    color: stringToRGB(tickLine.stroke),
+    width: tickLine.strokeWidth,
   });
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
@@ -39,14 +39,14 @@ export function renderTick(
 function renderVerticalTick(
   ctx: CanvasRenderingContext2D,
   position: Position,
-  axisWidth: number,
+  axisLength: number,
   tickSize: number,
   tickPosition: number,
   tickStyle: TickStyle,
 ) {
   const isLeftAxis = position === Position.Left;
-  const x1 = isLeftAxis ? axisWidth : 0;
-  const x2 = isLeftAxis ? axisWidth - tickSize : tickSize;
+  const x1 = isLeftAxis ? axisLength : 0;
+  const x2 = isLeftAxis ? axisLength - tickSize : tickSize;
   renderMultiLine(ctx, [{ x1, y1: tickPosition, x2, y2: tickPosition }], {
     color: stringToRGB(tickStyle.stroke),
     width: tickStyle.strokeWidth,
@@ -56,14 +56,14 @@ function renderVerticalTick(
 function renderHorizontalTick(
   ctx: CanvasRenderingContext2D,
   position: Position,
-  axisHeight: number,
+  axisLength: number,
   tickSize: number,
   tickPosition: number,
   tickStyle: TickStyle,
 ) {
   const isTopAxis = position === Position.Top;
-  const y1 = isTopAxis ? axisHeight - tickSize : 0;
-  const y2 = isTopAxis ? axisHeight : tickSize;
+  const y1 = isTopAxis ? axisLength - tickSize : 0;
+  const y2 = isTopAxis ? axisLength : tickSize;
 
   renderMultiLine(ctx, [{ x1: tickPosition, y1, x2: tickPosition, y2 }], {
     color: stringToRGB(tickStyle.stroke),

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
@@ -34,19 +34,17 @@ export function renderTick(
   const axisGirth = horizontal ? height : width;
   const tickSize = tickLine.size;
   const tickPosition = tick.position;
+  const isTopOrLeftAxis = position === Position.Top || position === Position.Left;
   if (horizontal) {
-    const isTopAxis = position === Position.Top;
-    const y1 = isTopAxis ? axisGirth - tickSize : 0;
-    const y2 = isTopAxis ? axisGirth : tickSize;
-
+    const y1 = isTopOrLeftAxis ? axisGirth - tickSize : 0;
+    const y2 = isTopOrLeftAxis ? axisGirth : tickSize;
     renderMultiLine(ctx, [{ x1: tickPosition, y1, x2: tickPosition, y2 }], {
       color: stringToRGB(tickLine.stroke),
       width: tickLine.strokeWidth,
     });
   } else {
-    const isLeftAxis = position === Position.Left;
-    const x1 = isLeftAxis ? axisGirth : 0;
-    const x2 = isLeftAxis ? axisGirth - tickSize : tickSize;
+    const x1 = isTopOrLeftAxis ? axisGirth : 0;
+    const x2 = isTopOrLeftAxis ? axisGirth - tickSize : tickSize;
     renderMultiLine(ctx, [{ x1, y1: tickPosition, x2, y2: tickPosition }], {
       color: stringToRGB(tickLine.stroke),
       width: tickLine.strokeWidth,

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
@@ -26,17 +26,14 @@ import { AxisTick } from '../../../utils/axis_utils';
 import { renderMultiLine } from '../primitives/line';
 
 /** @internal */
-export function renderTick(ctx: CanvasRenderingContext2D, tick: AxisTick, props: AxisProps) {
-  const {
-    axisSpec: { position },
-    size,
-    axisStyle: { tickLine },
-  } = props;
-  if (isVerticalAxis(position)) {
-    renderVerticalTick(ctx, position, size.width, tickLine.size, tick.position, tickLine);
-  } else {
-    renderHorizontalTick(ctx, position, size.height, tickLine.size, tick.position, tickLine);
-  }
+export function renderTick(
+  ctx: CanvasRenderingContext2D,
+  tick: AxisTick,
+  { axisSpec: { position }, size: { width, height }, axisStyle: { tickLine } }: AxisProps,
+) {
+  const vertical = isVerticalAxis(position); // todo avoid checking it per tick in the future
+  const render = vertical ? renderVerticalTick : renderHorizontalTick;
+  render(ctx, position, vertical ? width : height, tickLine.size, tick.position, tickLine);
 }
 
 function renderVerticalTick(

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
@@ -38,15 +38,15 @@ export function renderTick(
   const xy = horizontal
     ? {
         x1: tickPosition,
-        y1: isTopOrLeftAxis ? axisGirth - tickSize : 0,
         x2: tickPosition,
+        y1: isTopOrLeftAxis ? axisGirth - tickSize : 0,
         y2: isTopOrLeftAxis ? axisGirth : tickSize,
       }
     : {
-        x1: isTopOrLeftAxis ? axisGirth : 0,
         y1: tickPosition,
-        x2: isTopOrLeftAxis ? axisGirth - tickSize : tickSize,
         y2: tickPosition,
+        x1: isTopOrLeftAxis ? axisGirth : 0,
+        x2: isTopOrLeftAxis ? axisGirth - tickSize : tickSize,
       };
   renderMultiLine(ctx, [xy], { color: stringToRGB(tickLine.stroke), width: tickLine.strokeWidth });
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick.ts
@@ -20,7 +20,6 @@
 import { AxisProps } from '.';
 import { stringToRGB } from '../../../../../common/color_library_wrappers';
 import { Position } from '../../../../../utils/common';
-import { TickStyle } from '../../../../../utils/themes/theme';
 import { isHorizontalAxis } from '../../../utils/axis_type_utils';
 import { AxisTick } from '../../../utils/axis_utils';
 import { renderMultiLine } from '../primitives/line';
@@ -35,41 +34,22 @@ export function renderTick(
   const axisGirth = horizontal ? height : width;
   const tickSize = tickLine.size;
   const tickPosition = tick.position;
-  const render = horizontal ? renderHorizontalTick : renderVerticalTick;
-  render(ctx, position, axisGirth, tickSize, tickPosition, tickLine);
-}
+  if (horizontal) {
+    const isTopAxis = position === Position.Top;
+    const y1 = isTopAxis ? axisGirth - tickSize : 0;
+    const y2 = isTopAxis ? axisGirth : tickSize;
 
-function renderVerticalTick(
-  ctx: CanvasRenderingContext2D,
-  position: Position,
-  axisGirth: number,
-  tickSize: number,
-  tickPosition: number,
-  tickLine: TickStyle,
-) {
-  const isLeftAxis = position === Position.Left;
-  const x1 = isLeftAxis ? axisGirth : 0;
-  const x2 = isLeftAxis ? axisGirth - tickSize : tickSize;
-  renderMultiLine(ctx, [{ x1, y1: tickPosition, x2, y2: tickPosition }], {
-    color: stringToRGB(tickLine.stroke),
-    width: tickLine.strokeWidth,
-  });
-}
-
-function renderHorizontalTick(
-  ctx: CanvasRenderingContext2D,
-  position: Position,
-  axisGirth: number,
-  tickSize: number,
-  tickPosition: number,
-  tickLine: TickStyle,
-) {
-  const isTopAxis = position === Position.Top;
-  const y1 = isTopAxis ? axisGirth - tickSize : 0;
-  const y2 = isTopAxis ? axisGirth : tickSize;
-
-  renderMultiLine(ctx, [{ x1: tickPosition, y1, x2: tickPosition, y2 }], {
-    color: stringToRGB(tickLine.stroke),
-    width: tickLine.strokeWidth,
-  });
+    renderMultiLine(ctx, [{ x1: tickPosition, y1, x2: tickPosition, y2 }], {
+      color: stringToRGB(tickLine.stroke),
+      width: tickLine.strokeWidth,
+    });
+  } else {
+    const isLeftAxis = position === Position.Left;
+    const x1 = isLeftAxis ? axisGirth : 0;
+    const x2 = isLeftAxis ? axisGirth - tickSize : tickSize;
+    renderMultiLine(ctx, [{ x1, y1: tickPosition, x2, y2: tickPosition }], {
+      color: stringToRGB(tickLine.stroke),
+      width: tickLine.strokeWidth,
+    });
+  }
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/panels/global_title.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/panels/global_title.ts
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-import { AxisProps } from '.';
 import { Position } from '../../../../../utils/common';
 import { getSimplePadding } from '../../../../../utils/dimensions';
 import { Point } from '../../../../../utils/point';
 import { isHorizontalAxis } from '../../../utils/axis_type_utils';
 import { getTitleDimension, shouldShowTicks } from '../../../utils/axis_utils';
+import { AxisProps } from '../axes'; // todo revise if it should rely on AxisProps or axis-anything
 import { renderText } from '../primitives/text';
 import { renderDebugRect } from '../utils/debug';
 import { getFontStyle } from './panel_title';

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/panels/panel_title.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/panels/panel_title.ts
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-import { AxisProps } from '.';
 import { FontStyle } from '../../../../../common/text_utils';
 import { Position } from '../../../../../utils/common';
 import { getSimplePadding } from '../../../../../utils/dimensions';
-import { AxisStyle } from '../../../../../utils/themes/theme';
+import { AxisStyle } from '../../../../../utils/themes/theme'; // todo revise if it should rely on axis-anything
 import { isHorizontalAxis } from '../../../utils/axis_type_utils';
 import { getTitleDimension, shouldShowTicks } from '../../../utils/axis_utils';
+import { AxisProps } from '../axes';
 import { renderText, TextFont } from '../primitives/text';
 import { renderDebugRect } from '../utils/debug';
 

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/panels/panels.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/panels/panels.ts
@@ -18,27 +18,20 @@
  */
 
 import { stringToRGB } from '../../../../../common/color_library_wrappers';
-import { withContext } from '../../../../../renderers/canvas';
 import { Point } from '../../../../../utils/point';
 import { PanelGeoms } from '../../../state/selectors/compute_panels';
 import { renderRect } from '../primitives/rect';
 
 /** @internal */
-export function renderGridPanels(ctx: CanvasRenderingContext2D, chartAnchor: Point, panels: PanelGeoms) {
-  withContext(ctx, (ctx) => {
-    ctx.translate(chartAnchor.x, chartAnchor.y);
-    panels.forEach((panel) => {
-      withContext(ctx, (ctx) => {
-        ctx.translate(panel.panelAnchor.x, panel.panelAnchor.y);
-        withContext(ctx, (ctx) => {
-          renderRect(
-            ctx,
-            { x: 0, y: 0, ...panel },
-            { color: stringToRGB('#00000000') },
-            { color: stringToRGB('#000000'), width: 1 },
-          );
-        });
-      });
-    });
-  });
+export function renderGridPanels(ctx: CanvasRenderingContext2D, { x: chartX, y: chartY }: Point, panels: PanelGeoms) {
+  panels.forEach(({ width, height, panelAnchor: { x: panelX, y: panelY } }) =>
+    withContext(ctx, (ctx) =>
+      renderRect(
+        ctx,
+        { x: chartX + panelX, y: chartY + panelY, width, height },
+        { color: stringToRGB('#00000000') },
+        { color: stringToRGB('#000000'), width: 1 },
+      ),
+    ),
+  );
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/panels/panels.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/panels/panels.ts
@@ -28,7 +28,7 @@ import { shouldShowTicks } from '../../../utils/axis_utils';
 import { AxisSpec } from '../../../utils/specs';
 import { AxesProps, AxisProps } from '../axes';
 import { renderTitle } from '../axes/global_title';
-import { renderLine } from '../axes/line';
+import { renderAxisLine } from '../axes/line';
 import { renderPanelTitle } from '../axes/panel_title';
 import { renderTick } from '../axes/tick';
 import { renderTickLabel } from '../axes/tick_label';
@@ -61,7 +61,7 @@ function renderPanel(ctx: CanvasRenderingContext2D, props: AxisProps) {
 
     if (debug && !secondary) renderDebugRect(ctx, { x: 0, y: 0, ...size });
 
-    renderLine(ctx, props); // render the axis line
+    renderAxisLine(ctx, props); // render the axis line
 
     // TODO: compute axis dimensions per panels
     if (secondary) return; // For now, just render the axis line

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/panels/panels.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/panels/panels.ts
@@ -24,16 +24,12 @@ import { AxisId } from '../../../../../utils/ids';
 import { Point } from '../../../../../utils/point';
 import { PanelGeoms } from '../../../state/selectors/compute_panels';
 import { getSpecsById } from '../../../state/utils/spec';
-import { shouldShowTicks } from '../../../utils/axis_utils';
 import { AxisSpec } from '../../../utils/specs';
-import { AxesProps, AxisProps } from '../axes';
-import { renderTitle } from '../axes/global_title';
-import { renderAxisLine } from '../axes/line';
-import { renderPanelTitle } from '../axes/panel_title';
-import { renderTick } from '../axes/tick';
-import { renderTickLabel } from '../axes/tick_label';
+import { AxesProps, AxisProps, renderAxis } from '../axes';
 import { renderRect } from '../primitives/rect';
 import { renderDebugRect } from '../utils/debug';
+import { renderTitle } from './global_title';
+import { renderPanelTitle } from './panel_title';
 
 /** @internal */
 export function renderGridPanels(ctx: CanvasRenderingContext2D, { x: chartX, y: chartY }: Point, panels: PanelGeoms) {
@@ -50,27 +46,19 @@ export function renderGridPanels(ctx: CanvasRenderingContext2D, { x: chartX, y: 
 }
 
 function renderPanel(ctx: CanvasRenderingContext2D, props: AxisProps) {
-  const { ticks, size, anchorPoint, debug, axisStyle, axisSpec, panelAnchor, secondary } = props;
-  const showTicks = shouldShowTicks(axisStyle.tickLine, axisSpec.hide);
+  const { size, anchorPoint, debug, axisStyle, axisSpec, panelAnchor, secondary } = props;
   const { position } = axisSpec;
   const x = anchorPoint.x + (position === Position.Right ? -1 : 1) * panelAnchor.x;
   const y = anchorPoint.y + (position === Position.Bottom ? -1 : 1) * panelAnchor.y;
 
   withContext(ctx, (ctx) => {
     ctx.translate(x, y);
-
     if (debug && !secondary) renderDebugRect(ctx, { x: 0, y: 0, ...size });
-
-    renderAxisLine(ctx, props); // render the axis line
-
-    // TODO: compute axis dimensions per panels
-    if (secondary) return; // For now, just render the axis line
-
-    if (showTicks) ticks.forEach((tick) => renderTick(ctx, tick, props));
-    if (axisStyle.tickLabel.visible) ticks.forEach((tick) => renderTickLabel(ctx, tick, showTicks, props));
-
-    const { panelTitle, dimension } = props;
-    renderPanelTitle(ctx, { panelTitle, axisSpec, axisStyle, size, dimension, debug });
+    renderAxis(ctx, props); // For now, just render the axis line TODO: compute axis dimensions per panels
+    if (!secondary) {
+      const { panelTitle, dimension } = props;
+      renderPanelTitle(ctx, { panelTitle, axisSpec, axisStyle, size, dimension, debug }); // fixme axisSpec/Style?
+    }
   });
 }
 

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
@@ -18,7 +18,7 @@
  */
 
 import { RGBtoString } from '../../../../../common/color_library_wrappers';
-import { Stroke, Line } from '../../../../../geoms/types';
+import { Line, Stroke } from '../../../../../geoms/types';
 import { withContext } from '../../../../../renderers/canvas';
 
 /**
@@ -30,14 +30,10 @@ export const MIN_STROKE_WIDTH = 0.001;
 
 /** @internal */
 export function renderMultiLine(ctx: CanvasRenderingContext2D, lines: Line[] | string[], stroke: Stroke) {
-  if (stroke.width < MIN_STROKE_WIDTH) {
+  if (stroke.width < MIN_STROKE_WIDTH || lines.length === 0) {
     return;
   }
   withContext(ctx, (ctx) => {
-    const lineLength = lines.length;
-    if (lineLength === 0) {
-      return;
-    }
     ctx.strokeStyle = RGBtoString(stroke.color);
     ctx.lineJoin = 'round';
     ctx.lineWidth = stroke.width;
@@ -48,13 +44,13 @@ export function renderMultiLine(ctx: CanvasRenderingContext2D, lines: Line[] | s
     ctx.beginPath();
 
     if (isStringArray(lines)) {
-      for (let i = 0; i < lineLength; i++) {
+      for (let i = 0; i < lines.length; i++) {
         const path = lines[i];
         ctx.stroke(new Path2D(path));
       }
       return;
     }
-    for (let i = 0; i < lineLength; i++) {
+    for (let i = 0; i < lines.length; i++) {
       const { x1, y1, x2, y2 } = lines[i];
       ctx.moveTo(x1, y1);
       ctx.lineTo(x2, y2);

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
@@ -29,11 +29,6 @@ import { withContext } from '../../../../../renderers/canvas';
 export const MIN_STROKE_WIDTH = 0.001;
 
 /** @internal */
-export function renderLine(ctx: CanvasRenderingContext2D, line: Line, stroke: Stroke) {
-  renderMultiLine(ctx, [line], stroke);
-}
-
-/** @internal */
 export function renderMultiLine(ctx: CanvasRenderingContext2D, lines: Line[] | string[], stroke: Stroke) {
   if (stroke.width < MIN_STROKE_WIDTH) {
     return;

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
@@ -23,7 +23,7 @@ import { withContext } from '../../../../../renderers/canvas';
 
 /**
  * Canvas2d stroke ignores an exact zero line width
- * todo: decide whether it represents 0, or the minimum stroke width to render, as currently it's mixed in predicates
+ * Any value that's equal to or larger than MIN_STROKE_WIDTH
  * @internal
  */
 export const MIN_STROKE_WIDTH = 0.001;

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
@@ -23,6 +23,7 @@ import { withContext } from '../../../../../renderers/canvas';
 
 /**
  * Canvas2d stroke ignores an exact zero line width
+ * todo: decide whether it represents 0, or the minimum stroke width to render, as currently it's mixed in predicates
  * @internal
  */
 export const MIN_STROKE_WIDTH = 0.001;

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
@@ -43,21 +43,15 @@ export function renderMultiLine(ctx: CanvasRenderingContext2D, lines: Line[] | s
 
     ctx.beginPath();
 
-    if (isStringArray(lines)) {
-      for (let i = 0; i < lines.length; i++) {
-        ctx.stroke(new Path2D(lines[i]));
-      }
-    } else {
-      for (let i = 0; i < lines.length; i++) {
-        const { x1, y1, x2, y2 } = lines[i];
+    for (const line of lines) {
+      if (typeof line === 'string') {
+        ctx.stroke(new Path2D(line));
+      } else {
+        const { x1, y1, x2, y2 } = line;
         ctx.moveTo(x1, y1);
         ctx.lineTo(x2, y2);
       }
-      ctx.stroke();
     }
+    ctx.stroke();
   });
-}
-
-function isStringArray(lines: Line[] | string[]): lines is string[] {
-  return typeof lines[0] === 'string';
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
@@ -45,17 +45,16 @@ export function renderMultiLine(ctx: CanvasRenderingContext2D, lines: Line[] | s
 
     if (isStringArray(lines)) {
       for (let i = 0; i < lines.length; i++) {
-        const path = lines[i];
-        ctx.stroke(new Path2D(path));
+        ctx.stroke(new Path2D(lines[i]));
       }
-      return;
+    } else {
+      for (let i = 0; i < lines.length; i++) {
+        const { x1, y1, x2, y2 } = lines[i];
+        ctx.moveTo(x1, y1);
+        ctx.lineTo(x2, y2);
+      }
+      ctx.stroke();
     }
-    for (let i = 0; i < lines.length; i++) {
-      const { x1, y1, x2, y2 } = lines[i];
-      ctx.moveTo(x1, y1);
-      ctx.lineTo(x2, y2);
-    }
-    ctx.stroke();
   });
 }
 

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/text.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/text.ts
@@ -41,10 +41,6 @@ export function renderText(
   translation?: Partial<Point>,
   scale: number = 1,
 ) {
-  if (text === undefined || text === null) {
-    return;
-  }
-
   withRotatedOrigin(ctx, origin, degree, (ctx) => {
     withContext(ctx, (ctx) => {
       ctx.fillStyle = font.fill;

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/renderers.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/renderers.ts
@@ -22,12 +22,11 @@ import { Rect } from '../../../../geoms/types';
 import { withContext, renderLayers, clearCanvas } from '../../../../renderers/canvas';
 import { renderAnnotations } from './annotations';
 import { renderAreas } from './areas';
-import { renderAxes } from './axes';
 import { renderBars } from './bars';
 import { renderBubbles } from './bubbles';
 import { renderGrids } from './grids';
 import { renderLines } from './lines';
-import { renderGridPanels } from './panels/panels';
+import { renderGridPanels, renderPanelSubstrates } from './panels/panels';
 import { renderDebugRect } from './utils/debug';
 import { renderBarValues } from './values/bar';
 import { ReactiveChartStateProps } from './xy_chart';
@@ -88,7 +87,7 @@ export function renderXYChartCanvas2d(
         });
       },
       (ctx: CanvasRenderingContext2D) => {
-        renderAxes(ctx, {
+        renderPanelSubstrates(ctx, {
           axesSpecs,
           perPanelAxisGeoms,
           renderingArea,

--- a/packages/charts/src/chart_types/xy_chart/rendering/rendering.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/rendering/rendering.test.ts
@@ -463,7 +463,7 @@ describe('Rendering utils', () => {
       const getRadius = getRadiusFn([], 1);
 
       it('should return a function', () => {
-        expect(getRadius).toBeFunction();
+        expect(getRadius).toBeInstanceOf(Function);
       });
 
       it.each<[number, number]>([
@@ -487,7 +487,7 @@ describe('Rendering utils', () => {
       const getRadius = getRadiusFn(data, 1);
 
       it('should return a function', () => {
-        expect(getRadius).toBeFunction();
+        expect(getRadius).toBeInstanceOf(Function);
       });
 
       describe('Dataset validations', () => {

--- a/packages/charts/src/chart_types/xy_chart/rendering/rendering.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/rendering/rendering.test.ts
@@ -463,7 +463,7 @@ describe('Rendering utils', () => {
       const getRadius = getRadiusFn([], 1);
 
       it('should return a function', () => {
-        expect(getRadius).toBeInstanceOf(Function);
+        expect(getRadius).toBeFunction();
       });
 
       it.each<[number, number]>([
@@ -487,7 +487,7 @@ describe('Rendering utils', () => {
       const getRadius = getRadiusFn(data, 1);
 
       it('should return a function', () => {
-        expect(getRadius).toBeInstanceOf(Function);
+        expect(getRadius).toBeFunction();
       });
 
       describe('Dataset validations', () => {

--- a/packages/charts/src/chart_types/xy_chart/state/chart_state.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/chart_state.test.ts
@@ -22,7 +22,7 @@ import { SpecType } from '../../../specs/constants';
 import { Position, RecursivePartial } from '../../../utils/common';
 import { AxisId } from '../../../utils/ids';
 import { AxisStyle } from '../../../utils/themes/theme';
-import { AxisTicksDimensions, isDuplicateAxis } from '../utils/axis_utils';
+import { AxisTicksDimensions, hasDuplicateAxis } from '../utils/axis_utils';
 import { AxisSpec } from '../utils/specs';
 
 const style: RecursivePartial<AxisStyle> = {
@@ -71,7 +71,7 @@ describe('isDuplicateAxis', () => {
   it('should return true if axisSpecs and ticks match', () => {
     tickMap.set(AXIS_2_ID, axisTicksDimensions);
     specMap.push(axis2);
-    const result = isDuplicateAxis(axis1, axisTicksDimensions, tickMap, specMap);
+    const result = hasDuplicateAxis(axis1, axisTicksDimensions, tickMap, specMap);
 
     expect(result).toBe(true);
   });
@@ -82,7 +82,7 @@ describe('isDuplicateAxis', () => {
       ...axis2,
       title: 'TESTING',
     });
-    const result = isDuplicateAxis(
+    const result = hasDuplicateAxis(
       {
         ...axis1,
         title: 'TESTING',
@@ -103,7 +103,7 @@ describe('isDuplicateAxis', () => {
     tickMap.set(AXIS_2_ID, newAxisTicksDimensions);
     specMap.push(axis2);
 
-    const result = isDuplicateAxis(axis1, newAxisTicksDimensions, tickMap, specMap);
+    const result = hasDuplicateAxis(axis1, newAxisTicksDimensions, tickMap, specMap);
 
     expect(result).toBe(true);
   });
@@ -114,7 +114,7 @@ describe('isDuplicateAxis', () => {
       ...axis2,
       title: 'TESTING',
     });
-    const result = isDuplicateAxis(
+    const result = hasDuplicateAxis(
       {
         ...axis1,
         title: 'NOT TESTING',
@@ -130,7 +130,7 @@ describe('isDuplicateAxis', () => {
   it('should return false if axisSpecs and ticks match but position is different', () => {
     tickMap.set(AXIS_2_ID, axisTicksDimensions);
     specMap.push(axis2);
-    const result = isDuplicateAxis(
+    const result = hasDuplicateAxis(
       {
         ...axis1,
         position: Position.Top,
@@ -150,7 +150,7 @@ describe('isDuplicateAxis', () => {
     });
     specMap.push(axis2);
 
-    const result = isDuplicateAxis(axis1, axisTicksDimensions, tickMap, specMap);
+    const result = hasDuplicateAxis(axis1, axisTicksDimensions, tickMap, specMap);
 
     expect(result).toBe(false);
   });
@@ -162,14 +162,14 @@ describe('isDuplicateAxis', () => {
     });
     specMap.push(axis2);
 
-    const result = isDuplicateAxis(axis1, axisTicksDimensions, tickMap, specMap);
+    const result = hasDuplicateAxis(axis1, axisTicksDimensions, tickMap, specMap);
 
     expect(result).toBe(false);
   });
 
   it("should return false if can't find spec", () => {
     tickMap.set(AXIS_2_ID, axisTicksDimensions);
-    const result = isDuplicateAxis(axis1, axisTicksDimensions, tickMap, specMap);
+    const result = hasDuplicateAxis(axis1, axisTicksDimensions, tickMap, specMap);
 
     expect(result).toBe(false);
   });

--- a/packages/charts/src/chart_types/xy_chart/state/chart_state.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/chart_state.test.ts
@@ -22,7 +22,7 @@ import { SpecType } from '../../../specs/constants';
 import { Position, RecursivePartial } from '../../../utils/common';
 import { AxisId } from '../../../utils/ids';
 import { AxisStyle } from '../../../utils/themes/theme';
-import { AxisTicksDimensions, hasDuplicateAxis } from '../utils/axis_utils';
+import { AxisViewModel, hasDuplicateAxis } from '../utils/axis_utils';
 import { AxisSpec } from '../utils/specs';
 
 const style: RecursivePartial<AxisStyle> = {
@@ -51,7 +51,7 @@ describe('isDuplicateAxis', () => {
     id: AXIS_2_ID,
     groupId: 'group_2',
   };
-  const axisTicksDimensions: AxisTicksDimensions = {
+  const axisTicksDimensions: AxisViewModel = {
     tickValues: [],
     tickLabels: ['10', '20', '30'],
     maxLabelBboxWidth: 1,
@@ -60,11 +60,11 @@ describe('isDuplicateAxis', () => {
     maxLabelTextHeight: 1,
     isHidden: false,
   };
-  let tickMap: Map<AxisId, AxisTicksDimensions>;
+  let tickMap: Map<AxisId, AxisViewModel>;
   let specMap: AxisSpec[];
 
   beforeEach(() => {
-    tickMap = new Map<AxisId, AxisTicksDimensions>();
+    tickMap = new Map<AxisId, AxisViewModel>();
     specMap = [];
   });
 

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_axis_ticks_dimensions.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_axis_ticks_dimensions.ts
@@ -22,12 +22,7 @@ import { getChartThemeSelector } from '../../../../state/selectors/get_chart_the
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_specs';
 import { CanvasTextBBoxCalculator } from '../../../../utils/bbox/canvas_text_bbox_calculator';
 import { AxisId } from '../../../../utils/ids';
-import {
-  computeAxisTicksDimensions,
-  AxisViewModel,
-  hasDuplicateAxis,
-  defaultTickFormatter,
-} from '../../utils/axis_utils';
+import { axisViewModel, AxisViewModel, hasDuplicateAxis, defaultTickFormatter } from '../../utils/axis_utils';
 import { computeSeriesDomainsSelector } from './compute_series_domains';
 import { countBarsInClusterSelector } from './count_bars_in_cluster';
 import { getAxesStylesSelector } from './get_axis_styles';
@@ -66,7 +61,7 @@ export const computeAxisTicksDimensionsSelector = createCustomCachedSelector(
     axesSpecs.forEach((axisSpec) => {
       const { id } = axisSpec;
       const axisStyle = axesStyles.get(id) ?? chartTheme.axes;
-      const dimensions = computeAxisTicksDimensions(
+      const dimensions = axisViewModel(
         axisSpec,
         xDomain,
         yDomains,

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_axis_ticks_dimensions.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_axis_ticks_dimensions.ts
@@ -25,7 +25,7 @@ import { AxisId } from '../../../../utils/ids';
 import {
   computeAxisTicksDimensions,
   AxisTicksDimensions,
-  isDuplicateAxis,
+  hasDuplicateAxis,
   defaultTickFormatter,
 } from '../../utils/axis_utils';
 import { computeSeriesDomainsSelector } from './compute_series_domains';
@@ -80,7 +80,7 @@ export const computeAxisTicksDimensionsSelector = createCustomCachedSelector(
       );
       if (
         dimensions &&
-        (!settingsSpec.hideDuplicateAxes || !isDuplicateAxis(axisSpec, dimensions, axesTicksDimensions, axesSpecs))
+        (!settingsSpec.hideDuplicateAxes || !hasDuplicateAxis(axisSpec, dimensions, axesTicksDimensions, axesSpecs))
       ) {
         axesTicksDimensions.set(id, dimensions);
       }

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_axis_ticks_dimensions.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_axis_ticks_dimensions.ts
@@ -24,7 +24,7 @@ import { CanvasTextBBoxCalculator } from '../../../../utils/bbox/canvas_text_bbo
 import { AxisId } from '../../../../utils/ids';
 import {
   computeAxisTicksDimensions,
-  AxisTicksDimensions,
+  AxisViewModel,
   hasDuplicateAxis,
   defaultTickFormatter,
 } from '../../utils/axis_utils';
@@ -58,11 +58,11 @@ export const computeAxisTicksDimensionsSelector = createCustomCachedSelector(
     totalBarsInCluster,
     seriesSpecs,
     axesStyles,
-  ): Map<AxisId, AxisTicksDimensions> => {
+  ): Map<AxisId, AxisViewModel> => {
     const { xDomain, yDomains } = seriesDomainsAndData;
     const fallBackTickFormatter = seriesSpecs.find(({ tickFormat }) => tickFormat)?.tickFormat ?? defaultTickFormatter;
     const bboxCalculator = new CanvasTextBBoxCalculator();
-    const axesTicksDimensions: Map<AxisId, AxisTicksDimensions> = new Map();
+    const axesTicksDimensions: Map<AxisId, AxisViewModel> = new Map();
     axesSpecs.forEach((axisSpec) => {
       const { id } = axisSpec;
       const axisStyle = axesStyles.get(id) ?? chartTheme.axes;

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_debug_state.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_debug_state.ts
@@ -31,7 +31,7 @@ import {
 } from '../../../../state/types';
 import { AreaGeometry, BandedAccessorType, BarGeometry, LineGeometry, PerPanel } from '../../../../utils/geometry';
 import { FillStyle, Opacity, StrokeStyle, Visible } from '../../../../utils/themes/theme';
-import { isVerticalAxis } from '../../utils/axis_type_utils';
+import { isHorizontalAxis } from '../../utils/axis_type_utils';
 import { AxisGeometry } from '../../utils/axis_utils';
 import { LinesGrid } from '../../utils/grid_lines';
 import { computeAxesGeometriesSelector } from './compute_axes_geometries';
@@ -79,28 +79,20 @@ function getAxes(axesGeoms: AxisGeometry[], axesSpecs: AxisSpec[], gridLines: Li
 
       const gridlines = gridLines
         .flatMap(({ lineGroups }) => lineGroups.find(({ axisId }) => axisId === geom.axis.id)?.lines ?? [])
-        .map(({ x1, y1 }) => ({ x: x1, y: y1 }));
+        .map(({ x1: x, y1: y }) => ({ x, y }));
 
-      if (isVerticalAxis(position)) {
-        acc.y.push({
-          id,
-          title,
-          position,
-          // reverse for bottom/up coordinates
-          labels: labels.reverse(),
-          values: values.reverse(),
-          gridlines: gridlines.reverse(),
-        });
-      } else {
-        acc.x.push({ id, title, position, labels, values, gridlines });
-      }
+      acc[isHorizontalAxis(position) ? 'x' : 'y'].push({
+        id,
+        title,
+        position,
+        ...(isHorizontalAxis(position)
+          ? { labels, values, gridlines }
+          : { labels: labels.reverse(), values: values.reverse(), gridlines: gridlines.reverse() }),
+      });
 
       return acc;
     },
-    {
-      y: [],
-      x: [],
-    },
+    { x: [], y: [] },
   );
 }
 

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_debug_state.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_debug_state.ts
@@ -18,20 +18,19 @@
  */
 
 import { LegendItem } from '../../../../common/legend';
-import { Line } from '../../../../geoms/types';
 import { AxisSpec } from '../../../../specs';
 import { createCustomCachedSelector } from '../../../../state/create_selector';
 import {
   DebugState,
-  DebugStateValue,
-  DebugStateAxes,
   DebugStateArea,
-  DebugStateLine,
+  DebugStateAxes,
   DebugStateBar,
   DebugStateLegend,
+  DebugStateLine,
+  DebugStateValue,
 } from '../../../../state/types';
-import { AreaGeometry, BandedAccessorType, LineGeometry, BarGeometry, PerPanel } from '../../../../utils/geometry';
-import { FillStyle, Visible, StrokeStyle, Opacity } from '../../../../utils/themes/theme';
+import { AreaGeometry, BandedAccessorType, BarGeometry, LineGeometry, PerPanel } from '../../../../utils/geometry';
+import { FillStyle, Opacity, StrokeStyle, Visible } from '../../../../utils/themes/theme';
 import { isVerticalAxis } from '../../utils/axis_type_utils';
 import { AxisGeometry } from '../../utils/axis_utils';
 import { LinesGrid } from '../../utils/grid_lines';
@@ -83,15 +82,7 @@ function getAxes(axesGeoms: AxisGeometry[], axesSpecs: AxisSpec[], gridLines: Li
       const values = visibleTicks.map(({ value }) => value);
 
       const gridlines = gridLines
-        .reduce<Line[]>((accLines, { lineGroups }) => {
-          const groupLines = lineGroups.find(({ axisId }) => {
-            return axisId === geom.axis.id;
-          });
-          if (!groupLines) {
-            return accLines;
-          }
-          return [...accLines, ...groupLines.lines];
-        }, [])
+        .flatMap(({ lineGroups }) => lineGroups.find(({ axisId }) => axisId === geom.axis.id)?.lines ?? [])
         .map(({ x1, y1 }) => ({ x: x1, y: y1 }));
 
       if (isVerticalAxis(position)) {
@@ -105,14 +96,7 @@ function getAxes(axesGeoms: AxisGeometry[], axesSpecs: AxisSpec[], gridLines: Li
           gridlines: gridlines.reverse(),
         });
       } else {
-        acc.x.push({
-          id,
-          title,
-          position,
-          labels,
-          values,
-          gridlines,
-        });
+        acc.x.push({ id, title, position, labels, values, gridlines });
       }
 
       return acc;

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_debug_state.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_debug_state.ts
@@ -65,11 +65,7 @@ export const getDebugStateSelector = createCustomCachedSelector(
   },
 );
 
-function getAxes(axesGeoms: AxisGeometry[], axesSpecs: AxisSpec[], gridLines: LinesGrid[]): DebugStateAxes | undefined {
-  if (axesSpecs.length === 0) {
-    return;
-  }
-
+function getAxes(axesGeoms: AxisGeometry[], axesSpecs: AxisSpec[], gridLines: LinesGrid[]): DebugStateAxes {
   return axesSpecs.reduce<DebugStateAxes>(
     (acc, { position, title, id }) => {
       const geom = axesGeoms.find(({ axis }) => axis.id === id);

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/merge_y_custom_domains.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/merge_y_custom_domains.ts
@@ -19,7 +19,7 @@
 
 import { Rotation } from '../../../../utils/common';
 import { GroupId } from '../../../../utils/ids';
-import { isCompleteBound, isLowerBound, isUpperBound, isBounded } from '../../utils/axis_type_utils';
+import { isBounded, isCompleteBound, isLowerBound, isUpperBound } from '../../utils/axis_type_utils';
 import { isYDomain } from '../../utils/axis_utils';
 import { AxisSpec, YDomainRange } from '../../utils/specs';
 
@@ -37,9 +37,7 @@ export function mergeYCustomDomainsByGroupId(
       return;
     }
 
-    const isAxisYDomain = isYDomain(spec.position, chartRotation);
-
-    if (!isAxisYDomain) {
+    if (!isYDomain(spec.position, chartRotation)) {
       const errorMessage = `[Axis ${id}]: custom domain for xDomain should be defined in Settings`;
       throw new Error(errorMessage);
     }

--- a/packages/charts/src/chart_types/xy_chart/state/utils/utils.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/utils/utils.test.ts
@@ -220,8 +220,6 @@ describe('Chart State utils', () => {
         const { formattedDataSeries } = computeSeriesDomainsSelector(store.getState());
         const actual = getCustomSeriesColors(formattedDataSeries);
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         expect([...actual.values()]).toEqualArrayOf(color);
       });
 

--- a/packages/charts/src/chart_types/xy_chart/state/utils/utils.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/utils/utils.test.ts
@@ -220,6 +220,8 @@ describe('Chart State utils', () => {
         const { formattedDataSeries } = computeSeriesDomainsSelector(store.getState());
         const actual = getCustomSeriesColors(formattedDataSeries);
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         expect([...actual.values()]).toEqualArrayOf(color);
       });
 

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
@@ -1028,7 +1028,8 @@ describe('Axis computational utils', () => {
     const leftAxisPosition = getAxisPosition(
       chartDim,
       LIGHT_THEME.chartMargins,
-      axisTitleStyles(axisTitleHeight),
+      axisTitleStyles(axisTitleHeight).axisTitle,
+      axisTitleStyles(axisTitleHeight).axisPanelTitle,
       verticalAxisSpec,
       axis1Dims,
       emptySmScales,
@@ -1068,7 +1069,8 @@ describe('Axis computational utils', () => {
     const rightAxisPosition = getAxisPosition(
       chartDim,
       LIGHT_THEME.chartMargins,
-      axisTitleStyles(axisTitleHeight),
+      axisTitleStyles(axisTitleHeight).axisTitle,
+      axisTitleStyles(axisTitleHeight).axisPanelTitle,
       verticalAxisSpec,
       axis1Dims,
       emptySmScales,
@@ -1108,7 +1110,8 @@ describe('Axis computational utils', () => {
     const topAxisPosition = getAxisPosition(
       chartDim,
       LIGHT_THEME.chartMargins,
-      axisTitleStyles(axisTitleHeight),
+      axisTitleStyles(axisTitleHeight).axisTitle,
+      axisTitleStyles(axisTitleHeight).axisPanelTitle,
       horizontalAxisSpec,
       axis1Dims,
       emptySmScales,
@@ -1149,7 +1152,8 @@ describe('Axis computational utils', () => {
     const bottomAxisPosition = getAxisPosition(
       chartDim,
       LIGHT_THEME.chartMargins,
-      axisTitleStyles(axisTitleHeight),
+      axisTitleStyles(axisTitleHeight).axisTitle,
+      axisTitleStyles(axisTitleHeight).axisPanelTitle,
       horizontalAxisSpec,
       axis1Dims,
       emptySmScales,
@@ -1744,7 +1748,8 @@ describe('Axis computational utils', () => {
         const leftAxisPosition = getAxisPosition(
           chartDim,
           LIGHT_THEME.chartMargins,
-          axisStyles,
+          axisStyles.axisTitle,
+          axisStyles.axisPanelTitle,
           { ...verticalAxisSpec, title },
           axis1Dims,
           smScales,
@@ -1778,7 +1783,8 @@ describe('Axis computational utils', () => {
         const rightAxisPosition = getAxisPosition(
           chartDim,
           LIGHT_THEME.chartMargins,
-          axisStyles,
+          axisStyles.axisTitle,
+          axisStyles.axisPanelTitle,
           { ...verticalAxisSpec, title },
           axis1Dims,
           smScales,
@@ -1812,7 +1818,8 @@ describe('Axis computational utils', () => {
         const topAxisPosition = getAxisPosition(
           chartDim,
           LIGHT_THEME.chartMargins,
-          axisStyles,
+          axisStyles.axisTitle,
+          axisStyles.axisPanelTitle,
           { ...horizontalAxisSpec, title },
           axis1Dims,
           smScales,
@@ -1846,7 +1853,8 @@ describe('Axis computational utils', () => {
         const bottomAxisPosition = getAxisPosition(
           chartDim,
           LIGHT_THEME.chartMargins,
-          axisStyles,
+          axisStyles.axisTitle,
+          axisStyles.axisPanelTitle,
           { ...horizontalAxisSpec, title },
           axis1Dims,
           smScales,

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
@@ -44,7 +44,7 @@ import { mergeYCustomDomainsByGroupId } from '../state/selectors/merge_y_custom_
 import {
   AxisTick,
   AxisViewModel,
-  computeAxisTicksDimensions,
+  axisViewModel,
   computeRotatedLabelDimensions,
   getAvailableTicks,
   getAxisPosition,
@@ -226,7 +226,7 @@ describe('Axis computational utils', () => {
 
   test('should compute axis dimensions', () => {
     const bboxCalculator = new SvgTextBBoxCalculator();
-    const axisDimensions = computeAxisTicksDimensions(
+    const axisDimensions = axisViewModel(
       verticalAxisSpec,
       xDomain,
       [yDomain],
@@ -239,7 +239,7 @@ describe('Axis computational utils', () => {
     expect(axisDimensions).toEqual(axis1Dims);
 
     const ungroupedAxisSpec = { ...verticalAxisSpec, groupId: 'foo' };
-    const result = computeAxisTicksDimensions(
+    const result = axisViewModel(
       ungroupedAxisSpec,
       xDomain,
       [yDomain],
@@ -260,7 +260,7 @@ describe('Axis computational utils', () => {
   test('should not compute axis dimensions when spec is configured to hide', () => {
     const bboxCalculator = new CanvasTextBBoxCalculator();
     verticalAxisSpec.hide = true;
-    const axisDimensions = computeAxisTicksDimensions(
+    const axisDimensions = axisViewModel(
       verticalAxisSpec,
       xDomain,
       [yDomain],
@@ -281,7 +281,7 @@ describe('Axis computational utils', () => {
       minInterval: 0,
       timeZone: 'utc',
     });
-    let axisDimensions = computeAxisTicksDimensions(
+    let axisDimensions = axisViewModel(
       xAxisWithTime,
       xDomain,
       [yDomain],
@@ -295,7 +295,7 @@ describe('Axis computational utils', () => {
     expect(axisDimensions?.tickLabels[0]).toBe('11:00:00');
     expect(axisDimensions?.tickLabels[11]).toBe('11:55:00');
 
-    axisDimensions = computeAxisTicksDimensions(
+    axisDimensions = axisViewModel(
       xAxisWithTime,
       {
         ...xDomain,
@@ -312,7 +312,7 @@ describe('Axis computational utils', () => {
     expect(axisDimensions?.tickLabels[0]).toBe('14:00:00');
     expect(axisDimensions?.tickLabels[11]).toBe('14:55:00');
 
-    axisDimensions = computeAxisTicksDimensions(
+    axisDimensions = axisViewModel(
       xAxisWithTime,
       {
         ...xDomain,

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
@@ -50,7 +50,6 @@ import {
   getAxisPosition,
   getAxesGeometries,
   getHorizontalAxisTickLineProps,
-  getMaxLabelDimensions,
   getMinMaxRange,
   getScaleForAxisSpec,
   getTickLabelProps,
@@ -704,18 +703,6 @@ describe('Axis computational utils', () => {
       height: 50,
     });
     expect(minMax).toEqual({ minRange: 50, maxRange: 0 });
-  });
-  test('should get max bbox dimensions for a tick in comparison to previous values', () => {
-    const bboxCalculator = new CanvasTextBBoxCalculator();
-    const reducer = getMaxLabelDimensions(bboxCalculator, LIGHT_THEME.axes.tickLabel);
-
-    const accWithGreaterValues = {
-      maxLabelBboxWidth: 100,
-      maxLabelBboxHeight: 100,
-      maxLabelTextWidth: 100,
-      maxLabelTextHeight: 100,
-    };
-    expect(reducer(accWithGreaterValues, 'foo')).toEqual(accWithGreaterValues);
   });
 
   test('should compute positions and alignment of tick labels along a vertical axis', () => {

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
@@ -18,7 +18,6 @@
  */
 
 import { DateTime } from 'luxon';
-// @ts-ignore
 import moment from 'moment-timezone';
 
 import { ChartType } from '../..';

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
@@ -43,7 +43,7 @@ import { computeGridLinesSelector } from '../state/selectors/get_grid_lines';
 import { mergeYCustomDomainsByGroupId } from '../state/selectors/merge_y_custom_domains';
 import {
   AxisTick,
-  AxisTicksDimensions,
+  AxisViewModel,
   computeAxisTicksDimensions,
   computeRotatedLabelDimensions,
   getAvailableTicks,
@@ -363,7 +363,7 @@ describe('Axis computational utils', () => {
     expect(xScale).toBeDefined();
   });
 
-  const axisDimensions: AxisTicksDimensions = {
+  const axisDimensions: AxisViewModel = {
     maxLabelBboxWidth: 100,
     maxLabelBboxHeight: 100,
     maxLabelTextHeight: 100,
@@ -1193,7 +1193,7 @@ describe('Axis computational utils', () => {
   test('should not compute axis ticks positions if missaligned specs', () => {
     const axisSpecs = [verticalAxisSpec];
     const axisStyles = new Map();
-    const axisDims = new Map<AxisId, AxisTicksDimensions>();
+    const axisDims = new Map<AxisId, AxisViewModel>();
     axisDims.set('not_a_mapped_one', axis1Dims);
 
     const axisTicksPosition = getAxesGeometries(

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { DateTime } from 'luxon';
+// @ts-ignore
 import moment from 'moment-timezone';
 
 import { ChartType } from '../..';
@@ -347,7 +348,7 @@ describe('Axis computational utils', () => {
   });
 
   test('should generate a valid scale', () => {
-    const yScale = getScaleForAxisSpec(verticalAxisSpec, xDomain, [yDomain], 0, 0, 100, 0);
+    const yScale = getScaleForAxisSpec(verticalAxisSpec, xDomain, [yDomain], 0, 0, [100, 0]);
     expect(yScale).toBeDefined();
     expect(yScale?.bandwidth).toBe(0);
     expect(yScale?.domain).toEqual([0, 1]);
@@ -355,10 +356,10 @@ describe('Axis computational utils', () => {
     expect(yScale?.ticks()).toEqual([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]);
 
     const ungroupedAxisSpec = { ...verticalAxisSpec, groupId: 'foo' };
-    const nullYScale = getScaleForAxisSpec(ungroupedAxisSpec, xDomain, [yDomain], 0, 0, 100, 0);
+    const nullYScale = getScaleForAxisSpec(ungroupedAxisSpec, xDomain, [yDomain], 0, 0, [100, 0]);
     expect(nullYScale).toBe(null);
 
-    const xScale = getScaleForAxisSpec(horizontalAxisSpec, xDomain, [yDomain], 0, 0, 100, 0);
+    const xScale = getScaleForAxisSpec(horizontalAxisSpec, xDomain, [yDomain], 0, 0, [100, 0]);
     expect(xScale).toBeDefined();
   });
 
@@ -379,7 +380,7 @@ describe('Axis computational utils', () => {
 
   describe('getAvailableTicks', () => {
     test('should compute to end of domain when histogram mode not enabled', () => {
-      const scale = getScaleForAxisSpec(verticalAxisSpec, xDomain, [yDomain], 0, 0, 100, 0);
+      const scale = getScaleForAxisSpec(verticalAxisSpec, xDomain, [yDomain], 0, 0, [100, 0]);
       const axisPositions = getAvailableTicks(verticalAxisSpec, scale!, 0, false, (v) => `${v}`, 0);
       const expectedAxisPositions = [
         { label: '0', position: 100, value: 0 },
@@ -399,7 +400,7 @@ describe('Axis computational utils', () => {
 
     test('should compute positions with rotational offset', () => {
       const rotationalOffset = 2;
-      const scale = getScaleForAxisSpec(verticalAxisSpec, xDomain, [yDomain], 0, 0, 100, 0);
+      const scale = getScaleForAxisSpec(verticalAxisSpec, xDomain, [yDomain], 0, 0, [100, 0]);
       const axisPositions = getAvailableTicks(verticalAxisSpec, scale!, 0, false, (v) => `${v}`, rotationalOffset);
       const expectedAxisPositions = [
         { label: '0', position: 100 + rotationalOffset, value: 0 },
@@ -424,7 +425,7 @@ describe('Axis computational utils', () => {
         isBandScale: true,
         minInterval: 10,
       });
-      const xScale = getScaleForAxisSpec(horizontalAxisSpec, xBandDomain, [yDomain], 1, 0, 100, 0);
+      const xScale = getScaleForAxisSpec(horizontalAxisSpec, xBandDomain, [yDomain], 1, 0, [100, 0]);
       const histogramAxisPositions = getAvailableTicks(
         horizontalAxisSpec,
         xScale!,
@@ -444,7 +445,7 @@ describe('Axis computational utils', () => {
         isBandScale: true,
         minInterval: 90000,
       });
-      const xScale = getScaleForAxisSpec(horizontalAxisSpec, xBandDomain, [yDomain], 1, 0, 100, 0);
+      const xScale = getScaleForAxisSpec(horizontalAxisSpec, xBandDomain, [yDomain], 1, 0, [100, 0]);
       const histogramAxisPositions = getAvailableTicks(
         horizontalAxisSpec,
         xScale!,
@@ -481,7 +482,7 @@ describe('Axis computational utils', () => {
         isBandScale: true,
         minInterval: 90000,
       });
-      const xScale = getScaleForAxisSpec(horizontalAxisSpec, xBandDomain, [yDomain], 1, 0, 100, 0);
+      const xScale = getScaleForAxisSpec(horizontalAxisSpec, xBandDomain, [yDomain], 1, 0, [100, 0]);
       const histogramAxisPositions = getAvailableTicks(
         horizontalAxisSpec,
         xScale!,

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
@@ -205,8 +205,7 @@ export function computeRotatedLabelDimensions(unrotatedDims: BBox, degreesRotati
   };
 }
 
-/** @internal */
-export const getMaxLabelDimensions = (
+const getMaxLabelDimensions = (
   bboxCalculator: BBoxCalculator,
   { fontSize, fontFamily, rotation }: AxisStyle['tickLabel'],
 ) => (

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
@@ -126,8 +126,20 @@ export function axisViewModel(
 
   const tickFormat = axisSpec.labelFormat ?? axisSpec.tickFormat ?? fallBackTickFormatter;
   const tickFormatOptions = { timeZone: xDomain.timeZone };
-  const dimensions = computeTickDimensions(scale, tickFormat, bboxCalculator, tickLabel, tickFormatOptions);
-  return { ...dimensions, isHidden: axisSpec.hide && gridLineVisible };
+
+  const tickValues = scale.ticks();
+  const tickLabels = tickValues.map((d) => tickFormat(d, tickFormatOptions));
+  const defaultAcc = { maxLabelBboxWidth: 0, maxLabelBboxHeight: 0, maxLabelTextWidth: 0, maxLabelTextHeight: 0 };
+  const dimensions = tickLabel.visible
+    ? tickLabels.reduce(getMaxLabelDimensions(bboxCalculator, tickLabel), defaultAcc)
+    : defaultAcc;
+
+  return {
+    ...dimensions,
+    tickValues,
+    tickLabels,
+    isHidden: axisSpec.hide && gridLineVisible,
+  };
 }
 
 /** @internal */
@@ -216,27 +228,6 @@ export const getMaxLabelDimensions = (
     maxLabelTextHeight: prevLabelHeight > labelHeight ? prevLabelHeight : labelHeight,
   };
 };
-
-function computeTickDimensions(
-  scale: Scale,
-  tickFormat: TickFormatter,
-  bboxCalculator: BBoxCalculator,
-  tickLabel: AxisStyle['tickLabel'],
-  tickFormatOptions: TickFormatterOptions,
-) {
-  const tickValues = scale.ticks();
-  const tickLabels = tickValues.map((d) => tickFormat(d, tickFormatOptions));
-  const defaultAcc = { maxLabelBboxWidth: 0, maxLabelBboxHeight: 0, maxLabelTextWidth: 0, maxLabelTextHeight: 0 };
-  const dimensions = tickLabel.visible
-    ? tickLabels.reduce(getMaxLabelDimensions(bboxCalculator, tickLabel), defaultAcc)
-    : defaultAcc;
-
-  return {
-    ...dimensions,
-    tickValues,
-    tickLabels,
-  };
-}
 
 function getUserTextOffsets(dimensions: AxisViewModel, offset: TextOffset) {
   const defaults = {

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
@@ -52,7 +52,7 @@ export interface AxisTick {
 }
 
 /** @internal */
-export interface AxisTicksDimensions {
+export interface AxisViewModel {
   tickValues: string[] | number[];
   tickLabels: string[];
   maxLabelBboxWidth: number;
@@ -110,7 +110,7 @@ export function computeAxisTicksDimensions(
   fallBackTickFormatter: TickFormatter,
   barsPadding?: number,
   enableHistogramMode?: boolean,
-): AxisTicksDimensions | null {
+): AxisViewModel | null {
   const gridLineVisible = isVerticalAxis(axisSpec.position) ? gridLine.vertical.visible : gridLine.horizontal.visible;
 
   // don't compute anything on this axis if grid is hidden and axis is hidden
@@ -261,7 +261,7 @@ function computeTickDimensions(
   };
 }
 
-function getUserTextOffsets(dimensions: AxisTicksDimensions, offset: TextOffset) {
+function getUserTextOffsets(dimensions: AxisViewModel, offset: TextOffset) {
   const defaults = {
     x: 0,
     y: 0,
@@ -410,7 +410,7 @@ export function getTickLabelProps(
   position: Position,
   rotation: number,
   axisSize: Size,
-  tickDimensions: AxisTicksDimensions,
+  tickDimensions: AxisViewModel,
   showTicks: boolean,
   textOffset: TextOffset,
   textAlignment?: TextAlignment,
@@ -621,7 +621,7 @@ export function enableDuplicatedTicks(
 }
 
 /** @internal */
-export function getVisibleTicks(allTicks: AxisTick[], axisSpec: AxisSpec, axisDim: AxisTicksDimensions): AxisTick[] {
+export function getVisibleTicks(allTicks: AxisTick[], axisSpec: AxisSpec, axisDim: AxisViewModel): AxisTick[] {
   // We sort the ticks by position so that we can incrementally compute previousOccupiedSpace
   allTicks.sort((a: AxisTick, b: AxisTick) => a.position - b.position);
 
@@ -672,7 +672,7 @@ export function getAxisPosition(
   chartMargins: Margins,
   { axisTitle, axisPanelTitle }: Pick<AxisStyle, 'axisTitle' | 'axisPanelTitle'>,
   axisSpec: AxisSpec,
-  axisDim: AxisTicksDimensions,
+  axisDim: AxisViewModel,
   smScales: SmallMultipleScales,
   cumTopSum: number,
   cumBottomSum: number,
@@ -742,7 +742,7 @@ export interface AxisGeometry {
     panelTitle?: string; // defined later per panel
     secondary?: boolean; // defined later per panel
   };
-  dimension: AxisTicksDimensions;
+  dimension: AxisViewModel;
   ticks: AxisTick[];
   visibleTicks: AxisTick[];
 }
@@ -756,7 +756,7 @@ export function getAxesGeometries(
   { chartPaddings, chartMargins, axes: sharedAxesStyle }: Theme,
   chartRotation: Rotation,
   axisSpecs: AxisSpec[],
-  axisDimensions: Map<AxisId, AxisTicksDimensions>,
+  axisDimensions: Map<AxisId, AxisViewModel>,
   axesStyles: Map<AxisId, AxisStyle | null>,
   xDomain: XDomain,
   yDomains: YDomain[],
@@ -912,8 +912,8 @@ export function getAxesGeometries(
 /** @internal */
 export const hasDuplicateAxis = (
   { position, title }: AxisSpec,
-  { tickLabels }: AxisTicksDimensions,
-  tickMap: Map<AxisId, AxisTicksDimensions>,
+  { tickLabels }: AxisViewModel,
+  tickMap: Map<AxisId, AxisViewModel>,
   specs: AxisSpec[],
 ): boolean =>
   [...tickMap].some(([axisId, { tickLabels: axisTickLabels }]) => {

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
@@ -30,6 +30,7 @@ import {
   VerticalAlignment,
 } from '../../../utils/common';
 import { Dimensions, getSimplePadding, Margins, Size } from '../../../utils/dimensions';
+import { Range } from '../../../utils/domain';
 import { AxisId } from '../../../utils/ids';
 import { Logger } from '../../../utils/logger';
 import { Point } from '../../../utils/point';
@@ -169,7 +170,7 @@ export function getScaleForAxisSpec(
   yDomains: YDomain[],
   totalBarsInCluster: number,
   chartRotation: Rotation,
-  range: [number, number],
+  range: Range,
   barsPadding?: number,
   enableHistogramMode?: boolean,
 ): Scale | null {

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
@@ -910,7 +910,7 @@ export function getAxesGeometries(
 }
 
 /** @internal */
-export const isDuplicateAxis = (
+export const hasDuplicateAxis = (
   { position, title }: AxisSpec,
   { tickLabels }: AxisTicksDimensions,
   tickMap: Map<AxisId, AxisTicksDimensions>,

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
@@ -51,14 +51,17 @@ export interface AxisTick {
   position: number;
 }
 
-/** @internal */
-export interface AxisViewModel {
-  tickValues: string[] | number[];
-  tickLabels: string[];
+interface LabelSizeModel {
   maxLabelBboxWidth: number;
   maxLabelBboxHeight: number;
   maxLabelTextWidth: number;
   maxLabelTextHeight: number;
+}
+
+/** @internal */
+export interface AxisViewModel extends LabelSizeModel {
+  tickValues: string[] | number[];
+  tickLabels: string[];
   isHidden: boolean;
 }
 
@@ -79,6 +82,13 @@ export interface TickLabelProps {
     typeof VerticalAlignment.Top | typeof VerticalAlignment.Middle | typeof VerticalAlignment.Bottom
   >;
 }
+
+const initialLabelSizeModel = () => ({
+  maxLabelBboxWidth: 0,
+  maxLabelBboxHeight: 0,
+  maxLabelTextWidth: 0,
+  maxLabelTextHeight: 0,
+});
 
 /** @internal */
 export const defaultTickFormatter = (tick: unknown) => `${tick}`;
@@ -129,10 +139,9 @@ export function axisViewModel(
 
   const tickValues = scale.ticks();
   const tickLabels = tickValues.map((d) => tickFormat(d, tickFormatOptions));
-  const defaultAcc = { maxLabelBboxWidth: 0, maxLabelBboxHeight: 0, maxLabelTextWidth: 0, maxLabelTextHeight: 0 };
   const dimensions = tickLabel.visible
-    ? tickLabels.reduce(getMaxLabelDimensions(bboxCalculator, tickLabel), defaultAcc)
-    : defaultAcc;
+    ? tickLabels.reduce(getMaxLabelDimensions(bboxCalculator, tickLabel), initialLabelSizeModel())
+    : initialLabelSizeModel();
 
   return {
     ...dimensions,

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
@@ -43,16 +43,18 @@ import { getPanelSize, hasSMDomain } from './panel';
 import { computeXScale, computeYScales } from './scales';
 import { AxisSpec, TickFormatter, TickFormatterOptions } from './specs';
 
+type TickValue = number | string;
+
 /** @internal */
 export interface AxisTick {
-  value: number | string;
+  value: TickValue;
   label: string;
   position: number;
 }
 
 /** @internal */
 export interface AxisViewModel {
-  tickValues: string[] | number[];
+  tickValues: TickValue[];
   tickLabels: string[];
   maxLabelBboxWidth: number;
   maxLabelBboxHeight: number;

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
@@ -86,20 +86,9 @@ export const defaultTickFormatter = (tick: any) => `${tick}`;
 /**
  * Compute the ticks values and identify max width and height of the labels
  * so we can compute the max space occupied by the axis component.
- * @param axisSpec the spec of the axis
- * @param xDomain the x domain associated
- * @param yDomains the y domain array
- * @param totalBarsInCluster the total number of grouped series
- * @param bboxCalculator an instance of the boundingbox calculator
- * @param chartRotation the rotation of the chart
- * @param gridLine
- * @param tickLabel
- * @param fallBackTickFormatter
- * @param barsPadding
- * @param enableHistogramMode
  * @internal
  */
-export function computeAxisTicksDimensions(
+export function axisViewModel(
   axisSpec: AxisSpec,
   xDomain: XDomain,
   yDomains: YDomain[],
@@ -132,7 +121,6 @@ export function computeAxisTicksDimensions(
 
   if (!scale) {
     Logger.warn(`Cannot compute scale for axis spec ${axisSpec.id}. Axis will not be displayed.`);
-
     return null;
   }
 

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
@@ -81,7 +81,7 @@ export interface TickLabelProps {
 }
 
 /** @internal */
-export const defaultTickFormatter = (tick: any) => `${tick}`;
+export const defaultTickFormatter = (tick: unknown) => `${tick}`;
 
 /**
  * Compute the ticks values and identify max width and height of the labels
@@ -124,27 +124,16 @@ export function axisViewModel(
     return null;
   }
 
-  const dimensions = computeTickDimensions(
-    scale,
-    axisSpec.labelFormat ?? axisSpec.tickFormat ?? fallBackTickFormatter,
-    bboxCalculator,
-    tickLabel,
-    { timeZone: xDomain.timeZone },
-  );
-  return {
-    ...dimensions,
-    isHidden: axisSpec.hide && gridLineVisible,
-  };
+  const tickFormat = axisSpec.labelFormat ?? axisSpec.tickFormat ?? fallBackTickFormatter;
+  const tickFormatOptions = { timeZone: xDomain.timeZone };
+  const dimensions = computeTickDimensions(scale, tickFormat, bboxCalculator, tickLabel, tickFormatOptions);
+  return { ...dimensions, isHidden: axisSpec.hide && gridLineVisible };
 }
 
 /** @internal */
 export function isYDomain(position: Position, chartRotation: Rotation): boolean {
   const isStraightRotation = chartRotation === 0 || chartRotation === 180;
-  if (isVerticalAxis(position)) {
-    return isStraightRotation;
-  }
-
-  return !isStraightRotation;
+  return isVerticalAxis(position) === isStraightRotation;
 }
 
 /** @internal */
@@ -232,14 +221,14 @@ function computeTickDimensions(
   scale: Scale,
   tickFormat: TickFormatter,
   bboxCalculator: BBoxCalculator,
-  tickLabelStyle: AxisStyle['tickLabel'],
-  tickFormatOptions?: TickFormatterOptions,
+  tickLabel: AxisStyle['tickLabel'],
+  tickFormatOptions: TickFormatterOptions,
 ) {
   const tickValues = scale.ticks();
   const tickLabels = tickValues.map((d) => tickFormat(d, tickFormatOptions));
   const defaultAcc = { maxLabelBboxWidth: 0, maxLabelBboxHeight: 0, maxLabelTextWidth: 0, maxLabelTextHeight: 0 };
-  const dimensions = tickLabelStyle.visible
-    ? tickLabels.reduce(getMaxLabelDimensions(bboxCalculator, tickLabelStyle), defaultAcc)
+  const dimensions = tickLabel.visible
+    ? tickLabels.reduce(getMaxLabelDimensions(bboxCalculator, tickLabel), defaultAcc)
     : defaultAcc;
 
   return {

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
@@ -598,7 +598,8 @@ export function getTitleDimension({
 export function getAxisPosition(
   chartDimensions: Dimensions,
   chartMargins: Margins,
-  { axisTitle, axisPanelTitle }: Pick<AxisStyle, 'axisTitle' | 'axisPanelTitle'>,
+  axisTitle: AxisStyle['axisTitle'],
+  axisPanelTitle: AxisStyle['axisPanelTitle'],
   axisSpec: AxisSpec,
   axisDim: AxisViewModel,
   smScales: SmallMultipleScales,
@@ -706,7 +707,7 @@ export function getAxesGeometries(
         return acc;
       }
 
-      const { tickLine, tickLabel, ...otherStyles } = axesStyles.get(axisId) ?? sharedAxesStyle;
+      const { tickLine, tickLabel, axisTitle, axisPanelTitle } = axesStyles.get(axisId) ?? sharedAxesStyle;
       const labelPadding = getSimplePadding(tickLabel.padding);
       const showTicks = shouldShowTicks(tickLine, axisSpec.hide);
       const tickDimension = showTicks ? tickLine.size + tickLine.padding : 0;
@@ -715,7 +716,8 @@ export function getAxesGeometries(
       const { dimensions, topIncrement, bottomIncrement, leftIncrement, rightIncrement } = getAxisPosition(
         chartDimensions,
         chartMargins,
-        otherStyles,
+        axisTitle,
+        axisPanelTitle,
         axisSpec,
         dimension,
         smScales,

--- a/packages/charts/src/chart_types/xy_chart/utils/dimensions.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/dimensions.test.ts
@@ -24,7 +24,7 @@ import { Margins } from '../../../utils/dimensions';
 import { AxisId } from '../../../utils/ids';
 import { LIGHT_THEME } from '../../../utils/themes/light_theme';
 import { LegendStyle } from '../../../utils/themes/theme';
-import { AxisTicksDimensions } from './axis_utils';
+import { AxisViewModel } from './axis_utils';
 import { computeChartDimensions } from './dimensions';
 import { AxisSpec } from './specs';
 
@@ -48,7 +48,7 @@ describe('Computed chart dimensions', () => {
     bottom: 10,
   };
 
-  const axis1Dims: AxisTicksDimensions = {
+  const axis1Dims: AxisViewModel = {
     tickValues: [0, 1],
     tickLabels: ['first', 'second'],
     maxLabelBboxWidth: 10,
@@ -87,7 +87,7 @@ describe('Computed chart dimensions', () => {
   chartTheme.axes.axisTitle.fontSize = 10;
   chartTheme.axes.axisTitle.padding = 10;
   test('should be equal to parent dimension with no axis minus margins', () => {
-    const axisDims = new Map<AxisId, AxisTicksDimensions>();
+    const axisDims = new Map<AxisId, AxisViewModel>();
     const axisStyles = new Map();
     const axisSpecs: AxisSpec[] = [];
     const { chartDimensions } = computeChartDimensions(parentDim, chartTheme, axisDims, axisStyles, axisSpecs);
@@ -98,7 +98,7 @@ describe('Computed chart dimensions', () => {
   test('should be padded by a left axis', () => {
     // |margin|titleFontSize|titlePadding|maxLabelBboxWidth|tickPadding|tickSize|padding|
     // \10|10|10|10|10|10|10| = 70px from left
-    const axisDims = new Map<AxisId, AxisTicksDimensions>();
+    const axisDims = new Map<AxisId, AxisViewModel>();
     const axisStyles = new Map();
     const axisSpecs = [axisLeftSpec];
     axisDims.set('axis_1', axis1Dims);
@@ -110,7 +110,7 @@ describe('Computed chart dimensions', () => {
   test('should be padded by a right axis', () => {
     // |padding|tickSize|tickPadding|maxLabelBBoxWidth|titlePadding|titleFontSize\margin|
     // \10|10|10|10|10|10|10| = 70px from right
-    const axisDims = new Map<AxisId, AxisTicksDimensions>();
+    const axisDims = new Map<AxisId, AxisViewModel>();
     const axisStyles = new Map();
     const axisSpecs = [{ ...axisLeftSpec, position: Position.Right }];
     axisDims.set('axis_1', axis1Dims);
@@ -122,7 +122,7 @@ describe('Computed chart dimensions', () => {
   test('should be padded by a top axis', () => {
     // |margin|titleFontSize|titlePadding|maxLabelBboxHeight|tickPadding|tickSize|padding|
     // \10|10|10|10|10|10|10| = 70px from top
-    const axisDims = new Map<AxisId, AxisTicksDimensions>();
+    const axisDims = new Map<AxisId, AxisViewModel>();
     const axisStyles = new Map();
     const axisSpecs = [
       {
@@ -139,7 +139,7 @@ describe('Computed chart dimensions', () => {
   test('should be padded by a bottom axis', () => {
     // |margin|titleFontSize|titlePadding|maxLabelBboxHeight|tickPadding|tickSize|padding|
     // \10|10|10|10|10|10|10| = 70px from bottom
-    const axisDims = new Map<AxisId, AxisTicksDimensions>();
+    const axisDims = new Map<AxisId, AxisViewModel>();
     const axisStyles = new Map();
     const axisSpecs = [
       {
@@ -154,7 +154,7 @@ describe('Computed chart dimensions', () => {
     expect(chartDimensions).toMatchSnapshot();
   });
   test('should not add space for axis when no spec for axis dimensions or axis is hidden', () => {
-    const axisDims = new Map<AxisId, AxisTicksDimensions>();
+    const axisDims = new Map<AxisId, AxisViewModel>();
     const axisStyles = new Map();
     const axisSpecs = [
       {
@@ -177,7 +177,7 @@ describe('Computed chart dimensions', () => {
 
     expect(chartDimensions).toEqual(expectedDims);
 
-    const hiddenAxisDims = new Map<AxisId, AxisTicksDimensions>();
+    const hiddenAxisDims = new Map<AxisId, AxisViewModel>();
     const hiddenAxisSpecs = new Map<AxisId, AxisSpec>();
     hiddenAxisDims.set('axis_1', axis1Dims);
     hiddenAxisSpecs.set('axis_1', {

--- a/packages/charts/src/chart_types/xy_chart/utils/dimensions.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/dimensions.ts
@@ -22,7 +22,7 @@ import { Dimensions } from '../../../utils/dimensions';
 import { AxisId } from '../../../utils/ids';
 import { Theme, AxisStyle } from '../../../utils/themes/theme';
 import { computeAxesSizes } from '../axes/axes_sizes';
-import { AxisTicksDimensions } from './axis_utils';
+import { AxisViewModel } from './axis_utils';
 import { AxisSpec } from './specs';
 
 /**
@@ -47,7 +47,7 @@ export interface ChartDimensions {
 export function computeChartDimensions(
   parentDimensions: Dimensions,
   theme: Theme,
-  axisDimensions: Map<AxisId, AxisTicksDimensions>,
+  axisDimensions: Map<AxisId, AxisViewModel>,
   axesStyles: Map<AxisId, AxisStyle | null>,
   axisSpecs: AxisSpec[],
   smSpec?: SmallMultiplesSpec,


### PR DESCRIPTION
## Summary
Logic preserving refactoring in preparation for added time axis functionality. No change to the API or test results.
<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper chart type label was added (e.g. :xy, :partition) if the PR involves a specific chart type
- [x] The proper feature label was added (e.g. :interactions, :axis) if the PR involves a specific chart feature
- [x] This was checked for cross-browser compatibility
- [x] Unit tests were updated or added to match the most common scenarios
