### PR TITLE
test: add resize config for easy story and e2e resizing

### DIFF
--- a/e2e/page_objects/common.ts
+++ b/e2e/page_objects/common.ts
@@ -556,7 +556,6 @@ export class CommonPage {
     }
 
     await el.evaluate((element, { height, width }) => {
-      console.log({ height, width });
       if (height !== undefined) element.style.height = height;
       if (width !== undefined) element.style.width = width;
     }, dimensions);

--- a/e2e/page_objects/common.ts
+++ b/e2e/page_objects/common.ts
@@ -548,6 +548,19 @@ export class CommonPage {
         strict: false, // should be true but some stories have multiple charts
       });
     };
+
+  setResizeDimensions = (page: Page) => async (dimensions: { height?: string; width?: string }) => {
+    const el = page.locator('#story-resize-wrapper');
+    if (!(await el.isVisible())) {
+      throw new Error('setResizeDimensions was called when no #story-resize-wrapper exists');
+    }
+
+    await el.evaluate((element, { height, width }) => {
+      console.log({ height, width });
+      if (height !== undefined) element.style.height = height;
+      if (width !== undefined) element.style.width = width;
+    }, dimensions);
+  };
 }
 
 function getSnapshotOptions(options?: ScreenshotDOMElementOptions) {

--- a/e2e/tests/tooltip.test.ts
+++ b/e2e/tests/tooltip.test.ts
@@ -10,8 +10,6 @@ import { test } from '@playwright/test';
 
 import { common } from '../page_objects/common';
 
-process.env.ENV_URL = 'http://localhost:9002/';
-
 test.describe('Tooltip', () => {
   test.describe('Chart Types', () => {
     test.describe('Cartesian', () => {

--- a/e2e_server/server/generate/vrt_page_template.js
+++ b/e2e_server/server/generate/vrt_page_template.js
@@ -43,17 +43,24 @@ ReactDOM.render(<VRTPage />, document.getElementById('story-root') as HTMLElemen
 
 function pageTemplate(imports, routes, urls) {
   return `
-import React, { Suspense } from 'react';
+import React, { PropsWithChildren, FC, Suspense, CSSProperties } from 'react';
 import { EuiProvider } from '@elastic/eui';
 import { ThemeIdProvider, BackgroundIdProvider } from '../../storybook/use_base_theme';
 import { useGlobalsParameters } from '../server/mocks/use_global_parameters';
 import { StoryContext } from '../../storybook/types';
+
+const ResizeWrapper: FC<PropsWithChildren<{ resize?: boolean | CSSProperties }>> = ({ resize, children }) => resize ? (
+  <div id="story-resize-wrapper" style={resize === true ? {} : resize}>
+    { children }
+  </div>
+) : (<>{children}</>)
 
 export function VRTPage() {
   const {
     themeId,
     backgroundId,
     toggles,
+    resize,
     setParams,
   } = useGlobalsParameters();
   const urlParams = new URL(window.location.toString()).searchParams;
@@ -84,15 +91,17 @@ export function VRTPage() {
   }
 
   return (
-    <EuiProvider colorMode={colorMode}>
-      <ThemeIdProvider value={themeId as any}>
-        <BackgroundIdProvider value={backgroundId}>
-          <Suspense fallback={<div>Loading...</div>}>
-            ${routes.join('\n            ')}
-          </Suspense>
-        </BackgroundIdProvider>
-      </ThemeIdProvider>
-    </EuiProvider>
+    <ResizeWrapper resize={resize}>
+      <EuiProvider colorMode={colorMode}>
+        <ThemeIdProvider value={themeId as any}>
+          <BackgroundIdProvider value={backgroundId}>
+            <Suspense fallback={<div>Loading...</div>}>
+              ${routes.join('\n            ')}
+            </Suspense>
+          </BackgroundIdProvider>
+        </ThemeIdProvider>
+      </EuiProvider>
+    </ResizeWrapper>
   );
 }
 

--- a/e2e_server/server/mocks/use_global_parameters.ts
+++ b/e2e_server/server/mocks/use_global_parameters.ts
@@ -8,13 +8,13 @@
 
 import { useMemo, useState } from 'react';
 
-import type { StoryGlobals } from './../../../storybook/types';
+import type { StoryGlobals, StoryParameters } from './../../../storybook/types';
 import { BackgroundParameter } from '../../../storybook/node_modules/storybook-addon-background-toggle';
 import { ThemeParameter } from '../../../storybook/node_modules/storybook-addon-theme-toggle';
 import { storybookParameters as globalParams } from '../../../storybook/parameters';
 import { ThemeId } from '../../../storybook/use_base_theme';
 
-type Parameters = BackgroundParameter & ThemeParameter;
+type Parameters = BackgroundParameter & ThemeParameter & Pick<StoryParameters, 'resize'>;
 
 const themeParams = globalParams.theme!;
 const backgroundParams = globalParams.background!;
@@ -48,6 +48,7 @@ interface GlobalParameters {
   themeId: StoryGlobals['theme'];
   backgroundId: StoryGlobals['background'];
   toggles: StoryGlobals['toggles'];
+  resize: StoryParameters['resize'];
   setParams(params: URLSearchParams, parameters?: Parameters): void;
 }
 
@@ -55,6 +56,7 @@ export function useGlobalsParameters(): GlobalParameters {
   const [themeId, setThemeId] = useState<string>(ThemeId.Light);
   const [backgroundId, setBackgroundId] = useState<string | undefined>();
   const [togglesJSON, setTogglesJSON] = useState<string>('{}');
+  const [resize, setResize] = useState<StoryParameters['resize']>(false);
 
   /**
    * Handles setting global context values. Stub for theme and background addons
@@ -67,6 +69,7 @@ export function useGlobalsParameters(): GlobalParameters {
     setThemeId(themeIdFromParams);
     setTogglesJSON(JSON.stringify(globals.toggles ?? '{}'));
     applyThemeCSS(themeIdFromParams);
+    setResize(parameters?.resize);
   }
 
   // using toggles object creates an infinite update loop, thus using JSON state.
@@ -76,6 +79,7 @@ export function useGlobalsParameters(): GlobalParameters {
     themeId,
     backgroundId,
     toggles,
+    resize,
     setParams,
   };
 }

--- a/storybook/stories/metric/1_basic.story.tsx
+++ b/storybook/stories/metric/1_basic.story.tsx
@@ -117,40 +117,35 @@ export const Example: ChartsStory = (_, { title: storyTitle, description }) => {
 
   const configuredData = [[numberTextSwitch ? numericData : textualData]];
   return (
-    <div
-      style={{
-        resize: 'both',
-        padding: '0px',
-        overflow: 'auto',
-        height: '200px',
-        width: '200px',
-        maxWidth: '100%',
-        maxHeight: '80vh',
-      }}
-    >
-      <Chart title={storyTitle} description={description}>
-        <Settings
-          baseTheme={useBaseTheme()}
-          onElementClick={([d]) => {
-            if (isMetricElementEvent(d)) {
-              const { rowIndex, columnIndex } = d;
-              onEventClickAction(
-                `row:${rowIndex} col:${columnIndex} value:${configuredData[rowIndex][columnIndex].value}`,
-              );
-            }
-          }}
-          onElementOver={([d]) => {
-            if (isMetricElementEvent(d)) {
-              const { rowIndex, columnIndex } = d;
-              onEventOverAction(
-                `row:${rowIndex} col:${columnIndex} value:${configuredData[rowIndex][columnIndex].value}`,
-              );
-            }
-          }}
-          onElementOut={() => onEventOutAction('out')}
-        />
-        <Metric id="1" data={configuredData} />
-      </Chart>
-    </div>
+    <Chart title={storyTitle} description={description}>
+      <Settings
+        baseTheme={useBaseTheme()}
+        onElementClick={([d]) => {
+          if (isMetricElementEvent(d)) {
+            const { rowIndex, columnIndex } = d;
+            onEventClickAction(
+              `row:${rowIndex} col:${columnIndex} value:${configuredData[rowIndex][columnIndex].value}`,
+            );
+          }
+        }}
+        onElementOver={([d]) => {
+          if (isMetricElementEvent(d)) {
+            const { rowIndex, columnIndex } = d;
+            onEventOverAction(
+              `row:${rowIndex} col:${columnIndex} value:${configuredData[rowIndex][columnIndex].value}`,
+            );
+          }
+        }}
+        onElementOut={() => onEventOutAction('out')}
+      />
+      <Metric id="1" data={configuredData} />
+    </Chart>
   );
+};
+
+Example.parameters = {
+  resize: {
+    height: '200px',
+    width: '200px',
+  },
 };

--- a/storybook/stories/test_cases/11_resize_debounce.story.tsx
+++ b/storybook/stories/test_cases/11_resize_debounce.story.tsx
@@ -37,57 +37,46 @@ export const Example: ChartsStory = (_, { title, description }) => {
   const resizeDebounce = number('resizeDebounce (ms)', 10, { min: 0, step: 20 });
   const cardinality = number('cardinality', 100, { min: 1, max: maxCardinality });
   return (
-    <div
-      style={{
-        resize: 'both',
-        padding: '0px',
-        overflow: 'auto',
-        height: '100%',
-        width: '100%',
-        maxWidth: '100%',
-        maxHeight: '100vh',
-      }}
-    >
-      <Chart title={title} description={description}>
-        <Settings
-          showLegend
-          resizeDebounce={resizeDebounce}
-          onResize={action('onResize')}
-          onRenderChange={action('onRenderChange')}
-          baseTheme={useBaseTheme()}
-        />
-        <Axis
-          id="bottom"
-          position={Position.Bottom}
-          style={{
-            tickLine: { visible: true, size: 0.0001, padding: 4 },
-            tickLabel: {
-              alignment: { horizontal: Position.Left, vertical: Position.Bottom },
-              padding: 0,
-              offset: { x: 0, y: 0 },
-            },
-          }}
-          timeAxisLayerCount={3}
-        />
-        <Axis id="left" position={Position.Left} />
+    <Chart title={title} description={description}>
+      <Settings
+        showLegend
+        resizeDebounce={resizeDebounce}
+        onResize={action('onResize')}
+        onRenderChange={action('onRenderChange')}
+        baseTheme={useBaseTheme()}
+      />
+      <Axis
+        id="bottom"
+        position={Position.Bottom}
+        style={{
+          tickLine: { visible: true, size: 0.0001, padding: 4 },
+          tickLabel: {
+            alignment: { horizontal: Position.Left, vertical: Position.Bottom },
+            padding: 0,
+            offset: { x: 0, y: 0 },
+          },
+        }}
+        timeAxisLayerCount={3}
+      />
+      <Axis id="left" position={Position.Left} />
 
-        <BarSeries
-          id="Sensor 1"
-          enableHistogramMode
-          xScaleType={ScaleType.Time}
-          yScaleType={ScaleType.Linear}
-          xAccessor="t"
-          yAccessors={['v']}
-          splitSeriesAccessors={['cat']}
-          stackAccessors={['yes']}
-          data={data.flatMap(({ t, values }) => values.slice(0, cardinality).map(({ v, cat }) => ({ t, v, cat })))}
-        />
-      </Chart>
-    </div>
+      <BarSeries
+        id="Sensor 1"
+        enableHistogramMode
+        xScaleType={ScaleType.Time}
+        yScaleType={ScaleType.Linear}
+        xAccessor="t"
+        yAccessors={['v']}
+        splitSeriesAccessors={['cat']}
+        stackAccessors={['yes']}
+        data={data.flatMap(({ t, values }) => values.slice(0, cardinality).map(({ v, cat }) => ({ t, v, cat })))}
+      />
+    </Chart>
   );
 };
 
 Example.parameters = {
   markdown: `The \`resizeDebounce\` option on the \`Settings\` spec provides control over the eagerness of the chart to re-render upon resize. A value of \`0\` will remove the debounce altogether.
 You can play with the cardinality and debounce time to see how the debouncing affects the chart render timing`,
+  resize: true,
 };

--- a/storybook/story_wrapper.tsx
+++ b/storybook/story_wrapper.tsx
@@ -9,24 +9,35 @@
 import { EuiProvider, EuiMarkdownFormat, EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiText } from '@elastic/eui';
 import { DecoratorFunction } from '@storybook/addons';
 import classNames from 'classnames';
-import React from 'react';
+import React, { FC, PropsWithChildren } from 'react';
 
+import { StoryGlobals, StoryParameters } from './types';
 import { ThemeId, ThemeIdProvider, BackgroundIdProvider } from './use_base_theme';
+
+const ResizeWrapper: FC<PropsWithChildren<{ resize: StoryParameters['resize'] }>> = ({ resize, children }) =>
+  resize ? (
+    <div id="story-resize-wrapper" style={resize === true ? {} : resize}>
+      {children}
+    </div>
+  ) : (
+    <>{children}</>
+  );
 
 export const StoryWrapper: DecoratorFunction<JSX.Element> = (Story, context) => {
   if (!Story) return <div>No Story</div>;
 
-  const { globals, parameters } = context;
+  const globals = (context.globals as StoryGlobals) ?? {};
+  const parameters = (context.parameters as StoryParameters) ?? {};
 
-  const themeId = globals?.theme ?? ThemeId.Light;
-  const backgroundId = globals?.background;
+  const themeId = (globals.theme as ThemeId) ?? ThemeId.Light;
+  const backgroundId = globals.background;
   const {
     showHeader = false,
     showChartTitle = false,
     showChartDescription = false,
     showChartBoundary = false,
-  } = globals?.toggles ?? {};
-  const markdown = parameters?.markdown;
+  } = globals.toggles ?? {};
+  const { markdown, resize } = parameters;
   const colorMode = themeId.includes('light') ? 'light' : 'dark';
 
   return (
@@ -56,11 +67,13 @@ export const StoryWrapper: DecoratorFunction<JSX.Element> = (Story, context) => 
 
             <EuiFlexItem grow={false}>
               <div id="story-root" className={classNames({ showChartBoundary })}>
-                <Story
-                  {...context}
-                  title={showChartTitle ? context.kind : undefined}
-                  description={showChartDescription ? context.name : undefined}
-                />
+                <ResizeWrapper resize={resize}>
+                  <Story
+                    {...context}
+                    title={showChartTitle ? context.kind : undefined}
+                    description={showChartDescription ? context.name : undefined}
+                  />
+                </ResizeWrapper>
               </div>
             </EuiFlexItem>
             {markdown && (

--- a/storybook/style.scss
+++ b/storybook/style.scss
@@ -141,6 +141,15 @@ body {
   }
 }
 
+#story-resize-wrapper {
+  resize: both;
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+  max-width: 100%;
+  max-height: 80vh;
+}
+
 #story-header {
   padding: 20px 40px 16px;
 }

--- a/storybook/types.ts
+++ b/storybook/types.ts
@@ -8,7 +8,7 @@
 
 import type { Parameters as SBParameters } from '@storybook/addons';
 import { ArgTypes, Args, StoryContext as SBStoryContext } from '@storybook/react';
-import { ReactElement } from 'react';
+import { CSSProperties, ReactElement } from 'react';
 import { StoryBackgroundParameter, BackgroundGlobals } from 'storybook-addon-background-toggle';
 import { StoryThemeParameter, ThemeGlobals } from 'storybook-addon-theme-toggle';
 import { StoryTogglesParameter, TogglesGlobals } from 'storybook-addon-toggles';
@@ -16,7 +16,7 @@ import { StoryTogglesParameter, TogglesGlobals } from 'storybook-addon-toggles';
 /**
  * Parameter accessible at the story level
  */
-type StoryParameters = SBParameters &
+export type StoryParameters = SBParameters &
   StoryThemeParameter &
   StoryBackgroundParameter &
   StoryTogglesParameter & {
@@ -24,6 +24,10 @@ type StoryParameters = SBParameters &
      * Renders markdown content below story
      */
     markdown?: string;
+    /**
+     * Defines resize wrapper under `#story-root` to define
+     */
+    resize?: boolean | CSSProperties;
   };
 export type StoryGlobals = ThemeGlobals & BackgroundGlobals & TogglesGlobals;
 

--- a/storybook/types.ts
+++ b/storybook/types.ts
@@ -25,7 +25,7 @@ export type StoryParameters = SBParameters &
      */
     markdown?: string;
     /**
-     * Defines resize wrapper under `#story-root` to define
+     * Used to enable and style resize wrapper under `#story-root`
      */
     resize?: boolean | CSSProperties;
   };


### PR DESCRIPTION
## Summary

We've started adding `resize` wrapper elements around certain stories to allow for a better size per chart while also allowing the docs consumer to easily resize the chart to see how it changes.

This caused a bit of an issue in #2156 with clipping of the vrt screenshots.

This PR adds a `resize` config to the `Story.parameters`. This allows us to pass a `boolean` where if true we wrap the story in resizable `div`, matching the default size of the `.echChart`. You may also pass this parameter any css styles to be applied to this resize wrapper. For example the `Metric - Basic` story just adds the following to override the `height` and `width` of the resize wrapper to `200px`.

```tsx
Example.parameters = {
  resize: {
    height: '200px',
    width: '200px',
  },
};
```

Any provided styles override the default styles here...

https://github.com/elastic/elastic-charts/blob/3b83f53e31534d067df543d0c25889e87ee40f5e/storybook/style.scss#L144-L151

As for the the e2e tests, I added the `setResizeDimensions` method to the `common` page object for easily updating the height and width of this resize wrapper. This would look like...

```ts
test('should resize metric', async ({ page }) => {
    await common.expectChartAtUrlToMatchScreenshot(page)(
      'http://localhost:9001/xxxxx,
      {
        action: async () => {
          await common.setResizeDimensions(page)({ width: '400px' });
        },
      },
    );
  });
```

If no `resize` parameter was provided this method will throw and error!

> ⚠️ This feature only impacts the storybook docs and e2e testing.

Changes added to facilitate testing of Bullet as Metric in #2156.