### PR TITLE
feat(flame): node size and position tweening

### DIFF
--- a/packages/charts/src/chart_types/flame_chart/flame_api.ts
+++ b/packages/charts/src/chart_types/flame_chart/flame_api.ts
@@ -41,10 +41,11 @@ export interface ControlReceiverCallbacks {
  *   - label: array of N strings
  *   - value: Float64Array of N numbers, for tooltip value display
  *   - color: Float32Array of 4 * N numbers, eg. green[i] = color[4 * i + 1]
- *   - position0: Float32Array of 2 * N numbers with unit coordinates [x0, y0, x1, y1, ..., xN-1, yN-1]
- *   - position1: for now, the same typed array for position0 to be used
- *   - size0: Float32Array of N numbers with unit widths [width0, width1, ... , widthN-1]
- *   - size1: for now, the same typed array for size0 to be used
+ *   - position0: Tween from: Float32Array of 2 * N numbers with unit coordinates [x0, y0, x1, y1, ..., xN-1, yN-1]
+ *   - position1: Tween to: Float32Array of 2 * N numbers with unit coordinates [x0, y0, x1, y1, ..., xN-1, yN-1]
+ *   - size0: Tween from: Float32Array of N numbers with unit widths [width0, width1, ... , widthN-1]
+ *   - size1: Tween to: Float32Array of N numbers with unit widths [width0, width1, ... , widthN-1]
+ * If position0 === position1 and size0 === size1, then the nodes are not animated
  * @public
  */
 export interface ColumnarViewModel {

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -1089,17 +1089,18 @@ class FlameComponent extends React.Component<FlameProps> {
       this.currentFocus.y1 += convergenceRateY * dy1;
 
       this.wobbleTimeLeft -= msDeltaT;
-      const shouldWobble = this.wobbleTimeLeft > 0;
+      const wobbleAnimationInProgress = this.wobbleTimeLeft > 0;
       const timeFromWobbleStart = clamp(WOBBLE_DURATION - this.wobbleTimeLeft, 0, WOBBLE_DURATION);
 
       renderFrame(
         [this.currentFocus.x0, this.currentFocus.x1, this.currentFocus.y0, this.currentFocus.y1],
         this.wobbleIndex,
-        shouldWobble ? 0.01 + 0.99 * (0.5 - 0.5 * Math.cos(timeFromWobbleStart * WOBBLE_FREQUENCY)) : 0, // positive if it must wobble
+        wobbleAnimationInProgress ? 0.01 + 0.99 * (0.5 - 0.5 * Math.cos(timeFromWobbleStart * WOBBLE_FREQUENCY)) : 0, // positive if it must wobble
       );
 
       const maxDiff = Math.max(Math.abs(dx0), Math.abs(dx1), Math.abs(dy0), Math.abs(dy1));
-      if (maxDiff > 1e-12 || shouldWobble) {
+      const focusAnimationInProgress = maxDiff > 1e-12;
+      if (focusAnimationInProgress || wobbleAnimationInProgress) {
         this.animationRafId = window.requestAnimationFrame(anim);
       } else {
         this.prevT = NaN;

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -1092,10 +1092,13 @@ class FlameComponent extends React.Component<FlameProps> {
       const wobbleAnimationInProgress = this.wobbleTimeLeft > 0;
       const timeFromWobbleStart = clamp(WOBBLE_DURATION - this.wobbleTimeLeft, 0, WOBBLE_DURATION);
 
+      const nodeTweenTime = 1; // let's assume we already tweened the nodes to their final position
+
       renderFrame(
         [this.currentFocus.x0, this.currentFocus.x1, this.currentFocus.y0, this.currentFocus.y1],
         this.wobbleIndex,
         wobbleAnimationInProgress ? 0.01 + 0.99 * (0.5 - 0.5 * Math.cos(timeFromWobbleStart * WOBBLE_FREQUENCY)) : 0, // positive if it must wobble
+        nodeTweenTime,
       );
 
       const maxDiff = Math.max(Math.abs(dx0), Math.abs(dx1), Math.abs(dy0), Math.abs(dy1));

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -187,7 +187,7 @@ class FlameComponent extends React.Component<FlameProps> {
 
   // drilldown animation
   private animationRafId: number = NaN;
-  private prevT: number = NaN;
+  private prevFocusTime: number = NaN;
   private currentFocus: FocusRect;
   private targetFocus: FocusRect;
 
@@ -293,7 +293,7 @@ class FlameComponent extends React.Component<FlameProps> {
   private wobble(nodeIndex: number) {
     this.wobbleTimeLeft = WOBBLE_DURATION;
     this.wobbleIndex = nodeIndex;
-    this.prevT = NaN;
+    this.prevFocusTime = NaN;
     this.hoverIndex = NaN; // no highlight
     this.setState({});
   }
@@ -679,7 +679,7 @@ class FlameComponent extends React.Component<FlameProps> {
         this.targetFocus = focusRect(this.props.columnarViewModel, this.props.chartDimensions.height, datumIndex);
         // disable until we consider that part of the navigation
         // this.navigator.add({ ...this.targetFocus, index: NaN });
-        this.prevT = NaN;
+        this.prevFocusTime = NaN;
         this.hoverIndex = NaN; // no highlight
         this.wobbleTimeLeft = WOBBLE_DURATION;
         this.wobbleIndex = datumIndex;
@@ -1065,8 +1065,8 @@ class FlameComponent extends React.Component<FlameProps> {
     );
 
     const anim = (t: DOMHighResTimeStamp) => {
-      const msDeltaT = Number.isNaN(this.prevT) ? 0 : t - this.prevT;
-      this.prevT = t;
+      const msDeltaT = Number.isNaN(this.prevFocusTime) ? 0 : t - this.prevFocusTime;
+      this.prevFocusTime = t;
 
       const dx0 = this.targetFocus.x0 - this.currentFocus.x0;
       const dx1 = this.targetFocus.x1 - this.currentFocus.x1;
@@ -1106,7 +1106,7 @@ class FlameComponent extends React.Component<FlameProps> {
       if (focusAnimationInProgress || wobbleAnimationInProgress) {
         this.animationRafId = window.requestAnimationFrame(anim);
       } else {
-        this.prevT = NaN;
+        this.prevFocusTime = NaN;
         this.currentFocus.x0 = this.targetFocus.x0;
         this.currentFocus.x1 = this.targetFocus.x1;
         this.currentFocus.y0 = this.targetFocus.y0;

--- a/packages/charts/src/chart_types/flame_chart/render/draw_a_frame.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/draw_a_frame.ts
@@ -128,7 +128,7 @@ export const drawFrame =
     // focus layer text
     drawCanvas2d(
       ctx,
-      1,
+      nodeTweenTime,
       focusLayerCssWidth,
       focusLayerCssHeight,
       PADDING_LEFT,

--- a/packages/charts/src/chart_types/flame_chart/render/draw_a_frame.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/draw_a_frame.ts
@@ -53,7 +53,7 @@ export const drawFrame =
     currentColor: Float32Array,
     theme: FlamegraphStyle,
   ) =>
-  (currentFocus: [number, number, number, number], wobbleIndex: number, wobble: number) => {
+  (currentFocus: [number, number, number, number], wobbleIndex: number, wobble: number, nodeTweenTime: number) => {
     const canvasHeightExcess = (roundUpSize(cssHeight) - cssHeight) * dpr;
 
     const minimapBottom = minimapTop + minimapHeight;
@@ -76,7 +76,7 @@ export const drawFrame =
     const drawFocusLayer = (pickLayer: boolean) =>
       drawWebgl(
         gl,
-        1,
+        nodeTweenTime,
         focusLayerCanvasWidth,
         focusLayerCssHeight * dpr,
         focusLayerCanvasOffsetX,
@@ -96,7 +96,7 @@ export const drawFrame =
     const drawContextLayer = (pickLayer: boolean) =>
       drawWebgl(
         gl,
-        1,
+        nodeTweenTime,
         minimapCanvasWidth,
         minimapCanvasHeight,
         minimapCanvasX,

--- a/packages/charts/src/chart_types/flame_chart/render/draw_webgl.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/draw_webgl.ts
@@ -20,7 +20,7 @@ const DUMMY_INDEX = -1; // GLSL doesn't guarantee a NaN, and it's a shader integ
 /** @internal */
 export const drawWebgl = (
   gl: WebGL2RenderingContext,
-  logicalTime: number,
+  nodeTweenTime: number,
   canvasWidth: number,
   canvasHeight: number,
   xOffset: number,
@@ -40,7 +40,7 @@ export const drawWebgl = (
     target: pickLayer ? pickTexture.target() : null,
     uniformValues: {
       pickLayer,
-      t: Math.max(0.001, logicalTime), // for some reason, an exact zero will lead to `mix` as if it were 1 (glitch)
+      nodeTweenTime: Math.max(0.001, nodeTweenTime), // for some reason, an exact zero will lead to `mix` as if it were 1 (glitch)
       resolution: [canvasWidth, canvasHeight],
       gapPx: pickLayer || !focusLayer ? [0, 0] : [BOX_GAP_HORIZONTAL, BOX_GAP_VERTICAL], // in CSS pixels (but let's not leave a gap for shape picking)
       minFillRatio: MIN_FILL_RATIO,

--- a/packages/charts/src/chart_types/flame_chart/shaders.ts
+++ b/packages/charts/src/chart_types/flame_chart/shaders.ts
@@ -44,7 +44,7 @@ const uniformDefs = /* language=GLSL */ `
   uniform vec2 minFillRatio; // at least this ratio of the rectangle's full width/height must be filled
   uniform float rowHeight0;
   uniform float rowHeight1;
-  uniform float t; // 0: start position; 1: end position
+  uniform float nodeTweenTime; // 0: start position; 1: end position
   uniform float cornerRadiusPx;
   uniform float hoverIndex;
   uniform float wobbleIndex;
@@ -82,8 +82,8 @@ const getGeom = /* language=GLSL */ `
     int x = gl_VertexID & 1;        // x yields 0, 1, 0, 1 for gl_VertexID 0, 1, 2, 3
     int y = (gl_VertexID >> 1) & 1; // y yields 0, 0, 1, 1 for gl_VertexID 0, 1, 2, 3
     vec2 unitSquareCoord = vec2(x, y);
-    vec2 position = mix(position0, position1, t);
-    vec2 size = mix(vec2(size0, rowHeight0), vec2(size1, rowHeight1), t);
+    vec2 position = mix(position0, position1, nodeTweenTime);
+    vec2 size = mix(vec2(size0, rowHeight0), vec2(size1, rowHeight1), nodeTweenTime);
     vec2 fullSizeXY = size * unitSquareCoord;
 
     // determine what we're zooming/panning into

--- a/playground/playground.tsx
+++ b/playground/playground.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 
-import { Example } from '../storybook/stories/timeslip/01_timeslip.story';
+import { Example } from '../storybook/stories/icicle/04_cpu_profile_gl_flame.story';
 
 export function Playground() {
   return <Example />;

--- a/storybook/stories/icicle/04_cpu_profile_gl_flame.story.tsx
+++ b/storybook/stories/icicle/04_cpu_profile_gl_flame.story.tsx
@@ -10,7 +10,16 @@ import { action } from '@storybook/addon-actions';
 import { boolean, button } from '@storybook/addon-knobs';
 import React from 'react';
 
-import { Chart, Datum, Flame, Settings, PartialTheme, FlameGlobalControl, FlameNodeControl } from '@elastic/charts';
+import {
+  Chart,
+  Datum,
+  Flame,
+  Settings,
+  PartialTheme,
+  FlameGlobalControl,
+  FlameNodeControl,
+  ColumnarViewModel,
+} from '@elastic/charts';
 import columnarMock from '@elastic/charts/src/mocks/hierarchical/cpu_profile_tree_mock_columnar.json';
 import { getRandomNumberGenerator } from '@elastic/charts/src/mocks/utils';
 
@@ -36,16 +45,16 @@ const paletteColorBrewerCat12 = [
   [255, 237, 111],
 ];
 
-const columnarData = {
+const columnarData: ColumnarViewModel = {
   label: columnarMock.label.map((index: number) => columnarMock.dictionary[index]), // reversing the dictionary encoding
   value: new Float64Array(columnarMock.value),
   // color: new Float32Array((columnarMock.color.match(/.{2}/g) ?? []).map((hex: string) => Number.parseInt(hex, 16) / 255)),
   color: new Float32Array(
     columnarMock.label.flatMap(() => [...paletteColorBrewerCat12[pseudoRandom(0, 11)].map((c) => c / 255), 1]),
   ),
-  position0: position, // new Float32Array([...position].slice(1)), // try with the wrong array length
+  position0: position.map((p, i) => (i % 2 === 0 ? 1 - p - size[i / 2] : p)), //.map((p, i) => (i % 2 === 0 ? 1 - p - size[i / 2] : p)), // new Float32Array([...position].slice(1)), // try with the wrong array length
   position1: position,
-  size0: size,
+  size0: size.map((s) => 0.8 * s),
   size1: size,
 };
 


### PR DESCRIPTION
## Summary

Completes support for tweening node positions between `position0` -> `position1` and `size0` -> `size1`

The behavior is unchanged  if `columns.position0 === columns.position1 && columns.size0 === columns.size1`

This change allows the following functionality:

With node identities unchanged (meaning that the same node count is present, and the i-th node in both the `*0` and `*1` columns means the same entity: either the position, or size, or both can change. The tweening is currently linear, set to 500ms (as it can be a sweeping change).

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

If nodes would mismatch, for example, some nodes go away, while others are entered, with generally different node count between the start and target state:

1. Use the larger of the node count in all arrays; the superfluous entries will just get the appropriate position but their size should be set to zero, so it has no visible effect
2. Set the `size0` of nodes that enter to zero; set the `size1` of nodes that exit to zero
3. Rerender as usual; this will perform the tweening
4. If further updates may happen, it's worth rerendering once again, so that `size1` / `position1` go into both the `*0` and the `*1` columns. This will not cause a visible change, but it'll be easier to perform a similar enter/exit/change cycle in the future

The equality check of the vectors is done via array identity for performance reasons, rather than comparing values one by one in multiple, possibly very large vectors.

Color tweening isn't currently supported, but it'd be possible by adding a new column by the analogy of the position and size handling. Color tweening can be linear initially, as it's very brief anyway (easy to do it with `mix`) and for best results, color tweening in another color space would be the icing on the cake, assuming it leads to a noticeable difference.

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] The proper documentation and/or storybook story has been added or updated
- [x] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
