### PR TITLE
fix(Metric): Cards should only show one focus halo on `::focus` event

### DIFF
--- a/packages/charts/src/chart_types/metric/renderer/_index.scss
+++ b/packages/charts/src/chart_types/metric/renderer/_index.scss
@@ -31,10 +31,6 @@
     }
   }
 
-  &:focus-within button {
-    outline: none;
-  }
-
   &--rightBorder {
     border-right: 1px solid #343741;
   }

--- a/packages/charts/src/chart_types/metric/renderer/dom/_text.scss
+++ b/packages/charts/src/chart_types/metric/renderer/dom/_text.scss
@@ -15,6 +15,7 @@
       font-weight: bold;
       width: 100%;
       text-align: left;
+      outline: none;
     }
   }
   &__icon {

--- a/packages/charts/src/chart_types/metric/renderer/dom/_text.scss
+++ b/packages/charts/src/chart_types/metric/renderer/dom/_text.scss
@@ -15,7 +15,6 @@
       font-weight: bold;
       width: 100%;
       text-align: left;
-      outline: none;
     }
   }
   &__icon {

--- a/packages/charts/src/chart_types/metric/renderer/dom/text.tsx
+++ b/packages/charts/src/chart_types/metric/renderer/dom/text.tsx
@@ -216,6 +216,9 @@ export const MetricText: React.FunctionComponent<{
           <h2 id={id} className="echMetricText__title">
             {onElementClick ? (
               <button
+                // ".echMetric" displays an outline halo;
+                // inline styles protect us from unintended overrides of these styles.
+                style={{ outline: 'none' }}
                 onMouseDown={(e) => e.stopPropagation()}
                 onMouseUp={(e) => e.stopPropagation()}
                 onClick={(e) => {


### PR DESCRIPTION
Closes: https://github.com/elastic/observability-dev/issues/3430
Closes: https://github.com/elastic/observability-dev/issues/3391

When we use the `Metric Chart` in `Kibana`, we have a problem where the focus halo is shown twice. I think we can explicitly add the property `outline: none`; to the `echMetricText__title button` to resolve this issue

![image](https://github.com/elastic/elastic-charts/assets/20072247/acc4ad0d-fc05-423f-8c9b-61a1819bd5fe)
