### PR TITLE
feat(flame): pulsate node on click focus and search hit focus

### DIFF
--- a/packages/charts/src/chart_types/flame_chart/render/draw_a_frame.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/draw_a_frame.ts
@@ -49,7 +49,7 @@ export const drawFrame = (
   hoverIndex: number,
   unitRowHeight: number,
   currentColor: Float32Array,
-) => (currentFocus: [number, number, number, number]) => {
+) => (currentFocus: [number, number, number, number], wobbleIndex: number, wobble: number) => {
   const canvasHeightExcess = (roundUpSize(cssHeight) - cssHeight) * dpr;
 
   const minimapBottom = minimapTop + minimapHeight;
@@ -77,12 +77,14 @@ export const drawFrame = (
       (pickLayer ? 0 : canvasHeightExcess) + dpr * PADDING_BOTTOM,
       pickTexture,
       pickLayer ? pickTextureRenderer : roundedRectRenderer,
-      hoverIndex,
+      wobble ? NaN : hoverIndex, // no hover highlight during wobble
       unitRowHeight,
       currentFocus,
       columnarGeomData.label.length,
       true,
       pickLayer,
+      wobbleIndex,
+      wobble,
     );
 
   const drawContextLayer = (pickLayer: boolean) =>
@@ -101,6 +103,8 @@ export const drawFrame = (
       columnarGeomData.label.length,
       false,
       pickLayer,
+      wobbleIndex, // useful to wobble on the minimap too
+      wobble,
     );
 
   // base (focus) layer

--- a/packages/charts/src/chart_types/flame_chart/render/draw_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/draw_webgl.ts
@@ -33,6 +33,8 @@ export const drawWebgl = (
   instanceCount: number,
   focusLayer: boolean,
   pickLayer: boolean,
+  wobbleIndex: number,
+  wobble: number,
 ) =>
   renderer({
     target: pickLayer ? pickTexture.target() : null,
@@ -44,6 +46,8 @@ export const drawWebgl = (
       minFillRatio: MIN_FILL_RATIO,
       cornerRadiusPx: pickLayer ? 0 : canvasHeight * rowHeight * CORNER_RADIUS_RATIO, // note that for perf reasons the fragment shaders are split anyway
       hoverIndex: Number.isFinite(hoverIndex) ? hoverIndex + GEOM_INDEX_OFFSET : DUMMY_INDEX,
+      wobbleIndex: Number.isFinite(wobbleIndex) ? wobbleIndex + GEOM_INDEX_OFFSET : DUMMY_INDEX,
+      wobble,
       rowHeight0: rowHeight,
       rowHeight1: rowHeight,
       focus: [f[0], f[1], 0, 0, f[2], f[3], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
@@ -69,6 +69,8 @@ export function ensureWebgl(
       't',
       'cornerRadiusPx',
       'hoverIndex',
+      'wobbleIndex',
+      'wobble',
       'pickLayer',
     ],
     [geomProgram, pickProgram],


### PR DESCRIPTION
## Summary

As the chart zooms and pans, it's useful to briefly pulsate the activated node.

![hit pulsate](https://user-images.githubusercontent.com/1548516/171364825-33b24fd6-d738-4a2b-babe-eb0f5df999ff.gif)

It's a short pulsation for click focus, because
- the user knows where he/she clicked, it's a direct interaction
- the node will already be present in the current visible area

It's a long pulsation for the search hit focus, because
- the user doesn't know where it'll arrive
- there is no visual indicator for what the actual hit is
- esp. with the current, suboptimal pan (no zoom out/in) it takes time for the hit to arrive into the visible area

A more permanent, additional marker (eg. magenta border around the node, which stays until the next interaction not including hovering) is planned for a separate PR. It's a former item titled _Cycling through matches should have a more salient style on the actively selected element_ in the linked issue.

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

Partial fulfilment of https://github.com/elastic/elastic-charts/issues/1671

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [x] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
