### PR TITLE
chore: convert `substr` to `substring`

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/axes/timeslip/continuous_time_rasters.ts
+++ b/packages/charts/src/chart_types/xy_chart/axes/timeslip/continuous_time_rasters.ts
@@ -164,7 +164,7 @@ export const continuousTimeRasters = ({ minimumTickPixelDistance, locale }: Rast
   const minorDayFormat = (d: number) => {
     const numberString = minorDayBaseFormat(d);
     const number = Number.parseInt(numberString, 10);
-    return locale.substr(0, 2) === 'en' ? `${numberString}${englishOrdinalEnding(number)}` : numberString;
+    return locale.substring(0, 2) === 'en' ? `${numberString}${englishOrdinalEnding(number)}` : numberString;
   };
   const detailedDayFormat = new Intl.DateTimeFormat(locale, {
     year: 'numeric',


### PR DESCRIPTION
## Summary
'substr' is just as fine as it's string specific and well named. but it was deprecated. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr

Therefore, I changed the code to use String.prototype.substring() instead of String.prototype.substr().

### Checklist

- [X] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)

