### PR TITLE
test: don't import jsdom in node environment

### DIFF
--- a/integration/page_objects/common.ts
+++ b/integration/page_objects/common.ts
@@ -8,7 +8,6 @@
 
 import Url from 'url';
 
-import { JSDOM } from 'jsdom';
 import { AXNode } from 'puppeteer';
 
 import { DRAG_DETECTION_TIMEOUT } from '../../packages/charts/src/state/reducers/interactions';
@@ -469,16 +468,6 @@ class CommonPage {
       return value;
     });
     return accessibilitySnapshot;
-  }
-
-  /**
-   * Get HTML for element to test aria labels etc
-   */
-  // eslint-disable-next-line class-methods-use-this
-  async getSelectorHTML(url: string, tagName: string) {
-    await this.loadElementFromURL(url, '.echCanvasRenderer');
-    const xml = await page.evaluate(() => new XMLSerializer().serializeToString(document));
-    return new JSDOM(xml, { contentType: 'text/xml' }).window.document.getElementsByTagName(tagName);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@types/jest": "^26.0.19",
     "@types/jest-environment-puppeteer": "^4.4.1",
     "@types/jest-image-snapshot": "^4.1.3",
-    "@types/jsdom": "^16.2.5",
     "@types/lodash": "^4.14.121",
     "@types/luxon": "^1.25.0",
     "@types/marked": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5732,15 +5732,6 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/jsdom@^16.2.5":
-  version "16.2.5"
-  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-16.2.5.tgz#74ebad438741d249ecb416c5486dcde4217eb66c"
-  integrity sha512-k/ZaTXtReAjwWu0clU0KLS53dyqZnA8mm+jwKFeFrvufXgICp+VNbskETFxKKAguv0pkaEKTax5MaRmvalM+TA==
-  dependencies:
-    "@types/node" "*"
-    "@types/parse5" "*"
-    "@types/tough-cookie" "*"
-
 "@types/json-schema@^7.0.3":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
@@ -5906,7 +5897,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/parse5@*", "@types/parse5@^5.0.0":
+"@types/parse5@^5.0.0":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
@@ -6065,11 +6056,6 @@
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.7.tgz#545158342f949e8fd3bfd813224971ecddc3fac4"
   integrity sha512-0VBprVqfgFD7Ehb2vd8Lh9TG3jP98gvr8rgehQqzztZNI7o8zS8Ad4jyZneKELphpuE212D8J70LnSNQSyO6bQ==
-
-"@types/tough-cookie@*":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
-  integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
 "@types/uglify-js@*":
   version "3.13.0"
@@ -10612,7 +10598,8 @@ eslint-module-utils@^2.6.0:
     pkg-dir "^2.0.0"
 
 "eslint-plugin-elastic-charts@link:./packages/eslint-plugin-elastic-charts":
-  version "1.0.0"
+  version "0.0.0"
+  uid ""
 
 eslint-plugin-eslint-comments@^3.2.0:
   version "3.2.0"
@@ -15012,13 +14999,8 @@ lines-and-columns@^1.1.6:
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 "link-kibana@link:./packages/link_kibana":
-  version "1.0.0"
-  dependencies:
-    chalk "^4.1.1"
-    change-case "^4.1.2"
-    glob "^7.1.7"
-    inquirer "^8.0.0"
-    ora "^5.4.0"
+  version "0.0.0"
+  uid ""
 
 lint-staged@^10.5.3:
   version "10.5.3"


### PR DESCRIPTION
I've recently introduced a small change on the dependencies in our jest tests https://github.com/elastic/elastic-charts/pull/1367
After merging that PR, the Jenkins CI was suffering from a missing C++ library, used by the `canvas` package, updated in the mentioned PR.
The issue was that the `canvas` package doesn't need to be called in the VRT environment, but just in the uni test one.
I've discovered that the `canvas` package is only requested when using a `jsdom` environment in jest, but the current VRT tests runs in a `node` environment instead.
I've finally found the root cause: a JSDOM import, in `page_objects/common.ts` that causes the `canvas` lib to be requested and resolved in the jest `node` environment.
I've removed both the import and the unused function that was using that import.
