### PR TITLE
feat(style): expose point highlighter style

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/renderer/dom/highlighter.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/dom/highlighter.tsx
@@ -12,11 +12,13 @@ import { connect } from 'react-redux';
 import { RGBATupleToString } from '../../../../common/color_library_wrappers';
 import { GlobalChartState } from '../../../../state/chart_state';
 import { getChartRotationSelector } from '../../../../state/selectors/get_chart_rotation';
+import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
 import { InitStatus, getInternalIsInitializedSelector } from '../../../../state/selectors/get_internal_is_intialized';
-import { Rotation } from '../../../../utils/common';
+import { getColorFromVariant, Rotation } from '../../../../utils/common';
 import { Dimensions } from '../../../../utils/dimensions';
 import { isPointGeometry, IndexedGeometry, PointGeometry } from '../../../../utils/geometry';
-import { DEFAULT_HIGHLIGHT_PADDING } from '../../rendering/constants';
+import { LIGHT_THEME } from '../../../../utils/themes/light_theme';
+import { HighlighterStyle } from '../../../../utils/themes/theme';
 import { computeChartDimensionsSelector } from '../../state/selectors/compute_chart_dimensions';
 import { computeChartTransformSelector } from '../../state/selectors/compute_chart_transform';
 import { getHighlightedGeomsSelector } from '../../state/selectors/get_tooltip_values_highlighted_geoms';
