### PR TITLE
2021 10 01 fix null/missing values on percentage tooltip

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/rendering/bars.ts
+++ b/packages/charts/src/chart_types/xy_chart/rendering/bars.ts
@@ -17,6 +17,7 @@ import { BarSeriesStyle, DisplayValueStyle } from '../../../utils/themes/theme';
 import { IndexedGeometryMap } from '../utils/indexed_geometry_map';
 import { DataSeries, DataSeriesDatum, XYChartSeriesIdentifier } from '../utils/series';
 import { BarStyleAccessor, DisplayValueSpec, LabelOverflowConstraint, StackMode } from '../utils/specs';
+import { getDatumYValue } from './points';
 
 const PADDING = 1; // default padding for now
 const FONT_SIZE_FACTOR = 0.7; // Take 70% of space for the label text
@@ -87,8 +88,7 @@ export function renderBars(
       const width = clamp(seriesStyle.rect.widthPixel ?? xScale.bandwidth, minPixelWidth, maxPixelWidth);
       const x = xScaled + xScale.bandwidth * orderIndex + xScale.bandwidth / 2 - width / 2;
 
-      const y1Value =
-        stackMode === StackMode.Percentage ? (isNil(y1) || isNil(initialY1) ? null : y1 - (y0 ?? 0)) : initialY1;
+      const y1Value = getDatumYValue(datum, false, false, stackMode);
       const formattedDisplayValue = displayValueSettings?.valueFormatter?.(y1Value);
 
       // only show displayValue for even bars if showOverlappingValue

--- a/packages/charts/src/chart_types/xy_chart/rendering/bars.ts
+++ b/packages/charts/src/chart_types/xy_chart/rendering/bars.ts
@@ -87,8 +87,9 @@ export function renderBars(
       const width = clamp(seriesStyle.rect.widthPixel ?? xScale.bandwidth, minPixelWidth, maxPixelWidth);
       const x = xScaled + xScale.bandwidth * orderIndex + xScale.bandwidth / 2 - width / 2;
 
-      const originalY1Value = stackMode === StackMode.Percentage ? (isNil(y1) ? null : y1 - (y0 ?? 0)) : initialY1;
-      const formattedDisplayValue = displayValueSettings?.valueFormatter?.(originalY1Value);
+      const y1Value =
+        stackMode === StackMode.Percentage ? (isNil(y1) || isNil(initialY1) ? null : y1 - (y0 ?? 0)) : initialY1;
+      const formattedDisplayValue = displayValueSettings?.valueFormatter?.(y1Value);
 
       // only show displayValue for even bars if showOverlappingValue
       const displayValueText =
@@ -140,7 +141,7 @@ export function renderBars(
         width,
         height,
         color,
-        value: { x: datum.x, y: originalY1Value, mark: null, accessor: BandedAccessorType.Y1, datum: datum.datum },
+        value: { x: datum.x, y: y1Value, mark: null, accessor: BandedAccessorType.Y1, datum: datum.datum },
         seriesIdentifier,
         seriesStyle,
         panel,

--- a/packages/charts/src/chart_types/xy_chart/rendering/points.ts
+++ b/packages/charts/src/chart_types/xy_chart/rendering/points.ts
@@ -160,30 +160,25 @@ export function getPointStyleOverrides(
  * @param lookingForY0 if we are interested in the y0 value, false for y1
  * @param isBandChart if the chart is a band chart
  * @param stackMode an optional stack mode
+ * @internal
  */
-function getDatumYValue(
+export function getDatumYValue(
   { y1, y0, initialY1, initialY0 }: DataSeriesDatum,
   lookingForY0: boolean,
   isBandChart: boolean,
   stackMode?: StackMode,
 ) {
   if (isBandChart) {
-    return stackMode === StackMode.Percentage
-      ? // on band stacked charts in percentage mode, the values I'm looking for are the percentage value
-        // that are already computed and available on y0 and y1
-        lookingForY0
-        ? y0
-        : y1
-      : // in all other cases for band charts, I want to get back the original/initial value of y0 and y1
-      // not the computed value
-      lookingForY0
-      ? initialY0
-      : initialY1;
+    // on band stacked charts in percentage mode, the values I'm looking for are the percentage value
+    // that are already computed and available on y0 and y1
+    // in all other cases for band charts, I want to get back the original/initial value of y0 and y1
+    // not the computed value
+    return stackMode === StackMode.Percentage ? (lookingForY0 ? y0 : y1) : lookingForY0 ? initialY0 : initialY1;
   }
   // if not a band chart get use the original/initial value in every case except for stack as percentage
   // in this case, we should take the difference between the bottom position of the bar and the top position
   // of the bar
-  return stackMode === StackMode.Percentage ? (y1 ?? 0) - (y0 ?? 0) : initialY1;
+  return stackMode === StackMode.Percentage ? (isNil(y1) || isNil(initialY1) ? null : y1 - (y0 ?? 0)) : initialY1;
 }
 
 /**

--- a/packages/charts/src/chart_types/xy_chart/rendering/rendering.bars.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/rendering/rendering.bars.test.ts
@@ -6,10 +6,16 @@
  * Side Public License, v 1.
  */
 
+import { Store } from 'redux';
+
 import { MockGlobalSpec, MockSeriesSpec } from '../../../mocks/specs';
 import { MockStore } from '../../../mocks/store';
 import { ScaleType } from '../../../scales/constants';
+import { onPointerMove } from '../../../state/actions/mouse';
+import { GlobalChartState } from '../../../state/chart_state';
 import { computeSeriesGeometriesSelector } from '../state/selectors/compute_series_geometries';
+import { getTooltipInfoAndGeometriesSelector } from '../state/selectors/get_tooltip_values_highlighted_geoms';
+import { StackMode } from '../utils/specs';
 
 const SPEC_ID = 'spec_1';
 const GROUP_ID = 'group_1';
@@ -209,6 +215,88 @@ describe('Rendering bars', () => {
     });
     test('can render second spec bars', () => {
       expect(bars[1].value).toMatchSnapshot();
+    });
+  });
+
+  describe('BarGeometryValue', () => {
+    it('stacked tooltip should be consistent with the original nature of the datum', () => {
+      const barSpec = MockSeriesSpec.bar({
+        data: [
+          { x: 0, y: 0, g: 'a' },
+          { x: 1, y: null, g: 'a' },
+          { x: 0, y: 4, g: 'b' },
+          { x: 1, y: 5, g: 'b' },
+          { x: 2, y: 2, g: 'b' },
+        ],
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        stackAccessors: ['x'],
+        xScaleType: ScaleType.Ordinal,
+        yScaleType: ScaleType.Linear,
+      });
+      const store = MockStore.default({ width: 90, height: 100, top: 0, left: 0 });
+      MockStore.addSpecs(
+        [barSpec, MockGlobalSpec.settingsNoMargins({ theme: { colors: { vizColors: ['red', 'blue'] } } })],
+        store,
+      );
+      const tooltipValues = (store: Store) =>
+        getTooltipInfoAndGeometriesSelector(store.getState()).tooltip.values.map((d) => [d.label, d.value]);
+
+      // move over the 1st bar
+      store.dispatch(onPointerMove({ x: 15, y: 50 }, 0));
+      expect(tooltipValues(store)).toIncludeSameMembers([
+        ['a', 0],
+        ['b', 4],
+      ]);
+
+      // move over the 2nd bar (hide the null)
+      store.dispatch(onPointerMove({ x: 45, y: 50 }, 1));
+      expect(tooltipValues(store)).toIncludeSameMembers([['b', 5]]);
+
+      // move over the 3rd bar (hide missing series)
+      store.dispatch(onPointerMove({ x: 75, y: 50 }, 1));
+      expect(tooltipValues(store)).toIncludeSameMembers([['b', 2]]);
+    });
+    it('stacked as % tooltip should be consistent with the original nature of the datum', () => {
+      const barSpec = MockSeriesSpec.bar({
+        data: [
+          { x: 0, y: 0, g: 'a' },
+          { x: 1, y: null, g: 'a' },
+          { x: 0, y: 4, g: 'b' },
+          { x: 1, y: 5, g: 'b' },
+          { x: 2, y: 2, g: 'b' },
+        ],
+        xAccessor: 'x',
+        yAccessors: ['y'],
+        splitSeriesAccessors: ['g'],
+        stackAccessors: ['x'],
+        stackMode: StackMode.Percentage,
+        xScaleType: ScaleType.Ordinal,
+        yScaleType: ScaleType.Linear,
+      });
+      const store = MockStore.default({ width: 90, height: 100, top: 0, left: 0 });
+      MockStore.addSpecs(
+        [barSpec, MockGlobalSpec.settingsNoMargins({ theme: { colors: { vizColors: ['red', 'blue'] } } })],
+        store,
+      );
+      const tooltipValues = (store: Store) =>
+        getTooltipInfoAndGeometriesSelector(store.getState()).tooltip.values.map((d) => [d.label, d.value]);
+
+      // move over the 1st bar
+      store.dispatch(onPointerMove({ x: 15, y: 50 }, 0));
+      expect(tooltipValues(store)).toIncludeSameMembers([
+        ['a', 0],
+        ['b', 1],
+      ]);
+
+      // move over the 2nd bar (hide the null)
+      store.dispatch(onPointerMove({ x: 45, y: 50 }, 1));
+      expect(tooltipValues(store)).toIncludeSameMembers([['b', 1]]);
+
+      // move over the 3rd bar (hide missing series)
+      store.dispatch(onPointerMove({ x: 75, y: 50 }, 1));
+      expect(tooltipValues(store)).toIncludeSameMembers([['b', 1]]);
     });
   });
 });

--- a/packages/charts/src/chart_types/xy_chart/rendering/rendering.bars.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/rendering/rendering.bars.test.ts
@@ -6,15 +6,10 @@
  * Side Public License, v 1.
  */
 
-import { Store } from 'redux';
-
 import { MockGlobalSpec, MockSeriesSpec } from '../../../mocks/specs';
 import { MockStore } from '../../../mocks/store';
 import { ScaleType } from '../../../scales/constants';
-import { onPointerMove } from '../../../state/actions/mouse';
 import { computeSeriesGeometriesSelector } from '../state/selectors/compute_series_geometries';
-import { getTooltipInfoAndGeometriesSelector } from '../state/selectors/get_tooltip_values_highlighted_geoms';
-import { SeriesType, StackMode } from '../utils/specs';
 
 const SPEC_ID = 'spec_1';
 const GROUP_ID = 'group_1';
@@ -215,58 +210,5 @@ describe('Rendering bars', () => {
     test('can render second spec bars', () => {
       expect(bars[1].value).toMatchSnapshot();
     });
-  });
-
-  describe('BarGeometryValue', () => {
-    const partialSpec = {
-      data: [
-        { x: 0, y: 0, g: 'a' },
-        { x: 1, y: null, g: 'a' },
-        { x: 0, y: 4, g: 'b' },
-        { x: 1, y: 5, g: 'b' },
-        { x: 2, y: 2, g: 'b' },
-      ],
-      xAccessor: 'x',
-      yAccessors: ['y'],
-      splitSeriesAccessors: ['g'],
-      stackAccessors: ['x'],
-      xScaleType: ScaleType.Ordinal,
-      yScaleType: ScaleType.Linear,
-    };
-    let store: Store;
-    beforeEach(() => {
-      store = MockStore.default({ width: 90, height: 100, top: 0, left: 0 });
-    });
-
-    const tooltipValues = (s: Store) =>
-      getTooltipInfoAndGeometriesSelector(s.getState()).tooltip.values.map((d) => [d.label, d.value]);
-
-    it.each`
-      type               | stackMode               | first                   | second        | third
-      ${SeriesType.Bar}  | ${StackMode.Percentage} | ${[['a', 0], ['b', 1]]} | ${[['b', 1]]} | ${[['b', 1]]}
-      ${SeriesType.Bar}  | ${undefined}            | ${[['a', 0], ['b', 4]]} | ${[['b', 5]]} | ${[['b', 2]]}
-      ${SeriesType.Area} | ${StackMode.Percentage} | ${[['a', 0], ['b', 1]]} | ${[['b', 1]]} | ${[['b', 1]]}
-      ${SeriesType.Area} | ${undefined}            | ${[['a', 0], ['b', 4]]} | ${[['b', 5]]} | ${[['b', 2]]}
-    `(
-      'stacked $type $stackMode tooltip should be consistent with the original nature of the datum',
-      ({ type, stackMode, first, second, third }) => {
-        MockStore.addSpecs(
-          [
-            MockSeriesSpec.byTypePartial(type)({ ...partialSpec, stackMode }),
-            MockGlobalSpec.settingsNoMargins({ theme: { colors: { vizColors: ['red', 'blue'] } } }),
-          ],
-          store,
-        );
-        // move over the 1st bar
-        store.dispatch(onPointerMove({ x: 15, y: 50 }, 0));
-        expect(tooltipValues(store)).toIncludeSameMembers(first);
-        // move over the 2nd bar (hide the null)
-        store.dispatch(onPointerMove({ x: 45, y: 50 }, 1));
-        expect(tooltipValues(store)).toIncludeSameMembers(second);
-        // move over the 3rd bar (hide missing series)
-        store.dispatch(onPointerMove({ x: 75, y: 50 }, 1));
-        expect(tooltipValues(store)).toIncludeSameMembers(third);
-      },
-    );
   });
 });

