### PR TITLE
feat(flame): context loss handling

### DIFF
--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -291,9 +291,8 @@ class FlameComponent extends React.Component<FlameProps> {
     if (!this.isDragging(e)) {
       e.stopPropagation();
       this.updatePointerLocation(e);
-      if (this.pointerInMinimap(this.pointerX, this.pointerY)) return;
       const hovered = this.getHoveredDatumIndex(e);
-      const prevHoverIndex = this.hoverIndex >= 0 ? this.hoverIndex : NaN; // todo instead of translating NaN/-1 back and forth, just convert to -1 for shader rendering
+      const prevHoverIndex = this.hoverIndex >= 0 ? this.hoverIndex : NaN;
       if (hovered) {
         this.hoverIndex = hovered.datumIndex;
         if (!Object.is(this.hoverIndex, prevHoverIndex)) {

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -12,7 +12,7 @@ import { bindActionCreators, Dispatch } from 'redux';
 
 import { ChartType } from '..';
 import { DEFAULT_CSS_CURSOR } from '../../common/constants';
-import { bindFramebuffer, createTexture, NullTexture, readPixel, Texture } from '../../common/kingly';
+import { bindFramebuffer, createTexture, NullTexture, readPixel, testContextLoss, Texture } from '../../common/kingly';
 import { GL } from '../../common/webgl_constants';
 import { BasicTooltip } from '../../components/tooltip/tooltip';
 import { getTooltipType, SettingsSpec, SpecType, TooltipType } from '../../specs';
@@ -926,7 +926,7 @@ class FlameComponent extends React.Component<FlameProps> {
       );
 
       this.initializeGL(this.glContext);
-      // testContextLoss(this.glContext);
+      testContextLoss(this.glContext);
     }
   };
 }

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -906,7 +906,14 @@ class FlameComponent extends React.Component<FlameProps> {
     this.ensurePickTexture();
 
     if (glCanvas && this.glContext && this.glResources === NULL_GL_RESOURCES) {
-      glCanvas.addEventListener('webglcontextlost', (event) => event.preventDefault(), false); // we could log it for telemetry etc todo add the option for a callback
+      glCanvas.addEventListener(
+        'webglcontextlost',
+        (event) => {
+          window.cancelAnimationFrame(this.animationRafId);
+          event.preventDefault();
+        },
+        false,
+      ); // we could log it for telemetry etc todo add the option for a callback
       glCanvas.addEventListener(
         'webglcontextrestored',
         () => {

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -12,14 +12,8 @@ import { bindActionCreators, Dispatch } from 'redux';
 
 import { ChartType } from '..';
 import { DEFAULT_CSS_CURSOR } from '../../common/constants';
-import {
-  bindFramebuffer,
-  createTexture,
-  GL_READ_FRAMEBUFFER,
-  NullTexture,
-  readPixel,
-  Texture,
-} from '../../common/kingly';
+import { bindFramebuffer, createTexture, NullTexture, readPixel, Texture } from '../../common/kingly';
+import { GL } from '../../common/webgl_constants';
 import { BasicTooltip } from '../../components/tooltip/tooltip';
 import { getTooltipType, SettingsSpec, SpecType, TooltipType } from '../../specs';
 import { onChartRendered } from '../../state/actions/chart';
@@ -880,10 +874,10 @@ class FlameComponent extends React.Component<FlameProps> {
           textureIndex: 0,
           width: textureWidth,
           height: textureHeight,
-          internalFormat: this.glContext.RGBA8,
+          internalFormat: GL.RGBA8,
           data: null,
         }) ?? NullTexture;
-      bindFramebuffer(this.glContext, GL_READ_FRAMEBUFFER, this.pickTexture.target());
+      bindFramebuffer(this.glContext, GL.READ_FRAMEBUFFER, this.pickTexture.target());
     }
   };
 

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -12,7 +12,7 @@ import { bindActionCreators, Dispatch } from 'redux';
 
 import { ChartType } from '..';
 import { DEFAULT_CSS_CURSOR } from '../../common/constants';
-import { bindFramebuffer, createTexture, NullTexture, readPixel, testContextLoss, Texture } from '../../common/kingly';
+import { bindFramebuffer, createTexture, NullTexture, readPixel, Texture } from '../../common/kingly';
 import { GL } from '../../common/webgl_constants';
 import { BasicTooltip } from '../../components/tooltip/tooltip';
 import { getTooltipType, SettingsSpec, SpecType, TooltipType } from '../../specs';
@@ -938,7 +938,7 @@ class FlameComponent extends React.Component<FlameProps> {
       );
 
       this.initializeGL(this.glContext);
-      testContextLoss(this.glContext);
+      // testContextLoss(this.glContext);
     }
   };
 }

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -12,7 +12,7 @@ import { bindActionCreators, Dispatch } from 'redux';
 
 import { ChartType } from '..';
 import { DEFAULT_CSS_CURSOR } from '../../common/constants';
