### PR TITLE
performance(flame): uniform buffers and shader rework

### DIFF
--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -29,7 +29,7 @@ import { roundUpSize } from './render/common';
 import { drawFrame, EPSILON, PADDING_BOTTOM, PADDING_LEFT, PADDING_RIGHT, PADDING_TOP } from './render/draw_a_frame';
 import { ensureWebgl } from './render/ensure_webgl';
 import { uploadToWebgl } from './render/upload_to_webgl';
-import { GEOM_INDEX_OFFSET } from './shaders';
+import { attributeLocations, GEOM_INDEX_OFFSET } from './shaders';
 import { GLResources, NULL_GL_RESOURCES, nullColumnarViewModel, PickFunction } from './types';
 
 const PINCH_ZOOM_CHECK_INTERVAL_MS = 100;
@@ -120,6 +120,9 @@ const getRegExp = (searchString: string): RegExp => {
   }
   return regex;
 };
+
+const isAttributeKey = (keyCandidate: string): keyCandidate is keyof typeof attributeLocations =>
+  keyCandidate in attributeLocations;
 
 interface StateProps {
   columnarViewModel: FlameSpec['columnarData'];
@@ -891,7 +894,7 @@ class FlameComponent extends React.Component<FlameProps> {
   };
 
   private initializeGL = (gl: WebGL2RenderingContext) => {
-    this.glResources = ensureWebgl(gl, Object.keys(this.props.columnarViewModel));
+    this.glResources = ensureWebgl(gl, Object.keys(this.props.columnarViewModel).filter(isAttributeKey));
     uploadToWebgl(gl, this.glResources.attributes, this.props.columnarViewModel);
   };
 

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -27,7 +27,8 @@ import { Size } from '../../utils/dimensions';
 import { FlameSpec } from './flame_api';
 import { roundUpSize } from './render/common';
 import { drawFrame, EPSILON, PADDING_BOTTOM, PADDING_LEFT, PADDING_RIGHT, PADDING_TOP } from './render/draw_a_frame';
-import { ensureWebgl, uploadToWebgl } from './render/ensure_webgl';
+import { ensureWebgl } from './render/ensure_webgl';
+import { uploadToWebgl } from './render/upload_to_webgl';
 import { GEOM_INDEX_OFFSET } from './shaders';
 import { GLResources, NULL_GL_RESOURCES, nullColumnarViewModel, PickFunction } from './types';
 

--- a/packages/charts/src/chart_types/flame_chart/render/draw_a_frame.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/draw_a_frame.ts
@@ -112,7 +112,7 @@ export const drawFrame = (
   // base (focus) pick layer
   drawFocusLayer(true);
 
-  // minimap pick layer
+  // minimap pick layer -- just for clearing, to avoid hover tooltip
   drawContextLayer(true);
 
   // focus layer text

--- a/packages/charts/src/chart_types/flame_chart/render/draw_canvas.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/draw_canvas.ts
@@ -58,7 +58,7 @@ export const drawCanvas2d = (
     { fontFamily: DEFAULT_FONT_FAMILY, fontStyle: 'normal', fontVariant: 'normal', fontWeight: 'normal' },
     fontSize,
   );
-  ctx.clearRect(0, 0, roundUpSize(cssWidth), roundUpSize(cssHeight));
+  ctx.clearRect(0, 0, roundUpSize(cssWidth + cssOffsetX), roundUpSize(cssHeight + cssOffsetY));
   ctx.translate(cssOffsetX, cssOffsetY);
   ctx.beginPath();
   ctx.rect(0, 0, roundUpSize(cssWidth), cssHeight);

--- a/packages/charts/src/chart_types/flame_chart/render/draw_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/draw_webgl.ts
@@ -29,7 +29,7 @@ export const drawWebgl = (
   renderer: Render,
   hoverIndex: number,
   rowHeight: number,
-  currentFocus: [number, number, number, number],
+  f: [number, number, number, number],
   instanceCount: number,
   focusLayer: boolean,
   pickLayer: boolean,
@@ -46,7 +46,7 @@ export const drawWebgl = (
       hoverIndex: Number.isFinite(hoverIndex) ? hoverIndex + GEOM_INDEX_OFFSET : DUMMY_INDEX,
       rowHeight0: rowHeight,
       rowHeight1: rowHeight,
-      focus: currentFocus,
+      focus: [f[0], f[1], 0, 0, f[2], f[3], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     },
     viewport: { x: xOffset, y: yOffset, width: canvasWidth, height: canvasHeight }, // may conditionalize on textureWidthChanged || textureHeightChanged
     clear: {

--- a/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
@@ -105,5 +105,5 @@ export function ensureWebgl(
 
   const attributes = getAttributes(gl, geomProgram, attributeLocations);
 
-  return { roundedRectRenderer, pickTextureRenderer, uniforms, uboBuffer, attributes };
+  return { roundedRectRenderer, pickTextureRenderer, attributes };
 }

--- a/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
@@ -8,6 +8,7 @@
 
 import {
   bindVertexArray,
+  blockUniforms,
   createCompiledShader,
   createLinkedProgram,
   getAttributes,
@@ -15,34 +16,8 @@ import {
   resetState,
 } from '../../../common/kingly';
 import { GL } from '../../../common/webgl_constants';
-import { attributeLocations, colorFrag, roundedRectVert, roundedRectFrag, simpleRectVert } from '../shaders';
+import { attributeLocations, colorFrag, roundedRectFrag, roundedRectVert, simpleRectVert } from '../shaders';
 import { GLResources, NULL_GL_RESOURCES } from '../types';
-
-function blockUniforms(
-  gl: WebGL2RenderingContext,
-  uboVariableNames: string[],
-  [program, ...otherPrograms]: WebGLProgram[],
-) {
-  const blockIndex = gl.getUniformBlockIndex(program, 'Settings');
-  const blockSize = gl.getActiveUniformBlockParameter(program, blockIndex, GL.UNIFORM_BLOCK_DATA_SIZE);
-  const uboBuffer = gl.createBuffer();
-  if (uboBuffer === null) throw new Error('Whoa, could not create uboBuffer');
-  gl.bindBuffer(gl.UNIFORM_BUFFER, uboBuffer);
-  gl.bufferData(gl.UNIFORM_BUFFER, blockSize, gl.DYNAMIC_DRAW);
-  // gl.bindBuffer(gl.UNIFORM_BUFFER, null);
-  gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, uboBuffer);
-  const uboVariableIndices = gl.getUniformIndices(program, uboVariableNames);
-  if (uboVariableIndices === null) throw new Error('Whoa, could not get uboVariableIndices');
-  const uboVariableOffsets = gl.getActiveUniforms(program, uboVariableIndices, gl.UNIFORM_OFFSET);
-  const uniforms = new Map(
-    uboVariableNames.map((name, i) => [name, { index: uboVariableIndices[i], offset: uboVariableOffsets[i] }]),
-  );
-
-  // per program part
-  [program, ...otherPrograms].forEach((p) => gl.uniformBlockBinding(p, gl.getUniformBlockIndex(p, 'Settings'), 0));
-
-  return { uboBuffer, uniforms };
-}
 
 /** @internal */
 export function ensureWebgl(
@@ -81,24 +56,23 @@ export function ensureWebgl(
     attributeLocations,
   );
 
-  /**
-   * Uniform blocks
-   */
-
-  const uboVariableNames = [
-    'focus',
-    'resolution',
-    'gapPx',
-    'minFillRatio',
-    'rowHeight0',
-    'rowHeight1',
-    't',
-    'cornerRadiusPx',
-    'hoverIndex',
-    'pickLayer',
-  ];
-
-  const { uboBuffer, uniforms } = blockUniforms(gl, uboVariableNames, [geomProgram, pickProgram]);
+  const { uboBuffer, uniforms } = blockUniforms(
+    gl,
+    'Settings',
+    [
+      'focus',
+      'resolution',
+      'gapPx',
+      'minFillRatio',
+      'rowHeight0',
+      'rowHeight1',
+      't',
+      'cornerRadiusPx',
+      'hoverIndex',
+      'pickLayer',
+    ],
+    [geomProgram, pickProgram],
+  );
 
   /**
    * Resource allocation: Render setup

--- a/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
@@ -56,7 +56,7 @@ export function ensureWebgl(
     attributeLocations,
   );
 
-  const { uboBuffer, uniforms } = blockUniforms(
+  const blockUniformsData = blockUniforms(
     gl,
     'Settings',
     [
@@ -79,11 +79,8 @@ export function ensureWebgl(
    */
 
   // couple the program with the attribute input and global GL flags
-  const roundedRectRenderer = getRenderer(gl, geomProgram, uniforms, uboBuffer, vao, { depthTest: false, blend: true });
-  const pickTextureRenderer = getRenderer(gl, pickProgram, uniforms, uboBuffer, vao, {
-    depthTest: false,
-    blend: false,
-  });
+  const roundedRectRenderer = getRenderer(gl, geomProgram, blockUniformsData, vao, { depthTest: false, blend: true });
+  const pickTextureRenderer = getRenderer(gl, pickProgram, blockUniformsData, vao, { depthTest: false, blend: false });
 
   const attributes = getAttributes(gl, geomProgram, attributeLocations);
 

--- a/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
@@ -18,6 +18,32 @@ import { GL } from '../../../common/webgl_constants';
 import { attributeLocations, colorFrag, roundedRectVert, roundedRectFrag, simpleRectVert } from '../shaders';
 import { GLResources, NULL_GL_RESOURCES } from '../types';
 
+function blockUniforms(
+  gl: WebGL2RenderingContext,
+  uboVariableNames: string[],
+  [program, ...otherPrograms]: WebGLProgram[],
+) {
+  const blockIndex = gl.getUniformBlockIndex(program, 'Settings');
+  const blockSize = gl.getActiveUniformBlockParameter(program, blockIndex, GL.UNIFORM_BLOCK_DATA_SIZE);
+  const uboBuffer = gl.createBuffer();
+  if (uboBuffer === null) throw new Error('Whoa, could not create uboBuffer');
+  gl.bindBuffer(gl.UNIFORM_BUFFER, uboBuffer);
+  gl.bufferData(gl.UNIFORM_BUFFER, blockSize, gl.DYNAMIC_DRAW);
+  // gl.bindBuffer(gl.UNIFORM_BUFFER, null);
+  gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, uboBuffer);
+  const uboVariableIndices = gl.getUniformIndices(program, uboVariableNames);
+  if (uboVariableIndices === null) throw new Error('Whoa, could not get uboVariableIndices');
+  const uboVariableOffsets = gl.getActiveUniforms(program, uboVariableIndices, gl.UNIFORM_OFFSET);
+  const uniforms = new Map(
+    uboVariableNames.map((name, i) => [name, { index: uboVariableIndices[i], offset: uboVariableOffsets[i] }]),
+  );
+
+  // per program part
+  [program, ...otherPrograms].forEach((p) => gl.uniformBlockBinding(p, gl.getUniformBlockIndex(p, 'Settings'), 0));
+
+  return { uboBuffer, uniforms };
+}
+
 /** @internal */
 export function ensureWebgl(
   gl: WebGL2RenderingContext,
@@ -59,16 +85,6 @@ export function ensureWebgl(
    * Uniform blocks
    */
 
-  // common part
-  const program = geomProgram;
-  const blockIndex = gl.getUniformBlockIndex(program, 'Settings');
-  const blockSize = gl.getActiveUniformBlockParameter(program, blockIndex, GL.UNIFORM_BLOCK_DATA_SIZE);
-  const uboBuffer = gl.createBuffer();
-  if (uboBuffer === null) throw new Error('Whoa, could not create uboBuffer');
-  gl.bindBuffer(gl.UNIFORM_BUFFER, uboBuffer);
-  gl.bufferData(gl.UNIFORM_BUFFER, blockSize, gl.DYNAMIC_DRAW);
-  // gl.bindBuffer(gl.UNIFORM_BUFFER, null);
-  gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, uboBuffer);
   const uboVariableNames = [
     'focus',
     'resolution',
@@ -81,16 +97,8 @@ export function ensureWebgl(
     'hoverIndex',
     'pickLayer',
   ];
-  const uboVariableIndices = gl.getUniformIndices(program, uboVariableNames);
-  if (uboVariableIndices === null) throw new Error('Whoa, could not get uboVariableIndices');
-  const uboVariableOffsets = gl.getActiveUniforms(program, uboVariableIndices, gl.UNIFORM_OFFSET);
-  const uniforms = new Map(
-    uboVariableNames.map((name, i) => [name, { index: uboVariableIndices[i], offset: uboVariableOffsets[i] }]),
-  );
 
-  // per program part
-  gl.uniformBlockBinding(geomProgram, gl.getUniformBlockIndex(geomProgram, 'Settings'), 0);
-  gl.uniformBlockBinding(pickProgram, gl.getUniformBlockIndex(pickProgram, 'Settings'), 0);
+  const { uboBuffer, uniforms } = blockUniforms(gl, uboVariableNames, [geomProgram, pickProgram]);
 
   /**
    * Resource allocation: Render setup

--- a/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
@@ -15,11 +15,14 @@ import {
   resetState,
 } from '../../../common/kingly';
 import { GL } from '../../../common/webgl_constants';
-import { colorFrag, rectVert, roundedRectFrag } from '../shaders';
+import { attributeLocations, colorFrag, rectVert, roundedRectFrag } from '../shaders';
 import { GLResources, NULL_GL_RESOURCES } from '../types';
 
 /** @internal */
-export function ensureWebgl(gl: WebGL2RenderingContext, instanceAttributes: string[]): GLResources {
+export function ensureWebgl(
+  gl: WebGL2RenderingContext,
+  instanceAttributes: Array<keyof typeof attributeLocations>,
+): GLResources {
   resetState(gl);
 
   /**
@@ -31,13 +34,8 @@ export function ensureWebgl(gl: WebGL2RenderingContext, instanceAttributes: stri
 
   bindVertexArray(gl, vao);
 
-  const attributeLocations = new Map(instanceAttributes.map((name, i: GLuint) => [name, i]));
-
   // by how many instances should each attribute advance?
-  instanceAttributes.forEach((name) => {
-    const attributeLocation = attributeLocations.get(name);
-    if (typeof attributeLocation === 'number') gl.vertexAttribDivisor(attributeLocation, 1);
-  });
+  instanceAttributes.forEach((name) => gl.vertexAttribDivisor(attributeLocations[name], 1));
 
   /**
    * Programs

--- a/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
@@ -15,7 +15,7 @@ import {
   resetState,
 } from '../../../common/kingly';
 import { GL } from '../../../common/webgl_constants';
-import { attributeLocations, colorFrag, rectVert, roundedRectFrag } from '../shaders';
+import { attributeLocations, colorFrag, roundedRectVert, roundedRectFrag, simpleRectVert } from '../shaders';
 import { GLResources, NULL_GL_RESOURCES } from '../types';
 
 /** @internal */
@@ -43,14 +43,14 @@ export function ensureWebgl(
 
   const geomProgram = createLinkedProgram(
     gl,
-    createCompiledShader(gl, GL.VERTEX_SHADER, rectVert),
+    createCompiledShader(gl, GL.VERTEX_SHADER, roundedRectVert),
     createCompiledShader(gl, GL.FRAGMENT_SHADER, roundedRectFrag),
     attributeLocations,
   );
 
   const pickProgram = createLinkedProgram(
     gl,
-    createCompiledShader(gl, GL.VERTEX_SHADER, rectVert),
+    createCompiledShader(gl, GL.VERTEX_SHADER, simpleRectVert),
     createCompiledShader(gl, GL.FRAGMENT_SHADER, colorFrag),
     attributeLocations,
   );

--- a/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  Attributes,
   bindVertexArray,
   createCompiledShader,
   createLinkedProgram,
@@ -16,7 +15,6 @@ import {
   resetState,
 } from '../../../common/kingly';
 import { GL } from '../../../common/webgl_constants';
-import { ColumnarViewModel } from '../flame_api';
 import { colorFrag, rectVert, roundedRectFrag } from '../shaders';
 import { GLResources, NULL_GL_RESOURCES } from '../types';
 
@@ -70,16 +68,4 @@ export function ensureWebgl(gl: WebGL2RenderingContext, instanceAttributes: stri
   const attributes = getAttributes(gl, geomProgram, attributeLocations);
 
   return { roundedRectRenderer, pickTextureRenderer, attributes };
-}
-
-/** @internal */
-export function uploadToWebgl(
-  gl: WebGL2RenderingContext,
-  attributes: Attributes,
-  columnarViewModel: Partial<ColumnarViewModel>,
-) {
-  attributes.forEach((setValue, key) => {
-    const value = columnarViewModel[key as keyof ColumnarViewModel];
-    if (value instanceof Float32Array) setValue(value);
-  });
 }

--- a/packages/charts/src/chart_types/flame_chart/render/upload_to_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/upload_to_webgl.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Attributes } from '../../../common/kingly';
+import { ColumnarViewModel } from '../flame_api';
+
+/** @internal */
+export function uploadToWebgl(
+  gl: WebGL2RenderingContext,
+  attributes: Attributes,
+  columnarViewModel: Partial<ColumnarViewModel>,
+) {
+  attributes.forEach((setValue, key) => {
+    const value = columnarViewModel[key as keyof ColumnarViewModel];
+    if (value instanceof Float32Array) setValue(value);
+  });
+}

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -39,8 +39,6 @@ const fragTop = /* language=GLSL */ `#version 300 es
 
 const structGeom = /* language=GLSL */ `
   struct Geom {
-    int x;
-    int y;
     vec2 unitSquareCoord;
     vec2 size;
     vec2 fullSizeXY;
@@ -70,8 +68,6 @@ const getGeom = /* language=GLSL */ `
     vec2 pan = vec2(focusX[0], focusY[0]);
 
     return Geom(
-      x,
-      y,
       unitSquareCoord,
       size,
       fullSizeXY,
@@ -165,10 +161,10 @@ export const roundedRectVert = /* language=GLSL */ `${vertTop}
     radiusPx = min(cornerRadiusPx, 0.5 * min(pixelSize.x, pixelSize.y));
 
     // output the corner helper values  (approx. return values of our vertex shader)
-    corners[0] = vec2(g.x, g.y) * g.size * zoomedResolution - radiusPx;
-    corners[1] = vec2(1 - g.x, g.y) * g.size * zoomedResolution - radiusPx;
-    corners[2] = vec2(g.x, 1 - g.y) * g.size * zoomedResolution - radiusPx;
-    corners[3] = vec2(1 - g.x, 1 - g.y) * g.size * zoomedResolution - radiusPx;
+    corners[0] = g.unitSquareCoord * g.size * zoomedResolution - radiusPx;
+    corners[1] = (g.unitSquareCoord * vec2(-1, 1) + vec2(1, 0)) * g.size * zoomedResolution - radiusPx;
+    corners[2] = (g.unitSquareCoord * vec2(1, -1) + vec2(0, 1)) * g.size * zoomedResolution - radiusPx;
+    corners[3] = (1.0 - g.unitSquareCoord) * g.size * zoomedResolution - radiusPx;
   }`;
 
 /** @internal */
@@ -183,7 +179,7 @@ export const roundedRectFrag = /* language=GLSL */ `${fragTop}
     // rounded corners: discard pixels that lie beyond each corner "circle" in the quadrant beyond its respective corner
     for(int i = 0; i < 4; i++) {
       vec2 corner = corners[i];
-      if(corner.x < 0.0 && corner.y < 0.0 && length(corner) > radiusPx) discard;
+      if(corner.x < 0.0 && corner.y < 0.0 && length(corner) > radiusPx) discard; // consider derivatives
     }
     fragColor = fragmentColor;
   }`;

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -7,6 +7,15 @@
  */
 
 /** @internal */
+export const attributeLocations = {
+  position0: 0,
+  position1: 1,
+  size0: 2,
+  size1: 3,
+  color: 4,
+};
+
+/** @internal */
 export const GEOM_INDEX_OFFSET = 1; // zero color means, empty area (no rectangle) so the rectangles are base 1 indexed for pick coloring
 
 /** @internal */
@@ -15,9 +24,11 @@ export const rectVert = /* language=GLSL */ `#version 300 es
   precision highp int;
   precision highp float;
 
-  in vec2 position0, position1;
-  in float size0, size1;
-  in vec4 color;
+  layout(location=${attributeLocations.position0}) in vec2 position0;
+  layout(location=${attributeLocations.position1}) in vec2 position1;
+  layout(location=${attributeLocations.size0}) in float size0;
+  layout(location=${attributeLocations.size1}) in float size1;
+  layout(location=${attributeLocations.color}) in vec4 color;
 
   uniform bool pickLayer;
   uniform float t; // 0: start position; 1: end position

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -69,7 +69,7 @@ export const rectVert = /* language=GLSL */ vert`
     gl_Position = vec4(2.0 * zoomPannedXY - 1.0, 0, 1);
     fragmentColor = pickLayer
       ? vec4((uvec4(gl_InstanceID + GEOM_INDEX_OFFSET) >> BIT_SHIFTERS) % uvec4(256)) / 255.0
-      : vec4(color.rgb / (gl_InstanceID == hoverIndex - GEOM_INDEX_OFFSET ? HOVER_OPACITY : 1.0),  color.a);
+      : vec4(color.rgb, (gl_InstanceID == hoverIndex - GEOM_INDEX_OFFSET ? HOVER_OPACITY : 1.0) * color.a);
 
     // calculate rounded corner metrics for interpolation
     vec2 pixelSize = size * zoomedResolution;

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -18,14 +18,6 @@ export const attributeLocations = {
 /** @internal */
 export const GEOM_INDEX_OFFSET = 1; // zero color means, empty area (no rectangle) so the rectangles are base 1 indexed for pick coloring
 
-const attribDefs = /* language=GLSL */ `
-  layout(location=${attributeLocations.position0}) in vec2 position0;
-  layout(location=${attributeLocations.position1}) in vec2 position1;
-  layout(location=${attributeLocations.size0}) in float size0;
-  layout(location=${attributeLocations.size1}) in float size1;
-  layout(location=${attributeLocations.color}) in vec4 color;
-`;
-
 const vertTop = /* language=GLSL */ `#version 300 es
   #pragma STDGL invariant(all)
   precision highp int;
@@ -35,6 +27,14 @@ const vertTop = /* language=GLSL */ `#version 300 es
 const fragTop = /* language=GLSL */ `#version 300 es
   precision highp int;
   precision highp float;
+`;
+
+const attribDefs = /* language=GLSL */ `
+  layout(location=${attributeLocations.position0}) in vec2 position0;
+  layout(location=${attributeLocations.position1}) in vec2 position1;
+  layout(location=${attributeLocations.size0}) in float size0;
+  layout(location=${attributeLocations.size1}) in float size1;
+  layout(location=${attributeLocations.color}) in vec4 color;
 `;
 
 const constants = /* language=GLSL */ `
@@ -58,7 +58,8 @@ const getViewable = /* language=GLSL */ `
     float viewableX = focus[0][1] - focus[0][0];
     float viewableY = focus[1][1] - focus[1][0];
     return vec2(viewableX, viewableY);
-  }`;
+  }
+`;
 
 const getGeom = /* language=GLSL */ `
   Geom getGeom(vec2 viewable, vec2 gapRatio, vec2 maxGapRatio) {
@@ -95,18 +96,19 @@ const getGeom = /* language=GLSL */ `
       glPosition,
       fragmentColor
     );
-  }`;
+  }
+`;
 
 /** @internal */
 export const simpleRectVert = /* language=GLSL */ `${vertTop}
   ${attribDefs}
 
-  uniform bool pickLayer;
-  uniform float t; // 0: start position; 1: end position
+  uniform mat2 focus; // [[focusLoX, focusHiX], [focusLoY, focusHiY]]
   uniform vec2 resolution;
   uniform float rowHeight0, rowHeight1;
-  uniform mat2 focus; // [[focusLoX, focusHiX], [focusLoY, focusHiY]]
+  uniform float t; // 0: start position; 1: end position
   uniform int hoverIndex;
+  uniform bool pickLayer;
 
   out vec4 fragmentColor;
 
@@ -119,7 +121,8 @@ export const simpleRectVert = /* language=GLSL */ `${vertTop}
     Geom g = getGeom(getViewable(), vec2(0), vec2(0));
     gl_Position = g.glPosition;
     fragmentColor = g.fragmentColor;
-  }`;
+  }
+`;
 
 /** @internal */
 export const roundedRectVert = /* language=GLSL */ `${vertTop}
@@ -167,7 +170,8 @@ export const roundedRectVert = /* language=GLSL */ `${vertTop}
     corners[1] = (g.unitSquareCoord * vec2(-1, 1) + vec2(1, 0)) * g.size * zoomedResolution - radiusPx;
     corners[2] = (g.unitSquareCoord * vec2(1, -1) + vec2(0, 1)) * g.size * zoomedResolution - radiusPx;
     corners[3] = (1.0 - g.unitSquareCoord) * g.size * zoomedResolution - radiusPx;
-  }`;
+  }
+`;
 
 /** @internal */
 export const roundedRectFrag = /* language=GLSL */ `${fragTop}
@@ -184,10 +188,12 @@ export const roundedRectFrag = /* language=GLSL */ `${fragTop}
          + min(0.0, sign(corners[3].x) + sign(corners[3].y) + sign(radiusPx - length(corners[3])) + 2.0)
        ) < 0.0) discard;
     fragColor = fragmentColor;
-  }`;
+  }
+`;
 
 /** @internal */
 export const colorFrag = /* language=GLSL */ `${fragTop}
   in vec4 fragmentColor;
   out vec4 fragColor;
-  void main() { fragColor = fragmentColor; }`;
+  void main() { fragColor = fragmentColor; }
+`;

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -178,11 +178,11 @@ export const roundedRectFrag = /* language=GLSL */ `${fragTop}
   out vec4 fragColor;
 
   void main() {
-    // rounded corners: discard pixels that lie beyond each corner "circle" in the quadrant beyond its respective corner
-    for(int i = 0; i < 4; i++) {
-      vec2 corner = corners[i];
-      if(corner.x < 0.0 && corner.y < 0.0 && length(corner) > radiusPx) discard; // consider derivatives
-    }
+    if((   min(0.0, sign(corners[0].x) + sign(corners[0].y) + sign(radiusPx - length(corners[0])) + 2.0)
+         + min(0.0, sign(corners[1].x) + sign(corners[1].y) + sign(radiusPx - length(corners[1])) + 2.0)
+         + min(0.0, sign(corners[2].x) + sign(corners[2].y) + sign(radiusPx - length(corners[2])) + 2.0)
+         + min(0.0, sign(corners[3].x) + sign(corners[3].y) + sign(radiusPx - length(corners[3])) + 2.0)
+       ) < 0.0) discard;
     fragColor = fragmentColor;
   }`;
 

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -6,13 +6,15 @@
  * Side Public License, v 1.
  */
 
-import { frag, vert } from '../../common/kingly';
-
 /** @internal */
 export const GEOM_INDEX_OFFSET = 1; // zero color means, empty area (no rectangle) so the rectangles are base 1 indexed for pick coloring
 
 /** @internal */
-export const rectVert = /* language=GLSL */ vert`
+export const rectVert = /* language=GLSL */ `#version 300 es
+  #pragma STDGL invariant(all)
+  precision highp int;
+  precision highp float;
+
   in vec2 position0, position1;
   in float size0, size1;
   in vec4 color;
@@ -83,7 +85,10 @@ export const rectVert = /* language=GLSL */ vert`
   }`;
 
 /** @internal */
-export const roundedRectFrag = /* language=GLSL */ frag`
+export const roundedRectFrag = /* language=GLSL */ `#version 300 es
+  precision highp int;
+  precision highp float;
+
   in vec4 fragmentColor;
   in vec2 corners[4];
   in float radiusPx;
@@ -100,7 +105,10 @@ export const roundedRectFrag = /* language=GLSL */ frag`
   }`;
 
 /** @internal */
-export const colorFrag = /* language=GLSL */ frag`
+export const colorFrag = /* language=GLSL */ `#version 300 es
+  precision highp int;
+  precision highp float;
+
   in vec4 fragmentColor;
   out vec4 fragColor;
   void main() { fragColor = fragmentColor; }`;

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -26,6 +26,17 @@ const attribDefs = /* language=GLSL */ `
   layout(location=${attributeLocations.color}) in vec4 color;
 `;
 
+const vertTop = /* language=GLSL */ `#version 300 es
+  #pragma STDGL invariant(all)
+  precision highp int;
+  precision highp float;
+`;
+
+const fragTop = /* language=GLSL */ `#version 300 es
+  precision highp int;
+  precision highp float;
+`;
+
 const structGeom = /* language=GLSL */ `
   struct Geom {
     int x;
@@ -71,11 +82,7 @@ const getGeom = /* language=GLSL */ `
   }`;
 
 /** @internal */
-export const simpleRectVert = /* language=GLSL */ `#version 300 es
-  #pragma STDGL invariant(all)
-  precision highp int;
-  precision highp float;
-
+export const simpleRectVert = /* language=GLSL */ `${vertTop}
   ${attribDefs}
 
   uniform bool pickLayer;
@@ -86,8 +93,6 @@ export const simpleRectVert = /* language=GLSL */ `#version 300 es
   uniform int hoverIndex;
 
   out vec4 fragmentColor;
-  out vec2 corners[4];
-  out float radiusPx;
 
   const vec4 UNIT4 = vec4(1.0);
   const uvec4 BIT_SHIFTERS = uvec4(24, 16, 8, 0); // helps pack a 32bit unsigned integer into the RGBA bytes
@@ -110,23 +115,19 @@ export const simpleRectVert = /* language=GLSL */ `#version 300 es
   }`;
 
 /** @internal */
-export const roundedRectVert = /* language=GLSL */ `#version 300 es
-  #pragma STDGL invariant(all)
-  precision highp int;
-  precision highp float;
-
+export const roundedRectVert = /* language=GLSL */ `${vertTop}
   ${attribDefs}
 
   uniform bool pickLayer;
   uniform float t; // 0: start position; 1: end position
   uniform vec2 resolution;
-  uniform vec2 gapPx;
-  // at least this ratio of the rectangle's full width/height must be filled, else the pixel gap eats small rectangles:
-  uniform vec2 minFillRatio;
-  uniform float cornerRadiusPx;
   uniform float rowHeight0, rowHeight1;
   uniform mat2 focus; // [[focusLoX, focusHiX], [focusLoY, focusHiY]]
   uniform int hoverIndex;
+
+  uniform vec2 gapPx;
+  uniform vec2 minFillRatio; // at least this ratio of the rectangle's full width/height must be filled
+  uniform float cornerRadiusPx;
 
   out vec4 fragmentColor;
   out vec2 corners[4];
@@ -171,10 +172,7 @@ export const roundedRectVert = /* language=GLSL */ `#version 300 es
   }`;
 
 /** @internal */
-export const roundedRectFrag = /* language=GLSL */ `#version 300 es
-  precision highp int;
-  precision highp float;
-
+export const roundedRectFrag = /* language=GLSL */ `${fragTop}
   in vec4 fragmentColor;
   in vec2 corners[4];
   in float radiusPx;
@@ -191,10 +189,7 @@ export const roundedRectFrag = /* language=GLSL */ `#version 300 es
   }`;
 
 /** @internal */
-export const colorFrag = /* language=GLSL */ `#version 300 es
-  precision highp int;
-  precision highp float;
-
+export const colorFrag = /* language=GLSL */ `${fragTop}
   in vec4 fragmentColor;
   out vec4 fragColor;
   void main() { fragColor = fragmentColor; }`;

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -18,17 +18,104 @@ export const attributeLocations = {
 /** @internal */
 export const GEOM_INDEX_OFFSET = 1; // zero color means, empty area (no rectangle) so the rectangles are base 1 indexed for pick coloring
 
-/** @internal */
-export const rectVert = /* language=GLSL */ `#version 300 es
-  #pragma STDGL invariant(all)
-  precision highp int;
-  precision highp float;
-
+const attribDefs = /* language=GLSL */ `
   layout(location=${attributeLocations.position0}) in vec2 position0;
   layout(location=${attributeLocations.position1}) in vec2 position1;
   layout(location=${attributeLocations.size0}) in float size0;
   layout(location=${attributeLocations.size1}) in float size1;
   layout(location=${attributeLocations.color}) in vec4 color;
+`;
+
+const structGeom = /* language=GLSL */ `
+  struct Geom {
+    int x;
+    int y;
+    vec2 unitSquareCoord;
+    vec2 size;
+    vec2 fullSizeXY;
+    vec2 viewable;
+    vec2 baseXY;
+    vec2 pan;
+  };
+`;
+
+const getGeom = /* language=GLSL */ `
+  Geom getGeom() {
+    // calculate the basic geometry invariant of gaps, rounding or zoom levels
+    int x = gl_VertexID & 1;        // x yields 0, 1, 0, 1 for gl_VertexID 0, 1, 2, 3
+    int y = (gl_VertexID >> 1) & 1; // y yields 0, 0, 1, 1 for gl_VertexID 0, 1, 2, 3
+    vec2 unitSquareCoord = vec2(x, y);
+    vec2 position = mix(position0, position1, t);
+    vec2 size = mix(vec2(size0, rowHeight0), vec2(size1, rowHeight1), t);
+    vec2 fullSizeXY = size * unitSquareCoord;
+
+    // determine what we're zooming/panning into
+    vec2 focusX = focus[0];
+    vec2 focusY = focus[1];
+    float viewableX = focusX[1] - focusX[0];
+    float viewableY = focusY[1] - focusY[0];
+    vec2 viewable = vec2(viewableX, viewableY);
+    vec2 baseXY = fullSizeXY + position;
+    vec2 pan = vec2(focusX[0], focusY[0]);
+
+    return Geom(
+      x,
+      y,
+      unitSquareCoord,
+      size,
+      fullSizeXY,
+      viewable,
+      baseXY,
+      pan
+    );
+  }`;
+
+/** @internal */
+export const simpleRectVert = /* language=GLSL */ `#version 300 es
+  #pragma STDGL invariant(all)
+  precision highp int;
+  precision highp float;
+
+  ${attribDefs}
+
+  uniform bool pickLayer;
+  uniform float t; // 0: start position; 1: end position
+  uniform vec2 resolution;
+  uniform float rowHeight0, rowHeight1;
+  uniform mat2 focus; // [[focusLoX, focusHiX], [focusLoY, focusHiY]]
+  uniform int hoverIndex;
+
+  out vec4 fragmentColor;
+  out vec2 corners[4];
+  out float radiusPx;
+
+  const vec4 UNIT4 = vec4(1.0);
+  const uvec4 BIT_SHIFTERS = uvec4(24, 16, 8, 0); // helps pack a 32bit unsigned integer into the RGBA bytes
+  const float HOVER_OPACITY = 0.382; // arbitrary; set to the smaller part of the golden ratio
+  const int GEOM_INDEX_OFFSET = ${GEOM_INDEX_OFFSET};
+
+  ${structGeom}
+  ${getGeom}
+
+  void main() {
+    Geom g = getGeom();
+
+    vec2 zoomPannedXY = (g.baseXY - g.pan) / g.viewable;
+    // output the position and color values (approx. return values of our vertex shader)
+    // project [0, 1] normalized values to [-1, 1] homogeneous clip space values
+    gl_Position = vec4(2.0 * zoomPannedXY - 1.0, 0, 1);
+    fragmentColor = pickLayer
+      ? vec4((uvec4(gl_InstanceID + GEOM_INDEX_OFFSET) >> BIT_SHIFTERS) % uvec4(256)) / 255.0
+      : vec4(color.rgb, (gl_InstanceID == hoverIndex - GEOM_INDEX_OFFSET ? HOVER_OPACITY : 1.0) * color.a);
+  }`;
+
+/** @internal */
+export const roundedRectVert = /* language=GLSL */ `#version 300 es
+  #pragma STDGL invariant(all)
+  precision highp int;
+  precision highp float;
+
+  ${attribDefs}
 
   uniform bool pickLayer;
   uniform float t; // 0: start position; 1: end position
@@ -50,32 +137,20 @@ export const rectVert = /* language=GLSL */ `#version 300 es
   const float HOVER_OPACITY = 0.382; // arbitrary; set to the smaller part of the golden ratio
   const int GEOM_INDEX_OFFSET = ${GEOM_INDEX_OFFSET};
 
-  void main() {
-    // calculate the basic geometry invariant of gaps, rounding or zoom levels
-    int x = gl_VertexID & 1;        // x yields 0, 1, 0, 1 for gl_VertexID 0, 1, 2, 3
-    int y = (gl_VertexID >> 1) & 1; // y yields 0, 0, 1, 1 for gl_VertexID 0, 1, 2, 3
-    int datumIndex = gl_VertexID >> 2; // integer division by 2^2, as each geom is represented with 4 vertices
-    vec2 unitSquareCoord = vec2(x, y);
-    vec2 position = mix(position0, position1, t);
-    vec2 size = mix(vec2(size0, rowHeight0), vec2(size1, rowHeight1), t);
-    vec2 withGapXY = size * unitSquareCoord;
+  ${structGeom}
+  ${getGeom}
 
-    // determine what we're zooming/panning into
-    vec2 focusX = focus[0];
-    vec2 focusY = focus[1];
-    float viewableX = focusX[1] - focusX[0];
-    float viewableY = focusY[1] - focusY[0];
-    vec2 viewable = vec2(viewableX, viewableY);
-    vec2 zoomedResolution = resolution / viewable;
+  void main() {
+    Geom g = getGeom();
 
     // calculate the gap-aware geometry
+    vec2 zoomedResolution = resolution / g.viewable;
     vec2 gapRatio = gapPx / zoomedResolution;
     // gl_VertexID iterates as an integer index 0, 1, 2, ..., (offset + 0, offset + 1, ..., offset + count - 1)
     // these four coordinates form a rectangle, set up as two counterclockwise triangles with gl.TRIANGLE_STRIP
     // clip coordinate x/y goes from -1 to 1 of the viewport, so we center with this 0.5 subtraction
-    vec2 xy = withGapXY - min(gapRatio, (1.0 - minFillRatio) * withGapXY) * sign(unitSquareCoord) + position;
-    vec2 pan = vec2(focusX[0], focusY[0]);
-    vec2 zoomPannedXY = (xy - pan) / viewable;
+    vec2 xy = g.baseXY - min(gapRatio, (1.0 - minFillRatio) * g.fullSizeXY) * sign(g.unitSquareCoord);
+    vec2 zoomPannedXY = (xy - g.pan) / g.viewable;
 
     // output the position and color values (approx. return values of our vertex shader)
     // project [0, 1] normalized values to [-1, 1] homogeneous clip space values
@@ -85,14 +160,14 @@ export const rectVert = /* language=GLSL */ `#version 300 es
       : vec4(color.rgb, (gl_InstanceID == hoverIndex - GEOM_INDEX_OFFSET ? HOVER_OPACITY : 1.0) * color.a);
 
     // calculate rounded corner metrics for interpolation
-    vec2 pixelSize = size * zoomedResolution;
+    vec2 pixelSize = g.size * zoomedResolution;
     radiusPx = min(cornerRadiusPx, 0.5 * min(pixelSize.x, pixelSize.y));
 
     // output the corner helper values  (approx. return values of our vertex shader)
-    corners[0] = vec2(x, y) * size * zoomedResolution - radiusPx;
-    corners[1] = vec2(1 - x, y) * size * zoomedResolution - radiusPx;
-    corners[2] = vec2(x, 1 - y) * size * zoomedResolution - radiusPx;
-    corners[3] = vec2(1 - x, 1 - y) * size * zoomedResolution - radiusPx;
+    corners[0] = vec2(g.x, g.y) * g.size * zoomedResolution - radiusPx;
+    corners[1] = vec2(1 - g.x, g.y) * g.size * zoomedResolution - radiusPx;
+    corners[2] = vec2(g.x, 1 - g.y) * g.size * zoomedResolution - radiusPx;
+    corners[3] = vec2(1 - g.x, 1 - g.y) * g.size * zoomedResolution - radiusPx;
   }`;
 
 /** @internal */

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -37,6 +37,13 @@ const fragTop = /* language=GLSL */ `#version 300 es
   precision highp float;
 `;
 
+const constants = /* language=GLSL */ `
+  const vec4 UNIT4 = vec4(1.0);
+  const uvec4 BIT_SHIFTERS = uvec4(24, 16, 8, 0); // helps pack a 32bit unsigned integer into the RGBA bytes
+  const float HOVER_OPACITY = 0.382; // arbitrary; set to the smaller part of the golden ratio
+  const int GEOM_INDEX_OFFSET = ${GEOM_INDEX_OFFSET};
+`;
+
 const structGeom = /* language=GLSL */ `
   struct Geom {
     vec2 unitSquareCoord;
@@ -90,11 +97,7 @@ export const simpleRectVert = /* language=GLSL */ `${vertTop}
 
   out vec4 fragmentColor;
 
-  const vec4 UNIT4 = vec4(1.0);
-  const uvec4 BIT_SHIFTERS = uvec4(24, 16, 8, 0); // helps pack a 32bit unsigned integer into the RGBA bytes
-  const float HOVER_OPACITY = 0.382; // arbitrary; set to the smaller part of the golden ratio
-  const int GEOM_INDEX_OFFSET = ${GEOM_INDEX_OFFSET};
-
+  ${constants}
   ${structGeom}
   ${getGeom}
 
@@ -129,11 +132,7 @@ export const roundedRectVert = /* language=GLSL */ `${vertTop}
   out vec2 corners[4];
   out float radiusPx;
 
-  const vec4 UNIT4 = vec4(1.0);
-  const uvec4 BIT_SHIFTERS = uvec4(24, 16, 8, 0); // helps pack a 32bit unsigned integer into the RGBA bytes
-  const float HOVER_OPACITY = 0.382; // arbitrary; set to the smaller part of the golden ratio
-  const int GEOM_INDEX_OFFSET = ${GEOM_INDEX_OFFSET};
-
+  ${constants}
   ${structGeom}
   ${getGeom}
 

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -37,6 +37,21 @@ const attribDefs = /* language=GLSL */ `
   layout(location=${attributeLocations.color}) in vec4 color;
 `;
 
+const uniformDefs = /* language=GLSL */ `
+  uniform Settings {
+    mat4 focus; // [[focusLoX, focusHiX], [focusLoY, focusHiY]]
+    vec2 resolution;
+    vec2 gapPx;
+    vec2 minFillRatio; // at least this ratio of the rectangle's full width/height must be filled
+    float rowHeight0;
+    float rowHeight1;
+    float t; // 0: start position; 1: end position
+    float cornerRadiusPx;
+    int hoverIndex;
+    bool pickLayer;
+  };
+`;
+
 const constants = /* language=GLSL */ `
   const vec4 UNIT4 = vec4(1.0);
   const uvec4 BIT_SHIFTERS = uvec4(24, 16, 8, 0); // helps pack a 32bit unsigned integer into the RGBA bytes
@@ -102,13 +117,7 @@ const getGeom = /* language=GLSL */ `
 /** @internal */
 export const simpleRectVert = /* language=GLSL */ `${vertTop}
   ${attribDefs}
-
-  uniform mat2 focus; // [[focusLoX, focusHiX], [focusLoY, focusHiY]]
-  uniform vec2 resolution;
-  uniform float rowHeight0, rowHeight1;
-  uniform float t; // 0: start position; 1: end position
-  uniform int hoverIndex;
-  uniform bool pickLayer;
+  ${uniformDefs}
 
   out vec4 fragmentColor;
 
@@ -127,17 +136,7 @@ export const simpleRectVert = /* language=GLSL */ `${vertTop}
 /** @internal */
 export const roundedRectVert = /* language=GLSL */ `${vertTop}
   ${attribDefs}
-
-  uniform bool pickLayer;
-  uniform float t; // 0: start position; 1: end position
-  uniform vec2 resolution;
-  uniform float rowHeight0, rowHeight1;
-  uniform mat2 focus; // [[focusLoX, focusHiX], [focusLoY, focusHiY]]
-  uniform int hoverIndex;
-
-  uniform vec2 gapPx;
-  uniform vec2 minFillRatio; // at least this ratio of the rectangle's full width/height must be filled
-  uniform float cornerRadiusPx;
+  ${uniformDefs}
 
   out vec4 fragmentColor;
   out vec2 corners[4];

--- a/packages/charts/src/chart_types/flame_chart/types.ts
+++ b/packages/charts/src/chart_types/flame_chart/types.ts
@@ -7,14 +7,12 @@
  */
 
 import { Pixels } from '../../common/geometry';
-import { Attributes, Uniforms, UseInfo } from '../../common/kingly';
+import { Attributes, UseInfo } from '../../common/kingly';
 
 /** @internal */
 export interface GLResources {
   roundedRectRenderer: (u: UseInfo) => void;
   pickTextureRenderer: (u: UseInfo) => void;
-  uniforms: Uniforms;
-  uboBuffer: WebGLBuffer | null;
   attributes: Attributes;
 }
 
@@ -22,8 +20,6 @@ export interface GLResources {
 export const NULL_GL_RESOURCES: GLResources = {
   roundedRectRenderer: () => {},
   pickTextureRenderer: () => {},
-  uboBuffer: null,
-  uniforms: new Map(),
   attributes: new Map(),
 };
 

--- a/packages/charts/src/chart_types/flame_chart/types.ts
+++ b/packages/charts/src/chart_types/flame_chart/types.ts
@@ -7,19 +7,23 @@
  */
 
 import { Pixels } from '../../common/geometry';
-import { Attributes, UseInfo } from '../../common/kingly';
+import { Attributes, Uniforms, UseInfo } from '../../common/kingly';
 
 /** @internal */
 export interface GLResources {
   roundedRectRenderer: (u: UseInfo) => void;
   pickTextureRenderer: (u: UseInfo) => void;
+  uniforms: Uniforms;
+  uboBuffer: WebGLBuffer | null;
   attributes: Attributes;
 }
 
 /** @internal */
-export const NULL_GL_RESOURCES = {
+export const NULL_GL_RESOURCES: GLResources = {
   roundedRectRenderer: () => {},
   pickTextureRenderer: () => {},
+  uboBuffer: null,
+  uniforms: new Map(),
   attributes: new Map(),
 };
 

--- a/packages/charts/src/common/kingly.ts
+++ b/packages/charts/src/common/kingly.ts
@@ -433,6 +433,14 @@ export const createTexture = (
   };
 };
 
+const pickPixel = new Uint8Array(4);
+
+/** @internal */
+export const readPixel = (gl: WebGL2RenderingContext, canvasX: GLint, canvasY: GLint) => {
+  gl.readPixels(canvasX, canvasY, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pickPixel); // todo use bound FB/texture values to determine the 5th and 6th args
+  return pickPixel;
+};
+
 /****************
  * Attributes
  ***************/
@@ -590,37 +598,6 @@ export const getRenderer = (
     }
   };
 };
-
-/****************
- * Misc
- ***************/
-
-const pickPixel = new Uint8Array(4);
-
-/** @internal */
-export const readPixel = (gl: WebGL2RenderingContext, canvasX: GLint, canvasY: GLint) => {
-  gl.readPixels(canvasX, canvasY, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pickPixel); // todo use bound FB/texture values to determine the 5th and 6th args
-  return pickPixel;
-};
-
-const templateConcat = (strings: TemplateStringsArray, ...args: unknown[]) =>
-  strings
-    .map((s, i) => `${s}${args[i] ?? ''}`)
-    .join('')
-    .trim();
-
-/** @internal */
-export const vert = (strings: TemplateStringsArray, ...args: unknown[]) => `#version 300 es
-#pragma STDGL invariant(all)
-precision highp int;
-precision highp float;
-${templateConcat(strings, ...args)}`;
-
-/** @internal */
-export const frag = (strings: TemplateStringsArray, ...args: unknown[]) => `#version 300 es
-precision highp int;
-precision highp float;
-${templateConcat(strings, ...args)}`;
 
 /***********************
  *

--- a/packages/charts/src/common/kingly.ts
+++ b/packages/charts/src/common/kingly.ts
@@ -589,14 +589,12 @@ export const getRenderer = (
       // non-ubo uniforms
       uniforms.forEach((setValue, name) => uniformValues[name] && !uboInfo.has(name) && setValue(uniformValues[name]));
       // ubo uniforms
-      gl.bindBuffer(gl.UNIFORM_BUFFER, uboBuffer);
-      debugger;
+      gl.bindBuffer(GL.UNIFORM_BUFFER, uboBuffer);
       uboInfo.forEach(({ offset }, name) => {
         const value = new Float32Array([uniformValues[name]].flat());
-        console.log({ offset, value, name });
-        gl.bufferSubData(gl.UNIFORM_BUFFER, offset, value, 0);
+        gl.bufferSubData(GL.UNIFORM_BUFFER, offset, value, 0);
       });
-      // gl.bindBuffer(gl.UNIFORM_BUFFER, null);
+      // gl.bindBuffer(GL.UNIFORM_BUFFER, null);
     }
 
     bindFramebuffer(gl, GL.DRAW_FRAMEBUFFER, target);


### PR DESCRIPTION
## Summary

Switch from the conceptually simpler, less efficient (and removed by WebGPU) individual uniforms to the more verbose buffered uniform blocks (UBO) introduced with WebGL2.

The vertex shaders for visible rendering vs. the simpler, geom picking rendering (no gaps, no corner radius) have been split, but the common parts got abstracted out.

Avoidance of a loop with arbitrary branching and discard in favor of a single math expression with a single discard

Removal of the custom templated string functions as they didn't add a lot of value

Moving the context loss/regain event handlers into their own methods

Tighter typing for the keys of the column representation (vertex attribute names)

Reversal of a former shader change which resulted in a too light hover effect

Inclusion of the canvas offsets (introduced with margins) for the purpose of canvas clearing

Other misc. changes and improvements

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

Note to reviewers: the singular uniforms can be removed in the future, as they're not used, just kept around for the off-chance of encountering platform incompatibility with the block uniforms.

Once it's gone, we'll have gained back almost all of the line count gains in this PR. Just the `Singular uniforms` block in `kingly.js` is 100 lines, and there's some other code that will be culled then.

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [ ] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
