### PR TITLE
feat(utils): expose `roundDateToESInterval` fn

### DIFF
--- a/packages/charts/api/charts.api.md
+++ b/packages/charts/api/charts.api.md
@@ -927,7 +927,7 @@ export const entryKey: ([key]: ArrayEntry) => string;
 // @public (undocumented)
 export const entryValue: ([, value]: ArrayEntry) => ArrayNode;
 
-// @public (undocumented)
+// @public
 export interface ESCalendarInterval {
     // (undocumented)
     type: 'calendar';
@@ -937,10 +937,10 @@ export interface ESCalendarInterval {
     value: number;
 }
 
-// @public (undocumented)
+// @public
 export type ESCalendarIntervalUnit = 'minute' | 'm' | 'hour' | 'h' | 'day' | 'd' | 'week' | 'w' | 'month' | 'M' | 'quarter' | 'q' | 'year' | 'y';
 
-// @public (undocumented)
+// @public
 export interface ESFixedInterval {
     // (undocumented)
     type: 'fixed';
@@ -950,7 +950,7 @@ export interface ESFixedInterval {
     value: number;
 }
 
-// @public (undocumented)
+// @public
 export type ESFixedIntervalUnit = 'ms' | 's' | 'm' | 'h' | 'd';
 
 // @alpha
@@ -2196,6 +2196,9 @@ export type RgbaTuple = [r: RGB, g: RGB, b: RGB, alpha: A];
 // @public (undocumented)
 export type Rotation = 0 | 90 | -90 | 180;
 
+// @public
+export function roundDateToESInterval(date: UnixTimestamp | Date, interval: ESCalendarInterval | ESFixedInterval, snapTo: 'start' | 'end', timeZone: string): UnixTimestamp;
+
 // @public (undocumented)
 export type ScaleBandType = ScaleOrdinalType;
 
@@ -2772,6 +2775,9 @@ export interface UnaryAccessorFn<D extends BaseDatum = any, Return = any> {
     (datum: D): Return;
     fieldName?: string;
 }
+
+// @public
+export type UnixTimestamp = TimeMs;
 
 // @public
 export function useLegendAction<T extends HTMLElement>(): [ref: LegacyRef<T>, onClose: () => void];

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -123,12 +123,14 @@ export { Color } from './common/colors';
 export { RGB, A, RgbaTuple } from './common/color_library_wrappers';
 export { Predicate } from './common/predicate';
 
-export {
+export type {
   ESCalendarInterval,
   ESCalendarIntervalUnit,
   ESFixedInterval,
   ESFixedIntervalUnit,
 } from './utils/chrono/elasticsearch';
+export type { UnixTimestamp } from './utils/chrono/types';
+export { roundDateToESInterval } from './utils/chrono/elasticsearch';
 
 // data utils
 export { GroupKeysOrKeyFn, GroupByKeyFn } from './chart_types/xy_chart/utils/group_data_series';

--- a/packages/charts/src/utils/chrono/elasticsearch.test.ts
+++ b/packages/charts/src/utils/chrono/elasticsearch.test.ts
@@ -8,12 +8,12 @@
 
 import { DateTime } from 'luxon';
 
-import { snapDateToESInterval } from './elasticsearch';
+import { roundDateToESInterval } from './elasticsearch';
 
 describe('snap to interval', () => {
   it('should snap to begin of calendar interval', () => {
     const initialDate = DateTime.fromISO('2020-01-03T07:00:01Z');
-    const snappedDate = snapDateToESInterval(
+    const snappedDate = roundDateToESInterval(
       initialDate.toMillis(),
       { type: 'calendar', unit: 'd', value: 1 },
       'start',
@@ -24,7 +24,7 @@ describe('snap to interval', () => {
 
   it('should snap to end of calendar interval', () => {
     const initialDate = DateTime.fromISO('2020-01-03T07:00:01Z');
-    const snappedDate = snapDateToESInterval(
+    const snappedDate = roundDateToESInterval(
       initialDate.toMillis(),
       { type: 'calendar', unit: 'd', value: 1 },
       'end',
@@ -35,7 +35,7 @@ describe('snap to interval', () => {
 
   it('should snap to begin of fixed interval', () => {
     const initialDate = DateTime.fromISO('2020-01-03T07:00:01Z');
-    const snappedDate = snapDateToESInterval(
+    const snappedDate = roundDateToESInterval(
       initialDate.toMillis(),
       { type: 'fixed', unit: 'm', value: 30 },
       'start',
@@ -46,7 +46,7 @@ describe('snap to interval', () => {
 
   it('should snap to end of fixed interval', () => {
     const initialDate = DateTime.fromISO('2020-01-03T07:00:01Z');
-    const snappedDate = snapDateToESInterval(
+    const snappedDate = roundDateToESInterval(
       initialDate.toMillis(),
       { type: 'fixed', unit: 'm', value: 30 },
       'end',

--- a/packages/charts/src/utils/chrono/types.ts
+++ b/packages/charts/src/utils/chrono/types.ts
@@ -25,7 +25,10 @@ export type CalendarIntervalUnit = 'minute' | 'hour' | 'day' | 'week' | 'month' 
 /** @internal */
 export type FixedIntervalUnit = 'millisecond' | 'second' | 'minute' | 'hour' | 'day';
 
-/** @internal */
+/**
+ * It represents the number of milliseconds between 1 January 1970 00:00:00 UTC and the identified date/time.
+ * @public
+ */
 export type UnixTimestamp = TimeMs;
 
 /** @internal */


### PR DESCRIPTION
## Summary

This PR exposes the `roundDateToESInterval` utility function and adds a bit of documentation to the current function and types.


## Details

A possibility in the future is to expose this as it's own utility/time package, or expose it directly in Kibana because this is a really Elasticsearch specific feature.



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] New public API exports have been added to `packages/charts/src/index.ts`
- [x] Unit tests have been added or updated to match the most common scenarios
