### PR TITLE
[Heatmap] Expose axis title as debug data

### DIFF
--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_debug_state.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_debug_state.ts
@@ -10,6 +10,7 @@ import { getChartThemeSelector } from './../../../../state/selectors/get_chart_t
 import { computeChartElementSizesSelector } from './compute_chart_dimensions';
 import { computeLegendSelector } from './compute_legend';
 import { getHeatmapGeometries } from './geometries';
+import { getHeatmapSpecSelector } from './get_heatmap_spec';
 import { getHighlightedAreaSelector, getHighlightedDataSelector } from './get_highlighted_area';
 import { RGBATupleToString } from '../../../../common/color_library_wrappers';
 import { LegendItem } from '../../../../common/legend';
@@ -29,8 +30,17 @@ export const getDebugStateSelector = createCustomCachedSelector(
     getHighlightedDataSelector,
     getChartThemeSelector,
     computeChartElementSizesSelector,
+    getHeatmapSpecSelector,
   ],
-  (geoms, legend, pickedArea, highlightedData, { heatmap }, { xAxisTickCadence }): DebugState => {
+  (
+    geoms,
+    legend,
+    pickedArea,
+    highlightedData,
+    { heatmap },
+    { xAxisTickCadence },
+    { xAxisTitle, yAxisTitle },
+  ): DebugState => {
     const xAxisValues = geoms.heatmapViewModel.xValues.filter((_, i) => i % xAxisTickCadence === 0);
     return {
       // Common debug state
@@ -44,6 +54,7 @@ export const getDebugStateSelector = createCustomCachedSelector(
             values: xAxisValues.map(({ value }) => value),
             // vertical lines
             gridlines: geoms.heatmapViewModel.gridLines.x.map((line) => ({ x: line.x1, y: line.y2 })),
+            ...(xAxisTitle ? { title: xAxisTitle } : {}),
           },
         ],
         y: [
@@ -54,6 +65,7 @@ export const getDebugStateSelector = createCustomCachedSelector(
             values: geoms.heatmapViewModel.yValues.map(({ value }) => value),
             // horizontal lines
             gridlines: geoms.heatmapViewModel.gridLines.y.map((line) => ({ x: line.x2, y: line.y1 })),
+            ...(yAxisTitle ? { title: yAxisTitle } : {}),
           },
         ],
       },


### PR DESCRIPTION
## Summary

The heatmap debug data now contains axis titles.

Before:
<img width="254" alt="Screenshot 2023-02-20 at 15 15 47" src="https://user-images.githubusercontent.com/924948/220131583-137f9332-b4f8-4f15-bac0-ef5dce0041fa.png">

After:
<img width="211" alt="Screenshot 2023-02-20 at 15 15 32" src="https://user-images.githubusercontent.com/924948/220131623-197aead7-ab35-4cbf-aace-51bf5510183d.png">

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)