### PR TITLE
fix(animations): initialize all conditionalized props

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/annotations/rect/dimensions.ts
+++ b/packages/charts/src/chart_types/xy_chart/annotations/rect/dimensions.ts
@@ -40,7 +40,7 @@ export function computeRectAnnotationDimensions(
   getAxisStyle: (id?: AxisId) => AxisStyle,
   isHistogram: boolean = false,
 ): AnnotationRectProps[] | null {
-  const { dataValues, groupId, outside, id: annotationSpecId, id: specId } = annotationSpec;
+  const { dataValues, groupId, outside, id: annotationSpecId } = annotationSpec;
   const { xAxis, yAxis } = getAxesSpecForSpecId(axesSpecs, groupId);
   const yScale = yScales.get(groupId);
   const rectsProps: Omit<AnnotationRectProps, 'id' | 'panel'>[] = [];
@@ -95,7 +95,7 @@ export function computeRectAnnotationDimensions(
               }),
         };
         rectsProps.push({
-          specId,
+          specId: annotationSpecId,
           rect: rectDimensions,
           datum,
         });
@@ -138,7 +138,7 @@ export function computeRectAnnotationDimensions(
     };
 
     rectsProps.push({
-      specId,
+      specId: annotationSpecId,
       rect: rectDimensions,
       datum,
     });

--- a/packages/charts/src/chart_types/xy_chart/annotations/rect/dimensions.ts
+++ b/packages/charts/src/chart_types/xy_chart/annotations/rect/dimensions.ts
@@ -40,7 +40,7 @@ export function computeRectAnnotationDimensions(
   getAxisStyle: (id?: AxisId) => AxisStyle,
   isHistogram: boolean = false,
 ): AnnotationRectProps[] | null {
-  const { dataValues, groupId, outside, id: annotationSpecId } = annotationSpec;
+  const { dataValues, groupId, outside, id: annotationSpecId, id: specId } = annotationSpec;
   const { xAxis, yAxis } = getAxesSpecForSpecId(axesSpecs, groupId);
   const yScale = yScales.get(groupId);
   const rectsProps: Omit<AnnotationRectProps, 'id' | 'panel'>[] = [];
@@ -95,6 +95,7 @@ export function computeRectAnnotationDimensions(
               }),
         };
         rectsProps.push({
+          specId,
           rect: rectDimensions,
           datum,
         });
@@ -137,6 +138,7 @@ export function computeRectAnnotationDimensions(
     };
 
     rectsProps.push({
+      specId,
       rect: rectDimensions,
       datum,
     });

