### PR TITLE
ci: disable local puppeteer download 

### DIFF
--- a/.ci/global_setup.sh
+++ b/.ci/global_setup.sh
@@ -84,6 +84,8 @@ yarn config set yarn-offline-mirror "$cacheDir/yarn-offline-cache"
 yarnGlobalDir="$(yarn global bin)"
 export PATH="$PATH:$yarnGlobalDir"
 
+# avoid download puppeteer locally (we use the dockerized version)
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ###
 ### install dependencies
 ###

--- a/.github/workflows/api_extractor_check.yaml
+++ b/.github/workflows/api_extractor_check.yaml
@@ -14,6 +14,8 @@ jobs:
           node-version: '14.x'
       - name: Install dependencies
         run: yarn --frozen-lockfile
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - name: Run API-Extractor
         run: yarn api:check
       - name: API-Extractor failure

--- a/.github/workflows/auto_release.yaml
+++ b/.github/workflows/auto_release.yaml
@@ -17,7 +17,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - uses: bahmutov/npm-install@HEAD
+      - name: Install node_modules
+        uses: bahmutov/npm-install@HEAD
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - name: Build check
         run: yarn build
       - name: Lint check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,8 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
 
   eslint:
     name: Eslint
@@ -67,6 +69,8 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       # -----------------------------------
 
       - name: Eslint check
@@ -90,6 +94,8 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       # -----------------------------------
 
       - name: Prettier check
@@ -113,6 +119,8 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       # -----------------------------------
 
       - name: Run API-Extractor
@@ -144,6 +152,8 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       # -----------------------------------
 
       - name: TimeZone tests
@@ -170,6 +180,8 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       # -----------------------------------
 
       - name: Building storybook

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -17,7 +17,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - uses: bahmutov/npm-install@HEAD
+      - name: Install node_modules
+        uses: bahmutov/npm-install@HEAD
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - name: Build storybook
         run: yarn storybook:build
       - name: Deploy 🚀

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - uses: bahmutov/npm-install@HEAD
+      - name: Install node_modules
+        uses: bahmutov/npm-install@HEAD
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - name: Build check
         run: yarn build
       - name: Lint check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,8 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
-
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - name: Lint check
         run: yarn lint
       - name: Prettier check
@@ -90,7 +91,8 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
-
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - name: Build library
         run: yarn build
 

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -12,7 +12,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - uses: bahmutov/npm-install@HEAD
+      - name: Install node_modules
+        uses: bahmutov/npm-install@HEAD
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - name: TimeZone testing
         run: yarn test:tz --ci
       - name: Testing


### PR DESCRIPTION
Disabling the Puppeteer Download when installing the npm dependencies, following the advice here: https://github.com/gidztech/jest-puppeteer-docker

Could save few seconds on CI :)

