### PR TITLE
use typeof check to check for `process` variable

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/index.ts
@@ -12,7 +12,7 @@ import { Logger } from './../../../../../utils/logger';
 import { AnimatedValue, Animation, AnimationOptions, AnimationState } from './animation';
 
 // TODO find a better way to do this when we have an actual build process
-const DISABLE_ANIMATIONS = (process && process.env && process.env.VRT) === 'true';
+const DISABLE_ANIMATIONS = (typeof process === 'object' && process.env && process.env.VRT) === 'true';
 
 /**
  * Function used to animate values from within a render context.


### PR DESCRIPTION
## Summary

https://github.com/elastic/elastic-charts/pull/1672 fixed an issue where `process.env.VRT` was directly referenced in the code, which isn't available outside of specific environments. This broke ci-stats, which is broken again. It would seem that the module moved to a new chunk and in that chunk strict-mode is enabled which is now throwing a runtime error just by referencing `process`.

<img width="1127" alt="image" src="https://user-images.githubusercontent.com/1329312/178617125-1688c0eb-81fc-4742-b19d-429ab7ce6841.png">

This uses `typeof` to check for the `process` variable before doing additional accesses which will resolve to `undefined` in strict environments instead of throwing a runtime error.