### PR TITLE
feat(flame): expose search control

### DIFF
--- a/packages/charts/src/chart_types/flame_chart/flame_api.ts
+++ b/packages/charts/src/chart_types/flame_chart/flame_api.ts
@@ -26,6 +26,12 @@ export type FlameGlobalControl = () => void; // takes no argument
 export type FlameNodeControl = (nodeIndex: number) => void; // takes no arguments
 
 /**
+ * Control function for setting chart focus on a specific node
+ * @public
+ */
+export type FlameSearchControl = (text: string) => void; // takes no arguments
+
+/**
  * Provides direct controls for the Flame component user.
  * The call site supplied callback function is invoked on the chart component initialization as well as on component update,
  * so the callback must be idempotent.
@@ -34,6 +40,7 @@ export type FlameNodeControl = (nodeIndex: number) => void; // takes no argument
 export interface ControlReceiverCallbacks {
   resetFocus: (control: FlameGlobalControl) => void; // call site responsibility to store and use the `control` function
   focusOnNode: (control: FlameNodeControl) => void; // same but the control function passed to the call site uses one arg
+  search: (control: FlameSearchControl) => void;
 }
 
 /**

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -313,6 +313,13 @@ class FlameComponent extends React.Component<FlameProps> {
         this.focusOnNode(nodeIndex);
       });
     }
+    if (controlProviderCallback.search) {
+      controlProviderCallback.search((text: string) => {
+        if (!this.searchInputRef.current) return;
+        this.searchInputRef.current.value = text;
+        this.searchForText(false);
+      });
+    }
   }
 
   private resetFocus() {

--- a/storybook/stories/icicle/04_cpu_profile_gl_flame.story.tsx
+++ b/storybook/stories/icicle/04_cpu_profile_gl_flame.story.tsx
@@ -7,7 +7,7 @@
  */
 
 import { action } from '@storybook/addon-actions';
-import { boolean, button } from '@storybook/addon-knobs';
+import { boolean, button, text } from '@storybook/addon-knobs';
 import React from 'react';
 
 import {
@@ -18,6 +18,7 @@ import {
   FlameGlobalControl,
   FlameNodeControl,
   ColumnarViewModel,
+  FlameSearchControl,
 } from '@elastic/charts';
 import columnarMock from '@elastic/charts/src/mocks/hierarchical/cpu_profile_tree_mock_columnar.json';
 import { getRandomNumberGenerator } from '@elastic/charts/src/mocks/utils';
@@ -62,6 +63,7 @@ const noop = () => {};
 export const Example = () => {
   let resetFocusControl: FlameGlobalControl = noop; // initial value
   let focusOnNodeControl: FlameNodeControl = noop; // initial value
+  let searchText: FlameSearchControl = noop; // initial value
 
   const onElementListeners = {
     onElementClick: action('onElementClick'),
@@ -73,6 +75,10 @@ export const Example = () => {
   });
   button('Set focus on random node', () => {
     focusOnNodeControl(rng(0, 19));
+  });
+  const textSearch = text('Text to search', 'github');
+  button('Search', () => {
+    searchText(textSearch);
   });
   const debug = boolean('Debug history', false);
   return (
@@ -87,6 +93,7 @@ export const Example = () => {
         controlProviderCallback={{
           resetFocus: (control) => (resetFocusControl = control),
           focusOnNode: (control) => (focusOnNodeControl = control),
+          search: (control) => (searchText = control),
         }}
       />
     </Chart>


### PR DESCRIPTION
## Summary
This PR exposes the possibility to send a search term to the flamegraph and make it appear both on the search field and on the flame graph.

See the new storybook controls added to the flamegraph GL story that allows you to use an external textual input and issue the query with a button.

## Issues

fix https://github.com/elastic/elastic-charts/issues/2060


### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [x] New public API exports have been added to `packages/charts/src/index.ts`
- [ ] Unit tests have been added or updated to match the most common scenarios
- [x] The proper documentation and/or storybook story has been added or updated
