### PR TITLE
fix(flame): undo the conversion to uniform buffer objects

### DIFF
--- a/e2e/scripts/test.sh
+++ b/e2e/scripts/test.sh
@@ -41,5 +41,6 @@ echo "Connected to e2e server at ${ENV_URL}"
 # Install dependencies only e2e modules for testing
 yarn install --frozen-lockfile
 
+export VRT=true
 # Run playwright tests with passed args
 playwright test "$@"

--- a/e2e/tests/flame_stories.test.ts
+++ b/e2e/tests/flame_stories.test.ts
@@ -25,7 +25,7 @@ test.describe('Flame stories', () => {
           );
         },
         // replace this with render count selector when render count fixed
-        delay: 5000, // wait for tweening and blinking to finish
+        delay: 300, // wait for tweening and blinking to finish
       },
     );
   });

--- a/e2e/tests/flame_stories.test.ts
+++ b/e2e/tests/flame_stories.test.ts
@@ -25,7 +25,7 @@ test.describe('Flame stories', () => {
           );
         },
         // replace this with render count selector when render count fixed
-        delay: 300, // wait for tweening to finish
+        delay: 5000, // wait for tweening and blinking to finish
       },
     );
   });

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -51,9 +51,10 @@ const LEFT_MOUSE_BUTTON = 1;
 const MINIMAP_SIZE_RATIO_X = 3;
 const MINIMAP_SIZE_RATIO_Y = 3;
 const SHOWN_ANCESTOR_COUNT = 2; // how many rows above the focused in node should be shown
-const WOBBLE_DURATION = 1000;
+const SHOULD_DISABLE_WOBBLE = (typeof process === 'object' && process.env && process.env.VRT) === 'true';
+const WOBBLE_DURATION = SHOULD_DISABLE_WOBBLE ? 0 : 1000;
 const WOBBLE_REPEAT_COUNT = 2;
-const WOBBLE_FREQUENCY = 2 * Math.PI * (WOBBLE_REPEAT_COUNT / WOBBLE_DURATION); // e.g. 1/30 means a cycle of every 30ms
+const WOBBLE_FREQUENCY = SHOULD_DISABLE_WOBBLE ? 0 : 2 * Math.PI * (WOBBLE_REPEAT_COUNT / WOBBLE_DURATION); // e.g. 1/30 means a cycle of every 30ms
 
 const unitRowPitch = (position: Float32Array) => (position.length >= 4 ? position[1] - position[3] : 1);
 const initialPixelRowPitch = () => 16;

