### PR TITLE
chore(xy): avoid large dimensions in ctx.clearRect

### DIFF
--- a/packages/charts/src/chart_types/goal_chart/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/goal_chart/renderer/canvas/canvas_renderers.ts
@@ -30,10 +30,9 @@ export function renderCanvas2d(ctx: CanvasRenderingContext2D, dpr: number, geomO
 
     renderLayers(ctx, [
       // clear the canvas
-      (context: CanvasRenderingContext2D) => clearCanvas(context, 200000, 200000),
-
+      clearCanvas,
       (context: CanvasRenderingContext2D) =>
-        withContext(context, (ctx) => geomObjects.forEach((obj) => withContext(ctx, (ctx) => obj.render(ctx)))),
+        geomObjects.forEach((obj) => withContext(context, (ctxt) => obj.render(ctxt))),
     ]);
   });
 }

--- a/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
@@ -50,8 +50,7 @@ export function renderCanvas2d(
 
     renderLayers(context, [
       // clear the canvas
-      (ctx: CanvasRenderingContext2D) => clearCanvas(ctx, config.width, config.height),
-
+      clearCanvas,
       (ctx: CanvasRenderingContext2D) => {
         withContext(ctx, (ctx) => {
           // render grid

--- a/packages/charts/src/chart_types/partition_chart/renderer/canvas/partition.tsx
+++ b/packages/charts/src/chart_types/partition_chart/renderer/canvas/partition.tsx
@@ -148,10 +148,7 @@ class PartitionComponent extends React.Component<PartitionProps> {
       a11ySettings,
       debug,
     } = this.props;
-    if (!initialized || width === 0 || height === 0) {
-      return null;
-    }
-    return (
+    return width === 0 || height === 0 || !initialized ? null : (
       <figure aria-labelledby={a11ySettings.labelId} aria-describedby={a11ySettings.descriptionId}>
         <canvas
           ref={forwardStageRef}
@@ -176,20 +173,15 @@ class PartitionComponent extends React.Component<PartitionProps> {
 
   private drawCanvas() {
     if (this.ctx) {
-      const { width, height }: Dimensions = this.props.chartContainerDimensions;
-      clearCanvas(this.ctx, width * this.devicePixelRatio, height * this.devicePixelRatio);
-      const {
-        ctx,
-        devicePixelRatio,
-        props: { multiGeometries, geometriesFoci },
-      } = this;
-      multiGeometries.forEach((geometries, geometryIndex) => {
+      const { ctx, devicePixelRatio, props } = this;
+      clearCanvas(ctx);
+      props.multiGeometries.forEach((geometries, geometryIndex) => {
         const renderer = isSimpleLinear(geometries.config, geometries.layers)
           ? renderLinearPartitionCanvas2d
           : isWaffle(geometries.config.partitionLayout)
           ? renderWrappedPartitionCanvas2d
           : renderPartitionCanvas2d;
-        renderer(ctx, devicePixelRatio, geometries, geometriesFoci[geometryIndex], this.animationState);
+        renderer(ctx, devicePixelRatio, geometries, props.geometriesFoci[geometryIndex], this.animationState);
       });
     }
   }
@@ -201,12 +193,7 @@ class PartitionComponent extends React.Component<PartitionProps> {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch): ReactiveChartDispatchProps =>
-  bindActionCreators(
-    {
-      onChartRendered,
-    },
-    dispatch,
-  );
+  bindActionCreators({ onChartRendered }, dispatch);
 
 const DEFAULT_PROPS: ReactiveChartStateProps = {
   initialized: false,

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/renderers.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/renderers.ts
@@ -59,7 +59,7 @@ export function renderXYChartCanvas2d(
     // The layers are callbacks, because of the need to not bake in the `ctx`, it feels more composable and uncoupled this way.
     renderLayers(ctx, [
       // clear the canvas
-      (ctx: CanvasRenderingContext2D) => clearCanvas(ctx, 200000, 200000),
+      clearCanvas,
       // render panel grid
       (ctx: CanvasRenderingContext2D) => {
         if (debug) {

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/xy_chart.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/xy_chart.tsx
@@ -129,8 +129,9 @@ class XYChartComponent extends React.Component<XYChartProps> {
   private drawCanvas() {
     if (this.ctx) {
       const { renderingArea, rotation } = this.props;
-      const width = ([90, -90].includes(rotation) ? renderingArea.height : renderingArea.width) + CLIPPING_MARGINS * 2;
-      const height = ([90, -90].includes(rotation) ? renderingArea.width : renderingArea.height) + CLIPPING_MARGINS * 2;
+      const vertical = Math.abs(rotation) === 90;
+      const width = (vertical ? renderingArea.height : renderingArea.width) + CLIPPING_MARGINS * 2;
+      const height = (vertical ? renderingArea.width : renderingArea.height) + CLIPPING_MARGINS * 2;
       const clippings = { x: -CLIPPING_MARGINS, y: -CLIPPING_MARGINS, width, height };
       renderXYChartCanvas2d(this.ctx, this.devicePixelRatio, clippings, this.props);
     }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/xy_chart.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/xy_chart.tsx
@@ -77,12 +77,15 @@ export interface ReactiveChartStateProps {
 interface ReactiveChartDispatchProps {
   onChartRendered: typeof onChartRendered;
 }
+
 interface ReactiveChartOwnProps {
   forwardCanvasRef: RefObject<HTMLCanvasElement>;
 }
+
 const CLIPPING_MARGINS = 0.5;
 
 type XYChartProps = ReactiveChartStateProps & ReactiveChartDispatchProps & ReactiveChartOwnProps;
+
 class XYChartComponent extends React.Component<XYChartProps> {
   static displayName = 'XYChart';
 
@@ -126,12 +129,9 @@ class XYChartComponent extends React.Component<XYChartProps> {
   private drawCanvas() {
     if (this.ctx) {
       const { renderingArea, rotation } = this.props;
-      const clippings = {
-        x: -CLIPPING_MARGINS,
-        y: -CLIPPING_MARGINS,
-        width: ([90, -90].includes(rotation) ? renderingArea.height : renderingArea.width) + CLIPPING_MARGINS * 2,
-        height: ([90, -90].includes(rotation) ? renderingArea.width : renderingArea.height) + CLIPPING_MARGINS * 2,
-      };
+      const width = ([90, -90].includes(rotation) ? renderingArea.height : renderingArea.width) + CLIPPING_MARGINS * 2;
+      const height = ([90, -90].includes(rotation) ? renderingArea.width : renderingArea.height) + CLIPPING_MARGINS * 2;
+      const clippings = { x: -CLIPPING_MARGINS, y: -CLIPPING_MARGINS, width, height };
       renderXYChartCanvas2d(this.ctx, this.devicePixelRatio, clippings, this.props);
     }
   }

--- a/packages/charts/src/components/brush/brush.tsx
+++ b/packages/charts/src/components/brush/brush.tsx
@@ -94,20 +94,13 @@ class BrushToolComponent extends React.Component<Props> {
           width: mainProjectionArea.width,
           height: mainProjectionArea.height,
         },
-        (ctx) => {
-          clearCanvas(ctx, 200000, 200000);
-          ctx.translate(mainProjectionArea.left, mainProjectionArea.top);
+        (context) => {
+          clearCanvas(context);
+          context.translate(mainProjectionArea.left, mainProjectionArea.top);
           renderRect(
-            ctx,
-            {
-              x: left,
-              y: top,
-              width,
-              height,
-            },
-            {
-              color: fillColor ?? DEFAULT_FILL_COLOR,
-            },
+            context,
+            { x: left, y: top, width, height },
+            { color: fillColor ?? DEFAULT_FILL_COLOR },
             { width: 0, color: stringToRGB('transparent') },
           );
         },

--- a/packages/charts/src/renderers/canvas/index.ts
+++ b/packages/charts/src/renderers/canvas/index.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import { Coordinate } from '../../common/geometry';
 import { Rect } from '../../geoms/types';
 import { ClippedRanges } from '../../utils/geometry';
 
@@ -26,9 +25,10 @@ export function withContext(ctx: CanvasRenderingContext2D, fun: (ctx: CanvasRend
 }
 
 /** @internal */
-export function clearCanvas(ctx: CanvasRenderingContext2D, width: Coordinate, height: Coordinate) {
-  withContext(ctx, (ctx) => {
-    ctx.clearRect(-width, -height, 2 * width, 2 * height); // remove past contents
+export function clearCanvas(ctx: CanvasRenderingContext2D) {
+  withContext(ctx, (context) => {
+    context.setTransform(1, 0, 0, 1, 0, 0);
+    context.clearRect(0, 0, context.canvas.width, context.canvas.height);
   });
 }
 


### PR DESCRIPTION
## Summary

Removes the `ctx.clearRect(-200000, -200000, 400000, 400000)` present in a couple of chart types. Also, more places use the common, `clearCanvas` method that got updated for transform independence 

Also, removed one or two unnecessary `withContext` and lightly restructured some surrounding code 

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

The global canvas erasure (in `master` and in this branch too) is currently possible, because the canvas isn't shared: each chart type possesses it, so it's safe to clear everything. In the future, we do need to refine this, for example, if
- we want heterogeneous small multiples or tiling layouts
- we want to update just one panel, while leaving the rest untouched (eg. for perf reasons, no need to recalc/rerender)

<!-- Details beyond the summary to explain nuances -->


## Issues

Follow-up on #1286 which also eliminated some large canvas dimension operations

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper chart type label was added (e.g. :xy, :partition) if the PR involves a specific chart type
- [x] This was checked for cross-browser compatibility
