### PR TITLE
fix(legend): custom legend covered by background

### DIFF
--- a/packages/charts/src/components/_global.scss
+++ b/packages/charts/src/components/_global.scss
@@ -13,4 +13,5 @@
   bottom: 0;
   left: 0;
   right: 0;
+  z-index: -1;
 }

--- a/packages/charts/src/components/_global.scss
+++ b/packages/charts/src/components/_global.scss
@@ -13,5 +13,5 @@
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: -1;
+  z-index: 0;
 }

--- a/packages/charts/src/components/legend/_legend.scss
+++ b/packages/charts/src/components/legend/_legend.scss
@@ -1,4 +1,6 @@
 .echLegend {
+  z-index: 1;
+
   .echLegendList {
     display: grid;
     grid-template-columns: minmax(0, 1fr);

--- a/storybook/stories/legend/16_custom_legend.story.tsx
+++ b/storybook/stories/legend/16_custom_legend.story.tsx
@@ -42,7 +42,7 @@ const allMetrics = [...data3, ...data2, ...data1];
 
 export const Example: ChartsStory = (_, { title, description }) => {
   const customLegend: CustomLegend = ({ items, pointerValue }) => (
-    <div style={{ width: '100%', position: 'relative' }}>
+    <div style={{ width: '100%' }}>
       <p style={{ height: '1.5em' }}>{pointerValue ? moment(pointerValue?.value).format('HH:mm') : 'System Load'}</p>
       {items.map((i) => (
         <button


### PR DESCRIPTION
## Summary

Fixes an issue causing the legend to be placed behind the `.echChartBackground` element.

## Details

The `.echChartBackground` element had no `z-index` applied which causes any custom legend to be covered by the background.

## Issues

fix #2363

### Checklist

- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [x] Unit tests have been added or updated to match the most common scenarios
- [x] The proper documentation and/or storybook story has been added or updated
- [x] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)