### PR TITLE
feat(heatmap): highlight selected range from legend hover

### DIFF
--- a/packages/charts/src/chart_types/heatmap/layout/viewmodel/viewmodel.ts
+++ b/packages/charts/src/chart_types/heatmap/layout/viewmodel/viewmodel.ts
@@ -171,7 +171,7 @@ export function shapeViewModel<D extends BaseDatum = Datum>(
         width: heatmapTheme.cell.border.strokeWidth,
       },
       value: d.value,
-      visible: !isValueHidden(d.value, bandsToHide),
+      visible: !isValueInRanges(d.value, bandsToHide),
       formatted: formattedValue,
       fontSize,
       textColor: fillTextColor(background.fallbackColor, cellBackgroundColor, background.color),
@@ -443,8 +443,9 @@ function getCellKey(x: NonNullable<PrimitiveValue>, y: NonNullable<PrimitiveValu
   return [String(x), String(y)].join('&_&');
 }
 
-function isValueHidden(value: number, rangesToHide: Array<[number, number]>) {
-  return rangesToHide.some(([min, max]) => min <= value && value < max);
+/** @internal */
+export function isValueInRanges(value: number, ranges: Array<[number, number]>) {
+  return ranges.some(([min, max]) => min <= value && value < max);
 }
 
 /** @internal */

--- a/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
@@ -10,20 +10,24 @@ import { Color } from '../../../../common/colors';
 import { clearCanvas, renderLayers, withContext } from '../../../../renderers/canvas';
 import { radToDeg } from '../../../../utils/common';
 import { horizontalPad } from '../../../../utils/dimensions';
+import { SharedGeometryStateStyle } from '../../../../utils/themes/theme';
 import { renderMultiLine } from '../../../xy_chart/renderer/canvas/primitives/line';
 import { renderRect } from '../../../xy_chart/renderer/canvas/primitives/rect';
 import { renderText, TextFont, wrapLines } from '../../../xy_chart/renderer/canvas/primitives/text';
 import { ShapeViewModel } from '../../layout/types/viewmodel_types';
 import { ChartElementSizes } from '../../state/selectors/compute_chart_dimensions';
+import { getColorBandStyle, getGeometryStateStyle } from './utils';
 
 /** @internal */
 export function renderCanvas2d(
   ctx: CanvasRenderingContext2D,
   dpr: number,
   { theme, heatmapViewModel }: ShapeViewModel,
+  sharedGeometryStyle: SharedGeometryStateStyle,
   background: Color,
   elementSizes: ChartElementSizes,
   debug: boolean,
+  highlightedLegendBands: Array<[start: number, end: number]>,
 ) {
   withContext(ctx, () => {
     // set some defaults for the overall rendering
@@ -92,7 +96,11 @@ export function renderCanvas2d(
           const { x, y } = heatmapViewModel.gridOrigin;
           ctx.translate(x, y);
           filteredCells.forEach((cell) => {
-            if (cell.visible) renderRect(ctx, cell, cell.fill, cell.stroke);
+            if (cell.visible) {
+              const geometryStateStyle = getGeometryStateStyle(cell, sharedGeometryStyle, highlightedLegendBands);
+              const style = getColorBandStyle(cell, geometryStateStyle);
+              renderRect(ctx, cell, style.fill, style.stroke);
+            }
           });
         }),
 

--- a/packages/charts/src/chart_types/heatmap/renderer/canvas/connected_component.tsx
+++ b/packages/charts/src/chart_types/heatmap/renderer/canvas/connected_component.tsx
@@ -23,16 +23,21 @@ import { getChartThemeSelector } from '../../../../state/selectors/get_chart_the
 import { getInternalIsInitializedSelector, InitStatus } from '../../../../state/selectors/get_internal_is_intialized';
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_spec';
 import { Dimensions } from '../../../../utils/dimensions';
+import { LIGHT_THEME } from '../../../../utils/themes/light_theme';
+import { Theme } from '../../../../utils/themes/theme';
 import { nullShapeViewModel, ShapeViewModel } from '../../layout/types/viewmodel_types';
 import { ChartElementSizes, computeChartElementSizesSelector } from '../../state/selectors/compute_chart_dimensions';
 import { getHeatmapGeometries } from '../../state/selectors/geometries';
 import { getHeatmapContainerSizeSelector } from '../../state/selectors/get_heatmap_container_size';
+import { getHighlightedLegendBandsSelector } from '../../state/selectors/get_highlighted_legend_bands';
 import { renderCanvas2d } from './canvas_renderers';
 
 interface ReactiveChartStateProps {
   initialized: boolean;
   geometries: ShapeViewModel;
   chartContainerDimensions: Dimensions;
+  highlightedLegendBands: Array<[start: number, end: number]>;
+  theme: Theme;
   a11ySettings: A11ySettings;
   background: Color;
   elementSizes: ChartElementSizes;
@@ -99,9 +104,11 @@ class Component extends React.Component<Props> {
           ...this.props.geometries,
           theme: this.props.geometries.theme,
         },
+        this.props.theme.sharedStyle,
         this.props.background,
         this.props.elementSizes,
         this.props.debug,
+        this.props.highlightedLegendBands,
       );
     }
   }
@@ -155,6 +162,8 @@ const DEFAULT_PROPS: ReactiveChartStateProps = {
     left: 0,
     top: 0,
   },
+  theme: LIGHT_THEME,
+  highlightedLegendBands: [],
   a11ySettings: DEFAULT_A11Y_SETTINGS,
   background: Colors.Transparent.keyword,
   elementSizes: {
@@ -169,6 +178,7 @@ const DEFAULT_PROPS: ReactiveChartStateProps = {
   },
   debug: false,
 };
+
 const mapStateToProps = (state: GlobalChartState): ReactiveChartStateProps => {
   if (getInternalIsInitializedSelector(state) !== InitStatus.Initialized) {
     return DEFAULT_PROPS;
@@ -177,6 +187,8 @@ const mapStateToProps = (state: GlobalChartState): ReactiveChartStateProps => {
     initialized: true,
     geometries: getHeatmapGeometries(state),
     chartContainerDimensions: getHeatmapContainerSizeSelector(state),
+    highlightedLegendBands: getHighlightedLegendBandsSelector(state),
+    theme: getChartThemeSelector(state),
     a11ySettings: getA11ySettingsSelector(state),
     background: getChartThemeSelector(state).background.color,
     elementSizes: computeChartElementSizesSelector(state),

--- a/packages/charts/src/chart_types/heatmap/renderer/canvas/utils.ts
+++ b/packages/charts/src/chart_types/heatmap/renderer/canvas/utils.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { overrideOpacity } from '../../../../common/color_library_wrappers';
+import { Fill, Stroke } from '../../../../geoms/types';
+import { GeometryStateStyle, SharedGeometryStateStyle } from '../../../../utils/themes/theme';
+import { Cell } from '../../layout/types/viewmodel_types';
+import { isValueInRanges } from '../../layout/viewmodel/viewmodel';
+
+/** @internal */
+export function getGeometryStateStyle(
+  cell: Cell,
+  sharedGeometryStyle: SharedGeometryStateStyle,
+  highlightedLegendBands: Array<[start: number, end: number]>,
+): GeometryStateStyle {
+  const { default: defaultStyles, highlighted, unhighlighted } = sharedGeometryStyle;
+
+  if (highlightedLegendBands.length > 0) {
+    const isHighlightedBand = isValueInRanges(cell.value, highlightedLegendBands);
+    return isHighlightedBand ? highlighted : unhighlighted;
+  }
+
+  return defaultStyles;
+}
+
+/** @internal */
+export function getColorBandStyle(cell: Cell, geometryStateStyle: GeometryStateStyle): { fill: Fill; stroke: Stroke } {
+  const fillColor = overrideOpacity(cell.fill.color, (opacity) => opacity * geometryStateStyle.opacity);
+  const fill: Fill = {
+    ...cell.fill,
+    color: fillColor,
+  };
+
+  const strokeColor = overrideOpacity(cell.stroke.color, (opacity) => opacity * geometryStateStyle.opacity);
+  const stroke: Stroke = {
+    ...cell.stroke,
+    color: strokeColor,
+  };
+  return { fill, stroke };
+}

--- a/packages/charts/src/chart_types/heatmap/state/selectors/geometries.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/geometries.ts
@@ -32,16 +32,9 @@ export const getHeatmapGeometries = createCustomCachedSelector(
   ],
   (heatmapSpec, dims, heatmapTable, { bands, scale: colorScale }, deselectedSeries, theme, empty): ShapeViewModel => {
     // instead of using the specId, each legend item is associated with an unique band label
-    const disabledBandLabels = new Set(
-      deselectedSeries.map(({ specId }) => {
-        return specId;
-      }),
-    );
-
+    const disabledBandLabels = new Set(deselectedSeries.map(({ specId }) => specId));
     const bandsToHide: Array<[number, number]> = bands
-      .filter(({ label }) => {
-        return disabledBandLabels.has(label);
-      })
+      .filter(({ label }) => disabledBandLabels.has(label))
       .map(({ start, end }) => [start, end]);
 
     return heatmapSpec && !empty

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_highlighted_legend_bands.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_highlighted_legend_bands.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { createCustomCachedSelector } from '../../../../state/create_selector';
+import { getColorScale } from './get_color_scale';
+import { getHighlightedLegendItemSelector } from './get_highlighted_legend_item';
+
+/** @internal */
+export const getHighlightedLegendBandsSelector = createCustomCachedSelector(
+  [getHighlightedLegendItemSelector, getColorScale],
+  (highlightedLegendItem, { bands }): Array<[start: number, end: number]> => {
+    if (!highlightedLegendItem) return [];
+    // instead of using the specId, each legend item is associated with an unique band label
+    return bands.filter(({ label }) => highlightedLegendItem.label === label).map(({ start, end }) => [start, end]);
+  },
+);

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_highlighted_legend_item.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_highlighted_legend_item.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { LegendItem } from '../../../../common/legend';
+import { GlobalChartState } from '../../../../state/chart_state';
+import { createCustomCachedSelector } from '../../../../state/create_selector';
+import { computeLegendSelector } from './compute_legend';
+
+const getHighlightedLegendPath = (state: GlobalChartState) => state.interactions.highlightedLegendPath;
+
+/** @internal */
+export const getHighlightedLegendItemSelector = createCustomCachedSelector(
+  [getHighlightedLegendPath, computeLegendSelector],
+  (highlightedLegendPaths, legendItems): LegendItem | undefined => {
+    if (highlightedLegendPaths.length > 0) {
+      const lookup = new Set(highlightedLegendPaths.map(({ value }) => value));
+      return legendItems.find(({ seriesIdentifiers }) => seriesIdentifiers.some(({ key }) => lookup.has(key)));
+    }
+  },
+);

--- a/packages/charts/src/chart_types/xy_chart/rendering/utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/rendering/utils.ts
@@ -98,7 +98,6 @@ export function getGeometryStateStyle(
   seriesIdentifier: XYChartSeriesIdentifier,
   sharedGeometryStyle: SharedGeometryStateStyle,
   highlightedLegendItem?: LegendItem,
-  individualHighlight?: { [key: string]: boolean },
 ): GeometryStateStyle {
   const { default: defaultStyles, highlighted, unhighlighted } = sharedGeometryStyle;
 
@@ -108,14 +107,6 @@ export function getGeometryStateStyle(
     );
 
     return isPartOfHighlightedSeries ? highlighted : unhighlighted;
-  }
-
-  if (individualHighlight) {
-    const { hasHighlight, hasGeometryHover } = individualHighlight;
-    if (!hasGeometryHover) {
-      return highlighted;
-    }
-    return hasHighlight ? highlighted : unhighlighted;
   }
 
   return defaultStyles;


### PR DESCRIPTION
## Summary

Adds highlighting to cells based on actively hovered color band in legend. This feature is to match the current functionality for cartesian chart types.

![Screen Recording 2022-11-08 at 03 03 33 PM](https://user-images.githubusercontent.com/19007109/200685533-1eb9159a-cc7a-445a-8ca5-ada069867ec8.gif)


## Issues

Closes #1486

### Checklist

- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [ ] New public API exports have been added to `packages/charts/src/index.ts`
- [ ] Unit tests have been added or updated to match the most common scenarios
- [ ] Visual changes have been tested with all available themes including `dark`, `light`, `eui-dark` & `eui-light`
