### PR TITLE
fix(tooltip): check if scroll event target is null

### DIFF
--- a/packages/charts/src/components/tooltip/tooltip.tsx
+++ b/packages/charts/src/components/tooltip/tooltip.tsx
@@ -119,8 +119,11 @@ export const TooltipComponent = <D extends BaseDatum = Datum, SI extends SeriesI
   const chartRef = getChartContainerRef();
 
   const handleScroll = (e: Event) => {
-    const target = e.target as Element;
-    if (target.classList.contains('echTooltip__tableBody')) {
+    if (
+      e.target &&
+      e.target.hasOwnProperty('classList') &&
+      (e.target as Element).classList.contains('echTooltip__tableBody')
+    ) {
       // catch scroll when scrolling on tableBody
       e.stopImmediatePropagation();
       return;


### PR DESCRIPTION
## Summary
I've noticed the following error when trying to scroll a page with a chart:
```
TypeError: Cannot read properties of undefined (reading 'contains')
```
that was pointing to the `target.classList.contains('echTooltip__tableBody')` check in the `handleScroll` function of `tooltip.tsx`.

Checking the code seems that we ignore the possibility of the target being null, so I've added that check and ensured that the element has the `classList` property.


I don't have a reliable way to test this :(


### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