--- a/packages/charts/src/chart_types/xy_chart/state/chart_state.interactions.test.tsx
+++ b/packages/charts/src/chart_types/xy_chart/state/chart_state.interactions.test.tsx
@@ -17,7 +17,7 @@ import { Rect } from '../../../geoms/types';
 import { MockAnnotationSpec, MockGlobalSpec, MockSeriesSpec } from '../../../mocks/specs/specs';
 import { MockStore } from '../../../mocks/store';
 import { ScaleType } from '../../../scales/constants';
-import { BrushEvent, SettingsSpec } from '../../../specs';
+import { BrushEvent, SettingsSpec, StackMode } from '../../../specs';
 import { SpecType, TooltipType, BrushAxis } from '../../../specs/constants';
 import { onExternalPointerEvent } from '../../../state/actions/events';
 import { onPointerMove, onMouseDown, onMouseUp } from '../../../state/actions/mouse';
@@ -1352,6 +1352,59 @@ describe('Clickable annotations', () => {
     store.dispatch(onMouseDown({ x: 10, y: 10 }, 100));
     store.dispatch(onMouseUp({ x: 10, y: 10 }, 200));
     expect(onAnnotationClick).toBeCalled();
+  });
+
+  describe('Tooltip on null/missing values', () => {
+    const partialSpec = {
+      data: [
+        { x: 0, y: 0, g: 'a' },
+        { x: 1, y: null, g: 'a' },
+        { x: 0, y: 4, g: 'b' },
+        { x: 1, y: 5, g: 'b' },
+        { x: 2, y: 2, g: 'b' },
+      ],
+      xAccessor: 'x',
+      yAccessors: ['y'],
+      splitSeriesAccessors: ['g'],
+      stackAccessors: ['x'],
+      xScaleType: ScaleType.Ordinal,
+      yScaleType: ScaleType.Linear,
+    };
+    let store: Store;
+    beforeEach(() => {
+      store = MockStore.default({ width: 90, height: 100, top: 0, left: 0 });
+    });
+
+    const tooltipValues = (s: Store) =>
+      getTooltipInfoAndGeometriesSelector(s.getState()).tooltip.values.map((d) => [d.label, d.value]);
+
+    it.each`
+      type               | stackMode               | first                   | second        | third
+      ${SeriesType.Bar}  | ${StackMode.Percentage} | ${[['a', 0], ['b', 1]]} | ${[['b', 1]]} | ${[['b', 1]]}
+      ${SeriesType.Bar}  | ${undefined}            | ${[['a', 0], ['b', 4]]} | ${[['b', 5]]} | ${[['b', 2]]}
+      ${SeriesType.Area} | ${StackMode.Percentage} | ${[['a', 0], ['b', 1]]} | ${[['b', 1]]} | ${[['b', 1]]}
+      ${SeriesType.Area} | ${undefined}            | ${[['a', 0], ['b', 4]]} | ${[['b', 5]]} | ${[['b', 2]]}
+    `(
+      `tooltip should hide null/missing values on stacked $type in $stackMode mode`,
+      ({ type, stackMode, first, second, third }) => {
+        MockStore.addSpecs(
+          [
+            MockSeriesSpec.byTypePartial(type)({ ...partialSpec, stackMode }),
+            MockGlobalSpec.settingsNoMargins({ theme: { colors: { vizColors: ['red', 'blue'] } } }),
+          ],
+          store,
+        );
+        // move over the 1st bar
+        store.dispatch(onPointerMove({ x: 15, y: 50 }, 0));
+        expect(tooltipValues(store)).toIncludeSameMembers(first);
+        // move over the 2nd bar (hide the null)
+        store.dispatch(onPointerMove({ x: 45, y: 50 }, 1));
+        expect(tooltipValues(store)).toIncludeSameMembers(second);
+        // move over the 3rd bar (hide missing series)
+        store.dispatch(onPointerMove({ x: 75, y: 50 }, 1));
+        expect(tooltipValues(store)).toIncludeSameMembers(third);
+      },
+    );
   });
 });
 

