### PR TITLE
feat(flame): show two ancestors

### DIFF
--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -48,6 +48,7 @@ const ZOOM_FROM_EDGE_BAND_BOTTOM = ZOOM_FROM_EDGE_BAND + PADDING_BOTTOM;
 const LEFT_MOUSE_BUTTON = 1;
 const MINIMAP_SIZE_RATIO_X = 3;
 const MINIMAP_SIZE_RATIO_Y = 3;
+const SHOWN_ANCESTOR_COUNT = 2; // how many rows above the focused in node should be shown
 
 const unitRowPitch = (position: Float32Array) => (position.length >= 4 ? position[1] - position[3] : 1);
 const initialPixelRowPitch = () => 16;
@@ -74,11 +75,17 @@ interface FocusRect {
 }
 
 const focusForArea = (chartHeight: number, { x0, x1, y0, y1 }: { x0: number; x1: number; y0: number; y1: number }) => {
+  // horizontal
   const sideOvershoot = SIDE_OVERSHOOT_RATIO * (x1 - x0);
-  const unitHeight = (chartHeight / initialPixelRowPitch()) * (y1 - y0);
-  const intendedY0 = y1 - unitHeight;
+
+  // vertical
+  const unitRowHeight = y1 - y0;
+  const chartHeightInUnit = (chartHeight / initialPixelRowPitch()) * unitRowHeight;
+  const y = Math.min(1, y1 + unitRowHeight * SHOWN_ANCESTOR_COUNT);
+  const intendedY0 = y - chartHeightInUnit;
   const bottomOvershoot = Math.max(0, -intendedY0);
-  const top = Math.min(1, y1 + bottomOvershoot);
+  const top = Math.min(1, y + bottomOvershoot);
+
   return {
     x0: Math.max(0, x0 - sideOvershoot),
     x1: Math.min(1, x1 + sideOvershoot),

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -151,26 +151,26 @@ class FlameComponent extends React.Component<FlameProps> {
   static displayName = 'Flame';
 
   // DOM API Canvas2d and WebGL resources
-  private ctx: CanvasRenderingContext2D | null;
-  private glContext: WebGL2RenderingContext | null;
-  private pickTexture: Texture;
-  private glResources: GLResources;
-  private readonly glCanvasRef: RefObject<HTMLCanvasElement>;
+  private ctx: CanvasRenderingContext2D | null = null;
+  private glContext: WebGL2RenderingContext | null = null;
+  private pickTexture: Texture = NullTexture;
+  private glResources: GLResources = NULL_GL_RESOURCES;
+  private readonly glCanvasRef: RefObject<HTMLCanvasElement> = createRef();
 
   // native browser pinch zoom handling
-  private pinchZoomSetInterval: number;
+  private pinchZoomSetInterval: number = NaN;
   private pinchZoomScale: number;
 
   // mouse coordinates for the tooltip
-  private pointerX: number;
-  private pointerY: number;
+  private pointerX: number = NaN;
+  private pointerY: number = NaN;
 
   // currently hovered over datum
-  private hoverIndex: number;
+  private hoverIndex: number = NaN;
 
   // drilldown animation
-  private animationRafId: number;
-  private prevT: number;
+  private animationRafId: number = NaN;
+  private prevT: number = NaN;
   private currentFocus: FocusRect;
   private targetFocus: FocusRect;
 
@@ -181,7 +181,7 @@ class FlameComponent extends React.Component<FlameProps> {
   private startOfDragFocusTop: number = NaN; // todo top or bottom...does it even matter?
 
   // text search
-  private readonly searchInputRef: RefObject<HTMLInputElement>;
+  private readonly searchInputRef: RefObject<HTMLInputElement> = createRef();
   private currentSearchString = '';
   private currentSearchHitCount = 0;
   private currentColor: Float32Array;
@@ -191,19 +191,8 @@ class FlameComponent extends React.Component<FlameProps> {
 
   constructor(props: Readonly<FlameProps>) {
     super(props);
-    this.ctx = null;
-    this.glContext = null;
-    this.pickTexture = NullTexture;
-    this.glResources = NULL_GL_RESOURCES;
-    this.glCanvasRef = createRef();
-    this.searchInputRef = createRef();
-    this.animationRafId = NaN;
-    this.prevT = NaN;
     this.currentFocus = focusRect(this.props.columnarViewModel, props.chartDimensions.height, 0, -Infinity);
     this.targetFocus = { ...this.currentFocus };
-    this.hoverIndex = NaN;
-    this.pointerX = NaN;
-    this.pointerY = NaN;
 
     // browser pinch zoom handling
     this.pinchZoomSetInterval = NaN;


### PR DESCRIPTION
## Summary

When focusing via click or iterating through search results, attempt to show two layers above the focused node (parent, grandparent) for more context. The word "attempt" indicates that it's not always the end result:
- there are less than two layers above the focused node
- the focus box is already on the bottom of the chart, so it can't go lower, and more than two ancestors are shown

Partial fulfilment of https://github.com/elastic/elastic-charts/issues/1671

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [x] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
