### PR TITLE
fix(BarSeries): forced stacking for single series histogram

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/legend/legend.ts
+++ b/packages/charts/src/chart_types/xy_chart/legend/legend.ts
@@ -27,8 +27,8 @@ import {
   getSeriesName,
   DataSeries,
   getSeriesKey,
-  isBandedSpec,
   getSeriesIdentifierFromDataSeries,
+  isBandedSpecFn,
 } from '../utils/series';
 import {
   AxisSpec,
@@ -107,6 +107,7 @@ export function computeLegend(
 ): LegendItem[] {
   const legendItems: LegendItem[] = [];
   const defaultColor = theme.colors.defaultVizColor;
+  const isBandedSpec = isBandedSpecFn(specs);
 
   dataSeries.forEach((series) => {
     const { specId, yAccessor } = series;

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/get_tooltip_values_highlighted_geoms.ts
@@ -39,7 +39,7 @@ import { getTooltipCompareFn } from '../../../../utils/series_sort';
 import { isPointOnGeometry } from '../../rendering/utils';
 import { formatTooltipHeader, formatTooltipValue } from '../../tooltip/tooltip';
 import { defaultXYLegendSeriesSort } from '../../utils/default_series_sort_fn';
-import { DataSeries } from '../../utils/series';
+import { DataSeries, isBandedSpecFn } from '../../utils/series';
 import { BasicSeriesSpec, AxisSpec } from '../../utils/specs';
 import { getAxesSpecForSpecId, getSpecDomainGroupId, getSpecsById } from '../utils/spec';
 import { ComputedScales } from '../utils/types';
@@ -129,6 +129,7 @@ function getTooltipAndHighlightFromValue(
   const highlightedGeometries: IndexedGeometry[] = [];
   const xValues = new Set<any>();
   const hideNullValues = !tooltip.showNullValues;
+  const isBandedSpec = isBandedSpecFn(seriesSpecs);
   const values = matchingGeoms.reduce<TooltipValue[]>((acc, indexedGeometry) => {
     if (hideNullValues && indexedGeometry.value.y === null) {
       return acc;
@@ -161,7 +162,14 @@ function getTooltipAndHighlightFromValue(
     }
 
     // format the tooltip values
-    const formattedTooltip = formatTooltipValue(indexedGeometry, spec, isHighlighted, hasSingleSeries, yAxis);
+    const formattedTooltip = formatTooltipValue(
+      indexedGeometry,
+      spec,
+      isHighlighted,
+      hasSingleSeries,
+      isBandedSpec(spec),
+      yAxis,
+    );
 
     // format only one time the x value
     if (!header) {

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
@@ -28,7 +28,7 @@ import { clamp, Rotation } from '../../../../utils/common';
 import { Dimensions } from '../../../../utils/dimensions';
 import { hasDragged, DragCheckProps } from '../../../../utils/events';
 import { GroupId } from '../../../../utils/ids';
-import { isHistogramEnabled } from '../../domains/y_domain';
+import { hasHistogramBarSpec } from '../../domains/y_domain';
 import { isVerticalRotation } from '../utils/common';
 
 const getLastDragSelector = (state: GlobalChartState) => state.interactions.pointer.lastDrag;
@@ -155,7 +155,7 @@ function getXBrushExtent(
     return;
   }
   const offset = histogramMode ? 0 : -(xScale.bandwidth + xScale.bandwidthPadding) / 2;
-  const histogramEnabled = isHistogramEnabled(seriesSpecs);
+  const histogramEnabled = hasHistogramBarSpec(seriesSpecs);
   const invertValue =
     histogramEnabled && roundHistogramBrushValues
       ? (value: number) => xScale.invertWithStep(value, xScale.domain).value

--- a/packages/charts/src/chart_types/xy_chart/tooltip/tooltip.ts
+++ b/packages/charts/src/chart_types/xy_chart/tooltip/tooltip.ts
@@ -14,7 +14,7 @@ import { getAccessorFormatLabel } from '../../../utils/accessor';
 import { isDefined } from '../../../utils/common';
 import { BandedAccessorType, IndexedGeometry } from '../../../utils/geometry';
 import { defaultTickFormatter } from '../utils/axis_utils';
-import { getSeriesName, isBandedSpec } from '../utils/series';
+import { getSeriesName } from '../utils/series';
 import { AxisSpec, BasicSeriesSpec, isAreaSeriesSpec, isBarSeriesSpec, TickFormatterOptions } from '../utils/specs';
 
 /** @internal */
@@ -55,11 +55,12 @@ export function formatTooltipValue(
   spec: BasicSeriesSpec,
   isHighlighted: boolean,
   hasSingleSeries: boolean,
+  isBanded: boolean,
   axisSpec?: AxisSpec,
 ): TooltipValue {
   let label = getSeriesName(seriesIdentifier, hasSingleSeries, true, spec);
 
-  if (isBandedSpec(spec) && (isAreaSeriesSpec(spec) || isBarSeriesSpec(spec))) {
+  if (isBanded && (isAreaSeriesSpec(spec) || isBarSeriesSpec(spec))) {
     const { y0AccessorFormat = Y0_ACCESSOR_POSTFIX, y1AccessorFormat = Y1_ACCESSOR_POSTFIX } = spec;
     const formatter = accessor === BandedAccessorType.Y0 ? y0AccessorFormat : y1AccessorFormat;
     label = getAccessorFormatLabel(formatter, label);

--- a/storybook/stories/axes/11_fit_domain_extent.story.tsx
+++ b/storybook/stories/axes/11_fit_domain_extent.story.tsx
@@ -14,7 +14,6 @@ import {
   Chart,
   DomainPaddingUnit,
   LineAnnotation,
-  LineSeries,
   Position,
   RectAnnotation,
   ScaleType,
@@ -30,6 +29,7 @@ const dg = new SeededDataGenerator();
 const base = dg.generateBasicSeries(100, 0, 50);
 
 export const Example: ChartsStory = (_, { title, description }) => {
+  const [SeriesType] = customKnobs.enum.xySeries(undefined, 'line', { exclude: ['bubble'] });
   const positive = base.map(({ x, y }) => ({ x, y: y + 1000 }));
   const both = base.map(({ x, y }) => ({ x, y: y - 100 }));
   const negative = base.map(({ x, y }) => ({ x, y: y - 1000 }));
@@ -60,8 +60,10 @@ export const Example: ChartsStory = (_, { title, description }) => {
     ['theshold', 'rect'],
     'check',
   );
+  const enableHistogramMode = boolean('enableHistogramMode', true);
   const constrainPadding = boolean('constrain padding', true);
   const padding = number('domain padding', 0.1);
+  const seriesCount = number('number of series', 1, { min: 1, max: 3, range: true });
   const paddingUnit = customKnobs.fromEnum('Domain padding unit', DomainPaddingUnit, DomainPaddingUnit.DomainRatio);
   const thesholds = array('thesholds - line', ['200']).filter(Boolean).map(Number);
   const rectTheshold = object('theshold - rect', { y0: 100, y1: null });
@@ -105,14 +107,18 @@ export const Example: ChartsStory = (_, { title, description }) => {
           fill: '#f137407b',
         }}
       />
-      <LineSeries
-        id="lines"
-        xScaleType={ScaleType.Linear}
-        yScaleType={ScaleType.Linear}
-        xAccessor="x"
-        yAccessors={['y']}
-        data={dataset}
-      />
+      {Array.from({ length: seriesCount }, (_, i) => (
+        <SeriesType
+          id={`series-${i}`}
+          key={`series-${i}`}
+          enableHistogramMode={enableHistogramMode}
+          xScaleType={ScaleType.Linear}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={dataset}
+        />
+      ))}
     </Chart>
   );
 };

--- a/storybook/stories/utils/knobs/custom.ts
+++ b/storybook/stories/utils/knobs/custom.ts
@@ -67,7 +67,7 @@ export function getMultiSelectKnob<T extends OptionsTypeKnobSingleValue>(
   );
 
   if (Array.isArray(knob)) return knob as T[];
-  if (typeof knob === 'string') return knob.split(', ') as T[];
+  if (typeof knob === 'string') return knob.split(/\s*,\s*/) as T[];
   if (typeof knob === 'number') return [knob] as T[];
   return !knob ? [] : knob;
 }


### PR DESCRIPTION
## Summary

This PR was the first solution designed to fix #2223 however after more thought, this would solve one breaking behavior but not all. Namely, this would not solve the case where the user has multiple histogram bar series in a chart and wants to fit the domain to the data. This would force the bars to be stacked, against the chart config, and make domain fitting impossible.

### Before

![Screen Recording 2023-11-01 at 09 51 39 AM](https://github.com/elastic/elastic-charts/assets/19007109/b15e10d1-2cca-4b57-b26f-3f8ba489a2c3)

### After

![Screen Recording 2023-11-01 at 02 39 54 PM](https://github.com/elastic/elastic-charts/assets/19007109/ff23aa45-113c-46d9-af2d-645af2191060)

> Notice, when there are 2 bar series in the chart with `enableHistogramMode` set to `true` they are forced to stack and the domain fitting is set to start at `0`.