### PR TITLE
ci: fix semantic-release slack-bot config

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -25,12 +25,14 @@ module.exports = {
     ...(isDryRun
       ? []
       : [
-          'semantic-release-slack-bot',
-          {
-            notifyOnSuccess: true,
-            notifyOnFail: true,
-            markdownReleaseNotes: true,
-          },
+          [
+            'semantic-release-slack-bot',
+            {
+              notifyOnSuccess: true,
+              notifyOnFail: true,
+              markdownReleaseNotes: true,
+            },
+          ],
         ]),
   ],
 };


### PR DESCRIPTION
## Summary

The current spread operator wrongly spread the `semantic-release-slack-bot` plugin definition as there were two different plugin.
This PR correct that spread, keeping the plugin name and the configuration within an array as requested

