### PR TITLE
refactor: reduction of canvas context threading

### DIFF
--- a/packages/charts/src/chart_types/goal_chart/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/goal_chart/renderer/canvas/canvas_renderers.ts
@@ -31,7 +31,7 @@ export function renderCanvas2d(ctx: CanvasRenderingContext2D, dpr: number, geomO
     renderLayers(ctx, [
       // clear the canvas
       clearCanvas,
-      () => geomObjects.forEach(({ render }) => withContext(ctx, () => render(ctx))),
+      () => geomObjects.forEach((mark) => withContext(ctx, () => mark.render(ctx))),
     ]);
   });
 }

--- a/packages/charts/src/chart_types/goal_chart/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/goal_chart/renderer/canvas/canvas_renderers.ts
@@ -31,8 +31,7 @@ export function renderCanvas2d(ctx: CanvasRenderingContext2D, dpr: number, geomO
     renderLayers(ctx, [
       // clear the canvas
       clearCanvas,
-      (context: CanvasRenderingContext2D) =>
-        geomObjects.forEach((obj) => withContext(context, (ctxt) => obj.render(ctxt))),
+      (context) => geomObjects.forEach(({ render }) => withContext(context, render)),
     ]);
   });
 }

--- a/packages/charts/src/chart_types/goal_chart/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/goal_chart/renderer/canvas/canvas_renderers.ts
@@ -11,7 +11,7 @@ import { Mark } from '../../layout/viewmodel/geoms';
 
 /** @internal */
 export function renderCanvas2d(ctx: CanvasRenderingContext2D, dpr: number, geomObjects: Mark[]) {
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     // set some defaults for the overall rendering
 
     // let's set the devicePixelRatio once and for all; then we'll never worry about it again
@@ -31,7 +31,7 @@ export function renderCanvas2d(ctx: CanvasRenderingContext2D, dpr: number, geomO
     renderLayers(ctx, [
       // clear the canvas
       clearCanvas,
-      (context) => geomObjects.forEach(({ render }) => withContext(context, render)),
+      () => geomObjects.forEach(({ render }) => withContext(ctx, () => render(ctx))),
     ]);
   });
 }