@@ -33,6 +35,7 @@ interface HighlighterProps {
   chartTransform: Transform;
   chartDimensions: Dimensions;
   chartRotation: Rotation;
+  style: HighlighterStyle;
 }
 
 function getTransformForPanel(panel: Dimensions, rotation: Rotation, { left, top }: Pick<Dimensions, 'top' | 'left'>) {
@@ -40,10 +43,8 @@ function getTransformForPanel(panel: Dimensions, rotation: Rotation, { left, top
   return `translate(${left + panel.left + x}, ${top + panel.top + y}) rotate(${rotation})`;
 }
 
-/** @internal */
-function renderPath(geom: PointGeometry) {
+function renderPath(geom: PointGeometry, radius: number) {
   // keep the highlighter radius to a minimum
-  const radius = Math.max(geom.radius, DEFAULT_HIGHLIGHT_PADDING);
   const [shapeFn, rotate] = ShapeRendererFn[geom.style.shape];
   return {
     d: shapeFn(radius),
@@ -55,7 +56,7 @@ class HighlighterComponent extends React.Component<HighlighterProps> {
   static displayName = 'Highlighter';
 
   render() {
-    const { highlightedGeometries, chartDimensions, chartRotation, chartId, zIndex, isBrushing } = this.props;
+    const { highlightedGeometries, chartDimensions, chartRotation, chartId, zIndex, isBrushing, style } = this.props;
     if (isBrushing) return null;
     const clipWidth = [90, -90].includes(chartRotation) ? chartDimensions.height : chartDimensions.width;
     const clipHeight = [90, -90].includes(chartRotation) ? chartDimensions.width : chartDimensions.height;
@@ -75,8 +76,12 @@ class HighlighterComponent extends React.Component<HighlighterProps> {
           const geomTransform = getTransformForPanel(panel, chartRotation, chartDimensions);
 
           if (isPointGeometry(geom)) {
-            const { color } = geom.style.stroke;
-            const { d, rotate } = renderPath(geom);
+            // using the stroke because the fill is always white on points
+            const fillColor = getColorFromVariant(RGBATupleToString(geom.style.stroke.color), style.point.fill);
+            const strokeColor = getColorFromVariant(RGBATupleToString(geom.style.stroke.color), style.point.stroke);
+
+            const radius = Math.max(geom.radius, style.point.radius);
+            const { d, rotate } = renderPath(geom, radius);
             return (
               <g
                 key={i}
@@ -85,10 +90,11 @@ class HighlighterComponent extends React.Component<HighlighterProps> {
               >
                 <path
                   d={d}
-                  stroke={RGBATupleToString(color)}
-                  strokeWidth={4}
                   transform={`translate(${x}, ${y}) rotate(${rotate || 0})`}
-                  fill="transparent"
+                  fill={fillColor}
+                  stroke={strokeColor}
+                  strokeWidth={style.point.strokeWidth}
+                  opacity={style.point.opacity}
                 />
               </g>
             );
@@ -127,6 +133,7 @@ const mapStateToProps = (state: GlobalChartState): HighlighterProps => {
       },
       chartDimensions: { top: 0, left: 0, width: 0, height: 0 },
       chartRotation: 0,
+      style: LIGHT_THEME.highlighter,
     };
   }
 
@@ -139,6 +146,7 @@ const mapStateToProps = (state: GlobalChartState): HighlighterProps => {
     chartTransform: computeChartTransformSelector(state),
     chartDimensions: computeChartDimensionsSelector(state).chartDimensions,
     chartRotation: getChartRotationSelector(state),
+    style: getChartThemeSelector(state).highlighter,
   };
 };
 

--- a/packages/charts/src/chart_types/xy_chart/rendering/utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/rendering/utils.ts
@@ -135,10 +135,6 @@ export function isPointOnGeometry(
 
     const radiusBuffer = typeof buffer === 'number' ? buffer : buffer(radius);
 
-    if (radiusBuffer === Infinity) {
-      return distance <= radius + DEFAULT_HIGHLIGHT_PADDING;
-    }
-
     return distance <= radius + radiusBuffer;
   }
   const { width, height } = indexedGeometry;

--- a/packages/charts/src/utils/themes/dark_theme.ts
+++ b/packages/charts/src/utils/themes/dark_theme.ts
@@ -422,4 +422,13 @@ export const DARK_THEME: Theme = {
     scrollbarThumb: 'rgb(223, 229, 239)',
     scrollbarTrack: 'rgb(52, 55, 65)',
   },
+  highlighter: {
+    point: {
+      opacity: 1,
+      fill: ColorVariant.None,
+      stroke: ColorVariant.Series,
+      strokeWidth: 4,
+      radius: 10,
+    },
+  },
 };

--- a/packages/charts/src/utils/themes/light_theme.ts
+++ b/packages/charts/src/utils/themes/light_theme.ts
@@ -421,4 +421,13 @@ export const LIGHT_THEME: Theme = {
     scrollbarThumb: 'rgb(52, 55, 65)',
     scrollbarTrack: 'rgb(211, 218, 230)',
   },
+  highlighter: {
+    point: {
+      opacity: 1,
+      fill: ColorVariant.None,
+      stroke: ColorVariant.Series,
+      strokeWidth: 4,
+      radius: 10,
+    },
+  },
 };

--- a/packages/charts/src/utils/themes/theme.ts
+++ b/packages/charts/src/utils/themes/theme.ts
@@ -504,6 +504,8 @@ export interface Theme {
 
   /** @alpha */
   flamegraph: FlamegraphStyle;
+
+  highlighter: HighlighterStyle;
 }
 
 /** @public */
@@ -773,3 +775,14 @@ export interface LineAnnotationStyle {
 
 /** @public */
 export type RectAnnotationStyle = StrokeStyle & FillStyle & Opacity & Partial<StrokeDashArray>;
+
+/** @internal */
+export interface HighlighterStyle {
+  point: {
+    fill: Color | ColorVariant;
+    stroke: Color | ColorVariant;
+    strokeWidth: Pixels;
+    opacity: Ratio;
+    radius: Pixels;
+  };
+}

--- a/storybook/stories/stylings/26_highlighter_style.story.tsx
+++ b/storybook/stories/stylings/26_highlighter_style.story.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+
+import {
+  LineSeries,
+  Axis,
+  Chart,
+  ColorVariant,
+  Position,
+  ScaleType,
+  Settings,
+  timeFormatter,
+  Tooltip,
+} from '@elastic/charts';
+import { KIBANA_METRICS } from '@elastic/charts/src/utils/data_samples/test_dataset_kibana';
+
+import { useBaseTheme } from '../../use_base_theme';
+
+const dateFormatter = timeFormatter('HH:mm');
+
+export const Example = () => (
+  <Chart>
+    <Settings
+      showLegend
+      showLegendExtra
+      legendSize={100}
+      pointBuffer={Infinity}
+      legendPosition={Position.Right}
+      baseTheme={useBaseTheme()}
+      theme={{
+        highlighter: {
+          point: {
+            radius: 4,
+            opacity: 1,
+            fill: ColorVariant.Series,
+            stroke: ColorVariant.None,
+            strokeWidth: 0,
+          },
+        },
+      }}
+    />
+    <Axis
+      id="bottom"
+      position={Position.Bottom}
+      showOverlappingTicks
+      tickFormat={dateFormatter}
+      timeAxisLayerCount={2}
+      showGridLines
+      style={{
+        tickLine: { size: 0.0001, padding: 4 },
+        tickLabel: {
+          alignment: { horizontal: Position.Left, vertical: Position.Bottom },
+          padding: 0,
+          offset: { x: 0, y: 0 },
+        },
+      }}
+    />
+    <Tooltip customTooltip={() => null} />
+    <Axis
+      id="left"
+      position={Position.Left}
+      showGridLines
+      tickFormat={(d) => Number(d).toFixed(2)}
+      labelFormat={(d) => Number(d).toFixed(0)}
+      ticks={5}
+    />
+    <LineSeries
+      id="1"
+      name={KIBANA_METRICS.metrics.kibana_os_load[2].metric.label}
+      xScaleType={ScaleType.Time}
+      yScaleType={ScaleType.Linear}
+      xAccessor={0}
+      yAccessors={[1]}
+      stackAccessors={[0]}
+      yNice
+      data={KIBANA_METRICS.metrics.kibana_os_load[2].data}
+      lineSeriesStyle={{
+        point: {
+          visible: false,
+        },
+      }}
+    />
+    <LineSeries
+      id="2"
+      name={KIBANA_METRICS.metrics.kibana_os_load[1].metric.label}
+      xScaleType={ScaleType.Time}
+      yScaleType={ScaleType.Linear}
+      xAccessor={0}
+      yAccessors={[1]}
+      stackAccessors={[0]}
+      yNice
+      data={KIBANA_METRICS.metrics.kibana_os_load[1].data}
+      lineSeriesStyle={{
+        point: {
+          visible: false,
+        },
+      }}
+    />
+    <LineSeries
+      id="3"
+      name={KIBANA_METRICS.metrics.kibana_os_load[0].metric.label}
+      xScaleType={ScaleType.Time}
+      yScaleType={ScaleType.Linear}
+      xAccessor={0}
+      yAccessors={[1]}
+      stackAccessors={[0]}
+      yNice
+      data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
+      lineSeriesStyle={{
+        point: {
+          visible: false,
+        },
+      }}
+    />
+  </Chart>
+);

--- a/storybook/stories/stylings/stylings.stories.tsx
+++ b/storybook/stories/stylings/stylings.stories.tsx
@@ -36,3 +36,4 @@ export { Example as darkTheme } from './22_dark_theme.story';
 export { Example as withTexture } from './23_with_texture.story';
 export { Example as textureMultipleSeries } from './24_texture_multiple_series.story';
 export { Example as mixedPointShapes } from './25_mixed_point_shapes.story';
+export { Example as highlighterStyle } from './26_highlighter_style.story';


### PR DESCRIPTION
## Summary
This PR adds the ability to style the point highlighter through the theme.
It also gives the freedom to increase to `Infinity` the `pointBuffer` to allow you to always highlight the line points on hover:

You can also replace the tooltip with the legend itself by hiding completely the tooltip.
https://user-images.githubusercontent.com/1421091/202002573-d98f0271-3b9e-48a8-b951-f8fb7e8084d2.mov

See the newly added story for an example

## Issues

fix #1865


### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [ ] The `:theme` label has been added and the `@elastic/eui-design` team has been pinged when there are `Theme` API changes
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [ ] New public API exports have been added to `packages/charts/src/index.ts`
- [ ] Unit tests have been added or updated to match the most common scenarios
- [ ] The proper documentation and/or storybook story has been added or updated
- [ ] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
- [ ] Visual changes have been tested with all available themes including `dark`, `light`, `eui-dark` & `eui-light`
