### PR TITLE
ci: fix flaky animation story

### DIFF
--- a/.buildkite/utils/exec.ts
+++ b/.buildkite/utils/exec.ts
@@ -18,7 +18,21 @@ interface ExecOptions extends ExecSyncOptionsWithBufferEncoding {
   onFailure?: () => Promise<void> | void;
   onSuccess?: () => Promise<void> | void;
   cwd?: string;
+  /**
+   * Buildkite has network issues that require retrying
+   */
+  retry?: number;
+  /**
+   * Seconds to wait between retries
+   */
+  retryWait?: number;
+  /**
+   * Logic to run before next retry
+   */
+  onRetry?: () => void | Promise<void>;
 }
+
+export const wait = (n: number) => new Promise((resolve) => setTimeout(resolve, n));
 
 /**
  * Wrapper for execSync to catch and handle errors.
@@ -26,42 +40,64 @@ interface ExecOptions extends ExecSyncOptionsWithBufferEncoding {
  */
 export const exec = async (
   command: string,
-  { input, cwd, failureMsg, onFailure, onSuccess, env, stdio = ['pipe', 'inherit', 'inherit'] }: ExecOptions = {},
-) => {
-  try {
-    const result = execSync(command, {
-      input,
-      encoding: 'utf8',
-      cwd: cwd && path.isAbsolute(cwd) ? cwd : path.resolve(__dirname, '../../', cwd ?? ''),
-      stdio,
-      env: {
-        ...process.env,
-        ...env,
-      },
-    });
+  {
+    input,
+    cwd,
+    failureMsg,
+    onFailure,
+    onSuccess,
+    env,
+    stdio = ['pipe', 'inherit', 'inherit'],
+    retry = 0,
+    retryWait = 0,
+    onRetry,
+  }: ExecOptions = {},
+): Promise<string> => {
+  let retryCount = 0;
+  async function execInner(): Promise<string> {
+    try {
+      const result = execSync(command, {
+        input,
+        encoding: 'utf8',
+        cwd: cwd && path.isAbsolute(cwd) ? cwd : path.resolve(__dirname, '../../', cwd ?? ''),
+        stdio,
+        env: {
+          ...process.env,
+          ...env,
+        },
+      });
 
-    await onSuccess?.();
+      await onSuccess?.();
 
-    return result;
-  } catch (error) {
-    console.error(`Failed to run command: [${command}]`);
-    await setJobMetadata('failed', 'true');
-    await onFailure?.();
-    await updateCheckStatus(
-      {
-        status: 'completed',
-        conclusion: 'failure',
-      },
-      undefined,
-      failureMsg,
-    );
+      return result;
+    } catch (error) {
+      if (retryCount < retry) {
+        retryCount++;
+        console.log(`⚠️  Failed to run command: [${command}], attempting retry ${retryCount} of ${retry}`);
+        if (onRetry) await onRetry();
+        if (retryWait) await wait(retryWait * 1000);
+        return await execInner();
+      }
+      console.error(`❌ Failed to run command: [${command}]`);
+      await setJobMetadata('failed', 'true');
+      await onFailure?.();
+      await updateCheckStatus(
+        {
+          status: 'completed',
+          conclusion: 'failure',
+        },
+        undefined,
+        failureMsg,
+      );
 
-    throw error;
+      throw error;
+    }
   }
+  return await execInner();
 };
 
 export const yarnInstall = async (cwd?: string, ignoreScripts = true) => {
   startGroup(`Installing node modules${cwd ? ` [${cwd}]` : ''}`);
   const scriptFlag = ignoreScripts ? ' --ignore-scripts' : '';
-  await exec(`yarn install --frozen-lockfile${scriptFlag}`, { cwd });
+  await exec(`yarn install --frozen-lockfile${scriptFlag}`, { cwd, retry: 5, retryWait: 15 });
 };

--- a/e2e/page_objects/common.ts
+++ b/e2e/page_objects/common.ts
@@ -383,7 +383,7 @@ export class CommonPage {
       if (!element) {
         throw new Error(`Failed to find element at \`${selector}\`\n\n\t${url}`);
       } else {
-        expect(element).toMatchSnapshot(screenshotPath, options);
+        expect(element).toMatchSnapshot(screenshotPath, getSnapshotOptions(options));
       }
     };
 
@@ -525,6 +525,18 @@ export class CommonPage {
         strict: false, // should be true but some stories have multiple charts
       });
     };
+}
+
+function getSnapshotOptions(options?: ScreenshotDOMElementOptions) {
+  if (options?.maxDiffPixels !== undefined) {
+    // need to clear default options for maxDiffPixels to be respected, else could still fail on threshold or maxDiffPixelRatio
+    return {
+      threshold: 1,
+      maxDiffPixelRatio: 1,
+      ...options,
+    };
+  }
+  return options;
 }
 
 export const common = new CommonPage();

