### PR TITLE
fix(style): don't export EUI styles

### DIFF
--- a/packages/charts/src/_eui_imports.scss
+++ b/packages/charts/src/_eui_imports.scss
@@ -1,2 +1,4 @@
-@import '../../../node_modules/@elastic/eui/src/global_styling';
+@import '../../../node_modules/@elastic/eui/src/global_styling/functions/index';
+@import '../../../node_modules/@elastic/eui/src/global_styling/variables/index';
+@import '../../../node_modules/@elastic/eui/src/global_styling/mixins/index';
 @import '../../../node_modules/@elastic/eui/src/themes/amsterdam/globals';


### PR DESCRIPTION
## Summary

This fix reverts [a suggestion](https://github.com/elastic/elastic-charts/pull/1463#discussion_r747686611) that imported unwanted classes into our exported CSS files. 
We are now importing only mixins and variables that will not pollute the generated CSS with unwanted classes like the date picker and some utility classes

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
