### PR TITLE
ci: rename gh actions

### DIFF
--- a/.github/actions/base_diff_check/action.yml
+++ b/.github/actions/base_diff_check/action.yml
@@ -16,7 +16,7 @@ inputs:
   status-context:
     description: 'Commit status context'
     required: false
-    default: 'PR Checks / Sync status'
+    default: 'Test merge status'
   limit:
     description: 'Limit for max commits behind'
     required: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI Checks
+name: CI
 
 concurrency:
   group: '${{ github.workflow }} - ${{ github.head_ref || github.ref }}'
@@ -54,7 +54,7 @@ jobs:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
 
   eslint:
-    name: Eslint
+    name: ESLint
     needs: setup
     runs-on: ubuntu-latest
     steps:
@@ -75,7 +75,7 @@ jobs:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       # -----------------------------------
 
-      - name: Eslint check
+      - name: ESLint check
         run: yarn lint
 
   prettier:

--- a/.github/workflows/prs_merge_status.yaml
+++ b/.github/workflows/prs_merge_status.yaml
@@ -1,7 +1,7 @@
-name: 'PR Sync Check'
+name: 'PRs merge status'
 
 concurrency:
-  group: pr_sync_checker
+  group: test_prs_merge
   cancel-in-progress: true
 
 on:
@@ -16,6 +16,7 @@ on:
 
 jobs:
   fetch:
+    name: 'Fetch'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.json }}
@@ -38,7 +39,7 @@ jobs:
           include.*.base_ref: ${{ toJSON(fromJSON(steps.fetch.outputs.data).*.base.ref) }}
           include.*.base_sha: ${{ toJSON(fromJSON(steps.fetch.outputs.data).*.base.sha) }}
 
-  base-status-check:
+  base-diff-check:
     name: 'PR #${{ matrix.number }} - ${{ matrix.title }}'
     runs-on: ubuntu-latest
     needs: fetch
@@ -52,7 +53,7 @@ jobs:
           persist-credentials: false
       - name: Install local action packages
         run: npm --prefix ./.github/actions/base_diff_check ci
-      - name: Check PR sync status
+      - name: Check PR-merge diffs
         uses: ./.github/actions/base_diff_check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Publish a Release
+name: Release
 
 on:
   workflow_dispatch:
@@ -10,12 +10,12 @@ env:
 
 jobs:
   status:
-    name: Check status
+    name: Status check
     runs-on: ubuntu-latest
     outputs:
       allSuccess: ${{ steps.validate.outputs.allSuccess == 'true' }}
     steps:
-      - name: Get current check runs
+      - name: Get current checks status
         id: check
         uses: octokit/request-action@v2.x
         with:
@@ -24,7 +24,7 @@ jobs:
           ref: ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Validate check runs
+      - name: Validate checks status
         id: validate
         if: ${{ success() }}
         shell: python
@@ -42,7 +42,7 @@ jobs:
           print(f"::set-output name=allSuccess::{str(count >= 7 and allSuccess).lower()}")
 
   checks:
-    name: Release Checks
+    name: Pre-release test
     runs-on: ubuntu-latest
     needs: status
     # Runs checks when others running on master may be in process

--- a/.github/workflows/test_merge.yaml
+++ b/.github/workflows/test_merge.yaml
@@ -1,5 +1,5 @@
 # Checks related only to PRs and not code
-name: PR Checks
+name: 'Test merge'
 
 concurrency:
   group: '${{ github.workflow }} - ${{ github.head_ref }}'
@@ -34,8 +34,7 @@ on:
       - '[0-9]+.x'
 
 jobs:
-  pr-sync:
-    name: Sync
+  test_merge:
     runs-on: ubuntu-latest
     steps:
       - name: Check out branch # needed to use local action


### PR DESCRIPTION
Renamed our github actions with a less (probably) verbose version:
<img width="427" alt="Screenshot 2021-09-22 at 15 01 15" src="https://user-images.githubusercontent.com/1421091/134348347-d3baca58-89f0-4491-aa28-fad3b72e9288.png">
<img width="399" alt="Screenshot 2021-09-22 at 15 01 39" src="https://user-images.githubusercontent.com/1421091/134348349-253bc652-f209-4515-ad11-cdaa59a08413.png">

`Publish a Release` -> `Release`

and a few other small renaming

