### PR TITLE
chore(jest): fix jest warning

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,10 +22,13 @@ module.exports = {
     '/node_modules/',
   ],
   clearMocks: true,
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.jest.json',
-    },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.jest.json',
+      },
+    ],
   },
   moduleNameMapper: {
     // This forces Jest/jest-environment-jsdom to use a Node+CommonJS version of uuid, not a Browser+ESM one


### PR DESCRIPTION
## Summary

Latest ts-jest changes deprecated `globals` syntax, see [docs](https://kulshekhar.github.io/ts-jest/docs/getting-started/options/tsconfig/#path-to-a-tsconfig-file). This throws a warning when running tests, this updates to the latest config options.

```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
```