### PR TITLE
ci: fix vrt-specific style issues

### DIFF
--- a/storybook/style.scss
+++ b/storybook/style.scss
@@ -113,8 +113,10 @@ html {
     }
 
     #root {
-      padding-top: 200px;
-      padding-bottom: 200px;
+      // This is meant to provide space above and below the chart for tooltip placement
+      min-height: 800px;
+      display: flex;
+      align-items: center;
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes issues related to clipping of screenshot in vrt setup.

![image](https://github.com/elastic/elastic-charts/assets/19007109/0d8cde9e-00aa-47e6-9981-5d575364740a)


## Details

When we improved the tooltip placement logic we added styles to the e2e specific server. We added padding on the top and bottom of the chart to allow the tooltip to be unencumbered by the surrounding container to avoid unexpectedly pushing the tooltip into only the visible chart space.

But we recently have added charts with `resize` that are set to a greater height such that the top padding plus the height of the chart is greater than the playwright viewport, thus clipping the bottom of the chart in the screenshots.