### PR TITLE
style(tooltip): replace selection unicode check with svg

### DIFF
--- a/packages/charts/src/components/tooltip/components/_tooltip.scss
+++ b/packages/charts/src/components/tooltip/components/_tooltip.scss
@@ -176,7 +176,7 @@ $transitionTime: 200ms;
           min-width: 0;
         }
 
-        &:not(&--bg)::before {
+        &--icon {
           opacity: 1;
         }
       }
@@ -207,17 +207,14 @@ $transitionTime: 200ms;
   }
 
   &__colorStrip {
-    &::before {
+    &--icon {
       opacity: 0;
-      content: '✓';
       display: flex;
       justify-content: center;
       align-items: center;
-      height: 95%; // to center check
-      font-size: 130%;
-      font-weight: 200;
+      height: 100%; // to center check
       transition: opacity $transitionTime;
-      padding: 0 $colorStripPadding;
+      padding: 0 4px;
     }
 
     &--spacer {

--- a/packages/charts/src/components/tooltip/components/tooltip_table_color_cell.tsx
+++ b/packages/charts/src/components/tooltip/components/tooltip_table_color_cell.tsx
@@ -52,7 +52,17 @@ export function TooltipTableColorCell({
     return (
       <>
         <div className="echTooltip__colorStrip--bg" style={{ backgroundColor }} />
-        <div className="echTooltip__colorStrip" style={{ backgroundColor: color, color: dotColor }} />
+        <div className="echTooltip__colorStrip" style={{ backgroundColor: color }}>
+          <div className="echTooltip__colorStrip--icon" style={{ fill: dotColor }}>
+            {/* Check svg to match eui - https://github.com/elastic/eui/blob/main/src/components/icon/svgs/check.svg?short_path=5a87b2e */}
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+              <path
+                fillRule="evenodd"
+                d="M6.50025,12.00025 C6.37225,12.00025 6.24425,11.95125 6.14625,11.85425 L2.14625,7.85425 C1.95125,7.65825 1.95125,7.34225 2.14625,7.14625 C2.34225,6.95125 2.65825,6.95125 2.85425,7.14625 L6.50025,10.79325 L13.14625,4.14625 C13.34225,3.95125 13.65825,3.95125 13.85425,4.14625 C14.04925,4.34225 14.04925,4.65825 13.85425,4.85425 L6.85425,11.85425 C6.75625,11.95125 6.62825,12.00025 6.50025,12.00025"
+              />
+            </svg>
+          </div>
+        </div>
         <div className="echTooltip__colorStrip--spacer" />
       </>
     );


### PR DESCRIPTION
## Summary

Replaces selection unicode check with svg from eui.

![Screen Recording 2023-07-05 at 10 04 07 AM](https://github.com/elastic/elastic-charts/assets/19007109/169406b2-85f7-4f11-bc9a-9c0e5f622500)


## Details

The previous implementation of this selection UI was using a `::before` pseudo element with the `✓` ([U+2713](https://www.compart.com/en/unicode/U+2713)) unicode character. This lead to inconsistent check styles when used across different environments.

### Checklist

- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [ ] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
- [ ] Visual changes have been tested with all available themes including `dark`, `light`, `eui-dark` & `eui-light`
