### PR TITLE
fix: export deprecated partition config types

### DIFF
--- a/packages/charts/api/charts.api.md
+++ b/packages/charts/api/charts.api.md
@@ -2623,7 +2623,7 @@ export type YDomainRange = YDomainBase & DomainRange & LogScaleOptions;
 
 // Warnings were encountered during analysis:
 //
-// src/chart_types/partition_chart/layout/types/config.ts:61:5 - (ae-forgotten-export) The symbol "TimeMs" needs to be exported by the entry point index.d.ts
+// src/chart_types/partition_chart/layout/types/config.ts:60:5 - (ae-forgotten-export) The symbol "TimeMs" needs to be exported by the entry point index.d.ts
 // src/utils/themes/theme.ts:217:5 - (ae-forgotten-export) The symbol "TextAlign" needs to be exported by the entry point index.d.ts
 // src/utils/themes/theme.ts:218:5 - (ae-forgotten-export) The symbol "TextBaseline" needs to be exported by the entry point index.d.ts
 

--- a/packages/charts/api/charts.api.md
+++ b/packages/charts/api/charts.api.md
@@ -1589,6 +1589,19 @@ export type PartialTheme = RecursivePartial<Theme>;
 // @public (undocumented)
 export const Partition: React_2.FunctionComponent<SpecRequiredProps_7 & SpecOptionalProps_7>;
 
+// Warning: (ae-forgotten-export) The symbol "StaticConfig" needs to be exported by the entry point index.d.ts
+//
+// @public @deprecated
+export interface PartitionConfig extends StaticConfig {
+    // @alpha (undocumented)
+    animation: {
+        duration: TimeMs;
+        keyframes: Array<AnimKeyframe & {
+            keyframeConfig: Partial<StaticConfig>;
+        }>;
+    };
+}
+
 // @public (undocumented)
 export type PartitionElementEvent = [Array<LayerValue>, SeriesIdentifier];
 
@@ -1887,6 +1900,18 @@ export type RelativeBandsPadding = {
     outer: Ratio;
     inner: Ratio;
 };
+
+// @public (undocumented)
+export interface RelativeMargins {
+    // (undocumented)
+    bottom: SizeRatio;
+    // (undocumented)
+    left: SizeRatio;
+    // (undocumented)
+    right: SizeRatio;
+    // (undocumented)
+    top: SizeRatio;
+}
 
 // @public
 export type RenderChangeListener = (isRendered: boolean) => void;
@@ -2598,6 +2623,7 @@ export type YDomainRange = YDomainBase & DomainRange & LogScaleOptions;
 
 // Warnings were encountered during analysis:
 //
+// src/chart_types/partition_chart/layout/types/config.ts:61:5 - (ae-forgotten-export) The symbol "TimeMs" needs to be exported by the entry point index.d.ts
 // src/utils/themes/theme.ts:217:5 - (ae-forgotten-export) The symbol "TextAlign" needs to be exported by the entry point index.d.ts
 // src/utils/themes/theme.ts:218:5 - (ae-forgotten-export) The symbol "TextBaseline" needs to be exported by the entry point index.d.ts
 

--- a/packages/charts/src/chart_types/partition_chart/layout/types/config.ts
+++ b/packages/charts/src/chart_types/partition_chart/layout/types/config.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Color } from '../../../../common/colors';
+import { SizeRatio, Distance, Radian, Radius, Ratio, Pixels, TimeMs } from '../../../../common/geometry';
+import { FontFamily } from '../../../../common/text_utils';
+import { StrokeStyle } from '../../../../utils/common';
+import { FillFontSizeRange, FillLabelConfig, LinkLabelConfig } from '../../../../utils/themes/partition';
+import { AnimKeyframe, PartitionLayout } from './config_types';
+
+/** @public */
+export interface RelativeMargins {
+  left: SizeRatio;
+  right: SizeRatio;
+  top: SizeRatio;
+  bottom: SizeRatio;
+}
+
+interface StaticConfig extends FillFontSizeRange {
+  width: number;
+  height: number;
+  margin: RelativeMargins;
+  emptySizeRatio: SizeRatio;
+  outerSizeRatio: SizeRatio;
+  clockwiseSectors: boolean;
+  specialFirstInnermostSector: boolean;
+  partitionLayout: PartitionLayout;
+  drilldown: boolean;
+  fontFamily: FontFamily;
+  circlePadding: Distance;
+  radialPadding: Distance;
+  horizontalTextAngleThreshold: Radian;
+  horizontalTextEnforcer: Ratio;
+  maxRowCount: number;
+  fillOutside: boolean;
+  radiusOutside: Radius;
+  fillRectangleWidth: Distance;
+  fillRectangleHeight: Distance;
+  fillLabel: FillLabelConfig;
+  linkLabel: LinkLabelConfig;
+  backgroundColor: Color;
+  sectorLineWidth: Pixels;
+  sectorLineStroke: StrokeStyle;
+}
+
+/**
+ * Old config object for partition charts
+ *
+ * @deprecated assign values to theme.partition or PartitionSpec instead
+ * @public
+ */
+export interface PartitionConfig extends StaticConfig {
+  /** @alpha */
+  animation: {
+    duration: TimeMs;
+    keyframes: Array<
+      AnimKeyframe & {
+        keyframeConfig: Partial<StaticConfig>;
+      }
+    >;
+  };
+}

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -49,6 +49,9 @@ export { Layer as PartitionLayer } from './chart_types/partition_chart/specs/ind
 export * from './chart_types/goal_chart/specs/index';
 export * from './chart_types/wordcloud/specs/index';
 
+// TODO: Remove deprecated config types. Need for eui alignment
+export * from './chart_types/partition_chart/layout/types/config';
+
 export {
   Accessor,
   AccessorFn,


### PR DESCRIPTION
## Summary

This PR adds back the `PartitionConfig` types as deprecated to avoid breaking type changes in eui versioning. See https://github.com/elastic/eui/pull/5492