### PR TITLE
fix(partition): tooltip item series identifier

### DIFF
--- a/packages/charts/src/chart_types/partition_chart/layout/viewmodel/picked_shapes.ts
+++ b/packages/charts/src/chart_types/partition_chart/layout/viewmodel/picked_shapes.ts
@@ -139,7 +139,7 @@ function getTooltipValueFromNode(
     isVisible: true,
     seriesIdentifier: {
       specId: id,
-      key: id,
+      key: model?.dataName ?? '',
     },
     value: node[AGGREGATE_KEY],
     formattedValue: `${valueFormatter(value)}\u00A0(${percentFormatter(percentValueGetter(node))})`,


### PR DESCRIPTION
## Summary

Fixes bug with incorrect `key` for `SeriesIdentifier` on the tooltip items.

<!-- screenshot/gif/mpeg-4 for visual changes -->

![Screen Recording 2023-02-08 at 10 31 17 AM](https://user-images.githubusercontent.com/19007109/217607796-e386a837-0cdf-4ac5-822d-d2e5f2368674.gif)

## Details

In the alpha version of `Partition` charts we just set both the `key` and  `specId` of the `seriesIdentifier` to the `specId`. I believe later we added the proper `key` when working on partition changes to the legend and added the correct `key`, see snippet below for legend `key` value.

https://github.com/elastic/elastic-charts/blob/52c8a9eec3d1ee8cf8254c82ea6395790cb83f67/packages/charts/src/chart_types/partition_chart/layout/utils/legend.ts#L88-L99

Where the `key` is assigned the `dataName` value from the `QuadViewModel` item.

## Issues

Unblocks https://github.com/elastic/kibana/issues/150304

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)