### PR TITLE
build: release on main branch

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -10,6 +10,14 @@ const isDryRun = process.argv.includes('--dry-run');
  */
 
 module.exports = {
+  branches: [
+    '+([0-9])?(.{+([0-9]),x}).x',
+    'main',
+    'next',
+    'next-major',
+    { name: 'beta', prerelease: true },
+    { name: 'alpha', prerelease: true },
+  ],
   plugins: [
     [
       '@semantic-release/commit-analyzer',


### PR DESCRIPTION
## Summary

Semantic-release doesn't have `main` in their default `branches` rule. Adding to allow releasing on this branch.
Solves the following error on release:
>This test run was triggered on the branch main, while semantic-release is configured to only publish from 38.0.x, 39.x, 40.0.x, 40.1.x, 40.x, 46.0.x, 49.x, 50.2.x, next, alpha, therefore a new version won’t be published.

See https://semantic-release.gitbook.io/semantic-release/usage/configuration and https://github.com/semantic-release/semantic-release/issues/1581