### PR TITLE
fix(heatmap): wrong axes labels on hover

### DIFF
--- a/packages/charts/src/chart_types/heatmap/layout/viewmodel/viewmodel.ts
+++ b/packages/charts/src/chart_types/heatmap/layout/viewmodel/viewmodel.ts
@@ -267,7 +267,7 @@ export function shapeViewModel<D extends BaseDatum = Datum>(
       y < chartDimensions.top + chartDimensions.height
     ) {
       // look up for a Y axis elements
-      const yLabelKey = yInvertedScale(y);
+      const { y: yLabelKey } = getPanelPointCoordinates(x - chartDimensions.left, y);
       const yLabelValue = textYValues.find((v) => v.value === yLabelKey);
       if (yLabelValue) {
         return yLabelValue;


### PR DESCRIPTION
## Summary

Fixes minor issue related to the heatmap axes label tooltip values. Before the values were only respected on the top-left-most panel. Now all panels are correctly respected.

### Before
![Screen Recording 2023-04-24 at 12 18 10 PM](https://user-images.githubusercontent.com/19007109/234094584-1b8b8e20-c3fb-4997-8cad-15f38f9ab04e.gif)

> Notice the `3` value in the tooltip presented for all axes values.

### After
![Screen Recording 2023-04-24 at 12 18 58 PM](https://user-images.githubusercontent.com/19007109/234094775-c000dc67-2108-4e3d-a6ba-b398e2bb32a7.gif)


## Issues

fix #2022

### Checklist

- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [x] Unit tests have been added or updated to match the most common scenarios