### PR TITLE
fix(flamegraph): solve animation regression

### DIFF
--- a/packages/charts/src/chart_types/partition_chart/layout/types/config_types.ts
+++ b/packages/charts/src/chart_types/partition_chart/layout/types/config_types.ts
@@ -36,7 +36,7 @@ export interface AnimKeyframe {
 /** @public */
 export interface AnimationConfig {
   /** @alpha */
-  animation?: {
+  animation: {
     duration: TimeMs;
     keyframes?: Array<AnimKeyframe>;
   };

--- a/packages/charts/src/chart_types/partition_chart/layout/types/viewmodel_types.ts
+++ b/packages/charts/src/chart_types/partition_chart/layout/types/viewmodel_types.ts
@@ -208,6 +208,7 @@ export const nullShapeViewModel = (
     width: 0,
     height: 0,
   },
+  animation: { duration: 0 },
 });
 
 /** @internal */

--- a/packages/charts/src/chart_types/partition_chart/layout/viewmodel/viewmodel.ts
+++ b/packages/charts/src/chart_types/partition_chart/layout/viewmodel/viewmodel.ts
@@ -309,6 +309,7 @@ export function shapeViewModel(
     clockwiseSectors,
     maxRowCount,
     specialFirstInnermostSector,
+    animation,
   } = spec;
   const {
     emptySizeRatio,
@@ -511,6 +512,7 @@ export function shapeViewModel(
     pickQuads,
     outerRadius,
     chartDimensions,
+    animation,
   };
 }
 

--- a/packages/charts/src/chart_types/partition_chart/specs/index.ts
+++ b/packages/charts/src/chart_types/partition_chart/specs/index.ts
@@ -68,6 +68,7 @@ const defaultProps = {
   radiusOutside: 128,
   fillRectangleWidth: Infinity,
   fillRectangleHeight: Infinity,
+  animation: { duration: 0 },
 };
 
 /**
@@ -128,5 +129,6 @@ export const Partition: React.FunctionComponent<SpecRequiredProps & SpecOptional
     | 'radiusOutside'
     | 'fillRectangleWidth'
     | 'fillRectangleHeight'
+    | 'animation'
   >(defaultProps),
 );

--- a/packages/charts/src/mocks/specs/specs.ts
+++ b/packages/charts/src/mocks/specs/specs.ts
@@ -147,6 +147,7 @@ export class MockSeriesSpec {
         fillLabel: {},
       },
     ],
+    animation: { duration: 0 },
     data: [],
   };
 
@@ -177,6 +178,7 @@ export class MockSeriesSpec {
         fillLabel: {},
       },
     ],
+    animation: { duration: 0 },
     data: [],
   };
 


### PR DESCRIPTION
## Summary

Restored tweening (animation) to flamegraph that stopped working at 6db267718cbc37c678c565ac4a0a174cc3e9df9f 

## Details

The work that moved numerous config options into the theme turned the previously mandatory `animation` property optional. This watered up preexisting TS type checks, as optionals often do, and we don't yet have mid-flight VRT for (currently alpha) animations, so it flew under the radar.

The fix restores the mandatory nature of `animation` and supplies a default zero `duration` for it.
In the future it might become part of the theme, would need a convo.
 
## Issues

Closes https://github.com/elastic/elastic-charts/issues/1540

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [X] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [X] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [ ] ~~The `:theme` label has been added and the `@elastic/eui-design` team has been pinged when there are `Theme` API changes~~
- [X] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [ ] ~New public API exports have been added to `packages/charts/src/index.ts`~
- [X] Unit tests have been added or updated to match the most common scenarios
- [ ] ~The proper documentation and/or storybook story has been added or updated~
- [X] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
- [ ] ~Visual changes have been tested with all available themes including `dark`, `light`, `eui-dark` & `eui-light`~
