### PR TITLE
fix(events): remove async callbacks from code

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/state/selectors/on_projection_area_caller.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/on_projection_area_caller.ts
@@ -43,9 +43,7 @@ export function createOnProjectionAreaCaller(): (state: GlobalChartState) => voi
             isDiff(prevProps.projection, nextProps.projection) ||
             isDiff(nextProps.parent, nextProps.parent);
           if (onProjectionAreaChange && areDifferent) {
-            requestAnimationFrame(() => {
-              onProjectionAreaChange(nextProps);
-            });
+            onProjectionAreaChange(nextProps);
           }
           prevProps = nextProps;
         },

--- a/packages/charts/src/components/chart_container.tsx
+++ b/packages/charts/src/components/chart_container.tsx
@@ -151,16 +151,7 @@ class ChartContainerComponent extends React.Component<ReactiveChartProps> {
     const { onMouseUp } = this.props;
 
     window.removeEventListener('mouseup', this.handleBrushEnd);
-
-    requestAnimationFrame(() => {
-      onMouseUp(
-        {
-          x: -1,
-          y: -1,
-        },
-        Date.now(),
-      );
-    });
+    onMouseUp({ x: -1, y: -1 }, Date.now());
   };
 
   render() {

--- a/packages/charts/src/components/chart_status.tsx
+++ b/packages/charts/src/components/chart_status.tsx
@@ -38,12 +38,7 @@ class ChartStatusComponent extends React.Component<ChartStatusStateProps> {
   }
 
   dispatchRenderChange = () => {
-    const { onRenderChange, rendered } = this.props;
-    if (onRenderChange) {
-      window.requestAnimationFrame(() => {
-        onRenderChange(rendered);
-      });
-    }
+    this.props.onRenderChange?.(this.props.rendered);
   };
 
   render() {


### PR DESCRIPTION
## Summary

Working at #1729 leads to an interesting issue regarding the asynchronous callback.
In particular, we were calling the `onChartRendered` and `onProjectionAreaChanged` callbacks in a new macro task thanks to a `requestAnimationFrame`.

The reasons to avoid this way of handling callbacks are:
- give the freedom to the user to choose how they want to execute/queue the task in their own environment
- events caused by mouse events are already async by nature
- those callbacks should be used only for small side effects, like triggering a focus, a slight change in the state (like disabling a loading spinner) etc the user should not attach long-running sync methods to these events.

This PR removes the use of RAF in favor of sync calls.

This solves a side issue in the composable story where the chart render-complete was not called correctly.
