### PR TITLE
fix: clamp brushing min of last bucket (#2227) [60.x]

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/on_brush_end_caller.ts
@@ -165,7 +165,7 @@ function getXBrushExtent(
   const [domainStart, domainEnd] = xScale.domain;
   const maxDomainValue = domainEnd + (histogramEnabled && allowBrushingLastHistogramBin ? xScale.minInterval : 0);
 
-  const minValue = clamp(minPosScaled, domainStart, maxPosScaled);
+  const minValue = clamp(minPosScaled, domainStart, maxDomainValue);
   const maxValue = clamp(minPosScaled, maxPosScaled, maxDomainValue);
 
   return [minValue, maxValue];


### PR DESCRIPTION
Backports the following commits to 60.x:
 - fix: clamp brushing min of last bucket (#2227)