### PR TITLE
fix(flamegraph): show tooltip prompt only if pinnable

### DIFF
--- a/e2e/tests/tooltip.test.ts
+++ b/e2e/tests/tooltip.test.ts
@@ -100,6 +100,18 @@ test.describe('Tooltip', () => {
           'right',
         );
       });
+      test('show prompt with actions ', async ({ page }) => {
+        await common.expectChartWithMouseAtUrlToMatchScreenshot(page)(
+          'http://localhost:9001/?path=/story/components-tooltip--flamegraph&globals=theme:light&knob-Use tooltip actions=true&knob-Debug history=',
+          { left: 220, bottom: 220 },
+        );
+      });
+      test('hide prompt with no actions ', async ({ page }) => {
+        await common.expectChartWithMouseAtUrlToMatchScreenshot(page)(
+          'http://localhost:9001/?path=/story/components-tooltip--flamegraph&globals=theme:light&knob-Use tooltip actions=&knob-Debug history=',
+          { left: 220, bottom: 220 },
+        );
+      });
     });
   });
 });

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -27,6 +27,7 @@ import { SettingsSpec, SpecType, TooltipType, TooltipValue } from '../../specs';
 import { onChartRendered } from '../../state/actions/chart';
 import { ON_POINTER_MOVE } from '../../state/actions/mouse';
 import { BackwardRef, GlobalChartState } from '../../state/chart_state';
+import { isPinnableTooltip } from '../../state/selectors/can_pin_tooltip';
 import { getA11ySettingsSelector } from '../../state/selectors/get_accessibility_config';
 import { getChartThemeSelector } from '../../state/selectors/get_chart_theme';
 import { getSettingsSpecSelector } from '../../state/selectors/get_settings_spec';
@@ -145,7 +146,7 @@ interface StateProps {
   chartDimensions: Size;
   a11ySettings: ReturnType<typeof getA11ySettingsSelector>;
   tooltipRequired: boolean;
-  pinnableTooltip: boolean;
+  canPinTooltip: boolean;
   onElementOver: NonNullable<SettingsSpec['onElementOver']>;
   onElementClick: NonNullable<SettingsSpec['onElementClick']>;
   onElementOut: NonNullable<SettingsSpec['onElementOut']>;
@@ -850,6 +851,7 @@ class FlameComponent extends React.Component<FlameProps> {
       a11ySettings,
       debugHistory,
       theme,
+      canPinTooltip,
     } = this.props;
     const width = roundUpSize(requestedWidth);
     const height = roundUpSize(requestedHeight);
@@ -898,7 +900,7 @@ class FlameComponent extends React.Component<FlameProps> {
             height={canvasHeight}
             onMouseMove={this.handleMouseHoverMove}
             onMouseDown={this.handleMouseDown}
-            onContextMenu={this.props.pinnableTooltip ? this.handleContextMenu : undefined}
+            onContextMenu={canPinTooltip ? this.handleContextMenu : undefined}
             onMouseLeave={this.handleMouseLeave}
             onKeyPress={this.handleEnterKey}
             onKeyUp={this.handleEscapeKey}
@@ -1117,7 +1119,7 @@ class FlameComponent extends React.Component<FlameProps> {
           </p>
         </div>
         <BasicTooltip
-          canPinTooltip
+          canPinTooltip={canPinTooltip}
           onPointerMove={() => ({ type: ON_POINTER_MOVE, position: { x: NaN, y: NaN }, time: NaN })}
           position={
             this.tooltipPinned
@@ -1347,8 +1349,7 @@ const mapStateToProps = (state: GlobalChartState): StateProps => {
     chartDimensions: state.parentDimensions,
     a11ySettings: getA11ySettingsSelector(state),
     tooltipRequired: tooltipSpec.type !== TooltipType.None,
-    pinnableTooltip: tooltipSpec.actions.length > 0,
-
+    canPinTooltip: isPinnableTooltip(state),
     // mandatory charts API protocol; todo extract these mappings once there are other charts like Flame
     onElementOver: settingsSpec.onElementOver ?? (() => {}),
     onElementClick: settingsSpec.onElementClick ?? (() => {}),

--- a/packages/charts/src/state/selectors/can_pin_tooltip.ts
+++ b/packages/charts/src/state/selectors/can_pin_tooltip.ts
@@ -16,7 +16,12 @@ import { createCustomCachedSelector } from '../create_selector';
 /**
  * Enables tooltip pinning only for certain chart types
  */
-const pinnableTooltipCharts = new Set<ChartType>([ChartType.XYAxis, ChartType.Heatmap, ChartType.Partition]);
+const pinnableTooltipCharts = new Set<ChartType>([
+  ChartType.XYAxis,
+  ChartType.Heatmap,
+  ChartType.Partition,
+  ChartType.Flame,
+]);
 
 const getChartType = ({ chartType }: GlobalChartState) => chartType;
 

--- a/storybook/stories/components/tooltip/13_flamegraph.story.tsx
+++ b/storybook/stories/components/tooltip/13_flamegraph.story.tsx
@@ -80,24 +80,29 @@ export const Example = () => {
     focusOnNodeControl(Math.floor(20 * Math.random()));
   });
   const debug = boolean('Debug history', false);
+  const showTooltipActions = boolean('Use tooltip actions', true);
   return (
     <Chart>
       <Settings theme={theme} baseTheme={useBaseTheme()} {...onElementListeners} debug={debug} />
       <Tooltip
         maxVisibleTooltipItems={4}
         maxTooltipItems={4}
-        actions={[
-          {
-            label: () => 'Open detail view',
-            onSelect: (s) => action('open detail view')(s[0].datum),
-          },
-          {
-            label: () => 'Zoom to',
-            onSelect: (s) => {
-              focusOnNodeControl(s[0]?.valueAccessor as number);
-            },
-          },
-        ]}
+        actions={
+          showTooltipActions
+            ? [
+                {
+                  label: () => 'Open detail view',
+                  onSelect: (s) => action('open detail view')(s[0].datum),
+                },
+                {
+                  label: () => 'Zoom to',
+                  onSelect: (s) => {
+                    focusOnNodeControl(s[0]?.valueAccessor as number);
+                  },
+                },
+              ]
+            : undefined
+        }
       />
       <Flame
         id="spec_1"


### PR DESCRIPTION
## Summary

This PR fixes the WebGL flamegraph tooltip prompt by showing it only if the tooltip is really pinnable.
Previously it was always rendered, no matter what, we can show actions or not.


## Issues

fix #1966

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [x] Unit tests have been added or updated to match the most common scenarios
- [x] The proper documentation and/or storybook story has been added or updated
- [x] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
