### PR TITLE
fix(annotation): render annotations correctly based on passed handlers

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/_annotations.scss
+++ b/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/_annotations.scss
@@ -10,6 +10,7 @@
     user-select: none;
     font-size: $euiFontSizeXS;
     font-weight: $euiFontWeightBold;
+    line-height: normal;
   }
 
   &__details {

--- a/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
@@ -119,7 +119,7 @@ export function LineMarker({
   void popper?.current?.update?.();
 
   // want it to be tabbable if interactive if there is a click handler
-  return onDOMElementClick ? (
+  return clickable && onDOMElementClick ? (
     <button
       className="echAnnotation__marker"
       onMouseEnter={() => {

--- a/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
@@ -119,7 +119,7 @@ export function LineMarker({
   void popper?.current?.update?.();
 
   // want it to be tabbable if interactive if there is a click handler
-  return clickable && onDOMElementClick ? (
+  return clickable ? (
     <button
       className="echAnnotation__marker"
       onMouseEnter={() => {


### PR DESCRIPTION
## Summary

Annotations with no click handlers configured are no longer shown as interactive.

<img width="982" alt="Screenshot 2023-02-23 at 18 25 38" src="https://user-images.githubusercontent.com/924948/220984327-8aed151c-52de-4c98-8410-396f5c6e5abf.png">

## Issues

fix #1969 

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
