### PR TITLE
docs: fix custom legend story

### DIFF
--- a/storybook/stories/legend/16_custom_legend.story.tsx
+++ b/storybook/stories/legend/16_custom_legend.story.tsx
@@ -52,7 +52,7 @@ export const Example: ChartsStory = (_, { title, description }) => {
           onClick={() => i.onItemClickAction(false)}
           style={{ display: 'block', color: i.isSeriesHidden ? 'gray' : i.color }}
         >
-          {i.label} {i.extraValue}
+          {i.label} {i.extraValue?.formatted}
         </button>
       ))}
     </div>


### PR DESCRIPTION
## Summary
Fix error in custom legend story where the legend `extraValue` is passed as React node, but it instead is an object that can't be rendered directly.

