### PR TITLE
fix: remove unused redux dev tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
     "react-docgen-typescript-webpack-plugin": "^1.1.0",
     "react-dom": "^16.13.0",
     "react-is": "^16.13.0",
-    "redux-devtools-extension": "^2.13.8",
     "sass": "^1.49.9",
     "sass-graph": "^3.0.5",
     "seedrandom": "^3.0.5",

--- a/packages/charts/src/components/chart.tsx
+++ b/packages/charts/src/components/chart.tsx
@@ -9,7 +9,7 @@
 import classNames from 'classnames';
 import React, { CSSProperties, ReactNode, createRef } from 'react';
 import { Provider } from 'react-redux';
-import { createStore, Store, Unsubscribe, StoreEnhancer, applyMiddleware, Middleware } from 'redux';
+import { createStore, Store, Unsubscribe } from 'redux';
 import { OptionalKeys } from 'utility-types';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -56,21 +56,6 @@ interface ChartState {
   displayTitles: boolean;
 }
 
-const getMiddlware = (id: string): StoreEnhancer => {
-  const middlware: Middleware<any, any, any>[] = [];
-
-  // eslint-disable-next-line no-underscore-dangle
-  if (typeof window !== 'undefined' && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, no-underscore-dangle
-    return (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-      trace: true,
-      name: `@elastic/charts (id: ${id})`,
-    })(applyMiddleware(...middlware));
-  }
-
-  return applyMiddleware(...middlware);
-};
-
 /** @public */
 export class Chart extends React.Component<ChartProps, ChartState> {
   static defaultProps: Pick<ChartProps, OptionalKeys<ChartProps>> = {
@@ -92,8 +77,7 @@ export class Chart extends React.Component<ChartProps, ChartState> {
 
     const id = props.id ?? uuidv4();
     const storeReducer = chartStoreReducer(id, props.title, props.description);
-    const enhancer = getMiddlware(id);
-    this.chartStore = createStore(storeReducer, enhancer);
+    this.chartStore = createStore(storeReducer);
     this.state = {
       legendDirection: LayoutDirection.Vertical,
       paddingLeft: LIGHT_THEME.chartMargins.left,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11312,7 +11312,8 @@ eslint-module-utils@^2.7.4:
     debug "^3.2.7"
 
 "eslint-plugin-elastic-charts@link:./packages/eslint-plugin-elastic-charts":
-  version "1.0.0"
+  version "0.0.0"
+  uid ""
 
 eslint-plugin-eslint-comments@^3.2.0:
   version "3.2.0"
@@ -19392,11 +19393,6 @@ redeyed@~2.1.0:
   integrity sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=
   dependencies:
     esprima "~4.0.0"
-
-redux-devtools-extension@^2.13.8:
-  version "2.13.8"
-  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
-  integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
 
 redux@^4.0.0, redux@^4.0.4:
   version "4.0.4"


### PR DESCRIPTION
## Summary

The redux dev tools are not actively used in ECH developments and our state needs to be sanitized before using them correctly. So for now I prefer to remove their usage from charts and bring it back when https://github.com/elastic/elastic-charts/issues/2078 is fixed.


### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
