### PR TITLE
fix(flame): cross browser issues

### DIFF
--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -871,6 +871,10 @@ class FlameComponent extends React.Component<FlameProps> {
         this.animationRafId = window.requestAnimationFrame(anim);
       } else {
         this.prevT = NaN;
+        this.currentFocus.x0 = this.targetFocus.x0;
+        this.currentFocus.x1 = this.targetFocus.x1;
+        this.currentFocus.y0 = this.targetFocus.y0;
+        this.currentFocus.y1 = this.targetFocus.y1;
       }
     };
     window.cancelAnimationFrame(this.animationRafId);

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -50,7 +50,7 @@ const MINIMAP_SIZE_RATIO_X = 3;
 const MINIMAP_SIZE_RATIO_Y = 3;
 const SHOWN_ANCESTOR_COUNT = 2; // how many rows above the focused in node should be shown
 const WOBBLE_TIME_SEARCH_HIT = 1000;
-const WOBBLE_TIME_CLICK_FOCUS = 500; // shorter wobble for clicks, as users know where they clicked
+const WOBBLE_TIME_CLICK_FOCUS = 1000;
 const WOBBLE_FREQUENCY = 1 / 50; // e.g. 1/30 means a cycle of every 30ms
 
 const unitRowPitch = (position: Float32Array) => (position.length >= 4 ? position[1] - position[3] : 1);

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -205,7 +205,25 @@ class FlameComponent extends React.Component<FlameProps> {
 
   constructor(props: Readonly<FlameProps>) {
     super(props);
-    this.currentFocus = focusRect(this.props.columnarViewModel, props.chartDimensions.height, 0, -Infinity);
+    const columns = this.props.columnarViewModel;
+
+    // vector length checks
+    const datumCount = columns.position1.length / 2;
+    if (datumCount % 2) throw new Error('flame error: position0 vector must have even values (x/y pairs)');
+    if (datumCount * 2 !== columns.position0.length)
+      throw new Error('flame error: Mismatch between position0 (xy) and position1 (xy) length');
+    if (datumCount !== columns.size0.length)
+      throw new Error('flame error: Mismatch between position1 (xy) and size0 length');
+    if (datumCount !== columns.size1.length)
+      throw new Error('flame error: Mismatch between position1 (xy) and size1 length');
+    if (datumCount * 4 !== columns.color.length)
+      throw new Error('flame error: Mismatch between position1 (xy) and color (rgba) length');
+    if (datumCount !== columns.value.length)
+      throw new Error('flame error: Mismatch between position1 (xy) and value length');
+    if (datumCount !== columns.label.length)
+      throw new Error('flame error: Mismatch between position1 (xy) and label length');
+
+    this.currentFocus = focusRect(columns, props.chartDimensions.height, 0, -Infinity);
     this.targetFocus = { ...this.currentFocus };
 
     // browser pinch zoom handling
@@ -214,7 +232,7 @@ class FlameComponent extends React.Component<FlameProps> {
     this.setupViewportScaleChangeListener();
 
     // search
-    this.currentColor = this.props.columnarViewModel.color;
+    this.currentColor = columns.color;
   }
 
   private setupDevicePixelRatioChangeListener = () => {

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -775,7 +775,7 @@ class FlameComponent extends React.Component<FlameProps> {
         <BasicTooltip
           onPointerMove={() => ({ type: ON_POINTER_MOVE, position: { x: NaN, y: NaN }, time: NaN })}
           position={{ x: this.pointerX, y: this.pointerY, width: 0, height: 0 }}
-          visible={this.props.tooltipRequired && this.hoverIndex >= 0}
+          visible={this.props.tooltipRequired && this.hoverIndex >= 0 && !(this.wobbleTimeLeft > 0)}
           info={{
             header: null,
             values:

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -49,9 +49,9 @@ const LEFT_MOUSE_BUTTON = 1;
 const MINIMAP_SIZE_RATIO_X = 3;
 const MINIMAP_SIZE_RATIO_Y = 3;
 const SHOWN_ANCESTOR_COUNT = 2; // how many rows above the focused in node should be shown
-const WOBBLE_TIME_SEARCH_HIT = 1000;
-const WOBBLE_TIME_CLICK_FOCUS = 1000;
-const WOBBLE_FREQUENCY = 1 / 50; // e.g. 1/30 means a cycle of every 30ms
+const WOBBLE_DURATION = 1000;
+const WOBBLE_REPEAT_COUNT = 2;
+const WOBBLE_FREQUENCY = 2 * Math.PI * (WOBBLE_REPEAT_COUNT / WOBBLE_DURATION); // e.g. 1/30 means a cycle of every 30ms
 
 const unitRowPitch = (position: Float32Array) => (position.length >= 4 ? position[1] - position[3] : 1);
 const initialPixelRowPitch = () => 16;
@@ -413,7 +413,7 @@ class FlameComponent extends React.Component<FlameProps> {
           hovered.datumIndex,
           hovered.timestamp,
         );
-        this.wobbleTimeLeft = WOBBLE_TIME_CLICK_FOCUS;
+        this.wobbleTimeLeft = WOBBLE_DURATION;
         this.wobbleIndex = hovered.datumIndex;
         this.prevT = NaN;
         this.hoverIndex = NaN; // no highlight
@@ -576,7 +576,7 @@ class FlameComponent extends React.Component<FlameProps> {
         );
         this.prevT = NaN;
         this.hoverIndex = NaN; // no highlight
-        this.wobbleTimeLeft = WOBBLE_TIME_SEARCH_HIT;
+        this.wobbleTimeLeft = WOBBLE_DURATION;
         this.wobbleIndex = datumIndex;
       }
     }
@@ -858,11 +858,12 @@ class FlameComponent extends React.Component<FlameProps> {
 
       this.wobbleTimeLeft -= msDeltaT;
       const shouldWobble = this.wobbleTimeLeft > 0;
+      const timeFromWobbleStart = clamp(WOBBLE_DURATION - this.wobbleTimeLeft, 0, WOBBLE_DURATION);
 
       renderFrame(
         [this.currentFocus.x0, this.currentFocus.x1, this.currentFocus.y0, this.currentFocus.y1],
         this.wobbleIndex,
-        shouldWobble ? 0.01 + 0.99 * (0.5 * Math.sin(t * WOBBLE_FREQUENCY) + 0.5) : 0, // positive if it must wobble
+        shouldWobble ? 0.01 + 0.99 * (0.5 - 0.5 * Math.cos(timeFromWobbleStart * WOBBLE_FREQUENCY)) : 0, // positive if it must wobble
       );
 
       const maxDiff = Math.max(Math.abs(dx0), Math.abs(dx1), Math.abs(dy0), Math.abs(dy1));

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -109,7 +109,7 @@ const getGeom = /* language=GLSL */ `
           color.rgb,
           color.a
             * (gl_InstanceID == int(hoverIndex) - GEOM_INDEX_OFFSET ? HOVER_OPACITY : 1.0)
-            * (gl_InstanceID == int(wobbleIndex) - GEOM_INDEX_OFFSET && wobble > 0.0 ? wobble : 1.0)
+            * (gl_InstanceID == int(wobbleIndex) - GEOM_INDEX_OFFSET && wobble > 0.0 ? float(wobble) : 1.0)
         );
 
     return Geom(

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -109,7 +109,7 @@ const getGeom = /* language=GLSL */ `
           color.rgb,
           color.a
             * (gl_InstanceID == int(hoverIndex) - GEOM_INDEX_OFFSET ? HOVER_OPACITY : 1.0)
-            * (gl_InstanceID == int(wobbleIndex) - GEOM_INDEX_OFFSET && wobble > 0.0 ? float(wobble) : 1.0)
+            * (gl_InstanceID == int(wobbleIndex) - GEOM_INDEX_OFFSET && wobble > 0.0 ? 1.0 - wobble : 1.0)
         );
 
     return Geom(

--- a/packages/charts/src/common/kingly.ts
+++ b/packages/charts/src/common/kingly.ts
@@ -398,13 +398,10 @@ export const NullTexture: Texture = {
 /** @internal */
 export const createTexture = (
   gl: WebGL2RenderingContext,
-  { textureIndex, internalFormat, width: w, height: h, data, min = GL.NEAREST, mag = GL.NEAREST }: TextureSpecification,
+  { textureIndex, internalFormat, width, height, data, min = GL.NEAREST, mag = GL.NEAREST }: TextureSpecification,
 ): Texture => {
   if (GL_DEBUG && !(0 <= textureIndex && textureIndex <= gl.getParameter(GL.MAX_COMBINED_TEXTURE_IMAGE_UNITS)))
     throw new Error('WebGL2 is guaranteed to support at least 32 textures but not necessarily more than that');
-
-  const width: GLuint = Math.ceil(w);
-  const height: GLuint = Math.ceil(h);
 
   const srcFormat = textureSrcFormatLookup[internalFormat];
   const type = textureTypeLookup[internalFormat];

--- a/storybook/stories/icicle/04_cpu_profile_gl_flame.story.tsx
+++ b/storybook/stories/icicle/04_cpu_profile_gl_flame.story.tsx
@@ -42,7 +42,7 @@ const columnarData = {
   color: new Float32Array(
     columnarMock.label.flatMap(() => [...paletteColorBrewerCat12[pseudoRandom(0, 11)].map((c) => c / 255), 1]),
   ),
-  position0: position,
+  position0: position, // new Float32Array([...position].slice(1)), // try with the wrong array length
   position1: position,
   size0: size,
   size1: size,


### PR DESCRIPTION
## Summary

Fixes:
- the Safari Metal shader compiler has a bug (causing no render at all) that needed a 1-liner workaround, see the [1st commit](https://github.com/elastic/elastic-charts/pull/1695/commits/599db56f4cd240aa43e8bdd1c81127ab97f340e5).
- click focusing with certain browser zoom levels (eg. 110% in Chrome) and pinch zoom stopped working, due to a regression introduced with these [lines](https://github.com/elastic/elastic-charts/pull/1682/files#diff-f017ed451ccf2474f26b0e480ee6ade71500e04765029c93afd6925249d205bfR365-R371) - thanks @ghudgins for the report

The PR also contains 
- visual improvements to the blinking focus indicator: 
  - when clicking on a node, or advancing to another text search hit, the pulsation makes full periods, so the end of the pulsation is smooth
  - the pulsation length is now the same for click focus and search hit focus
- the tooltip won't show up during the pulsation (therefore, approx. during the focus animation)
- a test for congruent column array lengths

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

The workaround is that some operation had to be done with `wobble` in the `true` branch, see the first commit. All these worked:
- `float(wobble)` (it's already a float, of course)
- `wobble + 0.0`

To improve on the node blinking, I needed to switch to `1.0 - wobble` which is good too

Note: there are other less glaring cross browser issues under investigation.

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
