### PR TITLE
fix(axes): start of week label on multilayer time axis

### DIFF
--- a/packages/charts/src/chart_types/timeslip/timeslip/render/column.ts
+++ b/packages/charts/src/chart_types/timeslip/timeslip/render/column.ts
@@ -32,17 +32,17 @@ export const renderColumnTickLabels = (
   cartesianWidth: number,
   binStartList: Iterable<Interval>,
 ) => {
-  for (const { minimum, supremum } of binStartList) {
+  for (const { minimum, supremum, textSupremum } of binStartList) {
     const text =
       textNestLevelRowLimited === config.maxLabelRowCount
         ? labelFormat(minimum * 1000)
         : minorLabelFormat(minimum * 1000);
-    if (text.length <= 0) continue;
+    if (text.length === 0) continue;
     const pixelX = Math.max(0, getPixelX(minimum));
     const textX = pixelX + config.horizontalPixelOffset;
     const y = config.verticalPixelOffset + (textNestLevelRowLimited - 1) * config.rowPixelPitch;
     // the measured text width, plus the `config.horizontalPixelOffset` on the left side must fit inside `maxWidth`
-    const maxWidth = getPixelX(supremum) - config.horizontalPixelOffset;
+    const maxWidth = getPixelX(textSupremum || supremum) - config.horizontalPixelOffset;
     const leftShortening =
       maxWidth >= cartesianWidth
         ? 0

--- a/packages/charts/src/chart_types/xy_chart/axes/timeslip/README.md
+++ b/packages/charts/src/chart_types/xy_chart/axes/timeslip/README.md
@@ -1,0 +1,27 @@
+# Timeslip / Multilayer time Axis
+
+The timeslip axes rasters a continuos time range into discrete time unit layers.
+
+## Usages
+
+There are currently two usages of the `continuousTimeRasters`. The first is in the `timeslip` chart type here...
+
+https://github.com/elastic/elastic-charts/blob/045fb037a97db7fcad0c3d0af2b31f7a4260149d/packages/charts/src/chart_types/timeslip/timeslip/timeslip_render.ts#L117-L118
+
+The second is in the `xy_chart` via the multilayer ticks here...
+
+https://github.com/elastic/elastic-charts/blob/045fb037a97db7fcad0c3d0af2b31f7a4260149d/packages/charts/src/chart_types/xy_chart/axes/timeslip/multilayer_ticks.ts#L54-L57
+
+## Logical structure
+
+The `continuousTimeRasters` function contains a lot of definitions before finally exporting a final function to return the required `layers` given a `filter` predicate, see the [`notTooDense`](https://github.com/elastic/elastic-charts/blob/045fb037a97db7fcad0c3d0af2b31f7a4260149d/packages/charts/src/chart_types/xy_chart/axes/timeslip/multilayer_ticks.ts#L30-L43) predicate for an example.
+
+> The `notTooDense` filter uses the `minimumTickPixelDistance` value to determine when that layer is suitable for display. This value is static and calibrated manually.
+
+The important definitions are the `AxisLayer` that each define a unique discrete time unit raster layer. These raster layers range from very fine (i.e. milliseconds) to very course (i.e. decades). Generally, these raster layers define the constraints, style and intervals of each raster layer.
+
+The `allRasters` array lists the `AxisLayer`s in order from coarsest to finest.
+
+Last of the definitions is the `replacements`, these are used to replace any number of raster layers when a given layer is present. For example, say one of the final layers is `days`, in such case we would also have `daysUnlabelled` layer because it has the same spacing constraints, thus it's best to remove the `daysUnlabelled` layer because it would be a duplication. These replacements are executed in order so best to order them from coarsest to finest as we do the raster layers.
+
+For `labeled` raster layers, the `detailedLabelFormat` is used only if the raster layer is the last/bottom layer, `minorTickLabelFormat` is used otherwise.

--- a/packages/charts/src/chart_types/xy_chart/axes/timeslip/chrono/chrono.ts
+++ b/packages/charts/src/chart_types/xy_chart/axes/timeslip/chrono/chrono.ts
@@ -35,5 +35,9 @@ export const epochInSecondsToYear = (timeZone: string, seconds: number) =>
   timeObjToYear(timeObjFromEpochSeconds(timeZone, seconds));
 
 /** @internal */
+export const epochDaysInMonth = (timeZone: string, seconds: number) =>
+  timeObjFromEpochSeconds(timeZone, seconds).daysInMonth;
+
+/** @internal */
 export const addTime = (calendarObj: CalendarObject, timeZone: string, unit: CalendarUnit, count: number) =>
   timeObjToSeconds(addTimeToObj(timeObjFromCalendarObj(calendarObj, timeZone), unit, count));


### PR DESCRIPTION
## Summary

Resolves confusion around the start day of week labeling near the end of the month.

TODOs:

- [ ] Fix logic for small intervals where text is larger than interval to end of month, causing a strange disappearing text.

### Before

![Screen Recording 2023-04-27 at 09 58 27 AM](https://user-images.githubusercontent.com/19007109/234935759-48ccfdaa-44e3-43ed-b435-7684d3543fd7.gif)

### After

![Screen Recording 2023-04-27 at 09 53 41 AM](https://user-images.githubusercontent.com/19007109/234934712-a6a8bd69-7c19-4a5b-9544-a5adfdca6556.gif)

## Details

Currently the rater layer `intervals` are computed using a lower bound (i.e. `minimum`) and upper bound (i.e. `supremum`). This `supremum` value is used in determining how long we _stick_ the axis label before clipping it off the screen. In the case of this issue, the start day of the week sticks past the given month into the next creating confusion.

One solution, this pr, is to clamp the start day `supremum` between the `binStart` and the end of the given month.

One variant of this approach could be to provide a different raster layer for labels describing the interval start (i.e. `30th`) verses the interval as a whole (i.e. `Week 12`).

### Implementation changes

This PR adds a new property to the `Interval` type called `textSupremum`. This property is used as a false `supremum` only for purposes of label text placement. Changing the logic for the `supremum` would have created a conflict between the actual `supremum` and that used only for text resulting in a broken interval logic and scale marker logic.

### Pros

- No confusion about which month is represented
- Simple quick fix

### Cons

- We loose the context of the previous interval bin start

## Issues

fixes #1934

### Checklist

- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [ ] New public API exports have been added to `packages/charts/src/index.ts`
- [ ] Unit tests have been added or updated to match the most common scenarios