### PR TITLE
fix(theme): legacy margins (#2262) [61.0.x]

### DIFF
--- a/packages/charts/src/utils/themes/legacy_dark_theme.ts
+++ b/packages/charts/src/utils/themes/legacy_dark_theme.ts
@@ -9,10 +9,10 @@
 import { palettes } from './colors';
 import { Theme } from './theme';
 import {
-  DEFAULT_CHART_MARGINS,
-  DEFAULT_CHART_PADDING,
   DEFAULT_GEOMETRY_STYLES,
   DEFAULT_MISSING_COLOR,
+  LEGACY_CHART_MARGINS,
+  LEGACY_CHART_PADDING,
 } from './theme_common';
 import { Colors } from '../../common/colors';
 import { GOLDEN_RATIO, TAU } from '../../common/constants';
@@ -25,8 +25,8 @@ import { ColorVariant } from '../common';
  * @deprecated Use new `DARK_THEME`
  */
 export const LEGACY_DARK_THEME: Theme = {
-  chartPaddings: DEFAULT_CHART_PADDING,
-  chartMargins: DEFAULT_CHART_MARGINS,
+  chartPaddings: LEGACY_CHART_PADDING,
+  chartMargins: LEGACY_CHART_MARGINS,
   lineSeriesStyle: {
     line: {
       visible: true,

--- a/packages/charts/src/utils/themes/legacy_light_theme.ts
+++ b/packages/charts/src/utils/themes/legacy_light_theme.ts
@@ -9,10 +9,10 @@
 import { palettes } from './colors';
 import { Theme } from './theme';
 import {
-  DEFAULT_CHART_MARGINS,
-  DEFAULT_CHART_PADDING,
   DEFAULT_GEOMETRY_STYLES,
   DEFAULT_MISSING_COLOR,
+  LEGACY_CHART_MARGINS,
+  LEGACY_CHART_PADDING,
 } from './theme_common';
 import { Colors } from '../../common/colors';
 import { GOLDEN_RATIO, TAU } from '../../common/constants';
@@ -25,8 +25,8 @@ import { ColorVariant } from '../common';
  * @deprecated use new `LIGHT_THEME`
  */
 export const LEGACY_LIGHT_THEME: Theme = {
-  chartPaddings: DEFAULT_CHART_PADDING,
-  chartMargins: DEFAULT_CHART_MARGINS,
+  chartPaddings: LEGACY_CHART_PADDING,
+  chartMargins: LEGACY_CHART_MARGINS,
   lineSeriesStyle: {
     line: {
       visible: true,

--- a/packages/charts/src/utils/themes/theme_common.ts
+++ b/packages/charts/src/utils/themes/theme_common.ts
@@ -32,6 +32,17 @@ export const DEFAULT_CHART_MARGINS: Margins = {
  * Remove in next step to limit diffs
  * @internal
  */
+export const LEGACY_CHART_PADDING: Margins = {
+  left: 0,
+  right: 0,
+  top: 0,
+  bottom: 0,
+};
+
+/**
+ * Remove in next step to limit diffs
+ * @internal
+ */
 export const LEGACY_CHART_MARGINS: Margins = {
   left: 10,
   right: 10,


### PR DESCRIPTION
Backports the following commits to 61.0.x:
 - fix(theme): legacy margins (#2262)