### PR TITLE
ci: fix skip logic for dependabot

### DIFF
--- a/.buildkite/scripts/steps/eslint.ts
+++ b/.buildkite/scripts/steps/eslint.ts
@@ -21,6 +21,7 @@ void (async () => {
     'tsconfig.lint.json',
     'tsconfig.json',
     'package.json',
+    'yarn.lock',
   ]);
 
   await yarnInstall();

--- a/.buildkite/steps/api_check.ts
+++ b/.buildkite/steps/api_check.ts
@@ -24,6 +24,7 @@ export const apiCheckStep = createStep<CustomCommandStep>((ctx) => {
 function isSkippable(changes: ChangeContext): boolean | string {
   const hasTSChanges = changes.files.has('**/*.ts?(x)');
   const hasApiConfigChanges = changes.files.has([
+    'yarn.lock',
     'package.json',
     'packages/charts/package.json',
     'tsconfig.json',

--- a/.buildkite/steps/eslint.ts
+++ b/.buildkite/steps/eslint.ts
@@ -31,6 +31,7 @@ function isSkippable(changes: ChangeContext): boolean | string {
     'tsconfig.lint.json',
     'tsconfig.json',
     'package.json',
+    'yarn.lock',
   ]);
 
   if (hasTSChanges || hasLintConfigChanges) {

--- a/.buildkite/steps/jest.ts
+++ b/.buildkite/steps/jest.ts
@@ -25,6 +25,7 @@ export const jestStep = createStep<CustomCommandStep>((ctx) => {
 function isSkippable(changes: ChangeContext): boolean | string {
   const hasTSChanges = changes.files.has('packages/charts/src/**/*.ts?(x)');
   const hasJestConfigChanges = changes.files.has([
+    'yarn.lock',
     'jest.config.js',
     'jest.tz.config.js',
     'tsconfig.jest.json',

--- a/.buildkite/steps/type_check.ts
+++ b/.buildkite/steps/type_check.ts
@@ -23,7 +23,7 @@ export const typeCheckStep = createStep<CustomCommandStep>((ctx) => {
 
 function isSkippable(changes: ChangeContext): boolean | string {
   const hasTSChanges = changes.files.has('**/*.ts?(x)');
-  const hasConfigChanges = changes.files.has(['package.json', 'tsconfig.json']);
+  const hasConfigChanges = changes.files.has(['yarn.lock', 'package.json', 'tsconfig.json']);
 
   if (hasTSChanges || hasConfigChanges) {
     return false;

--- a/.buildkite/utils/github.ts
+++ b/.buildkite/utils/github.ts
@@ -24,6 +24,10 @@ import { OctokitParameters } from './types';
 
 if (!process.env.GITHUB_AUTH) throw new Error('GITHUB_AUTH env variable must be defined');
 
+const defaultMMOptions: MinimatchOptions = {
+  dot: true,
+};
+
 const auth = JSON.parse(process.env.GITHUB_AUTH);
 const MyOctokit = Octokit.plugin(retry);
 export const octokit = new MyOctokit({
@@ -68,7 +72,7 @@ class FilesContext {
 
     return this.names.filter((f) => {
       return patterns.some((pattern) =>
-        typeof pattern === 'string' ? minimatch(f, pattern, options) : pattern.exec(f),
+        typeof pattern === 'string' ? minimatch(f, pattern, { ...defaultMMOptions, ...options }) : pattern.exec(f),
       );
     });
   }
@@ -94,7 +98,7 @@ class FilesContext {
 
     return this.names.some((f) => {
       return patterns.some((pattern) =>
-        typeof pattern === 'string' ? minimatch(f, pattern, options) : pattern.exec(f),
+        typeof pattern === 'string' ? minimatch(f, pattern, { ...defaultMMOptions, ...options }) : pattern.exec(f),
       );
     });
   }


### PR DESCRIPTION
## Summary

When `dependabot` and others, update a PR it could update only the `yarn.lock` and not the touch the `package.json`. This fix triggers the step checks correctly in such a case. Also the `minimatch` options ignore dot paths (i.e. `.buildkite/`) by default, this now respects changes to dot paths by default.