### PR TITLE
PoC: Expose main projection area dimensions.

### DIFF
--- a/storybook/stories/line/16_expose_main_projection_area_dimensions.story.tsx
+++ b/storybook/stories/line/16_expose_main_projection_area_dimensions.story.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { boolean } from '@storybook/addon-knobs';
+import React, { useState } from 'react';
+
+import {
+  Axis,
+  Chart,
+  LineSeries,
+  niceTimeFormatByDay,
+  Position,
+  ScaleType,
+  Settings,
+  timeFormatter,
+} from '@elastic/charts';
+import { KIBANA_METRICS } from '@elastic/charts/src/utils/data_samples/test_dataset_kibana';
+
+import { useBaseTheme } from '../../use_base_theme';
+
+const dateFormatter = timeFormatter(niceTimeFormatByDay(1));
+
+interface Dimensions {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+}
+
+// MainProjectionAreaDimensions
+
+export const Example = ({
+  onInternalMainProjectionAreaDimensionsChange,
+}: {
+  onInternalMainProjectionAreaDimensionsChange: (d: Dimensions) => void;
+}) => {
+  const legendEnabled = boolean('enable legend', false);
+  const axisEnabled = boolean('enable y axis', true);
+
+  const [dimensions, setDimensions] = useState({ left: 0, width: 0 });
+
+  const onInternalMainProjectionAreaDimensionsHandler = (d: Dimensions) => {
+    onInternalMainProjectionAreaDimensionsChange(d);
+    setDimensions(d);
+  };
+
+  return (
+    <>
+      <div
+        style={{
+          marginLeft: `${dimensions.left}px`,
+          width: `${dimensions.width}px`,
+          height: '30px',
+          backgroundColor: 'darkgray',
+          color: 'white',
+        }}
+      >
+        left: {dimensions.left}, width: {dimensions.width}
+      </div>
+      <Chart onInternalMainProjectionAreaDimensionsChange={onInternalMainProjectionAreaDimensionsHandler}>
+        <Settings
+          showLegend={legendEnabled}
+          xDomain={{
+            min: NaN,
+            max: 2,
+          }}
+          baseTheme={useBaseTheme()}
+        />
+        <Axis id="bottom" position={Position.Bottom} showOverlappingTicks tickFormat={dateFormatter} />
+        {axisEnabled && (
+          <Axis
+            id="left"
+            title={KIBANA_METRICS.metrics.kibana_os_load[0].metric.title}
+            position={Position.Left}
+            tickFormat={(d) => `${Number(d).toFixed(2)}%`}
+          />
+        )}
+        <LineSeries
+          id="lines"
+          xScaleType={ScaleType.Time}
+          yScaleType={ScaleType.Linear}
+          xAccessor={0}
+          yAccessors={[1]}
+          data={KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 5)}
+        />
+      </Chart>
+    </>
+  );
+};
+
+Example.argTypes = {
+  onInternalMainProjectionAreaDimensionsChange: { action: 'onInternalMainProjectionAreaDimensionsChange' },
+};

--- a/storybook/stories/line/line.stories.tsx
+++ b/storybook/stories/line/line.stories.tsx
@@ -25,3 +25,4 @@ export { Example as testPathOrdering } from './10_test_path_ordering.story';
 export { Example as lineWithMarkAccessor } from './13_line_mark_accessor.story';
 export { Example as pointShapes } from './14_point_shapes.story';
 export { Example as testNegativePoints } from './15_test_negative_points.story';
+export { Example as exposeDimensions } from './16_expose_main_projection_area_dimensions.story';


### PR DESCRIPTION
## Summary

This is a PoC to expose the main projection area dimensions as a basis for further discussion. Having these dimensions available allows to align external elements with the inner chart area. In the GIF below, the gray area is a `div` element external to the chart that updates its position based on the exposed chart's inner dimensions.

![elastic-charts-dimensions-0001](https://user-images.githubusercontent.com/230104/147578368-7f9f60f3-2485-4c4f-b4a2-c7fa07c1472f.gif)



<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [ ] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [ ] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [ ] The `:theme` label has been added and the `@elastic/eui-design` team has been pinged when there are `Theme` API changes
- [ ] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [ ] New public API exports have been added to `packages/charts/src/index.ts`
- [ ] Unit tests have been added or updated to match the most common scenarios
- [x] The proper documentation and/or storybook story has been added or updated
- [ ] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
- [ ] Visual changes have been tested with all available themes including `dark`, `light`, `eui-dark` & `eui-light`