--- a/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/ensure_webgl.ts
@@ -8,7 +8,6 @@
 
 import {
   bindVertexArray,
-  blockUniforms,
   createCompiledShader,
   createLinkedProgram,
   getAttributes,
@@ -56,33 +55,13 @@ export function ensureWebgl(
     attributeLocations,
   );
 
-  const blockUniformsData = blockUniforms(
-    gl,
-    'Settings',
-    [
-      'focus',
-      'resolution',
-      'gapPx',
-      'minFillRatio',
-      'rowHeight0',
-      'rowHeight1',
-      't',
-      'cornerRadiusPx',
-      'hoverIndex',
-      'wobbleIndex',
-      'wobble',
-      'pickLayer',
-    ],
-    [geomProgram, pickProgram],
-  );
-
   /**
    * Resource allocation: Render setup
    */
 
   // couple the program with the attribute input and global GL flags
-  const roundedRectRenderer = getRenderer(gl, geomProgram, blockUniformsData, vao, { depthTest: false, blend: true });
-  const pickTextureRenderer = getRenderer(gl, pickProgram, blockUniformsData, vao, { depthTest: false, blend: false });
+  const roundedRectRenderer = getRenderer(gl, geomProgram, vao, { depthTest: false, blend: true });
+  const pickTextureRenderer = getRenderer(gl, pickProgram, vao, { depthTest: false, blend: false });
 
   const attributes = getAttributes(gl, geomProgram, attributeLocations);
 

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -38,20 +38,18 @@ const attribDefs = /* language=GLSL */ `
 `;
 
 const uniformDefs = /* language=GLSL */ `
-  uniform Settings {
-    mat4 focus; // [[focusLoX, focusHiX], [focusLoY, focusHiY]]
-    vec2 resolution;
-    vec2 gapPx;
-    vec2 minFillRatio; // at least this ratio of the rectangle's full width/height must be filled
-    float rowHeight0;
-    float rowHeight1;
-    float t; // 0: start position; 1: end position
-    float cornerRadiusPx;
-    float hoverIndex;
-    float wobbleIndex;
-    float wobble;
-    bool pickLayer;
-  };
+  uniform mat4 focus; // [[focusLoX, focusHiX], [focusLoY, focusHiY]]
+  uniform vec2 resolution;
+  uniform vec2 gapPx;
+  uniform vec2 minFillRatio; // at least this ratio of the rectangle's full width/height must be filled
+  uniform float rowHeight0;
+  uniform float rowHeight1;
+  uniform float t; // 0: start position; 1: end position
+  uniform float cornerRadiusPx;
+  uniform float hoverIndex;
+  uniform float wobbleIndex;
+  uniform float wobble;
+  uniform bool pickLayer;
 `;
 
 const constants = /* language=GLSL */ `

--- a/packages/charts/src/common/kingly.ts
+++ b/packages/charts/src/common/kingly.ts
@@ -14,15 +14,29 @@ const GL_DEBUG = true; // to be set to false once GL charts are in non-alpha and
  * Types
  *************/
 
+// there are two shader types
 type ShaderType = typeof GL.FRAGMENT_SHADER | typeof GL.VERTEX_SHADER;
+
+// a data structure that maps each uniform name (string) to a value setter for that uniform
 type UniformsMap = Map<string, (...args: any[]) => void>;
+
+// this wraps the uniforms details and the uniforms buffer object
 type UboData = { uniforms: Uniforms; uboBuffer: WebGLBuffer };
+
+// we can use a frame buffer (the Canvas itself, or a texture) for reading, writing or both
 type FrameBufferTarget = typeof GL.READ_FRAMEBUFFER | typeof GL.DRAW_FRAMEBUFFER | typeof GL.FRAMEBUFFER;
 
+// samplers (texture samplers) act as uniforms; `setUniform` sets the desired texture for the shader code to read (sample) from
 interface Sampler {
   setUniform: (location: WebGLUniformLocation) => void;
 }
 
+/**
+ * Clearing can be constrained to a rectangle; not just the color buffer but the depth buffer may also be cleared
+ * One role of the depth buffer (z-buffer) is to keep track of the Z coordinate closest to the viewer for each pixel on the screen
+ * as it can be used to reject future pixel (fragment) shading that would be beneath this and would be invisible anyway
+ * The stencil buffer may also be cleared simultaneously https://en.wikipedia.org/wiki/Stencil_buffer
+ */
 interface ClearInfo {
   rect?: [number, number, number, number];
   color?: [number, number, number, number];
@@ -30,14 +44,15 @@ interface ClearInfo {
   stencilIndex?: number;
 }
 
+// A tuple of texture data for functions like `gl.texImage2D` and `gl.texParameteri` - metadata of a texture
 interface TextureSpecification {
-  textureIndex: GLuint;
-  internalFormat: GLuint;
-  width: GLuint;
-  height: GLuint;
-  data: ArrayBufferView | null;
-  min?: GLuint;
-  mag?: GLuint;
+  textureIndex: GLuint; // used for identifying the specific texture in a `gl.activeTexture` setter call
+  internalFormat: GLuint; // colors and bits per color https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D
+  width: GLuint; // texture width in pixels
+  height: GLuint; // texture height in pixels
+  data: ArrayBufferView | null; // the buffer containing the actual pixel grid
+  min?: GLuint; // when using texture for data lookup, we usually want the nearest exact value, rather than interpolated or aggregated
+  mag?: GLuint; // when using texture for data lookup, we usually want the nearest exact value, rather than interpolated or aggregated
 }
 
 /** @internal */

--- a/packages/charts/src/common/webgl_constants.ts
+++ b/packages/charts/src/common/webgl_constants.ts
@@ -6,6 +6,16 @@
  * Side Public License, v 1.
  */
 
+/**
+ * WebGL uses integers (GLUInt, just a number in JS) as fake enums (mostly) for WebGL API function call parameters.
+ * While it's possible to use the integer code directly, there's documentational value in naming them, in line with specs.
+ * WebGL queries, typically run for exception handling and debugging situations, often return such "enums" too.
+ * By having the number here, it's easy to search for the meaning, though it's possible to do it on the web too.
+ * Most of these constants aren't currently used, but it'd be tedious to add them one by one.
+ *
+ * Note that there are functions (currently, `gl.activeTexture`) that take an "enum" but then add offset numbers to it.
+ */
+
 /** @internal */
 export const GL = {
   DEPTH_BUFFER_BIT: 256,


### PR DESCRIPTION
## Summary

PR #1690 (`main` commit 67052711) introduced, among numerous other improvements, a conversion to the WebGL2-only uniform buffer objects. Its purpose was mere preparation for eventual WebGPU conversion, which doesn't have singular uniforms, only UBOs. However, certain hardware, OS and browser combinations (specifically, some older Intel MBPs with Chrome and Safari) were flaky with UBOs. As it represented additional code anyway, this PR removes it.

This PR also includes commits with minor WebGL code cleanup and start of documentation. 

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

Easiest to review commit by commit

<!-- Details beyond the summary to explain nuances -->


## Issues



<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
