### PR TITLE
API type experiment

### DIFF
--- a/packages/charts/src/chart_types/goal_chart/specs/index.ts
+++ b/packages/charts/src/chart_types/goal_chart/specs/index.ts
@@ -17,6 +17,7 @@ import { SpecType } from '../../../specs/constants';
 import { buildSFProps, SFProps, useSpecFactory } from '../../../state/spec_factory';
 import { LabelAccessor, round, stripUndefined, ValueFormatter } from '../../../utils/common';
 import { Logger } from '../../../utils/logger';
+import { Prettify } from '../../../utils/types';
 import { defaultGoalSpec } from '../layout/types/viewmodel_types';
 
 /** @alpha */
@@ -130,4 +131,4 @@ To prevent overlapping, the value of \`angleEnd\` will be replaced.
 };
 
 /** @public */
-export type GoalProps = ComponentProps<typeof Goal>;
+export type GoalProps = Prettify<ComponentProps<typeof Goal>>;

--- a/packages/charts/src/chart_types/heatmap/specs/heatmap.ts
+++ b/packages/charts/src/chart_types/heatmap/specs/heatmap.ts
@@ -98,7 +98,7 @@ interface HeatmapSpecInternal<D extends BaseDatum = Datum> extends Spec {
   yAxisLabelFormatter: LabelAccessor<string | number>;
 }
 /** @public */
-export type HeatmapSpec = Prettify<HeatmapSpecInternal>;
+export type HeatmapSpec<D extends BaseDatum = Datum> = Prettify<HeatmapSpecInternal<D>>;
 
 /** @internal */
 export const buildProps = buildSFProps<HeatmapSpecInternal>()(

--- a/packages/charts/src/chart_types/heatmap/specs/heatmap.ts
+++ b/packages/charts/src/chart_types/heatmap/specs/heatmap.ts
@@ -19,6 +19,7 @@ import { buildSFProps, SFProps, useSpecFactory } from '../../../state/spec_facto
 import { Accessor, AccessorFn } from '../../../utils/accessor';
 import { ESCalendarInterval, ESFixedInterval } from '../../../utils/chrono/elasticsearch';
 import { Datum, LabelAccessor, stripUndefined, ValueFormatter } from '../../../utils/common';
+import { Prettify } from '../../../utils/types';
 import { Cell } from '../layout/types/viewmodel_types';
 
 /** @public */
@@ -55,10 +56,12 @@ export interface TimeScale {
   type: typeof ScaleType.Time;
 }
 
-/** @public */
-export interface RasterTimeScale extends TimeScale {
+interface RasterTimeScaleInt extends TimeScale {
   interval: ESCalendarInterval | ESFixedInterval;
 }
+
+/** @public */
+export type RasterTimeScale = Prettify<RasterTimeScaleInt>;
 
 /** @public */
 export interface LinearScale {
@@ -70,8 +73,8 @@ export interface OrdinalScale {
   type: typeof ScaleType.Ordinal;
 }
 
-/** @alpha */
-export interface HeatmapSpec<D extends BaseDatum = Datum> extends Spec {
+/** @internal */
+interface HeatmapSpecInternal<D extends BaseDatum = Datum> extends Spec {
   specType: typeof SpecType.Series;
   chartType: typeof ChartType.Heatmap;
   data: D[];
@@ -94,8 +97,11 @@ export interface HeatmapSpec<D extends BaseDatum = Datum> extends Spec {
   yAxisLabelName: string;
   yAxisLabelFormatter: LabelAccessor<string | number>;
 }
+/** @public */
+export type HeatmapSpec = Prettify<HeatmapSpecInternal>;
 
-const buildProps = buildSFProps<HeatmapSpec>()(
+/** @internal */
+export const buildProps = buildSFProps<HeatmapSpecInternal>()(
   {
     chartType: ChartType.Heatmap,
     specType: SpecType.Series,
@@ -126,7 +132,7 @@ const buildProps = buildSFProps<HeatmapSpec>()(
  */
 export const Heatmap = function <D extends BaseDatum = Datum>(
   props: SFProps<
-    HeatmapSpec<D>,
+    HeatmapSpecInternal<D>,
     keyof (typeof buildProps)['overrides'],
     keyof (typeof buildProps)['defaults'],
     keyof (typeof buildProps)['optionals'],
@@ -134,9 +140,9 @@ export const Heatmap = function <D extends BaseDatum = Datum>(
   >,
 ) {
   const { defaults, overrides } = buildProps;
-  useSpecFactory<HeatmapSpec<D>>({ ...defaults, ...stripUndefined(props), ...overrides });
+  useSpecFactory<HeatmapSpecInternal<D>>({ ...defaults, ...stripUndefined(props), ...overrides });
   return null;
 };
 
 /** @public */
-export type HeatmapProps = ComponentProps<typeof Heatmap>;
+export type HeatmapProps = Prettify<ComponentProps<typeof Heatmap>>;

--- a/packages/charts/src/chart_types/partition_chart/layout/types/viewmodel_types.ts
+++ b/packages/charts/src/chart_types/partition_chart/layout/types/viewmodel_types.ts
@@ -26,6 +26,7 @@ import { LegendPath } from '../../../../state/actions/legend';
 import { Size } from '../../../../utils/dimensions';
 import { LIGHT_THEME } from '../../../../utils/themes/light_theme';
 import { Theme } from '../../../../utils/themes/theme';
+import { Prettify } from '../../../../utils/types';
 import { ContinuousDomainFocus } from '../../renderer/canvas/partition';
 import { Layer } from '../../specs';
 import { MODEL_KEY, ValueGetterName } from '../config';
@@ -235,16 +236,18 @@ export interface LayerFromTo {
   y1: TreeLevel;
 }
 
-/**
- * @public
- */
-export interface TreeNode extends AngleFromTo {
+interface TreeNodeInternal extends AngleFromTo {
   x0: Radian;
   x1: Radian;
   y0: TreeLevel;
   y1: TreeLevel;
   fill?: Color;
 }
+
+/**
+ * @public
+ */
+export type TreeNode = Prettify<TreeNodeInternal>;
 
 /**
  * @public
@@ -257,8 +260,7 @@ export interface SectorGeomSpecY {
 /** @public */
 export type DataName = CategoryKey; // todo consider narrowing it to eg. primitives
 
-/** @public */
-export interface ShapeTreeNode extends TreeNode, SectorGeomSpecY {
+interface ShapeTreeNodeInternal extends TreeNode, SectorGeomSpecY {
   yMidPx: Distance;
   depth: number;
   sortIndex: number;
@@ -267,6 +269,9 @@ export interface ShapeTreeNode extends TreeNode, SectorGeomSpecY {
   value: number;
   [MODEL_KEY]: ArrayNode;
 }
+
+/** @public */
+export type ShapeTreeNode = Prettify<ShapeTreeNodeInternal>;
 
 /** @public */
 export type RawTextGetter = (node: ShapeTreeNode) => string;

--- a/packages/charts/src/utils/types.ts
+++ b/packages/charts/src/utils/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * @internal
+ */
+export type Prettify<T> = T extends Function ? T : T extends object ? { [K in keyof T]: Prettify<T[K]> } & {} : T;


### PR DESCRIPTION
## Summary

This PR makes types exposed at the API level unpacked and a bit easier to use within the development process.

Here's the previous type contract in a typical API type:
<img width="539" alt="Screenshot 2023-02-09 at 14 08 43" src="https://user-images.githubusercontent.com/924948/217821483-4bdd8d47-3bc6-43ce-b84e-b095df75e5f5.png">

Here's the new one:
<img width="519" alt="Screenshot 2023-02-09 at 13 58 22" src="https://user-images.githubusercontent.com/924948/217821529-b7ec1115-b86f-47ba-a188-e21a082b1184.png">

## Details

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [ ] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [ ] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [ ] The `:theme` label has been added and the `@elastic/eui-design` team has been pinged when there are `Theme` API changes
- [ ] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [ ] New public API exports have been added to `packages/charts/src/index.ts`
- [ ] Unit tests have been added or updated to match the most common scenarios
- [ ] The proper documentation and/or storybook story has been added or updated
- [ ] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
- [ ] Visual changes have been tested with all available themes including `dark`, `light`, `eui-dark` & `eui-light`
