### PR TITLE
fix: clamp brushing min of last bucket

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
@@ -165,7 +165,7 @@ function getXBrushExtent(
   const [domainStart, domainEnd] = xScale.domain;
   const maxDomainValue = domainEnd + (histogramEnabled && allowBrushingLastHistogramBin ? xScale.minInterval : 0);
 
-  const minValue = clamp(minPosScaled, domainStart, maxPosScaled);
+  const minValue = clamp(minPosScaled, domainStart, maxDomainValue);
   const maxValue = clamp(minPosScaled, maxPosScaled, maxDomainValue);
 
   return [minValue, maxValue];


### PR DESCRIPTION
## Summary

Clamps the `min` scaled value on the brushing event to the max bucket value when `allowBrushingLastHistogramBin` is set to `false`.

![Screen Recording 2023-11-01 at 04 50 57 PM](https://github.com/elastic/elastic-charts/assets/19007109/4f374026-20b0-4269-baec-453efe02f28f)

## Details

Leaving the `min` value unclamped would allow the value to exceed the last bucket starting value.

## Issues

fix #2224

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [x] Unit tests have been added or updated to match the most common scenarios