### PR TITLE
chore: cleanup types

### DIFF
--- a/.ci/global_setup.sh
+++ b/.ci/global_setup.sh
@@ -84,8 +84,6 @@ yarn config set yarn-offline-mirror "$cacheDir/yarn-offline-cache"
 yarnGlobalDir="$(yarn global bin)"
 export PATH="$PATH:$yarnGlobalDir"
 
-# avoid download puppeteer locally (we use the dockerized version)
-export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ###
 ### install dependencies
 ###

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -178,7 +178,16 @@ module.exports = {
     '@typescript-eslint/ban-ts-ignore': 0,
     '@typescript-eslint/indent': 0,
     '@typescript-eslint/no-inferrable-types': 0,
-    '@typescript-eslint/ban-ts-comment': 1,
+    '@typescript-eslint/ban-ts-comment': [
+      2,
+      {
+        'ts-expect-error': 'allow-with-description',
+        'ts-ignore': 'allow-with-description',
+        'ts-nocheck': 'allow-with-description',
+        'ts-check': 'allow-with-description',
+        minimumDescriptionLength: 3,
+      },
+    ],
     '@typescript-eslint/no-unused-vars': [
       'error',
       {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,8 @@ jobs:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       # -----------------------------------
 
+      - name: Run global typecheck
+        run: yarn typecheck:all
       - name: Run API-Extractor
         run: yarn api:check
       - name: Handle API-Extractor failure

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,8 +50,6 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
-        env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
 
   eslint:
     name: Eslint
@@ -71,8 +69,6 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
-        env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       # -----------------------------------
 
       - name: Eslint check
@@ -96,8 +92,6 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
-        env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       # -----------------------------------
 
       - name: Prettier check
@@ -121,8 +115,6 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
-        env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       # -----------------------------------
 
       - name: Run global typecheck
@@ -156,8 +148,6 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
-        env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       # -----------------------------------
 
       - name: TimeZone tests
@@ -184,8 +174,6 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
-        env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       # -----------------------------------
 
       - name: Building storybook

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,8 +62,6 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
-        env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - name: Lint check
         run: yarn lint
       - name: Prettier check
@@ -91,8 +89,6 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
-        env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - name: Build library
         run: yarn build
 

--- a/declarations/@types/jest.d.ts
+++ b/declarations/@types/jest.d.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export * from 'jest-extended'; // https://github.com/jest-community/jest-extended
+
+/**
+ * Final Matcher type with `this` and `received` args removed from jest matcher function
+ */
+type MatcherParameters<T extends (this: any, received: any, ...args: any[]) => any> = T extends (
+  this: any,
+  received: any,
+  ...args: infer P
+) => any
+  ? P
+  : never;
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      /**
+       * Expect array to be filled with value, and optionally length
+       */
+      toEqualArrayOf(...args: MatcherParameters<typeof toEqualArrayOf>): R;
+    }
+  }
+}
+
+export {}; // ensure this is parsed as a module.

--- a/declarations/@types/node.d.ts
+++ b/declarations/@types/node.d.ts
@@ -6,8 +6,7 @@
  * Side Public License, v 1.
  */
 
-import 'jest-extended'; // https://github.com/jest-community/jest-extended
-
+// Super flaky not sure why
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
@@ -56,3 +55,5 @@ declare global {
     }
   }
 }
+
+export {}; // ensure this is parsed as a module.

--- a/integration/helpers.ts
+++ b/integration/helpers.ts
@@ -15,7 +15,7 @@ import { getStorybook, configure } from '@storybook/react';
 
 import { Rotation } from '../packages/charts/src';
 import { ThemeId } from '../storybook/use_base_theme';
-// @ts-ignore
+// @ts-ignore - no type declarations
 import { isLegacyVRTServer } from './config';
 
 export type StoryInfo = [string, string, number];

