### PR TITLE
fix(heatmap): fix unpredictable tick count

### DIFF
--- a/packages/charts/src/chart_types/heatmap/layout/viewmodel/viewmodel.ts
+++ b/packages/charts/src/chart_types/heatmap/layout/viewmodel/viewmodel.ts
@@ -56,13 +56,12 @@ function getValuesInRange(
 
 function estimatedNonOverlappingTickCount(
   chartWidth: number,
-  formatter: HeatmapSpec['xAxisLabelFormatter'],
   style: HeatmapStyle['xAxisLabel'],
+  sampleLabel: string,
 ): number {
   return withTextMeasure((textMeasure) => {
-    const labelSample = formatter(Date.now());
     const { width } = textMeasure(
-      labelSample,
+      sampleLabel,
       {
         fontFamily: style.fontFamily,
         fontWeight: style.fontWeight,
@@ -454,6 +453,7 @@ function getXTicks(
     };
   };
   if (isRasterTimeScale(spec.xScale)) {
+    const sampleLabel = spec.xAxisLabelFormatter(xNumericExtent[0]);
     const timeScale = new ScaleContinuous(
       {
         type: ScaleType.Time,
@@ -462,7 +462,7 @@ function getXTicks(
         nice: false,
       },
       {
-        desiredTickCount: estimatedNonOverlappingTickCount(grid.width, spec.xAxisLabelFormatter, style.xAxisLabel),
+        desiredTickCount: estimatedNonOverlappingTickCount(grid.width, style.xAxisLabel, sampleLabel),
         timeZone: spec.timeZone,
       },
     );


### PR DESCRIPTION
## Summary

The current tick count estimation is based on a sample label created with `Date.now()`.
This can cause unpredictable tick count, in particular when running VRTs on the CI server.
The change uses the domain min value.


## Issues

This will fix the VRTs flakyness related to 
`integration/tests/__image_snapshots__/heatmap-stories-test-ts-heatmap-stories-time-snap-with-dataset-3-1.png`

![image](https://user-images.githubusercontent.com/1421091/149566186-d2fc2bca-9e8a-4297-87ec-3105a79210cd.png)


### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
