### PR TITLE
revert: remove of resize observer polyfill

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -46,6 +46,7 @@
     "react-redux": "^7.1.0",
     "redux": "^4.0.4",
     "reselect": "^4.0.0",
+    "resize-observer-polyfill": "^1.5.1",
     "ts-debounce": "^3.0.0",
     "utility-types": "^3.10.0",
     "uuid": "^3.3.2",

--- a/packages/charts/src/components/chart_resizer.tsx
+++ b/packages/charts/src/components/chart_resizer.tsx
@@ -9,6 +9,7 @@
 import React, { RefObject } from 'react';
 import { connect } from 'react-redux';
 import { Dispatch, bindActionCreators } from 'redux';
+import ResizeObserver from 'resize-observer-polyfill';
 import { debounce } from 'ts-debounce';
 
 import { updateParentDimensions } from '../state/actions/chart_settings';
@@ -43,7 +44,7 @@ class Resizer extends React.Component<ResizerProps> {
   constructor(props: ResizerProps) {
     super(props);
     this.containerRef = React.createRef();
-    this.ro = new window.ResizeObserver(this.handleResize);
+    this.ro = new ResizeObserver(this.handleResize);
     this.animationFrameID = null;
     this.onResizeDebounced = () => {};
   }


### PR DESCRIPTION
## Summary
The PR https://github.com/elastic/elastic-charts/pull/1569 doesn't fix completely the issue with the missing `resize-observer-polyfill`. Before digging deeper into the root cause I will revert the changes applied in 542f2bf3a20d5463c14d614cb55491430763e133