### PR TITLE
chore: update to uuid v9 for better exports support

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -30,14 +30,4 @@ module.exports = {
       },
     ],
   },
-  moduleNameMapper: {
-    // This forces Jest/jest-environment-jsdom to use a Node+CommonJS version of uuid, not a Browser+ESM one
-    // See https://github.com/uuidjs/uuid/pull/616
-    // See https://github.com/microsoft/accessibility-insights-web/pull/5421#issuecomment-1109168149
-    //
-    // WARNING: if your dependency tree has multiple paths leading to uuid, this will force all of them to resolve to
-    // whichever one happens to be hoisted to your root node_modules folder. This makes it much more dangerous
-    // to consume future uuid upgrades. Consider using a custom resolver instead of moduleNameMapper.
-    '^uuid$': require.resolve('uuid'),
-  },
 };

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@types/react-redux": "^7.1.1",
     "@types/seedrandom": "^2.4.28",
     "@types/url-parse": "^1.4.3",
-    "@types/uuid": "^8.3.2",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",
     "autoprefixer": "^9.0.0",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -50,7 +50,7 @@
     "resize-observer-polyfill": "^1.5.1",
     "ts-debounce": "^4.0.0",
     "utility-types": "^3.10.0",
-    "uuid": "^8.3.2",
+    "uuid": "^9",
     "luxon": "^1.25.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6538,7 +6538,7 @@
   resolved "https://registry.yarnpkg.com/@types/url-parse/-/url-parse-1.4.3.tgz#fba49d90f834951cb000a674efee3d6f20968329"
   integrity sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==
 
-"@types/uuid@^8.3.2":
+"@types/uuid@^8.3.4":
   version "8.3.4"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
   integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
@@ -10826,7 +10826,8 @@ eslint-module-utils@^2.7.3:
     find-up "^2.1.0"
 
 "eslint-plugin-elastic-charts@link:./packages/eslint-plugin-elastic-charts":
-  version "1.0.0"
+  version "0.0.0"
+  uid ""
 
 eslint-plugin-eslint-comments@^3.2.0:
   version "3.2.0"
@@ -21692,6 +21693,11 @@ uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache@2.3.0, v8-compile-cache@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
Bumps the uuid version so that uuid does not trigger loading an ESM version via jest. This wasn't previously a problem for Kibana because we had previously implemented a custom resolver for Jest. I'm trying to remove it but the uuid dep in `@elastic/charts` is breaking that branch.