### PR TITLE
ci: fix package versioning script

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -8,6 +8,9 @@ const isDryRun = process.argv.includes('--dry-run');
  *
  * see https://github.com/semantic-release/semantic-release/issues/193
  */
+
+const path = require('path');
+
 module.exports = {
   plugins: [
     '@semantic-release/commit-analyzer',
@@ -18,7 +21,7 @@ module.exports = {
       '@semantic-release/npm',
       {
         // must point to the child package
-        pkgRoot: 'packages/charts',
+        pkgRoot: path.resolve(__dirname, './packages/charts'),
       },
     ],
     '@semantic-release/git',

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/charts",
   "description": "Elastic-Charts data visualization library",
-  "version": "30.0.0",
+  "version": "33.2.0",
   "author": "Elastic DataVis",
   "license": "Apache-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Fix package versioning script

## Details
The path to the `pkgRoot` in the `@semantic-release/npm` config should be a full resolved path as shown below.

https://github.com/semantic-release/npm/blob/d5cab62ee88e38f2b866feda5c7af8fce95c0173/lib/prepare.js#L5-L6