### PR TITLE
fix(flame): no focus border

### DIFF
--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -695,7 +695,7 @@ class FlameComponent extends React.Component<FlameProps> {
             onKeyPress={this.handleEnterKey}
             onKeyUp={this.handleEscapeKey}
             onWheel={this.handleWheel}
-            style={style}
+            style={{ ...style, outline: 'none' }}
             // eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
             role="presentation"
           />

--- a/storybook/stories/wordcloud/1_wordcloud.story.tsx
+++ b/storybook/stories/wordcloud/1_wordcloud.story.tsx
@@ -270,8 +270,3 @@ export const Example = () => {
     </Chart>
   );
 };
-
-Example.parameters = {
-  background: { disable: true },
-  theme: { disable: true },
-};


### PR DESCRIPTION
## Summary

Removes the keyboard focus border that interferes with the zoom/pan focus indicators on the top and left. A future PR needs to address chart focusability including adding the missing keyboard interactions for navigation. Also contains a wordcloud story fix ht Marco

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

In current `master`, the issue is reproducible best in Chrome, when clicking on the large chart, then hitting the Escape or some other key. A keyboard focus line on top and left appear, coniciding with the rendered zoom/pan focus lines

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
