### PR TITLE
fix(theme): merge partial with empty initial partial

### DIFF
--- a/packages/charts/api/charts.api.md
+++ b/packages/charts/api/charts.api.md
@@ -1350,7 +1350,7 @@ export function mergeWithDefaultAnnotationLine(config?: Partial<LineAnnotationSt
 // @public (undocumented)
 export function mergeWithDefaultAnnotationRect(config?: Partial<RectAnnotationStyle>): RectAnnotationStyle;
 
-// @public
+// @public @deprecated
 export function mergeWithDefaultTheme(theme: PartialTheme, defaultTheme?: Theme, auxiliaryThemes?: PartialTheme[]): Theme;
 
 // @public (undocumented)

--- a/packages/charts/src/state/selectors/get_chart_theme.ts
+++ b/packages/charts/src/state/selectors/get_chart_theme.ts
@@ -6,8 +6,8 @@
  * Side Public License, v 1.
  */
 
+import { mergePartial } from '../../utils/common';
 import { LIGHT_THEME } from '../../utils/themes/light_theme';
-import { mergeWithDefaultTheme } from '../../utils/themes/merge_utils';
 import { PartialTheme, Theme } from '../../utils/themes/theme';
 import { createCustomCachedSelector } from '../create_selector';
 import { getSettingsSpecSelector } from './get_settings_specs';
@@ -19,12 +19,12 @@ export const getChartThemeSelector = createCustomCachedSelector(
 );
 
 function getTheme(baseTheme?: Theme, theme?: PartialTheme | PartialTheme[]): Theme {
-  const base = baseTheme || LIGHT_THEME;
+  const base = baseTheme ?? LIGHT_THEME;
 
   if (Array.isArray(theme)) {
     const [firstTheme, ...axillaryThemes] = theme;
-    return mergeWithDefaultTheme(firstTheme, base, axillaryThemes);
+    return mergePartial(base, firstTheme, {}, axillaryThemes);
   }
 
-  return theme ? mergeWithDefaultTheme(theme, base) : base;
+  return theme ? mergePartial(base, theme) : base;
 }

--- a/packages/charts/src/utils/common.test.ts
+++ b/packages/charts/src/utils/common.test.ts
@@ -105,28 +105,46 @@ describe('common utilities', () => {
       key6: 6,
     };
 
+    it('should allow undefined object', () => {
+      const result = getAllKeys(undefined, [object1]);
+
+      expect(result).toEqual(new Set(['key1', 'key2']));
+    });
+
+    it('should return allow undefined objects', () => {
+      const result = getAllKeys(undefined, undefined);
+
+      expect(result).toEqual(new Set([]));
+    });
+
+    it('should remove duplicates', () => {
+      const result = getAllKeys(object1, [object1]);
+
+      expect(result).toEqual(new Set(['key1', 'key2']));
+    });
+
     it('should return all keys from single object', () => {
       const result = getAllKeys(object1);
 
-      expect(result).toEqual(['key1', 'key2']);
+      expect(result).toEqual(new Set(['key1', 'key2']));
     });
 
     it('should return all keys from all objects x 2', () => {
       const result = getAllKeys(object1, [object2]);
 
-      expect(result).toEqual(['key1', 'key2', 'key3', 'key4']);
+      expect(result).toEqual(new Set(['key1', 'key2', 'key3', 'key4']));
     });
 
     it('should return all keys from single objects x 3', () => {
       const result = getAllKeys(object1, [object2, object3]);
 
-      expect(result).toEqual(['key1', 'key2', 'key3', 'key4', 'key5', 'key6']);
+      expect(result).toEqual(new Set(['key1', 'key2', 'key3', 'key4', 'key5', 'key6']));
     });
 
     it('should return all keys from only defined objects', () => {
       const result = getAllKeys(object1, [null, object2, {}, undefined]);
 
-      expect(result).toEqual(['key1', 'key2', 'key3', 'key4']);
+      expect(result).toEqual(new Set(['key1', 'key2', 'key3', 'key4']));
     });
   });
 
@@ -723,6 +741,58 @@ describe('common utilities', () => {
           nested: {
             ...newBase.nested,
             number: partials[0].nested!.number,
+          },
+        });
+      });
+
+      test('should traverse all partial keys', () => {
+        interface Test {
+          crosshair: {
+            line: {
+              dash?: number[];
+              strokeWidth: number;
+            };
+            band?: {
+              visible: boolean;
+            };
+          };
+        }
+        const customBase: Test = {
+          crosshair: {
+            line: {
+              strokeWidth: 1,
+            },
+          },
+        };
+        const partials: RecursivePartial<Test>[] = [
+          {
+            crosshair: {
+              line: {
+                dash: [4, 4],
+              },
+            },
+          },
+          {
+            crosshair: {
+              line: {
+                strokeWidth: 10,
+              },
+              band: {
+                visible: true,
+              },
+            },
+          },
+        ];
+        const newBase = mergePartial(customBase, {}, {}, partials);
+        expect(newBase).toEqual({
+          crosshair: {
+            line: {
+              strokeWidth: 10,
+              dash: [4, 4],
+            },
+            band: {
+              visible: true,
+            },
           },
         });
       });