--- a/storybook/stories/bar/12_stacked_as_percentage.story.tsx
+++ b/storybook/stories/bar/12_stacked_as_percentage.story.tsx
@@ -14,17 +14,17 @@ import { Axis, BarSeries, Chart, Position, ScaleType, Settings, StackMode } from
 import { useBaseTheme } from '../../use_base_theme';
 
 export const Example = () => {
-  const stackedAsPercentage = boolean('stacked as percentage', true);
-  const clusterBars = boolean('cluster', true);
+  const stackMode = boolean('stacked as percentage', true) ? StackMode.Percentage : undefined;
   return (
     <Chart>
       <Settings showLegend showLegendExtra legendPosition={Position.Right} baseTheme={useBaseTheme()} />
       <Axis id="bottom" position={Position.Bottom} title="Bottom axis" showOverlappingTicks />
+
       <Axis
         id="left2"
         title="Left axis"
         position={Position.Left}
-        tickFormat={(d: any) => (stackedAsPercentage && !clusterBars ? `${Number(d * 100).toFixed(0)} %` : d)}
+        tickFormat={(d: any) => (stackMode === StackMode.Percentage ? `${Number(d * 100).toFixed(0)} %` : d)}
       />
 
       <BarSeries
@@ -33,18 +33,18 @@ export const Example = () => {
         yScaleType={ScaleType.Linear}
         xAccessor="x"
         yAccessors={['y']}
-        stackAccessors={clusterBars ? [] : ['x']}
-        stackMode={clusterBars ? undefined : StackMode.Percentage}
+        stackMode={stackMode}
+        stackAccessors={['x']}
         splitSeriesAccessors={['g']}
         data={[
-          { x: 0, y: 2, g: 'a' },
-          { x: 1, y: 7, g: 'a' },
-          { x: 2, y: 3, g: 'a' },
-          { x: 3, y: 6, g: 'a' },
           { x: 0, y: 4, g: 'b' },
           { x: 1, y: 5, g: 'b' },
           { x: 2, y: 8, g: 'b' },
           { x: 3, y: 2, g: 'b' },
+          { x: 0, y: 2, g: 'a' },
+          { x: 1, y: 2, g: 'a' },
+          { x: 2, y: 0, g: 'a' },
+          { x: 3, y: null, g: 'a' },
         ]}
       />
     </Chart>


### PR DESCRIPTION
## Summary

A regression was introduced and caused null values to show up on the tooltip when rendering stacked bars and areas.
We fixed that issue including proper testing for the use case.

## Details
The file `chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts` is used to pick the tooltip values from the subset of geometries that the current mouse position intersect. A check was introduced in #1226 to check whenever to include or not a null Y value into a tooltip list.
That PR also altered the current data flow, allowing nullish value in the `y1` or `initialY1` to flow down within the `indexedGeometryMap` to be used on the tooltip, but filtered on the rendering side.
This together with a wrong logic and no test on that edge case caused the regression.

## Issues

fix #1414 


### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [x] Unit tests have been added or updated to match the most common scenarios
- [x] The proper documentation and/or storybook story has been added or updated
