### PR TITLE
fix(flamegraph): search on change

### DIFF
--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -775,9 +775,8 @@ class FlameComponent extends React.Component<FlameProps> {
   };
 
   private handleSearchFieldKeyPress = (e: React.KeyboardEvent<HTMLCanvasElement | HTMLInputElement>) => {
-    e.stopPropagation();
-    if (!this.handleEnterKey(e)) {
-      this.searchForText(false);
+    if (this.handleEnterKey(e)) {
+      e.stopPropagation();
     }
   };
 
@@ -984,6 +983,7 @@ class FlameComponent extends React.Component<FlameProps> {
             placeholder="Search string"
             onKeyPress={this.handleSearchFieldKeyPress}
             onKeyUp={this.handleEscapeKey}
+            onChange={() => this.searchForText(false)}
             style={{
               border: 'none',
               padding: 3,


### PR DESCRIPTION
## Summary

This commit fixes the current wrong behaviour on the flamegraph search input:
- the search is done only on the text minus the last character
- the search doesn't update when deleting the characters


## Details

The current code was configured to pick up key press on the input. This event happens before the actual key is appended to the input value and looking for the `input.value` just brings in the latest available text before the last key press.
The PR changes the behavior and attaches the search event to the `onChange` listener of the input.
This also fixes the event of handling the backspace and removing text.

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