--- a/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
@@ -15,25 +15,25 @@ import { ShapeViewModel } from '../../layout/types/viewmodel_types';
 
 /** @internal */
 export function renderCanvas2d(
-  globalCtx: CanvasRenderingContext2D,
+  ctx: CanvasRenderingContext2D,
   dpr: number,
   { config, heatmapViewModel }: ShapeViewModel,
 ) {
   // eslint-disable-next-line no-empty-pattern
   const {} = config;
-  withContext(globalCtx, (context) => {
+  withContext(ctx, () => {
     // set some defaults for the overall rendering
 
     // let's set the devicePixelRatio once and for all; then we'll never worry about it again
-    context.scale(dpr, dpr);
+    ctx.scale(dpr, dpr);
 
     // all texts are currently center-aligned because
     //     - the calculations manually compute and lay out text (word) boxes, so we can choose whatever
     //     - but center/middle has mathematical simplicity and the most unassuming thing
     //     - due to using the math x/y convention (+y is up) while Canvas uses screen convention (+y is down)
     //         text rendering must be y-flipped, which is a bit easier this way
-    context.textAlign = 'center';
-    context.textBaseline = 'middle';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
     // ctx.translate(chartCenter.x, chartCenter.y);
     // this applies the mathematical x/y conversion (+y is North) which is easier when developing geometry
     // functions - also, all renderers have flexibility (eg. SVG scale) and WebGL NDC is also +y up
@@ -48,18 +48,18 @@ export function renderCanvas2d(
       return yIndex < heatmapViewModel.pageSize;
     });
 
-    renderLayers(context, [
+    renderLayers(ctx, [
       // clear the canvas
       clearCanvas,
       (ctx: CanvasRenderingContext2D) => {
-        withContext(ctx, (ctx) => {
+        withContext(ctx, () => {
           // render grid
           renderMultiLine(ctx, heatmapViewModel.gridLines.x, heatmapViewModel.gridLines.stroke);
           renderMultiLine(ctx, heatmapViewModel.gridLines.y, heatmapViewModel.gridLines.stroke);
         });
       },
       (ctx: CanvasRenderingContext2D) =>
-        withContext(ctx, (ctx) => {
+        withContext(ctx, () => {
           // render cells
           const { x, y } = heatmapViewModel.gridOrigin;
           ctx.translate(x, y);
@@ -71,7 +71,7 @@ export function renderCanvas2d(
           });
         }),
       (ctx: CanvasRenderingContext2D) =>
-        withContext(ctx, (ctx) => {
+        withContext(ctx, () => {
           // render text on cells
           const { x, y } = heatmapViewModel.gridOrigin;
           ctx.translate(x, y);
@@ -94,7 +94,7 @@ export function renderCanvas2d(
           });
         }),
       (ctx: CanvasRenderingContext2D) =>
-        withContext(ctx, (ctx) => {
+        withContext(ctx, () => {
           // render text on Y axis
           if (!config.yAxisLabel.visible) {
             return;
@@ -136,7 +136,7 @@ export function renderCanvas2d(
           });
         }),
       (ctx: CanvasRenderingContext2D) =>
-        withContext(ctx, (ctx) => {
+        withContext(ctx, () => {
           // render text on X axis
           if (!config.xAxisLabel.visible) {
             return;

--- a/packages/charts/src/chart_types/partition_chart/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/partition_chart/renderer/canvas/canvas_renderers.ts
@@ -40,7 +40,7 @@ function renderTextRow(
     if (!Number.isFinite(crx) || !Number.isFinite(cry)) {
       return;
     }
-    withContext(ctx, (ctx) => {
+    withContext(ctx, () => {
       ctx.scale(1, -1);
       if (clipText) {
         ctx.rect(container.x0 + 1, container.y0 + 1, container.x1 - container.x0 - 2, container.y1 - container.y0 - 2);
@@ -59,7 +59,7 @@ function renderTextRow(
     });
     // for debug use: this draws magenta boxes for where the text needs to fit
     // note: `container` is a property of the RowSet, needs to be added
-    // withContext(ctx, (ctx) => {
+    // withContext(ctx, () => {
     //   ctx.scale(1, -1);
     //   ctx.rotate(-rotation);
     //   ctx.beginPath();
@@ -129,7 +129,7 @@ function renderTaperedBorder(
 }
 
 function renderSectors(ctx: CanvasRenderingContext2D, quadViewModel: QuadViewModel[]) {
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     ctx.scale(1, -1); // D3 and Canvas2d use a left-handed coordinate system (+y = down) but the ViewModel uses +y = up, so we must locally invert Y
     quadViewModel.forEach((quad: QuadViewModel) => {
       if (quad.x0 === quad.x1) return; // no slice will be drawn, and it avoids some division by zero as well
@@ -139,7 +139,7 @@ function renderSectors(ctx: CanvasRenderingContext2D, quadViewModel: QuadViewMod
 }
 
 function renderRectangles(ctx: CanvasRenderingContext2D, quadViewModel: QuadViewModel[]) {
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     ctx.scale(1, -1); // D3 and Canvas2d use a left-handed coordinate system (+y = down) but the ViewModel uses +y = up, so we must locally invert Y
     quadViewModel.forEach(({ strokeWidth, fillColor, x0, x1, y0px, y1px }) => {
       // only draw a shape if it would show up at all
@@ -168,7 +168,7 @@ function renderFillOutsideLinks(
   linkLabelTextColor: string,
   linkLabelLineWidth: Pixels,
 ) {
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     ctx.lineWidth = linkLabelLineWidth;
     ctx.strokeStyle = linkLabelTextColor;
     outsideLinksViewModel.forEach(({ points }) => {
@@ -192,7 +192,7 @@ function renderLinkLabels(
   const labelColor = addOpacity(labelFontSpec.textColor, labelFontSpec.textOpacity);
   const valueColor = addOpacity(valueFontSpec.textColor, valueFontSpec.textOpacity);
   const labelValueGap = linkLabelFontSize / 2; // one en space
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     ctx.lineWidth = linkLabelLineWidth;
     linkLabels.forEach(({ linkLabels, translate, textAlign, text, valueText, width, valueWidth }: LinkLabelVM) => {
       // label lines
@@ -202,7 +202,7 @@ function renderLinkLabels(
       ctx.strokeStyle = strokeColor ?? linkLineColor;
 
       ctx.stroke();
-      withContext(ctx, (ctx) => {
+      withContext(ctx, () => {
         ctx.translate(...translate);
         ctx.scale(1, -1); // flip for text rendering not to be upside down
         ctx.textAlign = textAlign;
@@ -245,7 +245,7 @@ export function renderPartitionCanvas2d(
 
   const linkLineColor = addOpacity(linkLabel.textColor, linkLabel.textOpacity);
 
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     // set some defaults for the overall rendering
 
     // let's set the devicePixelRatio once and for all; then we'll never worry about it again

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/areas.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/areas.ts
@@ -33,7 +33,7 @@ interface AreaGeometriesProps {
 export function renderAreas(ctx: CanvasRenderingContext2D, imgCanvas: HTMLCanvasElement, props: AreaGeometriesProps) {
   const { sharedStyle, highlightedLegendItem, areas, rotation, clippings, renderingArea } = props;
 
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     areas.forEach(({ panel, value: area }) => {
       const { seriesAreaLineStyle, seriesAreaStyle } = area;
       if (seriesAreaStyle.visible) {

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/bars.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/bars.ts
@@ -29,7 +29,7 @@ export function renderBars(
   highlightedLegendItem?: LegendItem,
   rotation?: Rotation,
 ) {
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     const barRenderer = renderPerPanelBars(
       ctx,
       imgCanvas,
@@ -75,7 +75,7 @@ function renderPerPanelBars(
             geometryStateStyle,
             rect,
           );
-          withContext(ctx, (ctx) => {
+          withContext(ctx, () => {
             renderRect(ctx, rect, fill, stroke);
           });
         });

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/bubbles.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/bubbles.ts
@@ -29,7 +29,7 @@ interface BubbleGeometriesDataProps {
 
 /** @internal */
 export function renderBubbles(ctx: CanvasRenderingContext2D, props: BubbleGeometriesDataProps) {
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     const { bubbles, sharedStyle, highlightedLegendItem, clippings, rotation, renderingArea } = props;
     const geometryStyles: Record<SeriesKey, GeometryStateStyle> = {};
     const pointStyles: Record<SeriesKey, PointStyle> = {};

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/grids.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/grids.ts
@@ -27,11 +27,11 @@ export function renderGrids(ctx: CanvasRenderingContext2D, props: GridProps) {
     perPanelGridLines,
     renderingArea: { left, top },
   } = props;
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     ctx.translate(left, top);
 
     perPanelGridLines.forEach(({ lineGroups, panelAnchor: { x, y } }) => {
-      withContext(ctx, (ctx) => {
+      withContext(ctx, () => {
         ctx.translate(x, y);
         lineGroups.forEach(({ lines, stroke }) => {
           renderMultiLine(ctx, lines, stroke);

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/lines.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/lines.ts
@@ -31,7 +31,7 @@ interface LineGeometriesDataProps {
 
 /** @internal */
 export function renderLines(ctx: CanvasRenderingContext2D, props: LineGeometriesDataProps) {
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     const { lines, sharedStyle, highlightedLegendItem, clippings, renderingArea, rotation } = props;
 
     lines.forEach(({ panel, value: line }) => {

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/panels/panels.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/panels/panels.ts
@@ -23,7 +23,7 @@ import { renderPanelTitle } from './panel_title';
 /** @internal */
 export function renderGridPanels(ctx: CanvasRenderingContext2D, { x: chartX, y: chartY }: Point, panels: PanelGeoms) {
   panels.forEach(({ width, height, panelAnchor: { x: panelX, y: panelY } }) =>
-    withContext(ctx, (ctx) =>
+    withContext(ctx, () =>
       renderRect(
         ctx,
         { x: chartX + panelX, y: chartY + panelY, width, height },
@@ -40,7 +40,7 @@ function renderPanel(ctx: CanvasRenderingContext2D, props: AxisProps) {
   const x = anchorPoint.x + (position === Position.Right ? -1 : 1) * panelAnchor.x;
   const y = anchorPoint.y + (position === Position.Bottom ? -1 : 1) * panelAnchor.y;
 
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     ctx.translate(x, y);
     if (debug && !secondary) renderDebugRect(ctx, { x: 0, y: 0, ...size });
     renderAxis(ctx, props); // For now, just render the axis line TODO: compute axis dimensions per panels

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/arc.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/arc.ts
@@ -32,7 +32,7 @@ export function renderArc(ctx: CanvasRenderingContext2D, arc: Arc, fill?: Fill, 
   if (!fill && !stroke) {
     return;
   }
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     const { x, y, radius, startAngle, endAngle } = arc;
     ctx.translate(x, y);
     ctx.beginPath();

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/line.ts
@@ -22,7 +22,7 @@ export function renderMultiLine(ctx: CanvasRenderingContext2D, lines: Line[] | s
   if (stroke.width < MIN_STROKE_WIDTH || lines.length === 0) {
     return;
   }
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     ctx.strokeStyle = RGBtoString(stroke.color);
     ctx.lineJoin = 'round';
     ctx.lineWidth = stroke.width;

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/path.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/path.ts
@@ -15,7 +15,7 @@ import { renderMultiLine } from './line';
 
 /** @internal */
 export function renderLinePaths(
-  context: CanvasRenderingContext2D,
+  ctx: CanvasRenderingContext2D,
   transform: Point,
   linePaths: Array<string>,
   stroke: Stroke,
@@ -24,21 +24,21 @@ export function renderLinePaths(
   hideClippedRanges = false,
 ) {
   if (clippedRanges.length > 0) {
-    withClipRanges(context, clippedRanges, clippings, false, (ctx) => {
+    withClipRanges(ctx, clippedRanges, clippings, false, (ctx) => {
       ctx.translate(transform.x, transform.y);
       renderMultiLine(ctx, linePaths, stroke);
     });
     if (hideClippedRanges) {
       return;
     }
-    withClipRanges(context, clippedRanges, clippings, true, (ctx) => {
+    withClipRanges(ctx, clippedRanges, clippings, true, (ctx) => {
       ctx.translate(transform.x, transform.y);
       renderMultiLine(ctx, linePaths, { ...stroke, dash: [5, 5] });
     });
     return;
   }
 
-  withContext(context, (ctx) => {
+  withContext(ctx, () => {
     ctx.translate(transform.x, transform.y);
     renderMultiLine(ctx, linePaths, stroke);
   });
@@ -55,7 +55,7 @@ export function renderAreaPath(
   hideClippedRanges = false,
 ) {
   if (clippedRanges.length === 0) {
-    withContext(ctx, (ctx) => renderPathFill(ctx, area, fill, transform));
+    withContext(ctx, () => renderPathFill(ctx, area, fill, transform));
   } else {
     withClipRanges(ctx, clippedRanges, clippings, false, (ctx) => renderPathFill(ctx, area, fill, transform));
     if (!hideClippedRanges) {

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/shapes.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/shapes.ts
@@ -24,7 +24,7 @@ export function renderShape(
   if (!stroke || !fill) {
     return;
   }
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     const [pathFn, rotation] = ShapeRendererFn[shape];
     const { x, y, radius } = coordinates;
     ctx.translate(x, y);

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/text.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/text.ts
@@ -32,7 +32,7 @@ export function renderText(
   translateY: number = 0,
   scale: number = 1,
 ) {
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     ctx.translate(origin.x, origin.y);
     ctx.rotate(degToRad(angle));
     ctx.translate(translateX, translateY);

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/renderers.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/renderers.ts
@@ -29,7 +29,7 @@ export function renderXYChartCanvas2d(
 ) {
   const imgCanvas = document.createElement('canvas');
 
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     // let's set the devicePixelRatio once and for all; then we'll never worry about it again
     ctx.scale(dpr, dpr);
     const {
@@ -87,7 +87,7 @@ export function renderXYChartCanvas2d(
       },
       // rendering background annotations
       (ctx: CanvasRenderingContext2D) => {
-        withContext(ctx, (ctx) => {
+        withContext(ctx, () => {
           renderAnnotations(
             ctx,
             {
@@ -103,7 +103,7 @@ export function renderXYChartCanvas2d(
 
       // rendering bars
       (ctx: CanvasRenderingContext2D) => {
-        withContext(ctx, (ctx) => {
+        withContext(ctx, () => {
           renderBars(
             ctx,
             imgCanvas,
@@ -118,7 +118,7 @@ export function renderXYChartCanvas2d(
       },
       // rendering areas
       (ctx: CanvasRenderingContext2D) => {
-        withContext(ctx, (ctx) => {
+        withContext(ctx, () => {
           renderAreas(ctx, imgCanvas, {
             areas: geometries.areas,
             clippings,
@@ -131,7 +131,7 @@ export function renderXYChartCanvas2d(
       },
       // rendering lines
       (ctx: CanvasRenderingContext2D) => {
-        withContext(ctx, (ctx) => {
+        withContext(ctx, () => {
           renderLines(ctx, {
             lines: geometries.lines,
             clippings,
@@ -155,7 +155,7 @@ export function renderXYChartCanvas2d(
       },
       (ctx: CanvasRenderingContext2D) => {
         geometries.bars.forEach(({ value: bars, panel }) => {
-          withContext(ctx, (ctx) => {
+          withContext(ctx, () => {
             renderBarValues(ctx, {
               bars,
               panel,
@@ -169,7 +169,7 @@ export function renderXYChartCanvas2d(
       },
       // rendering foreground annotations
       (ctx: CanvasRenderingContext2D) => {
-        withContext(ctx, (ctx) => {
+        withContext(ctx, () => {
           renderAnnotations(
             ctx,
             {
@@ -187,7 +187,7 @@ export function renderXYChartCanvas2d(
         if (!debug) {
           return;
         }
-        withContext(ctx, (ctx) => {
+        withContext(ctx, () => {
           const { left, top, width, height } = renderingArea;
 
           renderDebugRect(

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/utils/debug.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/utils/debug.ts
@@ -38,7 +38,7 @@ export function renderDebugRect(
   stroke = DEFAULT_DEBUG_STROKE,
   rotation: number = 0,
 ) {
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     ctx.translate(rect.x, rect.y);
     ctx.rotate(degToRad(rotation));
     renderRect(
@@ -66,7 +66,7 @@ export function renderDebugRectCenterRotated(
 ) {
   const { x, y } = center;
 
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     ctx.translate(x, y);
     ctx.rotate(degToRad(rotation));
     ctx.translate(-x, -y);

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/utils/panel_transform.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/utils/panel_transform.ts
@@ -14,7 +14,7 @@ import { computeChartTransform } from '../../../state/utils/utils';
 
 /** @internal */
 export function withPanelTransform(
-  context: CanvasRenderingContext2D,
+  ctx: CanvasRenderingContext2D,
   panel: Dimensions,
   rotation: Rotation,
   renderingArea: Dimensions,
@@ -25,7 +25,7 @@ export function withPanelTransform(
   },
 ) {
   const transform = computeChartTransform(panel, rotation);
-  withContext(context, (ctx) => {
+  withContext(ctx, () => {
     ctx.translate(renderingArea.left + panel.left + transform.x, renderingArea.top + panel.top + transform.y);
     ctx.rotate(degToRad(rotation));
 

--- a/packages/charts/src/components/brush/brush.tsx
+++ b/packages/charts/src/components/brush/brush.tsx
@@ -80,11 +80,12 @@ class BrushToolComponent extends React.Component<Props> {
 
   private drawCanvas = () => {
     const { brushArea, mainProjectionArea, fillColor } = this.props;
-    if (!this.ctx || !brushArea) {
+    const { ctx } = this;
+    if (!ctx || !brushArea) {
       return;
     }
     const { top, left, width, height } = brushArea;
-    withContext(this.ctx, (ctx) => {
+    withContext(ctx, () => {
       ctx.scale(this.devicePixelRatio, this.devicePixelRatio);
       withClip(
         ctx,

--- a/packages/charts/src/components/brush/brush.tsx
+++ b/packages/charts/src/components/brush/brush.tsx
@@ -94,11 +94,11 @@ class BrushToolComponent extends React.Component<Props> {
           width: mainProjectionArea.width,
           height: mainProjectionArea.height,
         },
-        (context) => {
-          clearCanvas(context);
-          context.translate(mainProjectionArea.left, mainProjectionArea.top);
+        () => {
+          clearCanvas(ctx);
+          ctx.translate(mainProjectionArea.left, mainProjectionArea.top);
           renderRect(
-            context,
+            ctx,
             { x: left, y: top, width, height },
             { color: fillColor ?? DEFAULT_FILL_COLOR },
             { width: 0, color: stringToRGB('transparent') },

--- a/packages/charts/src/renderers/canvas/index.ts
+++ b/packages/charts/src/renderers/canvas/index.ts
@@ -18,9 +18,9 @@ import { ClippedRanges } from '../../utils/geometry';
  * @param fun
  * @internal
  */
-export function withContext(ctx: CanvasRenderingContext2D, fun: () => void) {
+export function withContext(ctx: CanvasRenderingContext2D, fun: (context: CanvasRenderingContext2D) => void) {
   ctx.save();
-  fun();
+  fun(ctx);
   ctx.restore();
 }
 

--- a/packages/charts/src/renderers/canvas/index.ts
+++ b/packages/charts/src/renderers/canvas/index.ts
@@ -18,17 +18,17 @@ import { ClippedRanges } from '../../utils/geometry';
  * @param fun
  * @internal
  */
-export function withContext(ctx: CanvasRenderingContext2D, fun: (ctx: CanvasRenderingContext2D) => void) {
+export function withContext(ctx: CanvasRenderingContext2D, fun: () => void) {
   ctx.save();
-  fun(ctx);
+  fun();
   ctx.restore();
 }
 
 /** @internal */
 export function clearCanvas(ctx: CanvasRenderingContext2D) {
-  withContext(ctx, (context) => {
-    context.setTransform(1, 0, 0, 1, 0, 0);
-    context.clearRect(0, 0, context.canvas.width, context.canvas.height);
+  withContext(ctx, () => {
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
   });
 }
 
@@ -45,14 +45,14 @@ export function withClip(
   fun: (ctx: CanvasRenderingContext2D) => void,
   shouldClip = true,
 ) {
-  withContext(ctx, (ctx) => {
+  withContext(ctx, () => {
     if (shouldClip) {
       const { x, y, width, height } = clippings;
       ctx.beginPath();
       ctx.rect(x, y, width, height);
       ctx.clip();
     }
-    withContext(ctx, (ctx) => {
+    withContext(ctx, () => {
       fun(ctx);
     });
   });
@@ -69,30 +69,30 @@ export function withClipRanges(
   negate = false,
   fun: (ctx: CanvasRenderingContext2D) => void,
 ) {
-  withContext(ctx, (context) => {
+  withContext(ctx, () => {
     const { length } = clippedRanges;
     const { width, height, y } = clippings;
-    context.beginPath();
+    ctx.beginPath();
     if (negate) {
       clippedRanges.forEach(([x0, x1]) => {
-        context.rect(x0, y, x1 - x0, height);
+        ctx.rect(x0, y, x1 - x0, height);
       });
     } else {
       if (length > 0) {
-        context.rect(0, -0.5, clippedRanges[0][0], height);
+        ctx.rect(0, -0.5, clippedRanges[0][0], height);
         const lastX = clippedRanges[length - 1][1];
-        context.rect(lastX, y, width - lastX, height);
+        ctx.rect(lastX, y, width - lastX, height);
       }
 
       if (length > 1) {
         for (let i = 1; i < length; i++) {
           const [, x0] = clippedRanges[i - 1];
           const [x1] = clippedRanges[i];
-          context.rect(x0, y, x1 - x0, height);
+          ctx.rect(x0, y, x1 - x0, height);
         }
       }
     }
-    context.clip();
-    fun(context);
+    ctx.clip();
+    fun(ctx);
   });
 }


### PR DESCRIPTION
## Summary

Callbacks for `withContext` and, occasionally, other such wrappers to use the outer ctx, as we don't juggle them anyway. The main motivation is to avoid the awkwardness of avoidance of shadowing, while keeping the somewhat sensible rule against shadowing. Stemming from this [ask](https://github.com/elastic/elastic-charts/pull/1307#discussion_r691952011) by @markov00 

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper chart type label was added (e.g. :xy, :partition) if the PR involves a specific chart type
- [x] The proper feature label was added (e.g. :interactions, :axis) if the PR involves a specific chart feature
