### PR TITLE
fix(tooltip): heatmap visible tooltip option

### DIFF
--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_cursor_band.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_cursor_band.ts
@@ -7,7 +7,7 @@
  */
 
 import { Rect } from '../../../../geoms/types';
-import { isPointerOverEvent, PointerEvent, SettingsSpec } from '../../../../specs';
+import { isPointerOverEvent, PointerEvent } from '../../../../specs';
 import { GlobalChartState, PointerState } from '../../../../state/chart_state';
 import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_spec';
@@ -29,10 +29,9 @@ function getCursorBand(
   geoms: ShapeViewModel,
   externalPointerEvent: PointerEvent | null,
   currentPointer: PointerState,
-  settings: SettingsSpec,
 ): (Rect & { fromExternalEvent: boolean }) | undefined {
   // external pointer events takes precedence over the current mouse pointer
-  if (settings.externalPointerEvents.tooltip.visible && isPointerOverEvent(externalPointerEvent)) {
+  if (isPointerOverEvent(externalPointerEvent)) {
     const { x } = externalPointerEvent;
     if (!isNil(x)) {
       const band = geoms.pickCursorBand(x);


### PR DESCRIPTION
## Summary

Match behavior of `externalPointerEvents.tooltip.visible` option on heatmap. Currently, heatmap external band will only show when this option is set to `true`.

The current heatmap tooltip is only visible when both a x and y values are valid, hence not on external events. This could be improved upon in the future to add a list of categories for a given `x` value. Showing just the x value would not serve any purpose.

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [ ] Unit tests have been added or updated to match the most common scenarios