--- a/e2e/page_objects/common.ts
+++ b/e2e/page_objects/common.ts
@@ -88,6 +88,24 @@ interface ScreenshotDOMElementOptions {
    * @deprecated
    */
   debug?: boolean;
+  /**
+   * An acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1`. Default is
+   * configurable with `TestConfig.expect`. Unset by default.
+   */
+  maxDiffPixelRatio?: number;
+
+  /**
+   * An acceptable amount of pixels that could be different. Default is configurable with `TestConfig.expect`. Unset by
+   * default.
+   */
+  maxDiffPixels?: number;
+
+  /**
+   * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the same
+   * pixel in compared images, between zero (strict) and one (lax), default is configurable with `TestConfig.expect`.
+   * Defaults to `0.2`.
+   */
+  threshold?: number;
 }
 
 type ScreenshotElementAtUrlOptions = ScreenshotDOMElementOptions & {
@@ -365,7 +383,7 @@ export class CommonPage {
       if (!element) {
         throw new Error(`Failed to find element at \`${selector}\`\n\n\t${url}`);
       } else {
-        expect(element).toMatchSnapshot(screenshotPath);
+        expect(element).toMatchSnapshot(screenshotPath, options);
       }
     };
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -39,7 +39,7 @@ const config: PlaywrightTestConfig = {
     },
   },
   // TODO limit this to only flaky tests. Watch https://github.com/microsoft/playwright/issues/15657
-  retries: 3,
+  retries: 1,
   forbidOnly: isCI,
   timeout: 10 * 1000,
   preserveOutput: 'failures-only',

--- a/e2e/tests/annotations_stories.test.ts
+++ b/e2e/tests/annotations_stories.test.ts
@@ -39,10 +39,7 @@ test.describe('Annotations stories', () => {
           left: 225,
         },
         {
-          delay: 100,
           maxDiffPixels: 10,
-          threshold: 1,
-          maxDiffPixelRatio: 1,
         },
       );
     });

--- a/e2e/tests/annotations_stories.test.ts
+++ b/e2e/tests/annotations_stories.test.ts
@@ -40,6 +40,7 @@ test.describe('Annotations stories', () => {
         },
         {
           delay: 100,
+          maxDiffPixels: 10,
         },
       );
     });

--- a/e2e/tests/annotations_stories.test.ts
+++ b/e2e/tests/annotations_stories.test.ts
@@ -41,6 +41,8 @@ test.describe('Annotations stories', () => {
         {
           delay: 100,
           maxDiffPixels: 10,
+          threshold: 1,
+          maxDiffPixelRatio: 1,
         },
       );
     });


### PR DESCRIPTION
## Summary

Adds `maxDiffPixelRatio`, `maxDiffPixels` and `threshold` options to screenshot options and passes to playwright `expect(element).toMatchSnapshot()` method.

Fixes flaky annotation story with minor diff.

```
Error: Screenshot comparison failed:

  5 pixels (ratio 0.01 of all image pixels) are different

Expected: /app/e2e/test_failures/annotations_stories-Annotations-stories-Hover--acf9e-her-annotations-when-rect-annotation-is-hovered-chrome/annotations-stories/hover-state/should-fade-all-other-annotations-when-rect-annotation-is-hovered-expected.png
Received: /app/e2e/test_failures/annotations_stories-Annotations-stories-Hover--acf9e-her-annotations-when-rect-annotation-is-hovered-chrome/annotations-stories/hover-state/should-fade-all-other-annotations-when-rect-annotation-is-hovered-actual.png
    Diff: /app/e2e/test_failures/annotations_stories-Annotations-stories-Hover--acf9e-her-annotations-when-rect-annotation-is-hovered-chrome/annotations-stories/hover-state/should-fade-all-other-annotations-when-rect-annotation-is-hovered-diff.png

  33 |     });
  34 |     test('should fade all other annotations when rect annotation is hovered', async ({ page }) => {
> 35 |       await common.expectChartWithMouseAtUrlToMatchScreenshot(page)(
     |       ^
  36 |         url,
  37 |         {
  38 |           bottom: 188,

    at /app/e2e/page_objects/common.ts:368:25
    at /app/e2e/page_objects/common.ts:379:5
    at /app/e2e/page_objects/common.ts:414:7
    at /app/e2e/tests/annotations_stories.test.ts:35:7
```

### Minor diff screenshot below 🧐

![image](https://user-images.githubusercontent.com/19007109/187497073-1d1a70c5-d228-4d75-875f-44fad91231d4.png)

---

Adds retry logic to `exec` helper function to retry processes when needed. This was the suggestion from ops team as they have similar network issues with buildkite agents. This does not fix network issues with commands not using `exec`.

Should prevent errors such as...

```
yarn install v1.22.15
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
info There appears to be trouble with your network connection. Retrying...
error An unexpected error occurred: "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz: Request failed \"503 Service Unavailable\"".
info If you think this is a bug, please open a bug report with the information provided in "/app/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Failed to run command: [yarn install --frozen-lockfile --ignore-scripts]
```