### PR TITLE
fix(heatmap): correctly compute vertical axis width max size

### DIFF
--- a/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
@@ -130,7 +130,7 @@ export function renderCanvas2d(
               text,
               font,
               theme.yAxisLabel.fontSize,
-              heatmapViewModel.gridOrigin.x - horizontalPadding,
+              Math.max(elementSizes.yAxis.width - horizontalPadding, 0),
               theme.yAxisLabel.fontSize,
               { shouldAddEllipsis: true, wrapAtWord: false },
             ).lines;

--- a/packages/charts/src/chart_types/heatmap/state/selectors/compute_chart_dimensions.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/compute_chart_dimensions.ts
@@ -151,7 +151,7 @@ function getYAxisHorizontalUsedSpace(
     return Math.max(width + horizontalPad(style.padding), acc);
   }, 0);
 
-  return style.width === 'auto' ? longestLabelWidth : Math.max(longestLabelWidth, style.width.max);
+  return style.width === 'auto' ? longestLabelWidth : Math.min(longestLabelWidth, style.width.max);
 }
 
 function getTextSizeDimension(

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/text.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/primitives/text.ts
@@ -82,8 +82,8 @@ export function wrapLines(
   const lineHeightPx = lineHeight * fontSize;
 
   const padding = 0;
-  const maxWidth = fixedWidth - padding * 2;
-  const maxHeightPx = fixedHeight - padding * 2;
+  const maxWidth = Math.max(fixedWidth - padding * 2, 0);
+  const maxHeightPx = Math.max(fixedHeight - padding * 2, 0);
   let currentHeightPx = 0;
   const shouldWrap = true;
   const textArr: string[] = [];
@@ -96,7 +96,7 @@ export function wrapLines(
   for (let i = 0, max = lines.length; i < max; ++i) {
     let line = lines[i];
     let lineWidth = getTextWidth(line);
-    if (fixedWidth && lineWidth > maxWidth) {
+    if (lineWidth > maxWidth) {
       while (line.length > 0) {
         let low = 0;
         let high = line.length;

--- a/storybook/stories/heatmap/5_theming.story.tsx
+++ b/storybook/stories/heatmap/5_theming.story.tsx
@@ -7,7 +7,7 @@
  */
 
 import { action } from '@storybook/addon-actions';
-import { boolean, color, number, text } from '@storybook/addon-knobs';
+import { boolean, select, color, number, text } from '@storybook/addon-knobs';
 import React from 'react';
 
 import {
@@ -38,6 +38,10 @@ export const Example = () => {
       },
     },
   };
+
+  const yAxisLabelWidthType = select('yAxisLabel width type', ['auto', 'static', 'max'], 'auto', 'Theme');
+  const yAxisLabelWidthSize = number('yAxisLabel width max/static', 100, { min: 0, max: 200, step: 1 }, 'Theme');
+
   const heatmap: RecursivePartial<HeatmapStyle> = {
     brushArea: {
       visible: boolean('brushArea visible', true, 'Theme'),
@@ -64,6 +68,12 @@ export const Example = () => {
       fontSize: number('yAxisLabel fontSize', 12, { range: true, min: 5, max: 20 }, 'Theme'),
       textColor: color('yAxisLabel textColor', 'black', 'Theme'),
       padding: number('yAxisLabel padding', 5, { range: true, min: 0, max: 15 }, 'Theme'),
+      width:
+        yAxisLabelWidthType === 'static'
+          ? yAxisLabelWidthSize
+          : yAxisLabelWidthType === 'max'
+          ? { max: yAxisLabelWidthSize }
+          : 'auto',
     },
     grid: {
       stroke: {


### PR DESCRIPTION
## Summary

This PR fixes a small bug related to the way we compute the max width size of the vertical axis.

See the deployed story `Heatmap -> Theming` and check the two added theaming knobs: `yAxisLabel width type` and `yAxisLabel width max/static`


## Issues

The current configuration in the theme `yAxisLabel:{width:{max: number}}` wasn't working correctly

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [ ] Unit tests have been added or updated to match the most common scenarios
- [ ] The proper documentation and/or storybook story has been added or updated
