### PR TITLE
chore: attempt deep defaults in spec factory

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/specs/axis.tsx
+++ b/packages/charts/src/chart_types/xy_chart/specs/axis.tsx
@@ -10,11 +10,11 @@ import React from 'react';
 
 import { ChartType } from '../..';
 import { SpecType } from '../../../specs/constants';
-import { specComponentFactory, getConnect } from '../../../state/spec_factory';
+import { specComponentFactory, getConnect, DefaultFactorProps } from '../../../state/spec_factory';
 import { Position } from '../../../utils/common';
 import { AxisSpec, DEFAULT_GLOBAL_ID } from '../utils/specs';
 
-const defaultProps = {
+const defaultProps: DefaultProps = {
   chartType: ChartType.XYAxis,
   specType: SpecType.Axis,
   groupId: DEFAULT_GLOBAL_ID,
@@ -22,14 +22,18 @@ const defaultProps = {
   showOverlappingTicks: false,
   showOverlappingLabels: false,
   position: Position.Left,
+  domain: {
+    min: NaN,
+    max: NaN,
+  },
 };
 
 type SpecRequired = Pick<AxisSpec, 'id'>;
 type SpecOptionals = Partial<Omit<AxisSpec, 'chartType' | 'specType' | 'seriesType' | 'id'>>;
+type DefaultKeys = 'groupId' | 'hide' | 'showOverlappingTicks' | 'showOverlappingLabels' | 'position' | 'domain';
+type DefaultProps = DefaultFactorProps<AxisSpec, DefaultKeys>;
 
 /** @public */
 export const Axis: React.FunctionComponent<SpecRequired & SpecOptionals> = getConnect()(
-  specComponentFactory<AxisSpec, 'groupId' | 'hide' | 'showOverlappingTicks' | 'showOverlappingLabels' | 'position'>(
-    defaultProps,
-  ),
+  specComponentFactory<AxisSpec, DefaultKeys>(defaultProps, ['domain']),
 );

--- a/packages/charts/src/utils/common.tsx
+++ b/packages/charts/src/utils/common.tsx
@@ -623,3 +623,8 @@ export function range(start: number, stop: number, step: number): Array<number> 
   }
   return output;
 }
+
+/** @internal */
+export function isObject(o: unknown): o is Record<string, unknown> {
+  return Boolean(o) && typeof o === 'object' && !Array.isArray(o);
+}

--- a/storybook/stories/bar/32_scale_to_extent.story.tsx
+++ b/storybook/stories/bar/32_scale_to_extent.story.tsx
@@ -9,7 +9,7 @@
 import { boolean, number, select } from '@storybook/addon-knobs';
 import React from 'react';
 
-import { Axis, Chart, DomainPaddingUnit, Position, ScaleType, Settings } from '@elastic/charts';
+import { Axis, Chart, DomainPaddingUnit, Position, ScaleType, Settings, YDomainRange } from '@elastic/charts';
 import { computeContinuousDataDomain } from '@elastic/charts/src/utils/domain';
 
 import { useBaseTheme } from '../../use_base_theme';
@@ -67,10 +67,9 @@ export const Example = () => {
     default:
       data = mixed;
   }
-  const customDomain = { fit, padding, paddingUnit, constrainPadding, nice, min: NaN, max: NaN };
 
   if (shouldLogDomains) {
-    logDomains(data, customDomain);
+    logDomains(data, { fit, padding, paddingUnit, constrainPadding });
   }
 
   return (
@@ -79,7 +78,7 @@ export const Example = () => {
       <Axis id="top" position={Position.Top} title="Top axis" />
       <Axis
         id="left"
-        domain={customDomain}
+        domain={{ fit, padding, paddingUnit, constrainPadding }}
         title="Left axis"
         position={Position.Left}
         tickFormat={(d: any) => Number(d).toFixed(2)}


### PR DESCRIPTION
Attempt at deep defaults.

Findings:
- The types would be loose but the values are all typed going into the spec factory so shouldn't be too concerning
- The props would need to be overridden before passing the the `upsertSpec` function which is not idea.
- The breaking point for me was the `domain` having partial keys. So either I make the whole `domain` partial on the spec causing type checks everywhere. Or we somehow find a way to type which props are objects whose keys can be deep and values can be partials.

All in all this really hurt my brain and I think it's a future consideration when we separate the final spec types from the props the user must defined which could differ. But currently I think this is more effort than it is worth.