### PR TITLE
fix: Wait a tick before reporting render status

### DIFF
--- a/packages/charts/src/components/chart_status.tsx
+++ b/packages/charts/src/components/chart_status.tsx
@@ -38,7 +38,12 @@ class ChartStatusComponent extends React.Component<ChartStatusStateProps> {
   }
 
   dispatchRenderChange = () => {
-    this.props.onRenderChange?.(this.props.rendered);
+    const { onRenderChange, rendered } = this.props;
+    if (onRenderChange) {
+      window.requestAnimationFrame(() => {
+        onRenderChange(rendered);
+      });
+    }
   };
 
   render() {


### PR DESCRIPTION
## Summary
This increases the accuracy of when we report render changes to account for asynchronous render operations.

## Issues
Fix https://github.com/elastic/elastic-charts/issues/2124

### Checklist

- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [x] Unit tests have been added or updated to match the most common scenarios
