### PR TITLE
ci: move buildkite to new datavis agent queue

### DIFF
--- a/.buildkite/utils/pipeline/steps.ts
+++ b/.buildkite/utils/pipeline/steps.ts
@@ -17,6 +17,7 @@ import { Plugins } from './plugins';
  */
 export type AgentQueue =
   | 'default'
+  | 'datavis-n2-2'
   | 'ci-group'
   | 'ci-group-4d'
   | 'ci-group-6'
@@ -48,7 +49,7 @@ export type Step = CustomGroupStep | CustomCommandStep;
 
 export const commandStepDefaults: Partial<CustomCommandStep> = {
   agents: {
-    queue: 'n2-2' as AgentQueue,
+    queue: 'datavis-n2-2' as AgentQueue,
   },
   skip: false,
   priority: 10,

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -38,6 +38,8 @@ const config: PlaywrightTestConfig = {
       maxDiffPixels: 0,
     },
   },
+  // TODO limit this to only flaky tests. Watch https://github.com/microsoft/playwright/issues/15657
+  retries: 3,
   forbidOnly: isCI,
   timeout: 10 * 1000,
   preserveOutput: 'failures-only',


### PR DESCRIPTION
Move all buildkite jobs to `datavis-n2-2` agent `queue`.