### PR TITLE
build: fix eslint got stuck on e2e reports

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -23,3 +23,4 @@ packages/charts/src/utils/d3-delaunay
 **/tmp
 docs/
 .buildkite/buildkite.d.ts
+e2e/reports/


### PR DESCRIPTION
## Summary

`eslint` got stuck if you have an e2e report locally (probably due to the minified/uglified nature of the generated code for the report).
This PR should fix that by ignoring that directory.
