### PR TITLE
build: disable commenting on successfully release PRs

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -21,7 +21,13 @@ module.exports = {
         execCwd: '.',
       },
     ],
-    '@semantic-release/github',
+    [
+      '@semantic-release/github',
+      {
+        successComment: false,
+        failComment: false,
+      },
+    ],
     [
       '@semantic-release/npm',
       {


### PR DESCRIPTION
## Summary

The current `semantic-release` configuration creates a comment on each PR that is released. There is a [bug](https://github.com/semantic-release/github/issues/359) that cause re-commenting on the same PR over and over again if the commit message has the `fix #123`  caption like in https://github.com/elastic/elastic-charts/issues/1108#issuecomment-854838687

This creates a lot of noises in the github notifications.