### PR TITLE
docs: fix snap tooltip issue

### DIFF
--- a/storybook/stories/legend/13_inside_chart.story.tsx
+++ b/storybook/stories/legend/13_inside_chart.story.tsx
@@ -106,7 +106,7 @@ export const Example = () => {
       />
       <AreaSeries
         id={KIBANA_METRICS.metrics.kibana_os_load[0].metric.label}
-        xScaleType={ScaleType.Time}
+        xScaleType={ScaleType.Linear}
         yScaleType={ScaleType.Linear}
         xAccessor="x"
         yAccessors={['y']}


### PR DESCRIPTION
## Summary

This appeared at first to be an issue in code but was revealed to be a misaligned `xScaleType` that was set to `Time` instead of `Linear`.

### Before

![Screen Recording 2022-07-18 at 09 10 11 AM](https://user-images.githubusercontent.com/19007109/179555328-5c33c1c7-ff8f-44e9-954c-b50d7cab3679.gif)

### After

![Screen Recording 2022-07-19 at 08 35 56 PM](https://user-images.githubusercontent.com/19007109/179891328-b9e39c78-73d3-4ec6-a3b8-a054efd8459e.gif)

> Note the toggle at the halfway point

Closes #1756