### PR TITLE
fix(cartesian): fill missing datapoints only for stacked area charts

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/state/utils/utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/utils/utils.ts
@@ -134,7 +134,7 @@ export function computeSeriesDomains(
   const xDomain = mergeXDomain(scaleConfigs.x, xValues, fallbackScale);
 
   // fill series with missing x values
-  const filledDataSeries = fillSeries(dataSeries, xValues, xDomain.type);
+  const filledDataSeries = fillSeries(dataSeries, xValues);
 
   const seriesSortFn = getRenderingCompareFn((a: SeriesIdentifier, b: SeriesIdentifier) => {
     return defaultXYSeriesSort(a as DataSeries, b as DataSeries);

--- a/storybook/stories/area/22_fit_and_fill_band_area_chart.story.tsx
+++ b/storybook/stories/area/22_fit_and_fill_band_area_chart.story.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+
+import {
+  AreaSeries,
+  LineSeries,
+  CurveType,
+  Chart,
+  ScaleType,
+  Settings,
+  Axis,
+  Position,
+  Fit,
+  niceTimeFormatter,
+} from '@elastic/charts';
+
+import { useBaseTheme } from '../../use_base_theme';
+
+export const Example = () => {
+  return (
+    <div className="App">
+      <Chart size={['100%', 500]}>
+        <Settings showLegend theme={useBaseTheme()} />
+        <Axis id="value" position={Position.Left} />
+        <Axis id="time" position={Position.Bottom} tickFormat={niceTimeFormatter([1625253120000, 1625254560000])} />
+
+        <LineSeries
+          id="Throughput"
+          data={[
+            [1625253300000, 243.8],
+            [1625253600000, 303.2],
+            [1625253900000, 290.6],
+            [1625254200000, 307],
+            [1625254500000, 302],
+          ]}
+          xScaleType={ScaleType.Time}
+          yScaleType={ScaleType.Linear}
+          curve={CurveType.CURVE_MONOTONE_X}
+          xAccessor={0}
+          yAccessors={[1]}
+          stackAccessors={[0]}
+          yNice
+        />
+
+        <AreaSeries
+          id="Expected bounds"
+          data={[
+            [1625253120000, null, null],
+            [1625253480000, 300.5849842903525, 394.38103396943154],
+            [1625253840000, 299.52027100052254, 394.42301093407673],
+            [1625254200000, 300.883705475389, 392.8469455894186],
+            [1625254560000, 301.1673718583745, 392.1260821195367],
+          ]}
+          xScaleType={ScaleType.Time}
+          yScaleType={ScaleType.Linear}
+          curve={CurveType.CURVE_MONOTONE_X}
+          fit={{ type: Fit.Linear, endValue: Fit.Nearest }}
+          xAccessor={0}
+          yAccessors={[2]}
+          y0Accessors={[1]}
+          yNice
+          areaSeriesStyle={{
+            point: {
+              visible: true,
+            },
+          }}
+        />
+      </Chart>
+    </div>
+  );
+};

--- a/storybook/stories/area/area.stories.tsx
+++ b/storybook/stories/area/area.stories.tsx
@@ -32,3 +32,4 @@ export { Example as steppedArea } from './20_stepped_area.story';
 export { Example as testLinear } from './11_test_linear.story';
 export { Example as testTime } from './12_test_time.story';
 export { Example as testStackedWithMissingValues } from './16_test_stacked_with_missing.story';
+export { Example as testFitAndFillAreaChart } from './22_fit_and_fill_band_area_chart.story';


### PR DESCRIPTION
## Summary
This PR fixes an issue caused by a mixed configuration with a data fill functionality, the fit functionality within a band chart.

There are multiple factors that are causing the rendering error in #1683:
- the fit functionality doesn't work for band charts yet, it applies the fit function only to the `y1` values
- we are wrongly filling charts with null data points on every missing x value depending on some wrongly configured constraints.
- when rendering a band both y values needs to exist to be considered a defined value. If only one is missing, then that band section is considered not defined and will not be rendered.

The mix of these factors cause the issue linked below.


<!-- screenshot/gif/mpeg-4 for visual changes -->
On master:
<img width="557" alt="Screenshot 2022-05-27 at 11 07 39" src="https://user-images.githubusercontent.com/1421091/170669533-9cf23ada-6034-409c-ac99-5d0994099114.png">

On this PR:
<img width="547" alt="Screenshot 2022-05-27 at 11 09 16" src="https://user-images.githubusercontent.com/1421091/170669543-0625c573-3084-40d7-a2e6-b3d275aa9adc.png">


## Details
The current dataset filling operation can be described as the following:
- collect every available value along the X axis across all series
- if the filling operation is required (a constraint previously defined by negating the `isXFillNotRequired` method) then we loop through the data array, adding a partial data point (with null Y values) on every missing x datapoint.

I've chosen to fix the current policy on filling data sets with empty X values expressed in the `isXFillNotRequired` method.
I've decided to apply the filling policy only to stacked area charts. The fill policy should be required only for that case because:
- stacked area charts need to perfectly juxtapose areas on top of each other. If we miss a data point in one area,  the area above or below can overlap or not completely touch the nearest area, causing the chart to be wrongly rendered creating a bad data representation.
- bar chart don't need this fill policy at all.
- line charts can clearly overlaps, we don't stack line charts so that policy is completely useless.
- non stacked area charts, behaves like line charts, so to the policy doesn't need to be applied.


## Issues

fix #1683
<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [ ] Unit tests have been added or updated to match the most common scenarios
- [x] The proper documentation and/or storybook story has been added or updated
