### PR TITLE
fix(axis): always render `tickLine` unless `visible` is `false`

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/annotations/rect/dimensions.ts
+++ b/packages/charts/src/chart_types/xy_chart/annotations/rect/dimensions.ts
@@ -243,10 +243,8 @@ function maxOf(base: number, value: number | string | null | undefined): number 
   return typeof value === 'number' ? Math.max(value, base) : typeof value === 'string' ? value : base;
 }
 
-function getOutsideDimension(style: AxisStyle): number {
-  const { visible, size, strokeWidth } = style.tickLine;
-
-  return visible && size > 0 && strokeWidth > 0 ? size : 0;
+function getOutsideDimension({ tickLine: { visible, size } }: AxisStyle): number {
+  return visible ? size : 0;
 }
 
 /**

--- a/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts
@@ -24,7 +24,6 @@ import { Range } from '../../../utils/domain';
 import { AxisId } from '../../../utils/ids';
 import { Point } from '../../../utils/point';
 import { AxisStyle, TextAlignment, TextOffset, Theme } from '../../../utils/themes/theme';
-import { MIN_STROKE_WIDTH } from '../renderer/canvas/primitives/line';
 import { Projection } from '../state/selectors/visible_ticks';
 import { SeriesDomainsAndData } from '../state/utils/types';
 
@@ -291,8 +290,8 @@ export function getPosition(
 }
 
 /** @internal */
-export function shouldShowTicks({ visible, strokeWidth, size }: AxisStyle['tickLine'], axisHidden: boolean): boolean {
-  return !axisHidden && visible && size > 0 && strokeWidth >= MIN_STROKE_WIDTH;
+export function shouldShowTicks({ visible }: AxisStyle['tickLine'], axisHidden: boolean): boolean {
+  return !axisHidden && visible;
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary

Now axes `tickLine` are always rendered unless `visible` is `false`, thereby including the `tickLine.padding` even if the `tickLine.size` or `tickLine.strokeWidth` are `0`.

**BREAKING CHANGE:** Now displays `padding` where before would be hidden possibly creating an inadvertent breaking style change.

![Screen Recording 2023-10-10 at 02 54 19 PM](https://github.com/elastic/elastic-charts/assets/19007109/2449aaed-357b-4e91-8b6a-1058427f5372)

> Notice the bottom axes, as the `tickLine.size` goes to `0` the padding does not get removed.

## Details

This logic was added back in #711 with a complete overhall of the axes logic. This was added to render only things that absolutely needed to be rendered and a `0` `length` or `strokeWidth` line does not. However this would unexpectedly strip away the `tickLine.padding` even with the `tickLine.visible` set to `true`. This change should have minimal impact across kibana but better to perform this change now with the major theme breaking changes.

https://github.com/elastic/elastic-charts/blob/132327d980f4941d81a6df5e9e76cdf065f7d744/packages/charts/src/chart_types/xy_chart/utils/axis_utils.ts#L294-L296

## Issues

Fix #2187

### Checklist

- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [ ] Unit tests have been added or updated to match the most common scenarios