### PR TITLE
ci: fix execSync input parameter

### DIFF
--- a/.buildkite/scripts/steps/eslint.ts
+++ b/.buildkite/scripts/steps/eslint.ts
@@ -39,14 +39,14 @@ void (async () => {
     const filesToLint = changes.files.filter('**/*.ts?(x)').join(' ');
 
     if (filesToLint.length > 0) {
-      startGroup('Running eslint checks');
+      startGroup(`Running eslint checks - ${filesToLint.length} files`);
 
       await exec('yarn lint:it', {
         input: filesToLint,
       });
     }
   } else {
-    startGroup('Running eslint checks');
+    startGroup('Running eslint checks - all files');
     await exec('yarn lint');
   }
 })();

--- a/.buildkite/scripts/steps/eslint.ts
+++ b/.buildkite/scripts/steps/eslint.ts
@@ -42,7 +42,7 @@ void (async () => {
       startGroup(`Running eslint checks - ${filesToLint.length} files`);
 
       await exec('yarn lint:it', {
-        input: filesToLint,
+        args: filesToLint,
       });
     }
   } else {

--- a/.buildkite/utils/exec.ts
+++ b/.buildkite/utils/exec.ts
@@ -13,7 +13,8 @@ import { setJobMetadata, startGroup } from './buildkite';
 import { updateCheckStatus } from './github';
 
 interface ExecOptions extends ExecSyncOptionsWithBufferEncoding {
-  /** input appended to the command as args */
+  /** arguments to appended to the command */
+  args?: string;
   input?: string;
   failureMsg?: string;
   onFailure?: () => Promise<void> | void;
@@ -42,6 +43,7 @@ export const wait = (n: number) => new Promise((resolve) => setTimeout(resolve, 
 export const exec = async (
   command: string,
   {
+    args = '',
     input,
     cwd,
     failureMsg,
@@ -57,8 +59,9 @@ export const exec = async (
   let retryCount = 0;
   async function execInner(): Promise<string> {
     try {
-      const result = execSync(`${command} ${input}`, {
+      const result = execSync([command, args].filter(Boolean).join(' '), {
         encoding: 'utf8',
+        input,
         cwd: cwd && path.isAbsolute(cwd) ? cwd : path.resolve(__dirname, '../../', cwd ?? ''),
         stdio,
         env: {

--- a/.buildkite/utils/exec.ts
+++ b/.buildkite/utils/exec.ts
@@ -13,6 +13,7 @@ import { setJobMetadata, startGroup } from './buildkite';
 import { updateCheckStatus } from './github';
 
 interface ExecOptions extends ExecSyncOptionsWithBufferEncoding {
+  /** input appended to the command as args */
   input?: string;
   failureMsg?: string;
   onFailure?: () => Promise<void> | void;
@@ -56,8 +57,7 @@ export const exec = async (
   let retryCount = 0;
   async function execInner(): Promise<string> {
     try {
-      const result = execSync(command, {
-        input,
+      const result = execSync(`${command} ${input}`, {
         encoding: 'utf8',
         cwd: cwd && path.isAbsolute(cwd) ? cwd : path.resolve(__dirname, '../../', cwd ?? ''),
         stdio,

--- a/.buildkite/utils/github.ts
+++ b/.buildkite/utils/github.ts
@@ -229,9 +229,6 @@ export const updateCheckStatus = async (
   // revert the completed check run is to create a new check run. This will not show as a duplicate run.
   const newCheckNeeded = options.status !== 'completed' && checkRun?.status === 'completed';
 
-  // console.trace('updateCheckStatus', checkId, title);
-  // console.log(JSON.stringify(options, null, 2));
-
   try {
     const output =
       title && typeof title === 'string'
@@ -252,7 +249,7 @@ export const updateCheckStatus = async (
         name,
         external_id: checkId,
         head_sha: bkEnv.commit,
-      } as any); // octokit types are bad :(
+      });
       await syncCheckRun(check);
     } else {
       const { data: check } = await octokit.checks.update({
@@ -267,7 +264,7 @@ export const updateCheckStatus = async (
         output,
         external_id: checkId,
         check_run_id: checkRun.id, // required
-      } as any); // octokit types are bad :(
+      });
       await syncCheckRun(check);
     }
   } catch (error) {

--- a/packages/charts/src/chart_types/metric/renderer/dom/index.tsx
+++ b/packages/charts/src/chart_types/metric/renderer/dom/index.tsx
@@ -31,7 +31,7 @@ import { getInternalIsInitializedSelector, InitStatus } from '../../../../state/
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_spec';
 import { LIGHT_THEME } from '../../../../utils/themes/light_theme';
 import { MetricStyle } from '../../../../utils/themes/theme';
-import { MetricSpec } from '../../specs';
+import {MetricSpec} from '../../specs';
 import { chartSize } from '../../state/selectors/chart_size';
 import { getMetricSpecs } from '../../state/selectors/data';
 import { hasChartTitles } from '../../state/selectors/has_chart_titles';

--- a/packages/charts/src/chart_types/metric/renderer/dom/index.tsx
+++ b/packages/charts/src/chart_types/metric/renderer/dom/index.tsx
@@ -31,7 +31,7 @@ import { getInternalIsInitializedSelector, InitStatus } from '../../../../state/
 import { getSettingsSpecSelector } from '../../../../state/selectors/get_settings_spec';
 import { LIGHT_THEME } from '../../../../utils/themes/light_theme';
 import { MetricStyle } from '../../../../utils/themes/theme';
-import {MetricSpec} from '../../specs';
+import { MetricSpec } from '../../specs';
 import { chartSize } from '../../state/selectors/chart_size';
 import { getMetricSpecs } from '../../state/selectors/data';
 import { hasChartTitles } from '../../state/selectors/has_chart_titles';


### PR DESCRIPTION
## Summary

Fixes issue with ci linting check where the files to lint were not properly being passed to the `yarn lint:it` command, resulting in a noop execution.

Added group naming to differentiate running linting checks on all vs some files, removed unneeded code and comments.

## Details

I don't understand the usage of the `input` parameter on the [`execSync`](https://nodejs.org/api/child_process.html#child_processexecsynccommand-options) util, it works to pass the buildkite `json` pipeline but apparently not not to pass arguments to the command as I had thought. Fixed by adding `args` option to `exec` util to append `command`.

## Issues

fixes #1823