--- a/packages/charts/src/utils/themes/merge_utils.ts
+++ b/packages/charts/src/utils/themes/merge_utils.ts
@@ -6,9 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { mergePartial } from '../common';
-import { LIGHT_THEME } from './light_theme';
-import { LineAnnotationStyle, PartialTheme, RectAnnotationStyle, Theme } from './theme';
+import { LineAnnotationStyle, RectAnnotationStyle } from './theme';
 
 /** @public */
 export const DEFAULT_ANNOTATION_LINE_STYLE: LineAnnotationStyle = {
@@ -70,23 +68,4 @@ export function mergeWithDefaultAnnotationRect(config?: Partial<RectAnnotationSt
     ...DEFAULT_ANNOTATION_RECT_STYLE,
     ...config,
   };
-}
-
-/**
- * Merge theme or themes with a base theme
- *
- * priority is based on spatial order
- *
- * @param theme - primary partial theme
- * @param defaultTheme - base theme
- * @param auxiliaryThemes - additional themes to be merged
- *
- * @public
- */
-export function mergeWithDefaultTheme(
-  theme: PartialTheme,
-  defaultTheme: Theme = LIGHT_THEME,
-  auxiliaryThemes: PartialTheme[] = [],
-): Theme {
-  return mergePartial(defaultTheme, theme, {}, auxiliaryThemes);
 }

--- a/packages/charts/src/utils/themes/merge_utils.ts
+++ b/packages/charts/src/utils/themes/merge_utils.ts
@@ -6,7 +6,9 @@
  * Side Public License, v 1.
  */
 
-import { LineAnnotationStyle, RectAnnotationStyle } from './theme';
+import { mergePartial } from '../common';
+import { LIGHT_THEME } from './light_theme';
+import { LineAnnotationStyle, PartialTheme, RectAnnotationStyle, Theme } from './theme';
 
 /** @public */
 export const DEFAULT_ANNOTATION_LINE_STYLE: LineAnnotationStyle = {
@@ -68,4 +70,24 @@ export function mergeWithDefaultAnnotationRect(config?: Partial<RectAnnotationSt
     ...DEFAULT_ANNOTATION_RECT_STYLE,
     ...config,
   };
+}
+
+/**
+ * Merge theme or themes with a base theme
+ *
+ * priority is based on spatial order
+ *
+ * @param theme - primary partial theme
+ * @param defaultTheme - base theme
+ * @param auxiliaryThemes - additional themes to be merged
+ *
+ * @public
+ * @deprecated - Please use `baseTheme` and `theme` on Settings instead
+ */
+export function mergeWithDefaultTheme(
+  theme: PartialTheme,
+  defaultTheme: Theme = LIGHT_THEME,
+  auxiliaryThemes: PartialTheme[] = [],
+): Theme {
+  return mergePartial(defaultTheme, theme, {}, auxiliaryThemes);
 }


### PR DESCRIPTION
## Summary

Fix theming override logic to allow initial partial value as empty object (`{}`). 

Before something like the chart below would ignore the `dash` definition because the first partial is empty.

```tsx
export const Example = () => {
  return (
    <Chart>
      <Settings
        baseTheme={useBaseTheme()}
        theme={[
          {},
          {
            crosshair: {
              line: {
                dash: [4, 4],
              },
            },
          },
          EUI_CHARTS_THEME_LIGHT.theme,
        ]}
      />
    </Chart>
  );
};
```

Now the dash is correctly shown.

![Screen Recording 2021-11-01 at 06 29 11 PM](https://user-images.githubusercontent.com/19007109/139755547-9de91b24-7783-40fd-9402-b2a60614b07a.gif)

## Details

The `mergePartial` logic had two issues...

1. The merge optional values logic only ran if the first partial was not `undefined`. Now it checks for any keys on all partial values at the given level and applies mutations to the `baseClone` as needed, if either the `partial` has applicable keys or any `additionalPartials` have applicable keys.
2. The final mapping over the new `baseClone` was only looking at the keys of the `base` and not the `baseClone`.

Unrelated, deprecates `mergeWithDefaultTheme` and removes all internal usage.

## Issues

Actually fixes #1284 

Related to https://github.com/elastic/kibana/issues/116754 

### Checklist

- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [x] New public API exports have been added to `packages/charts/src/index.ts`
- [x] Unit tests have been added or updated to match the most common scenarios
