### PR TITLE
fix(xy): cursor while dragging with no brushing

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_cursor_pointer.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_cursor_pointer.ts
@@ -52,7 +52,7 @@ export const getPointerCursorSelector = createCustomCachedSelector(
     const xPos = x - chartDimensions.left;
     const yPos = y - chartDimensions.top;
 
-    if (isDragging) return 'crosshair';
+    if (isBrushAvailable && isDragging) return 'crosshair';
 
     // limit cursorPosition to chartDimensions
     if (xPos < 0 || xPos >= chartDimensions.width || yPos < 0 || yPos >= chartDimensions.height) {


### PR DESCRIPTION
## Summary

Fixes cursor while dragging cursor when brushing is not available.

### Before

![Screen Recording 2022-11-15 at 01 52 06 PM](https://user-images.githubusercontent.com/19007109/202023033-ab780761-59e0-4573-b93c-6e4ecd494398.gif)

### After

![Screen Recording 2022-11-15 at 01 51 16 PM](https://user-images.githubusercontent.com/19007109/202022856-3ff44107-4f84-45e7-8ef0-bba45f04e385.gif)


## Issues

fix #1857 
fix #1882

### Checklist

- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)