### PR TITLE
fix: use window scope to call the ResizeObserver

### DIFF
--- a/packages/charts/src/components/chart_resizer.tsx
+++ b/packages/charts/src/components/chart_resizer.tsx
@@ -43,7 +43,7 @@ class Resizer extends React.Component<ResizerProps> {
   constructor(props: ResizerProps) {
     super(props);
     this.containerRef = React.createRef();
-    this.ro = new ResizeObserver(this.handleResize);
+    this.ro = new window.ResizeObserver(this.handleResize);
     this.animationFrameID = null;
     this.onResizeDebounced = () => {};
   }


### PR DESCRIPTION
## Summary

JSDOM doesn't have the `ResizeObserver` available in the `global` object but instead is available directly from the `window` object.

Solves Kibana jest test failures [here](https://buildkite.com/elastic/kibana-pull-request/builds/19241)