-import { bindFramebuffer, createTexture, NullTexture, readPixel, testContextLoss, Texture } from '../../common/kingly';
+import { bindFramebuffer, createTexture, NullTexture, readPixel, Texture } from '../../common/kingly';
 import { GL } from '../../common/webgl_constants';
 import { BasicTooltip } from '../../components/tooltip/tooltip';
 import { getTooltipType, SettingsSpec, SpecType, TooltipType } from '../../specs';
@@ -254,10 +254,15 @@ class FlameComponent extends React.Component<FlameProps> {
     this.props.containerRef().current?.removeEventListener('wheel', this.preventScroll);
   }
 
+  private ensureTextureAndDraw = () => {
+    this.ensurePickTexture();
+    this.drawCanvas();
+  };
+
   componentDidUpdate = () => {
     if (!this.ctx) this.tryCanvasContext();
-    this.ensurePickTexture();
-    this.drawCanvas(); // eg. due to chartDimensions (parentDimensions) change
+    this.ensureTextureAndDraw();
+    // eg. due to chartDimensions (parentDimensions) change
     // this.props.onChartRendered() // creates and infinite update loop
   };
 
@@ -896,7 +901,8 @@ class FlameComponent extends React.Component<FlameProps> {
 
     const restoreGL = (gl: WebGL2RenderingContext) => {
       initializeGL(gl);
-      this.drawCanvas();
+      this.pickTexture = NullTexture;
+      this.ensureTextureAndDraw();
     };
 
     if (glCanvas && this.glContext && this.glResources === NULL_GL_RESOURCES) {

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -12,7 +12,7 @@ import { bindActionCreators, Dispatch } from 'redux';
 
 import { ChartType } from '..';
 import { DEFAULT_CSS_CURSOR } from '../../common/constants';
-import { bindFramebuffer, createTexture, NullTexture, readPixel, Texture } from '../../common/kingly';
+import { bindFramebuffer, createTexture, NullTexture, readPixel, testContextLoss, Texture } from '../../common/kingly';
 import { GL } from '../../common/webgl_constants';
 import { BasicTooltip } from '../../components/tooltip/tooltip';
 import { getTooltipType, SettingsSpec, SpecType, TooltipType } from '../../specs';
@@ -892,6 +892,7 @@ class FlameComponent extends React.Component<FlameProps> {
     if (this.glContext && this.glResources === NULL_GL_RESOURCES) {
       this.glResources = ensureWebgl(this.glContext, Object.keys(this.props.columnarViewModel));
       uploadToWebgl(this.glContext, this.glResources.attributes, this.props.columnarViewModel);
+      testContextLoss(this.glContext);
     }
   };
 }

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -12,7 +12,7 @@ import { bindActionCreators, Dispatch } from 'redux';
 
 import { ChartType } from '..';
 import { DEFAULT_CSS_CURSOR } from '../../common/constants';
-import { bindFramebuffer, createTexture, NullTexture, readPixel, testContextLoss, Texture } from '../../common/kingly';
+import { bindFramebuffer, createTexture, NullTexture, readPixel, Texture } from '../../common/kingly';
 import { GL } from '../../common/webgl_constants';
 import { BasicTooltip } from '../../components/tooltip/tooltip';
 import { getTooltipType, SettingsSpec, SpecType, TooltipType } from '../../specs';
@@ -926,7 +926,7 @@ class FlameComponent extends React.Component<FlameProps> {
       );
 
       initializeGL(this.glContext);
-      testContextLoss(this.glContext);
+      // testContextLoss(this.glContext);
     }
   };
 }

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -12,7 +12,7 @@ import { bindActionCreators, Dispatch } from 'redux';
 
 import { ChartType } from '..';
 import { DEFAULT_CSS_CURSOR } from '../../common/constants';