--- a/packages/charts/src/chart_types/xy_chart/annotations/rect/types.ts
+++ b/packages/charts/src/chart_types/xy_chart/annotations/rect/types.ts
@@ -12,6 +12,7 @@ import { RectAnnotationDatum } from '../../utils/specs';
 
 /** @internal */
 export interface AnnotationRectProps {
+  specId: string;
   id: string;
   datum: RectAnnotationDatum;
   rect: Rect;

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/README.md
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/README.md
@@ -87,7 +87,7 @@ function render(aCtx: AnimationContext) {
 
 Here the `computedOpacity` is passed to the `aCtx.getValue` with defined `AnimationOptions` and returns the tween `opacity` used to render. The `aCtx.getValue` method uses [currying](https://javascript.info/currying-partials) to enable the same animated options to be used in multiple places.
 
-The `'my-opacity'` string is used to identify this value from all other tracked animated values. This prop should be uniuqe given all animation states. For example, using two props for `n` bars to define `highlighted-bar-opacity` and `unhighlighted-bar-opacity` minimizes the total tracked values. This is fine so long as the two values change in unisoun everywhere they are used. An error will throw if a single key is used with diverging values.
+The `'my-opacity'` string is used to identify this value from all other tracked animated values. This prop should be uniuqe given all animation states. For example, using two props for `n` bars to define `highlighted-bar-opacity` and `unhighlighted-bar-opacity` minimizes the total tracked values. This is fine so long as the two values change in unisoun everywhere they are used and all prop variants are initialized/used on each render to avoid, https://github.com/elastic/elastic-charts/pull/1665. An error will throw if a single key is used with diverging values.
 
 The full list of `AnimationOptions` is shown below.
 

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/README.md
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/README.md
@@ -4,7 +4,7 @@ This directory contains shared logic for implementing animations throught charts
 
 ## Animating a value
 
-Currently this animation framework only targets animation or tweening of a specific value that is mapped to a provided `prop` string to identify the given value.
+Currently this animation framework only targets animation or tweening of a specific value that is mapped to a provided `key` string to identify the given value.
 
 ### Setup
 
@@ -87,7 +87,9 @@ function render(aCtx: AnimationContext) {
 
 Here the `computedOpacity` is passed to the `aCtx.getValue` with defined `AnimationOptions` and returns the tween `opacity` used to render. The `aCtx.getValue` method uses [currying](https://javascript.info/currying-partials) to enable the same animated options to be used in multiple places.
 
-The `'my-opacity'` string is used to identify this value from all other tracked animated values. This prop should be uniuqe given all animation states. For example, using two props for `n` bars to define `highlighted-bar-opacity` and `unhighlighted-bar-opacity` minimizes the total tracked values. This is fine so long as the two values change in unisoun everywhere they are used and all prop variants are initialized/used on each render to avoid, https://github.com/elastic/elastic-charts/pull/1665. An error will throw if a single key is used with diverging values.
+The `'my-opacity'` string is used to identify this value from all other tracked animated values. This key should be uniuqe given all animation states.
+
+For the time being, using multiple parameterized keys should be _avoided_. For example, given a bar chart with `n` bars using two keys to define `highlighted-bar-opacity` and `unhighlighted-bar-opacity` could minimizes the total tracked values. However, this is currently not supported as the animations work by reacting to changes in values, in this case if key changes when the value changes, the animations state will be malformed causing flashing and instant tweening, see https://github.com/elastic/elastic-charts/pull/1665.
 
 The full list of `AnimationOptions` is shown below.
 

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/README.md
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/README.md
@@ -1,6 +1,6 @@
 # Animation in charts
 
-This directory contains shared logic for implementing animations throught charts canvas render methods.
+This directory contains shared logic for implementing animations throughout charts canvas render methods.
 
 ## Animating a value
 
@@ -87,7 +87,7 @@ function render(aCtx: AnimationContext) {
 
 Here the `computedOpacity` is passed to the `aCtx.getValue` with defined `AnimationOptions` and returns the tween `opacity` used to render. The `aCtx.getValue` method uses [currying](https://javascript.info/currying-partials) to enable the same animated options to be used in multiple places.
 
-The `'my-opacity'` string is used to identify this value from all other tracked animated values. This key should be uniuqe given all animation states.
+The `'my-opacity'` string is used to identify this value from all other tracked animated values. This key should be unique given all animation states.
 
 For the time being, using multiple parameterized keys should be _avoided_. For example, given a bar chart with `n` bars using two keys to define `highlighted-bar-opacity` and `unhighlighted-bar-opacity` could minimizes the total tracked values. However, this is currently not supported as the animations work by reacting to changes in values, in this case if key changes when the value changes, the animations state will be malformed causing flashing and instant tweening, see https://github.com/elastic/elastic-charts/pull/1665.
 
@@ -134,7 +134,7 @@ export interface AnimationOptions {
 
 ### Event-driven
 
-Create a parallel event-driven animation mechanism to offer less control but more predicatability for what animations are rendered.
+Create a parallel event-driven animation mechanism to offer less control but more predictability for what animations are rendered.
 
 ### Greater value support
 

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/index.ts
@@ -19,7 +19,7 @@ const DISABLE_ANIMATIONS = Boolean(process.env.VRT);
  * `options` are applied only on initial render and never changed.
  * @internal
  */
-export type AnimateFn = (options?: AnimationOptions) => (prop: string, value: AnimatedValue) => AnimatedValue;
+export type AnimateFn = (options?: AnimationOptions) => (key: string, value: AnimatedValue) => AnimatedValue;
 
 /** @internal */
 export interface AnimationContext {
@@ -38,22 +38,22 @@ export const getAnimationPoolFn = (
   return debounce(
     function getAnimationPoolFnDebounce() {
       const propValuesForRun = new Map<string, number>();
-      const getAnimatedValueFn = (t: number): AnimateFn => (options) => (prop, value) => {
-        if (t === 0 && propValuesForRun.has(prop) && propValuesForRun.get(prop) !== value) {
+      const getAnimatedValueFn = (t: number): AnimateFn => (options) => (key, value) => {
+        if (t === 0 && propValuesForRun.has(key) && propValuesForRun.get(key) !== value) {
           Logger.error(
-            `aCtx.getValue(\`${prop}\`, <value>) was called multiple times in a single render with different values.\
+            `aCtx.getValue(\`${key}\`, <value>) was called multiple times in a single render with different values.\
  Please animate these values independently to avoid collisions.`,
           );
         }
 
         if (DISABLE_ANIMATIONS || !(options?.enabled ?? true)) return value;
 
-        propValuesForRun.set(prop, value);
-        if (!animationState.pool.has(prop)) {
-          animationState.pool.set(prop, new Animation(value, options));
+        propValuesForRun.set(key, value);
+        if (!animationState.pool.has(key)) {
+          animationState.pool.set(key, new Animation(value, options));
         }
 
-        const animation = animationState.pool.get(prop);
+        const animation = animationState.pool.get(key);
         if (!animation) return value;
 
         animation.setTarget(value);

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/annotations/lines.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/annotations/lines.ts
@@ -10,6 +10,7 @@ import { colorToRgba, overrideOpacity } from '../../../../../common/color_librar
 import { Stroke } from '../../../../../geoms/types';
 import { Rotation } from '../../../../../utils/common';
 import { Dimensions } from '../../../../../utils/dimensions';
+import { SpecId } from '../../../../../utils/ids';
 import { LineAnnotationStyle } from '../../../../../utils/themes/theme';
 import { AnnotationLineProps } from '../../../annotations/line/types';
 import { AnnotationHoverParams } from '../../common/utils';
@@ -28,10 +29,11 @@ export function renderLineAnnotations(
   renderingArea: Dimensions,
 ) {
   const getAnimatedValue = aCtx.getValue(lineStyle.animations);
-  const getStroke = (id: string): Stroke => {
+  const getStroke = (id: string, specId: SpecId): Stroke => {
     const { style, isHighlighted } = getHoverParams(id);
-    const prop = isHighlighted ? `anno-line-opacity-highlighted` : `anno-line-opacity-unhighlighted`;
-    const hoverOpacity = getAnimatedValue(prop, style.opacity);
+    const highlightedOpacity = getAnimatedValue(`anno-line-${specId}-opacity-highlighted`, style.opacity);
+    const unhighlightedOpacity = getAnimatedValue(`anno-line-${specId}-opacity-unhighlighted`, style.opacity);
+    const hoverOpacity = isHighlighted ? highlightedOpacity : unhighlightedOpacity;
     const strokeColor = overrideOpacity(
       colorToRgba(lineStyle.line.stroke),
       (opacity) => opacity * lineStyle.line.opacity * hoverOpacity,
@@ -43,9 +45,9 @@ export function renderLineAnnotations(
     };
   };
 
-  annotations.forEach(({ linePathPoints, panel, id }) =>
+  annotations.forEach(({ linePathPoints, panel, id, specId }) =>
     withPanelTransform(ctx, panel, rotation, renderingArea, () =>
-      renderMultiLine(ctx, [linePathPoints], getStroke(id)),
+      renderMultiLine(ctx, [linePathPoints], getStroke(id, specId)),
     ),
   );
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/annotations/lines.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/annotations/lines.ts
@@ -10,7 +10,6 @@ import { colorToRgba, overrideOpacity } from '../../../../../common/color_librar
 import { Stroke } from '../../../../../geoms/types';
 import { Rotation } from '../../../../../utils/common';
 import { Dimensions } from '../../../../../utils/dimensions';
-import { SpecId } from '../../../../../utils/ids';
 import { LineAnnotationStyle } from '../../../../../utils/themes/theme';
 import { AnnotationLineProps } from '../../../annotations/line/types';
 import { AnnotationHoverParams } from '../../common/utils';
@@ -29,11 +28,12 @@ export function renderLineAnnotations(
   renderingArea: Dimensions,
 ) {
   const getAnimatedValue = aCtx.getValue(lineStyle.animations);
-  const getStroke = (id: string, specId: SpecId): Stroke => {
-    const { style, isHighlighted } = getHoverParams(id);
-    const highlightedOpacity = getAnimatedValue(`anno-line-${specId}-opacity-highlighted`, style.opacity);
-    const unhighlightedOpacity = getAnimatedValue(`anno-line-${specId}-opacity-unhighlighted`, style.opacity);
-    const hoverOpacity = isHighlighted ? highlightedOpacity : unhighlightedOpacity;
+  const getStroke = (id: string): Stroke => {
+    const { style } = getHoverParams(id);
+
+    const opacityKey = `anno-rect-opacity--${id}`;
+    const hoverOpacity = getAnimatedValue(opacityKey, style.opacity);
+
     const strokeColor = overrideOpacity(
       colorToRgba(lineStyle.line.stroke),
       (opacity) => opacity * lineStyle.line.opacity * hoverOpacity,
@@ -45,9 +45,9 @@ export function renderLineAnnotations(
     };
   };
 
-  annotations.forEach(({ linePathPoints, panel, id, specId }) =>
+  annotations.forEach(({ linePathPoints, panel, id }) =>
     withPanelTransform(ctx, panel, rotation, renderingArea, () =>
-      renderMultiLine(ctx, [linePathPoints], getStroke(id, specId)),
+      renderMultiLine(ctx, [linePathPoints], getStroke(id)),
     ),
   );
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/annotations/rect.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/annotations/rect.ts
@@ -10,7 +10,6 @@ import { colorToRgba, overrideOpacity } from '../../../../../common/color_librar
 import { Fill, Stroke } from '../../../../../geoms/types';
 import { Rotation } from '../../../../../utils/common';
 import { Dimensions } from '../../../../../utils/dimensions';
-import { SpecId } from '../../../../../utils/ids';
 import { RectAnnotationStyle } from '../../../../../utils/themes/theme';
 import { AnnotationRectProps } from '../../../annotations/rect/types';
 import { AnnotationHoverParams } from '../../common/utils';
@@ -29,11 +28,11 @@ export function renderRectAnnotations(
   renderingArea: Dimensions,
 ) {
   const getAnimatedValue = aCtx.getValue(rectStyle.animations);
-  const getFillAndStroke = (id: string, specId: SpecId): [Fill, Stroke] => {
-    const { style, isHighlighted } = getHoverParams(id);
-    const highlightedOpacity = getAnimatedValue(`anno-rect-${specId}-opacity-highlighted`, style.opacity);
-    const unhighlightedOpacity = getAnimatedValue(`anno-rect-${specId}-opacity-unhighlighted`, style.opacity);
-    const hoverOpacity = isHighlighted ? highlightedOpacity : unhighlightedOpacity;
+  const getFillAndStroke = (id: string): [Fill, Stroke] => {
+    const { style } = getHoverParams(id);
+
+    const opacityKey = `anno-rect-opacity--${id}`;
+    const hoverOpacity = getAnimatedValue(opacityKey, style.opacity);
 
     const fill: Fill = {
       color: overrideOpacity(colorToRgba(rectStyle.fill), (opacity) => opacity * rectStyle.opacity * hoverOpacity),
@@ -46,9 +45,7 @@ export function renderRectAnnotations(
     return [fill, stroke];
   };
 
-  annotations.forEach(({ rect, panel, id, specId }) =>
-    withPanelTransform(ctx, panel, rotation, renderingArea, () =>
-      renderRect(ctx, rect, ...getFillAndStroke(id, specId)),
-    ),
+  annotations.forEach(({ rect, panel, id }) =>
+    withPanelTransform(ctx, panel, rotation, renderingArea, () => renderRect(ctx, rect, ...getFillAndStroke(id))),
   );
 }

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/annotations/rect.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/annotations/rect.ts
@@ -10,6 +10,7 @@ import { colorToRgba, overrideOpacity } from '../../../../../common/color_librar
 import { Fill, Stroke } from '../../../../../geoms/types';
 import { Rotation } from '../../../../../utils/common';
 import { Dimensions } from '../../../../../utils/dimensions';
+import { SpecId } from '../../../../../utils/ids';
 import { RectAnnotationStyle } from '../../../../../utils/themes/theme';
 import { AnnotationRectProps } from '../../../annotations/rect/types';
 import { AnnotationHoverParams } from '../../common/utils';
@@ -28,10 +29,12 @@ export function renderRectAnnotations(
   renderingArea: Dimensions,
 ) {
   const getAnimatedValue = aCtx.getValue(rectStyle.animations);
-  const getFillAndStroke = (id: string): [Fill, Stroke] => {
+  const getFillAndStroke = (id: string, specId: SpecId): [Fill, Stroke] => {
     const { style, isHighlighted } = getHoverParams(id);
-    const prop = isHighlighted ? `anno-rect-opacity-highlighted` : `anno-rect-opacity-unhighlighted`;
-    const hoverOpacity = getAnimatedValue(prop, style.opacity);
+    const highlightedOpacity = getAnimatedValue(`anno-rect-${specId}-opacity-highlighted`, style.opacity);
+    const unhighlightedOpacity = getAnimatedValue(`anno-rect-${specId}-opacity-unhighlighted`, style.opacity);
+    const hoverOpacity = isHighlighted ? highlightedOpacity : unhighlightedOpacity;
+
     const fill: Fill = {
       color: overrideOpacity(colorToRgba(rectStyle.fill), (opacity) => opacity * rectStyle.opacity * hoverOpacity),
     };
@@ -43,7 +46,9 @@ export function renderRectAnnotations(
     return [fill, stroke];
   };
 
-  annotations.forEach(({ rect, panel, id }) =>
-    withPanelTransform(ctx, panel, rotation, renderingArea, () => renderRect(ctx, rect, ...getFillAndStroke(id))),
+  annotations.forEach(({ rect, panel, id, specId }) =>
+    withPanelTransform(ctx, panel, rotation, renderingArea, () =>
+      renderRect(ctx, rect, ...getFillAndStroke(id, specId)),
+    ),
   );
 }

--- a/packages/charts/src/mocks/annotations/annotations.ts
+++ b/packages/charts/src/mocks/annotations/annotations.ts
@@ -51,6 +51,7 @@ export class MockAnnotationLineProps {
 export class MockAnnotationRectProps {
   private static readonly base: AnnotationRectProps = {
     id: 'testing',
+    specId: 'rect',
     datum: { coordinates: { x0: 0, x1: 1, y0: 0, y1: 1 } },
     rect: { x: 0, y: 0, width: 0, height: 0 },
     panel: { width: 100, height: 100, top: 0, left: 0 },


### PR DESCRIPTION
## Summary

Fix bug with animations logic flashing from `0` values to target values with multiple annotation specs.

### Before


https://user-images.githubusercontent.com/19007109/166853537-dbbb9dcc-ca98-425c-ac19-84f92ca97067.mp4

Notice:

- The flashing when both annotations are blurred as the value transitions, it does not know the current value and defaults to `0` as a fallback, hence the flashing.
- The instant tweening when hovering the annotations then hovering over a bar/geom.

### After

https://user-images.githubusercontent.com/19007109/166853348-277f93b3-ac49-43d8-8742-20caaeb08bc5.mp4

Both issues are no longer present

## Details

The issue was caused by using conditional or parameterized keys. The animations logic work by tracking new values for each animated value.  If you have an animation key that is conditional, say highlighted and unhighlighted opacity, the animated value for each is tracked across all usages. So when a bar goes from highlighted to unhighlighted, the value across all usages never change, hence there is not tweening to be performed and the values jumps to the target value instantly. So think of it as each independently animated value must have its own unique key to track the initial and target state. If all annotation opacities for a given `specId` were changed as one you could combine them into a single key, but in this case each annotation across all annotation specs are  independently. This was done as an optimization in #1628 but unknowingly created undesirable results.

### Checklist

- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)