--- a/integration/jest.config.js
+++ b/integration/jest.config.js
@@ -13,7 +13,7 @@ const tsPreset = require('ts-jest/jest-preset');
 const { debug } = require('./config');
 
 module.exports = {
-  setupFilesAfterEnv: ['<rootDir>/jest_env_setup.ts'],
+  setupFilesAfterEnv: ['<rootDir>/jest_env_setup.ts', 'jest-extended'],
   globals: {
     'ts-jest': {
       tsconfig: '<rootDir>/tsconfig.json',

--- a/integration/page_objects/common.ts
+++ b/integration/page_objects/common.ts
@@ -11,14 +11,13 @@ import Url from 'url';
 import { AXNode } from 'puppeteer';
 
 import { DRAG_DETECTION_TIMEOUT } from '../../packages/charts/src/state/reducers/interactions';
-// @ts-ignore
+// @ts-ignore - no type declarations
 import { port, hostname, debug, isLegacyVRTServer } from '../config';
 import { toMatchImageSnapshot } from '../jest_env_setup';
 
 const legacyBaseUrl = `http://${hostname}:${port}/iframe.html`;
 
-// Use to log console statements from within the page.evaluate blocks
-// @ts-ignore
+// @ts-ignore - used to log console statements from within the page.evaluate blocks
 // page.on('console', (msg) => (msg._type === 'log' ? console.log('PAGE LOG:', msg._text) : null)); // eslint-disable-line no-console
 
 expect.extend({ toMatchImageSnapshot });

--- a/integration/server/mocks/@storybook/addon-knobs/index.ts
+++ b/integration/server/mocks/@storybook/addon-knobs/index.ts
@@ -45,14 +45,14 @@ export function text(name: string, dftValue: string, groupId?: string) {
 
 export function array(name: string, dftValues: unknown[], options: any, groupId?: string) {
   const params = getParams();
-  const values = [];
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  for (const [key, value] of params) {
+  const values: string[] = [];
+
+  params.forEach((value, key) => {
     if (key.startsWith(`${getKnobKey(name, groupId)}[`)) {
       values.push(value);
     }
-  }
+  });
+
   if (values.length === 0) {
     return dftValues;
   }

--- a/integration/tsconfig.json
+++ b/integration/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig",
-  "include": ["./**/*", "../**/*.d.ts", "../scripts/custom_matchers.ts"]
+  "include": ["./**/*", "../scripts/custom_matchers.mock.ts"]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,11 @@ module.exports = {
   testMatch: ['**/?(*.)+(test).[jt]s?(x)'],
   roots: ['<rootDir>/packages/charts/src'],
   preset: 'ts-jest',
-  setupFilesAfterEnv: ['<rootDir>/scripts/setup_enzyme.ts', '<rootDir>/scripts/custom_matchers.ts'],
+  setupFilesAfterEnv: [
+    '<rootDir>/scripts/setup_enzyme.ts',
+    '<rootDir>/scripts/custom_matchers.mock.ts',
+    'jest-extended',
+  ],
   coveragePathIgnorePatterns: [
     '<rootDir>/packages/charts/src/mocks',
     '<rootDir>/packages/charts/src/utils/d3-delaunay',

--- a/packages/charts/src/chart_types/wordcloud/renderer/svg/connected_component.tsx
+++ b/packages/charts/src/chart_types/wordcloud/renderer/svg/connected_component.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-// @ts-ignore
+// @ts-ignore - remove in workcloud refactor
 import d3TagCloud from 'd3-cloud';
 import React from 'react';
 import { connect } from 'react-redux';

--- a/packages/charts/src/chart_types/xy_chart/state/chart_state.interactions.test.tsx
+++ b/packages/charts/src/chart_types/xy_chart/state/chart_state.interactions.test.tsx
@@ -6,10 +6,8 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable jest/no-conditional-expect */
 
-import 'jest-extended';
 import React from 'react';
 import { Store } from 'redux';
 
@@ -1356,3 +1354,5 @@ describe('Clickable annotations', () => {
     expect(onAnnotationClick).toBeCalled();
   });
 });
+
+/* eslint-enable jest/no-conditional-expect */

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_legend.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_legend.ts
@@ -52,7 +52,7 @@ export const computeLegendSelector = createCustomCachedSelector(
       siDataSeriesMap,
       deselectedDataSeries,
       chartTheme,
-      // @ts-ignore
+      // @ts-ignore - hidden method for vislib usage only
       settings.sortSeriesBy,
     );
   },

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_series_domains.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_series_domains.ts
@@ -32,7 +32,7 @@ export const computeSeriesDomainsSelector = createCustomCachedSelector(
       deselectedDataSeries,
       settingsSpec.orderOrdinalBinsBy,
       smallMultiples,
-      // @ts-ignore
+      // @ts-ignore - hidden method for vislib usage only
       settingsSpec.sortSeriesBy,
     );
   },

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.test.ts
@@ -7,10 +7,8 @@
  */
 
 import { DateTime } from 'luxon';
-// @ts-ignore
 import moment from 'moment-timezone';
 
-import 'jest-extended';
 import { ChartType } from '../..';
 import { MockGlobalSpec, MockSeriesSpec } from '../../../mocks/specs/specs';
 import { MockStore } from '../../../mocks/store/store';

--- a/packages/charts/src/chart_types/xy_chart/utils/fit_function.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/fit_function.test.ts
@@ -504,13 +504,13 @@ describe('Fit Function', () => {
     describe('sorting', () => {
       const spies: jest.SpyInstance[] = [];
       const mockArray: any[] = [];
-      // @ts-ignore
+      // @ts-ignore - mocking array prototype method
       jest.spyOn(mockArray, 'sort');
 
       beforeAll(() => {
-        // @ts-ignore
+        // @ts-ignore - mocking array prototype method
         spies.push(jest.spyOn(dataSeries.data, 'sort'));
-        // @ts-ignore
+        // @ts-ignore - mocking array prototype method
         spies.push(jest.spyOn(dataSeries.data, 'slice').mockReturnValue(mockArray));
       });
 

--- a/packages/charts/src/components/portal/tooltip_portal.tsx
+++ b/packages/charts/src/components/portal/tooltip_portal.tsx
@@ -95,7 +95,7 @@ const TooltipPortalComponent = ({
    */
   const popper = useRef<Instance | null>(null);
   const popperSettings = useMemo(
-    // @ts-ignore
+    // @ts-ignore - nesting limitation
     () => mergePartial(DEFAULT_POPPER_SETTINGS, settings, { mergeOptionalPartialValues: true }),
     [settings],
   );

--- a/packages/charts/src/mocks/specs/specs.ts
+++ b/packages/charts/src/mocks/specs/specs.ts
@@ -343,7 +343,7 @@ export class MockGlobalSpec {
   };
 
   static settings(partial?: Partial<SettingsSpec>): SettingsSpec {
-    // @ts-ignore
+    // @ts-ignore - nesting limitation
     return mergePartial<SettingsSpec>(MockGlobalSpec.settingsBase, partial, { mergeOptionalPartialValues: true });
   }
 

--- a/packages/charts/src/scales/scale_continuous.test.ts
+++ b/packages/charts/src/scales/scale_continuous.test.ts
@@ -498,7 +498,7 @@ describe('Scale Continuous', () => {
     });
 
     it('should throw for NaN values', () => {
-      // @ts-ignore
+      // @ts-ignore - d3Scale method
       jest.spyOn(scale, 'd3Scale').mockImplementationOnce(() => NaN);
       expect(() => scale.scaleOrThrow(1)).toThrow();
     });

--- a/packages/charts/src/utils/common.test.ts
+++ b/packages/charts/src/utils/common.test.ts
@@ -77,14 +77,14 @@ describe('common utilities', () => {
     });
 
     it('should return second partial if partial is undefined', () => {
-      // @ts-ignore
+      // @ts-ignore - nesting limitation
       const result = getPartialValue(base, undefined, [undefined, partial]);
 
       expect(result).toBe(partial);
     });
 
     it('should return base if no partials are defined', () => {
-      // @ts-ignore
+      // @ts-ignore - nesting limitation
       const result = getPartialValue(base, undefined, [undefined, undefined]);
 
       expect(result).toBe(base);

--- a/packages/charts/src/utils/fast_deep_equal.ts
+++ b/packages/charts/src/utils/fast_deep_equal.ts
@@ -51,16 +51,16 @@ export function deepEqual(a: any, b: any, partial = false): boolean {
     }
     if (a instanceof Map && b instanceof Map) {
       if (a.size !== b.size) return false;
-      // @ts-ignore
+      // @ts-ignore - 3rd party code
       for (i of a.entries()) if (!b.has(i[0])) return false;
-      // @ts-ignore
+      // @ts-ignore - 3rd party code
       for (i of a.entries()) if (!deepEqual(i[1], b.get(i[0]))) return false;
       return true;
     }
 
     if (a instanceof Set && b instanceof Set) {
       if (a.size !== b.size) return false;
-      // @ts-ignore
+      // @ts-ignore - 3rd party code
       for (i of a.entries()) if (!b.has(i[0])) return false;
       return true;
     }

--- a/packages/charts/src/utils/series_sort.ts
+++ b/packages/charts/src/utils/series_sort.ts
@@ -7,7 +7,7 @@
  */
 
 import { SeriesIdentifier } from '../common/series_id';
-import { SettingsSpec, SortSeriesByConfig } from '../specs/settings';
+import { SortSeriesByConfig } from '../specs/settings';
 
 /**
  * A compare function used to determine the order of the elements. It is expected to return
@@ -24,8 +24,7 @@ export const DEFAULT_SORTING_FN = () => {
 
 /** @internal */
 export function getRenderingCompareFn(
-  // @ts-ignore
-  sortSeriesBy: SettingsSpec['sortSeriesBy'],
+  sortSeriesBy?: SeriesCompareFn | SortSeriesByConfig,
   defaultSortFn?: SeriesCompareFn,
 ): SeriesCompareFn {
   return getCompareFn('rendering', sortSeriesBy, defaultSortFn);
@@ -33,8 +32,7 @@ export function getRenderingCompareFn(
 
 /** @internal */
 export function getLegendCompareFn(
-  // @ts-ignore
-  sortSeriesBy: SettingsSpec['sortSeriesBy'],
+  sortSeriesBy?: SeriesCompareFn | SortSeriesByConfig,
   defaultSortFn?: SeriesCompareFn,
 ): SeriesCompareFn {
   return getCompareFn('legend', sortSeriesBy, defaultSortFn);
@@ -42,8 +40,7 @@ export function getLegendCompareFn(
 
 /** @internal */
 export function getTooltipCompareFn(
-  // @ts-ignore
-  sortSeriesBy: SettingsSpec['sortSeriesBy'],
+  sortSeriesBy?: SeriesCompareFn | SortSeriesByConfig,
   defaultSortFn?: SeriesCompareFn,
 ): SeriesCompareFn {
   return getCompareFn('tooltip', sortSeriesBy, defaultSortFn);
@@ -51,8 +48,7 @@ export function getTooltipCompareFn(
 
 function getCompareFn(
   aspect: keyof SortSeriesByConfig,
-  // @ts-ignore
-  sortSeriesBy: SettingsSpec['sortSeriesBy'],
+  sortSeriesBy?: SeriesCompareFn | SortSeriesByConfig,
   defaultSortFn: SeriesCompareFn = DEFAULT_SORTING_FN,
 ): SeriesCompareFn {
   if (typeof sortSeriesBy === 'object') {

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -5,6 +5,6 @@
     "target": "es5",
     "resolveJsonModule": true
   },
-  "include": ["../packages/charts/src/**/*", "./**/*", "../**/*.d.ts", "../scripts/custom_matchers.ts"],
+  "include": ["../packages/charts/src/**/*", "./**/*", "../scripts/custom_matchers.mock.ts"],
   "exclude": ["../**/*.test.*"]
 }

--- a/scripts/custom_matchers.mock.ts
+++ b/scripts/custom_matchers.mock.ts
@@ -7,33 +7,6 @@
  */
 
 import { matcherErrorMessage } from 'jest-matcher-utils';
-import 'jest-extended'; // require to load jest-extended matchers
-
-// ensure this is parsed as a module.
-export {};
-
-/**
- * Final Matcher type with `this` and `received` args removed from jest matcher function
- */
-type MatcherParameters<T extends (this: any, received: any, ...args: any[]) => any> = T extends (
-  this: any,
-  received: any,
-  ...args: infer P
-) => any
-  ? P
-  : never;
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace jest {
-    interface Matchers<R> {
-      /**
-       * Expect array to be filled with value, and optionally length
-       */
-      toEqualArrayOf(...args: MatcherParameters<typeof toEqualArrayOf>): R;
-    }
-  }
-}
 
 /**
  * Expect array to be filled with value, and optionally length

--- a/scripts/setup_enzyme.ts
+++ b/scripts/setup_enzyme.ts
@@ -38,10 +38,10 @@ class ResizeObserverMock {
   disconnect() {}
 }
 
-// @ts-ignore
+// @ts-ignore - setting mock override
 window.ResizeObserver = ResizeObserverMock;
 
 // Some tests will fail due to undefined Path2D, this mock doesn't create issues on test env
 class Path2D {}
-// @ts-ignore
+// @ts-ignore - setting mock override
 window.Path2D = Path2D;

--- a/storybook/preload_icons.ts
+++ b/storybook/preload_icons.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-// @ts-ignore
+// @ts-ignore - no type declarations
 import { appendIconComponentCache } from '@elastic/eui/es/components/icon/icon';
 
 /**

--- a/storybook/stories/annotations/lines/6_test_single_bar_histogram.story.tsx
+++ b/storybook/stories/annotations/lines/6_test_single_bar_histogram.story.tsx
@@ -49,6 +49,8 @@ export const Example = () => {
   };
 
   const xDomain = {
+    min: NaN,
+    max: NaN,
     minInterval: 1,
   };
 

--- a/storybook/stories/annotations/rects/6_zero_domain.story.tsx
+++ b/storybook/stories/annotations/rects/6_zero_domain.story.tsx
@@ -40,7 +40,16 @@ export const Example = () => {
       <RectAnnotation id="rect" dataValues={[{ coordinates: xAxisKnobs }]} style={{ fill: 'red' }} />
       <Settings baseTheme={useBaseTheme()} />
       <Axis id="bottom" position={Position.Bottom} title="x-domain axis" />
-      <Axis domain={{ fit }} id="left" title="y-domain axis" position={Position.Left} />
+      <Axis
+        domain={{
+          min: NaN,
+          max: NaN,
+          fit,
+        }}
+        id="left"
+        title="y-domain axis"
+        position={Position.Left}
+      />
       <BarSeries
         id="bars"
         xScaleType={ScaleType.Linear}

--- a/storybook/stories/area/13_band_area.story.tsx
+++ b/storybook/stories/area/13_band_area.story.tsx
@@ -50,7 +50,11 @@ export const Example = () => {
       />
       <Axis
         id="left"
-        domain={{ fit }}
+        domain={{
+          min: NaN,
+          max: NaN,
+          fit,
+        }}
         title={KIBANA_METRICS.metrics.kibana_os_load[0].metric.title}
         position={Position.Left}
         tickFormat={(d) => Number(d).toFixed(2)}

--- a/storybook/stories/area/17_negative.story.tsx
+++ b/storybook/stories/area/17_negative.story.tsx
@@ -37,7 +37,11 @@ export const Example = () => {
         title="negative metric"
         position={Position.Left}
         tickFormat={(d) => Number(d).toFixed(2)}
-        domain={{ logMinLimit: number('Y log limit', 1, { min: 0 }) }}
+        domain={{
+          min: NaN,
+          max: NaN,
+          logMinLimit: number('Y log limit', 1, { min: 0 }),
+        }}
       />
 
       <AreaSeries

--- a/storybook/stories/area/18_negative_positive.story.tsx
+++ b/storybook/stories/area/18_negative_positive.story.tsx
@@ -42,7 +42,11 @@ export const Example = () => {
         title={dataset.metric.title}
         position={Position.Left}
         tickFormat={(d) => Number(d).toFixed(2)}
-        domain={{ logMinLimit: number('Y log limit', 1, { min: 0 }) }}
+        domain={{
+          min: NaN,
+          max: NaN,
+          logMinLimit: number('Y log limit', 1, { min: 0 }),
+        }}
       />
 
       <AreaSeries

--- a/storybook/stories/area/19_negative_band.story.tsx
+++ b/storybook/stories/area/19_negative_band.story.tsx
@@ -38,7 +38,11 @@ export const Example = () => {
         showLegend
         theme={{ areaSeriesStyle: { point: { visible: true } }, lineSeriesStyle: { point: { visible: false } } }}
         baseTheme={useBaseTheme()}
-        xDomain={{ minInterval: 1 }}
+        xDomain={{
+          min: NaN,
+          max: NaN,
+          minInterval: 1,
+        }}
       />
       <Axis id="bottom" title="timestamp" position={Position.Bottom} showOverlappingTicks />
       <Axis id="left" title="metric" position={Position.Left} tickFormat={(d) => Number(d).toFixed(2)} />

--- a/storybook/stories/area/21_with_time_timeslip.story.tsx
+++ b/storybook/stories/area/21_with_time_timeslip.story.tsx
@@ -9,7 +9,7 @@
 import { boolean } from '@storybook/addon-knobs';
 import React from 'react';
 
-import { AreaSeries, Axis, Chart, Position, ScaleType, Settings } from '@elastic/charts';
+import { AreaSeries, Axis, Chart, Position, ScaleType, Settings, AxisSpec } from '@elastic/charts';
 import { mergePartial } from '@elastic/charts/src/utils/common';
 import { KIBANA_METRICS } from '@elastic/charts/src/utils/data_samples/test_dataset_kibana';
 
@@ -32,7 +32,7 @@ const tooltipDateFormatter = (d: any) =>
     minute: 'numeric',
   }).format(d);
 
-const xAxisStyle = {
+const xAxisStyle: AxisSpec['style'] = {
   tickLine: { size: 0.0001, padding: -6, ...gridStyle },
   axisLine: { stroke: 'magenta', strokeWidth: 10, visible: false },
   tickLabel: {
@@ -77,8 +77,6 @@ export const Example = () => {
         gridLine={gridStyle}
         style={mergePartial(xAxisStyle, {
           axisTitle: { visible: true, fontFamily, fontSize: 24, fill: 'grey' },
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
           tickLabel: horizontalAxisTitle
             ? {
                 fill: 'rgb(64,64,64)',

--- a/storybook/stories/axes/10_one_domain_bound.story.tsx
+++ b/storybook/stories/axes/10_one_domain_bound.story.tsx
@@ -16,9 +16,11 @@ import { useBaseTheme } from '../../use_base_theme';
 export const Example = () => {
   const leftDomain = {
     min: number('left min', 0),
+    max: NaN,
   };
 
   const xDomain = {
+    min: NaN,
     max: number('xDomain max', 3),
   };
 

--- a/storybook/stories/axes/11_fit_domain_extent.story.tsx
+++ b/storybook/stories/axes/11_fit_domain_extent.story.tsx
@@ -52,7 +52,14 @@ export const Example = () => {
       <Settings baseTheme={useBaseTheme()} />
       <Axis id="bottom" title="index" position={Position.Bottom} />
       <Axis
-        domain={{ fit, padding, paddingUnit, constrainPadding }}
+        domain={{
+          min: NaN,
+          max: NaN,
+          fit,
+          padding,
+          paddingUnit,
+          constrainPadding,
+        }}
         id="left"
         title="Value"
         position={Position.Left}

--- a/storybook/stories/axes/12_duplicate_ticks.story.tsx
+++ b/storybook/stories/axes/12_duplicate_ticks.story.tsx
@@ -8,7 +8,7 @@
 
 import { boolean, select } from '@storybook/addon-knobs';
 import { DateTime } from 'luxon';
-import * as moment from 'moment-timezone';
+import moment from 'moment-timezone';
 import React from 'react';
 
 import {

--- a/storybook/stories/bar/26_single_data_linear.story.tsx
+++ b/storybook/stories/bar/26_single_data_linear.story.tsx
@@ -19,6 +19,7 @@ export const Example = () => {
   const xDomain = hasCustomDomain
     ? {
         min: 0,
+        max: NaN,
       }
     : undefined;
 

--- a/storybook/stories/bar/30_stacked_to_extent.story.tsx
+++ b/storybook/stories/bar/30_stacked_to_extent.story.tsx
@@ -22,7 +22,11 @@ export const Example = () => {
       <Axis id="bottom" position={Position.Bottom} title="Bottom axis" />
       <Axis
         id="left2"
-        domain={{ fit }}
+        domain={{
+          min: NaN,
+          max: NaN,
+          fit,
+        }}
         title="Left axis"
         position={Position.Left}
         tickFormat={(d: any) => Number(d).toFixed(2)}

--- a/storybook/stories/bar/33_band_bar.story.tsx
+++ b/storybook/stories/bar/33_band_bar.story.tsx
@@ -39,7 +39,11 @@ export const Example = () => {
       />
       <Axis
         id="left"
-        domain={{ fit }}
+        domain={{
+          min: NaN,
+          max: NaN,
+          fit,
+        }}
         title={KIBANA_METRICS.metrics.kibana_os_load[0].metric.title}
         position={Position.Left}
         tickFormat={(d: any) => Number(d).toFixed(2)}

--- a/storybook/stories/bar/43_test_discover.story.tsx
+++ b/storybook/stories/bar/43_test_discover.story.tsx
@@ -42,6 +42,8 @@ export const Example = () => {
   const formatter = timeFormatter(niceTimeFormatByDay(1));
 
   const xDomain = {
+    min: NaN,
+    max: NaN,
     minInterval: 30000,
   };
 

--- a/storybook/stories/bar/44_test_single_histogram.story.tsx
+++ b/storybook/stories/bar/44_test_single_histogram.story.tsx
@@ -27,6 +27,8 @@ export const Example = () => {
   const formatter = timeFormatter(niceTimeFormatByDay(1));
 
   const xDomain = {
+    min: NaN,
+    max: NaN,
     minInterval: 60000,
   };
 

--- a/storybook/stories/bar/6_linear_no_linear_interval.story.tsx
+++ b/storybook/stories/bar/6_linear_no_linear_interval.story.tsx
@@ -14,7 +14,13 @@ import { useBaseTheme } from '../../use_base_theme';
 
 export const Example = () => (
   <Chart>
-    <Settings xDomain={{ max: 100 }} baseTheme={useBaseTheme()} />
+    <Settings
+      xDomain={{
+        min: NaN,
+        max: 100,
+      }}
+      baseTheme={useBaseTheme()}
+    />
     <Axis id="bottom" position={Position.Bottom} title="Bottom axis" showOverlappingTicks />
     <Axis id="left2" title="Left axis" position={Position.Left} tickFormat={(d: any) => Number(d).toFixed(2)} />
 

--- a/storybook/stories/bar/8_with_log_yaxis.story.tsx
+++ b/storybook/stories/bar/8_with_log_yaxis.story.tsx
@@ -18,7 +18,11 @@ export const Example = () => (
     <Axis id="bottom" position={Position.Bottom} title="Bottom axis" showOverlappingTicks />
     <Axis
       id="left2"
-      domain={{ fit: true }}
+      domain={{
+        min: NaN,
+        max: NaN,
+        fit: true,
+      }}
       title="Left axis"
       position={Position.Left}
       tickFormat={(d: any) => Number(d).toFixed(2)}

--- a/storybook/stories/bar/9_with_stacked_log.story.tsx
+++ b/storybook/stories/bar/9_with_stacked_log.story.tsx
@@ -18,7 +18,11 @@ export const Example = () => (
     <Axis id="bottom" position={Position.Bottom} title="Bottom axis" showOverlappingTicks />
     <Axis
       id="left2"
-      domain={{ fit: true }}
+      domain={{
+        min: NaN,
+        max: NaN,
+        fit: true,
+      }}
       title="Left axis"
       position={Position.Left}
       tickFormat={(d: any) => Number(d).toFixed(2)}

--- a/storybook/stories/bubble/1_simple.story.tsx
+++ b/storybook/stories/bubble/1_simple.story.tsx
@@ -36,7 +36,7 @@ export const Example = () => {
     max: 100,
     step: 10,
   });
-  const shape = select('shape', PointShape, PointShape.Circle);
+  const shape = select<PointShape>('shape', PointShape, PointShape.Circle);
   const opacity = number('shape fill opacity', 1, {
     range: true,
     min: 0,

--- a/storybook/stories/heatmap/1_basic.story.tsx
+++ b/storybook/stories/heatmap/1_basic.story.tsx
@@ -20,6 +20,8 @@ import {
   RecursivePartial,
   ScaleType,
   Settings,
+  HeatmapBrushEvent,
+  ElementClickListener,
 } from '@elastic/charts';
 import { Config } from '@elastic/charts/src/chart_types/heatmap/layout/types/config_types';
 import { SWIM_LANE_DATA } from '@elastic/charts/src/utils/data_samples/test_anomaly_swim_lane';
@@ -91,12 +93,13 @@ export const Example = () => {
     }
   }, 100);
 
-  // @ts-ignore
-  const onElementClick: ElementClickListener = useCallback((e: HeatmapElementEvent[]) => {
+  const onElementClick: ElementClickListener = useCallback((event) => {
+    const e = event as HeatmapElementEvent[];
     const cell = e[0][0];
-    // @ts-ignore
     setSelection({ x: [cell.datum.x, cell.datum.x], y: [cell.datum.y] });
   }, []);
+
+  const onBrushEnd = action('onBrushEnd');
 
   return (
     <Chart>
@@ -110,8 +113,9 @@ export const Example = () => {
         debugState={debugState}
         baseTheme={useBaseTheme()}
         onBrushEnd={(e) => {
-          action('onBrushEnd');
-          setSelection({ x: e.x, y: e.y });
+          onBrushEnd(e);
+          const { x, y } = e as HeatmapBrushEvent;
+          setSelection({ x, y });
         }}
       />
       <Heatmap

--- a/storybook/stories/interactions/14_crosshair_time.story.tsx
+++ b/storybook/stories/interactions/14_crosshair_time.story.tsx
@@ -65,7 +65,11 @@ export const Example = () => {
       <Axis
         id="left2"
         title="Left axis"
-        domain={{ fit: hideBars }}
+        domain={{
+          min: NaN,
+          max: NaN,
+          fit: hideBars,
+        }}
         position={Position.Left}
         tickFormat={[0, 180].includes(chartRotation) ? numberFormatter : formatter}
       />

--- a/storybook/stories/interactions/17_png_export.story.tsx
+++ b/storybook/stories/interactions/17_png_export.story.tsx
@@ -51,17 +51,12 @@ export const Example = () => {
     }
     // will save as chart.png
     const fileName = 'chart.png';
-    switch (snapshot.browser) {
-      case 'IE11':
-        return navigator.msSaveBlob(snapshot.blobOrDataUrl, fileName);
-      default:
-        const link = document.createElement('a');
-        link.download = fileName;
-        link.href = snapshot.blobOrDataUrl;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-    }
+    const link = document.createElement('a');
+    link.download = fileName;
+    link.href = snapshot.blobOrDataUrl;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
   };
   button('Export PNG', handler);
   const selectedChart = select('chart type', [ChartType.XYAxis, ChartType.Partition, ChartType.Goal], ChartType.XYAxis);
@@ -111,7 +106,15 @@ function renderXYAxisChart() {
         position={Position.Bottom}
         tickFormat={niceTimeFormatter([data[0][0], data[data.length - 1][0]])}
       />
-      <Axis id="count" domain={{ fit: true }} position={Position.Left} />
+      <Axis
+        id="count"
+        domain={{
+          min: NaN,
+          max: NaN,
+          fit: true,
+        }}
+        position={Position.Left}
+      />
 
       <BarSeries
         id="series bars chart"

--- a/storybook/stories/legend/10_sunburst.story.tsx
+++ b/storybook/stories/legend/10_sunburst.story.tsx
@@ -92,7 +92,6 @@ export const Example = () => {
           fillLabel: {
             valueFormatter: (d: number) => `$${config.fillLabel.valueFormatter(Math.round(d / 1000000000))}\u00A0Bn`,
             fontStyle: 'italic',
-            textInvertible: true,
             fontWeight: 900,
             valueFont: {
               fontFamily: 'Menlo',

--- a/storybook/stories/legend/10_sunburst_repeated_label.story.tsx
+++ b/storybook/stories/legend/10_sunburst_repeated_label.story.tsx
@@ -28,7 +28,7 @@ export const Example = () => {
       <Settings
         showLegend
         flatLegend={flatLegend}
-        legendStrategy={select('legendStrategy', LegendStrategy, LegendStrategy.Key)}
+        legendStrategy={select<LegendStrategy>('legendStrategy', LegendStrategy, LegendStrategy.Key)}
         legendMaxDepth={legendMaxDepth}
         baseTheme={useBaseTheme()}
       />

--- a/storybook/stories/line/13_line_mark_accessor.story.tsx
+++ b/storybook/stories/line/13_line_mark_accessor.story.tsx
@@ -52,7 +52,10 @@ export const Example = () => {
         title="Left axis"
         position={Position.Left}
         tickFormat={(d) => Number(d).toFixed(2)}
-        domain={{ max: 5 }}
+        domain={{
+          min: NaN,
+          max: 5,
+        }}
       />
 
       <LineSeries

--- a/storybook/stories/line/2_w_axis.story.tsx
+++ b/storybook/stories/line/2_w_axis.story.tsx
@@ -26,7 +26,13 @@ const dateFormatter = timeFormatter(niceTimeFormatByDay(1));
 
 export const Example = () => (
   <Chart>
-    <Settings xDomain={{ max: 2 }} baseTheme={useBaseTheme()} />
+    <Settings
+      xDomain={{
+        min: NaN,
+        max: 2,
+      }}
+      baseTheme={useBaseTheme()}
+    />
     <Axis id="bottom" position={Position.Bottom} showOverlappingTicks tickFormat={dateFormatter} />
     <Axis
       id="left"

--- a/storybook/stories/scales/7_log_scale_options.story.tsx
+++ b/storybook/stories/scales/7_log_scale_options.story.tsx
@@ -53,12 +53,13 @@ const getScaleType = (type: ScaleType, group: string) =>
     'log' | 'linear'
   >;
 
-const getLogKnobs = (isXAxis = false): LogKnobs => {
+const getLogKnobs = (isXAxis = false) => {
   const group = isXAxis ? 'X - Axis' : 'Y - Axis';
   const useDefaultLimit = boolean('Use default limit', isXAxis, group);
   const limit = number('Log min limit', 1, { min: 0 }, group);
 
   return {
+    ...{ min: NaN, max: NaN },
     ...(!isXAxis && { fit: boolean('Fit domain', true, group) }),
     dataType: getDataType(group, isXAxis ? undefined : 'upDown'),
     negative: boolean('Use negative values', false, group),

--- a/storybook/stories/small_multiples/3_grid_lines.story.tsx
+++ b/storybook/stories/small_multiples/3_grid_lines.story.tsx
@@ -24,6 +24,7 @@ import {
   niceTimeFormatByDay,
   timeFormatter,
   AxisSpec,
+  XYBrushEvent,
 } from '@elastic/charts';
 import { isVerticalAxis } from '@elastic/charts/src/chart_types/xy_chart/utils/axis_type_utils';
 import { SeededDataGenerator } from '@elastic/charts/src/mocks/utils';
@@ -72,6 +73,7 @@ const getAxisOptions = (
     tickFormat: isVertical ? (d) => d.toFixed(2) : tickTimeFormatter,
     domain: isVertical
       ? {
+          min: NaN,
           max: 10,
         }
       : undefined,
@@ -107,9 +109,10 @@ export const Example = () => {
           },
         }}
         baseTheme={useBaseTheme()}
-        onBrushEnd={(d: { x: any[] }) => {
-          if (d.x) {
-            action('brushEvent')(tickTimeFormatter(d.x[0] ?? 0), tickTimeFormatter(d.x[1] ?? 0));
+        onBrushEnd={(e) => {
+          const { x } = e as XYBrushEvent;
+          if (x) {
+            action('brushEvent')(tickTimeFormatter(x[0] ?? 0), tickTimeFormatter(x[1] ?? 0));
           }
         }}
       />

--- a/storybook/stories/test_cases/4_filter_zero_values_log.story.tsx
+++ b/storybook/stories/test_cases/4_filter_zero_values_log.story.tsx
@@ -26,7 +26,7 @@ export const Example = () => {
       <Axis
         id="count"
         position={Position.Left}
-        domain={{ fit, logMinLimit }}
+        domain={{ min: NaN, max: NaN, fit, logMinLimit }}
         tickFormat={logFormatter(LogBase.Common)}
       />
       <Axis id="x" position={Position.Bottom} integersOnly />

--- a/storybook/stories/utils/knobs.ts
+++ b/storybook/stories/utils/knobs.ts
@@ -93,7 +93,7 @@ export const getKnobsFromEnum = <T extends SelectTypeKnobValue, O extends Record
       .filter(([, v]) => !include || include.includes(v))
       .filter(([, v]) => !exclude || !exclude.includes(v))
       .reduce<O>((acc, [key, value]) => {
-        // @ts-ignore
+        // @ts-ignore - override key casing
         acc[startCase(kebabCase(key))] = value;
         return acc;
       }, (allowUndefined ? { Undefined: undefined } : ({} as unknown)) as O),
@@ -214,15 +214,11 @@ export const getFallbackPlacementsKnob = (): Placement[] | undefined => {
     },
   );
 
-  if (typeof knob === 'string') {
-    // @ts-ignore
-    return knob.split(', ');
-  }
-
-  // @ts-ignore
   if (knob.length === 0) {
     return;
   }
+
+  if (typeof knob === 'string') return knob.split(', ') as Placement[];
 
   return knob;
 };

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "../tsconfig",
-  "include": [
-    "../packages/charts/src/**/*",
-    "./**/*",
-    "../storybook-docs/config.docs.ts",
-  ],
+  "include": ["../packages/charts/src/**/*", "./**/*", "../storybook-docs/config.docs.ts"],
   "exclude": ["../**/*.test.*"]
 }

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -4,8 +4,6 @@
     "../packages/charts/src/**/*",
     "./**/*",
     "../storybook-docs/config.docs.ts",
-    "../**/*.d.ts",
-    "../scripts/custom_matchers.ts"
   ],
   "exclude": ["../**/*.test.*"]
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["packages/charts/src/**/*", "scripts/setup_enzyme.ts", "scripts/custom_matchers.ts"]
+  "include": ["packages/charts/src", "scripts", "declarations"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "downlevelIteration": true,
     "stripInternal": true,
     "resolveJsonModule": true,
-    "typeRoots": ["./node_modules/@types", "./**/*.d.ts", "./scripts/custom_matchers.ts"],
+    "typeRoots": ["./node_modules/@types"],
     "paths": {
       "*": ["./declarations/*", "./*"],
       "/@elastic/charts$": ["./packages/charts/src"],


### PR DESCRIPTION
## Details

- remove unnecessary `// @ts-ignore` comments
- add descriptions to legit `// @ts-ignore` comments
- add [rule](https://github.com/typescript-eslint/typescript-eslint/blob/v4.31.1/packages/eslint-plugin/docs/rules/ban-ts-comment.md) to error on all ts-comments with no description
- remove `global.d.ts` in favor of `declarations/`
- fix type issue related to `jest-extended` and custom matchers
- fix types around `sortSeriesBy` hidden setting
- fix type errors around required `domain` options
- fix type errors around union brush events
- remove deprecated [`msSaveBlob`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/msSaveBlob) usage
- add step to ci to check `yarn typecheck:all` as type errors somehow snuck into `master`


### Eslint changes

Before eslint would **WARN** ⚠️ you when using `// @ts-ignore`, `// @ts-expect-error`, `// @ts-nocheck` or `// @ts-check`. This caused some to ignore the eslint warning but now it is explicit why we are ignoring a given line.

Now it will **ERROR** ❌  when using any of the above _without_ a description, otherwise it will not complain.

![Image 2021-09-23 at 12 48 21 PM](https://user-images.githubusercontent.com/19007109/134560296-5211740c-4d63-4ed0-8be2-24bf1a77f8ca.jpg)

### Checklist

- [x] New public API exports have been added to `packages/charts/src/index.ts`