-import { bindFramebuffer, createTexture, NullTexture, readPixel, Texture } from '../../common/kingly';
+import { bindFramebuffer, createTexture, NullTexture, readPixel, testContextLoss, Texture } from '../../common/kingly';
 import { GL } from '../../common/webgl_constants';
 import { BasicTooltip } from '../../components/tooltip/tooltip';
 import { getTooltipType, SettingsSpec, SpecType, TooltipType } from '../../specs';
@@ -926,7 +926,7 @@ class FlameComponent extends React.Component<FlameProps> {
       );
 
       initializeGL(this.glContext);
-      // testContextLoss(this.glContext);
+      testContextLoss(this.glContext);
     }
   };
 }

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -509,6 +509,13 @@ class FlameComponent extends React.Component<FlameProps> {
     }
   };
 
+  private uploadSearchColors = () => {
+    const colorSetter = this.glResources.attributes.get('color');
+    if (this.glContext && colorSetter && this.currentColor.length === this.props.columnarViewModel.color.length) {
+      uploadToWebgl(this.glContext, new Map([['color', colorSetter]]), { color: this.currentColor });
+    }
+  };
+
   private searchForText = (force: boolean) => {
     const input = this.searchInputRef.current;
     const searchString = input?.value;
@@ -519,10 +526,7 @@ class FlameComponent extends React.Component<FlameProps> {
     this.focusOnAllMatches();
 
     // update colors
-    const colorSetter = this.glResources.attributes.get('color');
-    if (this.glContext && colorSetter) {
-      uploadToWebgl(this.glContext, new Map([['color', colorSetter]]), { color: this.currentColor });
-    }
+    this.uploadSearchColors();
 
     // render
     this.focusedMatchIndex = NaN;
@@ -893,6 +897,7 @@ class FlameComponent extends React.Component<FlameProps> {
   private restoreGL = (gl: WebGL2RenderingContext) => {
     this.initializeGL(gl);
     this.pickTexture = NullTexture;
+    this.uploadSearchColors();
     this.ensureTextureAndDraw();
   };
 

--- a/packages/charts/src/chart_types/flame_chart/render/draw_canvas.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/draw_canvas.ts
@@ -7,6 +7,7 @@
  */
 
 import { DEFAULT_FONT_FAMILY } from '../../../common/default_theme_attributes';
+import { cssFontShorthand } from '../../../common/text_utils';
 import { LabelAccessor } from '../../../utils/common';
 import { ColumnarViewModel } from '../flame_api';
 import { BOX_GAP_HORIZONTAL, BOX_GAP_VERTICAL, roundUpSize } from './common';
@@ -53,7 +54,10 @@ export const drawCanvas2d = (
   ctx.textAlign = 'left';
   ctx.textBaseline = 'middle';
   ctx.scale(dpr, dpr);
-  ctx.font = `${fontSize}px ${DEFAULT_FONT_FAMILY}`;
+  ctx.font = cssFontShorthand(
+    { fontFamily: DEFAULT_FONT_FAMILY, fontStyle: 'normal', fontVariant: 'normal', fontWeight: 'normal' },
+    fontSize,
+  );
   ctx.clearRect(0, 0, roundUpSize(cssWidth), roundUpSize(cssHeight));
   ctx.translate(cssOffsetX, cssOffsetY);
   ctx.beginPath();

--- a/packages/charts/src/chart_types/flame_chart/render/draw_canvas.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/draw_canvas.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { DEFAULT_FONT_FAMILY } from '../../../common/default_theme_attributes';
 import { LabelAccessor } from '../../../utils/common';
 import { ColumnarViewModel } from '../flame_api';
 import { BOX_GAP_HORIZONTAL, BOX_GAP_VERTICAL, roundUpSize } from './common';
@@ -52,7 +53,7 @@ export const drawCanvas2d = (
   ctx.textAlign = 'left';
   ctx.textBaseline = 'middle';
   ctx.scale(dpr, dpr);
-  ctx.font = `${fontSize}px sans-serif`;
+  ctx.font = `${fontSize}px ${DEFAULT_FONT_FAMILY}`;
   ctx.clearRect(0, 0, roundUpSize(cssWidth), roundUpSize(cssHeight));
   ctx.translate(cssOffsetX, cssOffsetY);
   ctx.beginPath();

--- a/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
@@ -13,9 +13,8 @@ import {
   createLinkedProgram,
   getAttributes,
   getRenderer,
-  GL_FRAGMENT_SHADER,
-  GL_VERTEX_SHADER,
 } from '../../../common/kingly';
+import { GL } from '../../../common/webgl_constants';
 import { ColumnarViewModel } from '../flame_api';
 import { colorFrag, rectVert, roundedRectFrag } from '../shaders';
 import { GLResources, NULL_GL_RESOURCES } from '../types';
@@ -45,15 +44,15 @@ export function ensureWebgl(gl: WebGL2RenderingContext, instanceAttributes: stri
 
   const geomProgram = createLinkedProgram(
     gl,
-    createCompiledShader(gl, GL_VERTEX_SHADER, rectVert),
-    createCompiledShader(gl, GL_FRAGMENT_SHADER, roundedRectFrag),
+    createCompiledShader(gl, GL.VERTEX_SHADER, rectVert),
+    createCompiledShader(gl, GL.FRAGMENT_SHADER, roundedRectFrag),
     attributeLocations,
   );
 
   const pickProgram = createLinkedProgram(
     gl,
-    createCompiledShader(gl, GL_VERTEX_SHADER, rectVert),
-    createCompiledShader(gl, GL_FRAGMENT_SHADER, colorFrag),
+    createCompiledShader(gl, GL.VERTEX_SHADER, rectVert),
+    createCompiledShader(gl, GL.FRAGMENT_SHADER, colorFrag),
     attributeLocations,
   );
 

--- a/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
@@ -13,6 +13,7 @@ import {
   createLinkedProgram,
   getAttributes,
   getRenderer,
+  resetState,
 } from '../../../common/kingly';
 import { GL } from '../../../common/webgl_constants';
 import { ColumnarViewModel } from '../flame_api';
@@ -21,6 +22,8 @@ import { GLResources, NULL_GL_RESOURCES } from '../types';
 
 /** @internal */
 export function ensureWebgl(gl: WebGL2RenderingContext, instanceAttributes: string[]): GLResources {
+  resetState(gl);
+
   /**
    * Vertex array attributes
    */

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -69,7 +69,7 @@ export const rectVert = /* language=GLSL */ vert`
     gl_Position = vec4(2.0 * zoomPannedXY - 1.0, 0, 1);
     fragmentColor = pickLayer
       ? vec4((uvec4(gl_InstanceID + GEOM_INDEX_OFFSET) >> BIT_SHIFTERS) % uvec4(256)) / 255.0
-      : vec4(color.rgb, (gl_InstanceID == hoverIndex - GEOM_INDEX_OFFSET ? HOVER_OPACITY : 1.0) * color.a);
+      : vec4(color.rgb / (gl_InstanceID == hoverIndex - GEOM_INDEX_OFFSET ? HOVER_OPACITY : 1.0),  color.a);
 
     // calculate rounded corner metrics for interpolation
     vec2 pixelSize = size * zoomedResolution;

--- a/packages/charts/src/common/default_theme_attributes.ts
+++ b/packages/charts/src/common/default_theme_attributes.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/** @internal */
+export const DEFAULT_FONT_FAMILY =
+  '"Inter UI", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"';

--- a/packages/charts/src/common/kingly.ts
+++ b/packages/charts/src/common/kingly.ts
@@ -95,12 +95,7 @@ const flagSet = (gl: WebGL2RenderingContext, key: number, value: boolean) => {
  * Programs
  ***************/
 
-/** @internal */
-export const GL_FRAGMENT_SHADER = 0x8b30;
-/** @internal */
-export const GL_VERTEX_SHADER = 0x8b31;
-
-type ShaderType = typeof GL_FRAGMENT_SHADER | typeof GL_VERTEX_SHADER;
+type ShaderType = typeof GL.FRAGMENT_SHADER | typeof GL.VERTEX_SHADER;
 
 /** @internal */
 export const createCompiledShader = (
@@ -113,7 +108,7 @@ export const createCompiledShader = (
   gl.shaderSource(shader, source);
   gl.compileShader(shader);
   if (GL_DEBUG && !gl.getShaderParameter(shader, GL.COMPILE_STATUS)) {
-    const shaderTypeName = shaderType === GL_VERTEX_SHADER ? 'vertex' : 'fragment';
+    const shaderTypeName = shaderType === GL.VERTEX_SHADER ? 'vertex' : 'fragment';
     throw new Error(`Whoa, compilation error in a ${shaderTypeName} shader: ${gl.getShaderInfoLog(shader)}`);
   }
   return shader;
@@ -305,14 +300,7 @@ const textureTypeLookup = {
   [GL.RGBA32F]: GL.FLOAT,
 };
 
-/** @internal */
-export const GL_READ_FRAMEBUFFER = 0x8ca8;
-/** @internal */
-export const GL_DRAW_FRAMEBUFFER = 0x8ca9;
-/** @internal */
-export const GL_FRAMEBUFFER = 0x8d40;
-
-type FrameBufferTarget = typeof GL_READ_FRAMEBUFFER | typeof GL_DRAW_FRAMEBUFFER | typeof GL_FRAMEBUFFER;
+type FrameBufferTarget = typeof GL.READ_FRAMEBUFFER | typeof GL.DRAW_FRAMEBUFFER | typeof GL.FRAMEBUFFER;
 
 /** @internal */
 export const bindFramebuffer = (
@@ -321,10 +309,10 @@ export const bindFramebuffer = (
   targetFrameBuffer: WebGLFramebuffer | null,
 ) => {
   const updateReadTarget =
-    (target === GL_READ_FRAMEBUFFER || target === GL_FRAMEBUFFER) &&
+    (target === GL.READ_FRAMEBUFFER || target === GL.FRAMEBUFFER) &&
     targetFrameBuffer !== currentReadFrameBuffers.get(gl);
   const updateWriteTarget =
-    (target === GL_DRAW_FRAMEBUFFER || target === GL_FRAMEBUFFER) &&
+    (target === GL.DRAW_FRAMEBUFFER || target === GL.FRAMEBUFFER) &&
     targetFrameBuffer !== currentDrawFrameBuffers.get(gl);
 
   if (updateReadTarget) currentReadFrameBuffers.set(gl, targetFrameBuffer);
@@ -333,10 +321,10 @@ export const bindFramebuffer = (
   if (updateReadTarget || updateWriteTarget) {
     const targetToUpdate =
       updateReadTarget && updateWriteTarget
-        ? GL_FRAMEBUFFER
+        ? GL.FRAMEBUFFER
         : updateReadTarget
-        ? GL_READ_FRAMEBUFFER
-        : GL_DRAW_FRAMEBUFFER;
+        ? GL.READ_FRAMEBUFFER
+        : GL.DRAW_FRAMEBUFFER;
     gl.bindFramebuffer(targetToUpdate, targetFrameBuffer);
   }
 };
@@ -409,9 +397,9 @@ export const createTexture = (
   const getTarget = () => {
     if (!frameBuffer) {
       frameBuffer = gl.createFramebuffer();
-      bindFramebuffer(gl, GL_DRAW_FRAMEBUFFER, frameBuffer);
-      gl.framebufferTexture2D(GL_FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.TEXTURE_2D, texture, 0);
-      if (GL_DEBUG && gl.checkFramebufferStatus(GL_DRAW_FRAMEBUFFER) !== GL.FRAMEBUFFER_COMPLETE) {
+      bindFramebuffer(gl, GL.DRAW_FRAMEBUFFER, frameBuffer);
+      gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.TEXTURE_2D, texture, 0);
+      if (GL_DEBUG && gl.checkFramebufferStatus(GL.DRAW_FRAMEBUFFER) !== GL.FRAMEBUFFER_COMPLETE) {
         throw new Error(`Target framebuffer is not complete`);
       }
     }
@@ -420,15 +408,15 @@ export const createTexture = (
 
   return {
     clear: () => {
-      bindFramebuffer(gl, GL_DRAW_FRAMEBUFFER, getTarget());
+      bindFramebuffer(gl, GL.DRAW_FRAMEBUFFER, getTarget());
       clearRect(gl, { color: [0, 0, 0, 0] }); // alternatives: texImage2D/texSubImage2D/render
     },
     setUniform: (location: WebGLUniformLocation) => gl.uniform1i(location, textureIndex),
     target: getTarget,
     delete: (): true => {
       if (frameBuffer) {
-        if (currentReadFrameBuffers.get(gl) === frameBuffer) bindFramebuffer(gl, GL_READ_FRAMEBUFFER, null);
-        if (currentDrawFrameBuffers.get(gl) === frameBuffer) bindFramebuffer(gl, GL_DRAW_FRAMEBUFFER, null);
+        if (currentReadFrameBuffers.get(gl) === frameBuffer) bindFramebuffer(gl, GL.READ_FRAMEBUFFER, null);
+        if (currentDrawFrameBuffers.get(gl) === frameBuffer) bindFramebuffer(gl, GL.DRAW_FRAMEBUFFER, null);
         gl.deleteFramebuffer(frameBuffer);
       }
       gl.deleteTexture(texture);
@@ -581,7 +569,7 @@ export const getRenderer = (
     if (viewport) setViewport(gl, viewport.x, viewport.y, viewport.width, viewport.height);
     if (uniformValues) uniforms.forEach((setValue, name) => uniformValues[name] && setValue(uniformValues[name]));
 
-    bindFramebuffer(gl, GL_DRAW_FRAMEBUFFER, target);
+    bindFramebuffer(gl, GL.DRAW_FRAMEBUFFER, target);
 
     if (clear) clearRect(gl, clear);
 

--- a/packages/charts/src/common/kingly.ts
+++ b/packages/charts/src/common/kingly.ts
@@ -647,3 +647,19 @@ const flushErrors = (gl: WebGL2RenderingContext, text: string) => {
   } while (hasError); // clear the error code
 };
 */
+
+/** @internal */
+export const testContextLoss = (gl: WebGL2RenderingContext) => {
+  // simulates a context loss at `lossTimeMs` and context recovery at `regainTimeMs` after that
+  const lossTimeMs = 5000;
+  const regainTimeMs = 0;
+  const ext = gl.getExtension('WEBGL_lose_context');
+  if (ext) {
+    window.setTimeout(() => {
+      // eslint-disable-next-line no-console
+      console.log('Context loss test triggered, the webgl rendering will freeze or disappear');
+      ext.loseContext();
+      window.setTimeout(() => ext.restoreContext(), regainTimeMs);
+    }, lossTimeMs);
+  }
+};

--- a/packages/charts/src/state/selectors/get_legend_size.ts
+++ b/packages/charts/src/state/selectors/get_legend_size.ts
@@ -6,11 +6,12 @@
  * Side Public License, v 1.
  */
 
+import { DEFAULT_FONT_FAMILY } from '../../common/default_theme_attributes';
 import { LEGEND_HIERARCHY_MARGIN } from '../../components/legend/legend_item';
 import { LEGEND_TO_FULL_CONFIG } from '../../components/legend/position_style';
 import { LegendPositionConfig } from '../../specs/settings';
 import { withTextMeasure } from '../../utils/bbox/canvas_text_bbox_calculator';
-import { Position, isDefined, LayoutDirection } from '../../utils/common';
+import { isDefined, LayoutDirection, Position } from '../../utils/common';
 import { Size } from '../../utils/dimensions';
 import { GlobalChartState } from '../chart_state';
 import { createCustomCachedSelector } from '../create_selector';
@@ -25,8 +26,6 @@ const MARKER_WIDTH = 16;
 const SHARED_MARGIN = 4;
 const VERTICAL_PADDING = 4;
 const TOP_MARGIN = 2;
-const MAGIC_FONT_FAMILY =
-  '"Inter UI", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"';
 
 /** @internal */
 export type LegendSizing = Size & {
@@ -47,7 +46,7 @@ export const getLegendSizeSelector = createCustomCachedSelector(
         (acc, { label, depth }) => {
           const { width, height } = textMeasure(
             label,
-            { fontFamily: MAGIC_FONT_FAMILY, fontVariant: 'normal', fontWeight: 400, fontStyle: 'normal' },
+            { fontFamily: DEFAULT_FONT_FAMILY, fontVariant: 'normal', fontWeight: 400, fontStyle: 'normal' },
             12,
             1.5,
           );


### PR DESCRIPTION
## Summary

This PR adds context loss handling to the WebGL flame chart. 

Web standards do not guarantee that rendering resources aren't lost. Rendering resources can be lost for various reasons, such as an overloaded system (even due to other applications), graphics driver error, or too many contexts. In fact, a context loss may even happen with Canvas2d. But it's more important for WebGL, where a context can be lost even simply having too many distinct WebGL canvases on a page (more than 16).

The PR contains other minor refactoring, such as pulling the font type from the default font, and updating `kingly.ts` to the version that can run more WebGL charts that are in the pipeline. For example, via configurable polygon vertex winding order.

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
