### PR TITLE
fix: return always a full projection in multilayerAxisEntry

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/axes/timeslip/multilayer_ticks.ts
+++ b/packages/charts/src/chart_types/xy_chart/axes/timeslip/multilayer_ticks.ts
@@ -9,8 +9,7 @@
 import { Scale, ScaleContinuous } from '../../../../scales';
 import { XDomain } from '../../domains/types';
 import { AxisLabelFormatter } from '../../state/selectors/axis_tick_formatter';
-import { GetMeasuredTicks } from '../../state/selectors/visible_ticks';
-import { AxisTick } from '../../utils/axis_utils';
+import { GetMeasuredTicks, Projection } from '../../state/selectors/visible_ticks';
 import { rasters, TimeBin, TimeRaster } from './rasters';
 
 const MAX_TIME_TICK_COUNT = 50; // this doesn't do much for narrow charts, but limits tick count to a maximum on wider ones
@@ -42,7 +41,7 @@ export function multilayerAxisEntry(
   timeAxisLayerCount: any,
   scale: Scale<string | number> | ScaleContinuous, // fixme it's only the latter for now
   getMeasuredTicks: GetMeasuredTicks,
-) {
+): Projection {
   const rasterSelector = rasters({ minimumTickPixelDistance: 24, locale: 'en-US' }, xDomain.timeZone);
   const domainValues = xDomain.domain; // todo consider a property or object type rename
   const domainFromS = Number(domainValues[0]) / 1000; // todo rely on a type guard or check rather than conversion
@@ -63,8 +62,8 @@ export function multilayerAxisEntry(
       fallbackAskedTickCount: NaN,
     };
   };
-  return layers.reduce(
-    (combinedEntry: { ticks: AxisTick[] }, l: TimeRaster<TimeBin>, detailedLayerIndex) => {
+  return layers.reduce<Projection>(
+    (combinedEntry, l, detailedLayerIndex) => {
       if (l.labeled) layerIndex++; // we want three (or however many) _labeled_ axis layers; others are useful for minor ticks/gridlines, and for giving coarser structure eg. stronger gridline for every 6th hour of the day
       if (layerIndex >= timeAxisLayerCount) return combinedEntry;
       const binWidthS = binWidth / 1000;
@@ -85,8 +84,9 @@ export function multilayerAxisEntry(
       }
 
       return {
-        ...entry,
         ...combinedEntry,
+        ...entry,
+        scale,
         ticks: (combinedEntry.ticks || []).concat(
           entry.ticks.filter(
             (tick, i, a) =>
@@ -97,6 +97,16 @@ export function multilayerAxisEntry(
         ),
       };
     },
-    { ticks: [] }, // this should turn into a full Projection
+    {
+      ticks: [],
+      labelBox: {
+        maxLabelBboxWidth: 0,
+        maxLabelBboxHeight: 0,
+        maxLabelTextWidth: 0,
+        maxLabelTextHeight: 0,
+        isHidden: true,
+      },
+      scale,
+    }, // this should turn into a full Projection
   );
 }

--- a/packages/charts/src/chart_types/xy_chart/axes/timeslip/multilayer_ticks.ts
+++ b/packages/charts/src/chart_types/xy_chart/axes/timeslip/multilayer_ticks.ts
@@ -86,7 +86,6 @@ export function multilayerAxisEntry(
       return {
         ...combinedEntry,
         ...entry,
-        scale,
         ticks: (combinedEntry.ticks || []).concat(
           entry.ticks.filter(
             (tick, i, a) =>
@@ -107,6 +106,6 @@ export function multilayerAxisEntry(
         isHidden: true,
       },
       scale,
-    }, // this should turn into a full Projection
+    },
   );
 }

--- a/storybook/stories/area/21_with_time_timeslip.story.tsx
+++ b/storybook/stories/area/21_with_time_timeslip.story.tsx
@@ -39,6 +39,7 @@ const topAxisLabelFormat = (d: any) =>
   `${new Intl.DateTimeFormat('en-US', { minute: 'numeric' }).format(d).padStart(2, '0')}′  `;
 
 export const Example = () => {
+  const showLegend = boolean('Show legend', false);
   const minorGridLines = boolean('Minor grid lines', true);
   const horizontalAxisTitle = boolean('Horizontal axis title', false);
   const yAxisTitle = 'CPU utilization';
@@ -70,6 +71,7 @@ export const Example = () => {
   return (
     <Chart>
       <Settings
+        showLegend={showLegend}
         baseTheme={useBaseTheme()}
         theme={{ axes: { tickLine: { visible: true } } }}
         xDomain={
@@ -120,7 +122,7 @@ export const Example = () => {
         tickFormat={(d) => `${Number(d).toFixed(0)}%`}
       />
       <AreaSeries
-        id="Utilization"
+        id="CPU Utilization"
         xScaleType={ScaleType.Time}
         yScaleType={ScaleType.Linear}
         xAccessor={0}


### PR DESCRIPTION
## Summary

When resizing too much a time series chart with a multilayer time axis, the function that computes the ticks can receive a a zero-length array of `layers`.  Typescript probably doesn't pick up correctly a mis-typed reduce and it propagated through without getting noticed causing an un-recoverable error as reported in the [linked issue](#https://github.com/elastic/elastic-charts/issues/1592) and the Kibana one.

This PR fixes it by adding the correct return type to the function and fixing the reduce function initialization.

The timeslip story is also updated with a switch to show the legend simplifying the reproducibility of the issue.


## Issues

fix #1592



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [ ] Unit tests have been added or updated to match the most common scenarios
- [ ] The proper documentation and/or storybook story has been added or updated
