### PR TITLE
fix(build): fix license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "elastic-charts-mono",
   "description": "Mono repo for @elastic/charts",
   "author": "Elastic DataVis",
-  "license": "Apache-2.0",
+  "license": "SEE LICENSE IN LICENSE.txt",
   "private": "true",
   "repository": "git@github.com:elastic/elastic-charts.git",
   "workspaces": {


### PR DESCRIPTION
After migrating to `Elastic License 2.0` we forgot to upgrade the package.json license header to the right one.

cc @ghudgins 

ref: https://github.com/elastic/kibana/issues/105614