### PR TITLE
fix(deps): remove the ResizeObserver polyfill

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -46,7 +46,6 @@
     "react-redux": "^7.1.0",
     "redux": "^4.0.4",
     "reselect": "^4.0.0",
-    "resize-observer-polyfill": "^1.5.1",
     "ts-debounce": "^3.0.0",
     "utility-types": "^3.10.0",
     "uuid": "^3.3.2",

--- a/packages/charts/src/components/chart_resizer.tsx
+++ b/packages/charts/src/components/chart_resizer.tsx
@@ -9,13 +9,12 @@
 import React, { RefObject } from 'react';
 import { connect } from 'react-redux';
 import { Dispatch, bindActionCreators } from 'redux';
-import ResizeObserver from 'resize-observer-polyfill';
 import { debounce } from 'ts-debounce';
 
 import { updateParentDimensions } from '../state/actions/chart_settings';
 import { GlobalChartState } from '../state/chart_state';
 import { getSettingsSpecSelector } from '../state/selectors/get_settings_specs';
-import { isDefined } from '../utils/common';
+import { isFiniteNumber } from '../utils/common';
 import { Dimensions } from '../utils/dimensions';
 
 interface ResizerStateProps {
@@ -33,7 +32,7 @@ const DEFAULT_RESIZE_DEBOUNCE = 200;
 class Resizer extends React.Component<ResizerProps> {
   private initialResizeComplete = false;
 
-  private containerRef: RefObject<HTMLDivElement>;
+  private readonly containerRef: RefObject<HTMLDivElement>;
 
   private ro: ResizeObserver;
 
@@ -99,12 +98,9 @@ const mapDispatchToProps = (dispatch: Dispatch): ResizerDispatchProps =>
   );
 
 const mapStateToProps = (state: GlobalChartState): ResizerStateProps => {
-  const settings = getSettingsSpecSelector(state);
-  const resizeDebounce =
-    settings.resizeDebounce === undefined || settings.resizeDebounce === null ? 200 : settings.resizeDebounce;
+  const { resizeDebounce } = getSettingsSpecSelector(state);
   return {
-    resizeDebounce:
-      !isDefined(resizeDebounce) || Number.isNaN(resizeDebounce) ? DEFAULT_RESIZE_DEBOUNCE : resizeDebounce,
+    resizeDebounce: isFiniteNumber(resizeDebounce) ? resizeDebounce : DEFAULT_RESIZE_DEBOUNCE,
   };
 };
 


### PR DESCRIPTION
## Summary
The [Resize Observer API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) is available in all major browsers and we don't need to polyfill it anymore.

@nickofthyme I've also updated the ech version in the storybook package. I know that it's not used directly, but this can prevent downloading unnecessary libraries if we keep them in sync. Do you know a better way to link a workspace as a dependency without using the specific package version?
