### PR TITLE
chore: reduce non-numeric number noise in logs

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/utils/series.test.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/series.test.ts
@@ -595,26 +595,26 @@ describe('Series', () => {
   });
 
   test('clean datum shall parse string as number for y values', () => {
-    let datum = extractYAndMarkFromDatum([0, 1, 2], 1, [], false, 2);
+    let datum = extractYAndMarkFromDatum([0, 1, 2], 1, new Map(), false, 2);
     expect(datum).toBeDefined();
     expect(datum?.y1).toBe(1);
     expect(datum?.y0).toBe(null);
-    datum = extractYAndMarkFromDatum([0, '1', 2], 1, [], false, 2);
-    expect(datum).toBeDefined();
-    expect(datum?.y1).toBe(1);
-    expect(datum?.y0).toBe(null);
-
-    datum = extractYAndMarkFromDatum([0, '1', '2'], 1, [], false, 2);
+    datum = extractYAndMarkFromDatum([0, '1', 2], 1, new Map(), false, 2);
     expect(datum).toBeDefined();
     expect(datum?.y1).toBe(1);
     expect(datum?.y0).toBe(null);
 
-    datum = extractYAndMarkFromDatum([0, 1, '2'], 1, [], false, 2);
+    datum = extractYAndMarkFromDatum([0, '1', '2'], 1, new Map(), false, 2);
     expect(datum).toBeDefined();
     expect(datum?.y1).toBe(1);
     expect(datum?.y0).toBe(null);
 
-    datum = extractYAndMarkFromDatum([0, 'invalid', 'invalid'], 1, [], false, 2);
+    datum = extractYAndMarkFromDatum([0, 1, '2'], 1, new Map(), false, 2);
+    expect(datum).toBeDefined();
+    expect(datum?.y1).toBe(1);
+    expect(datum?.y0).toBe(null);
+
+    datum = extractYAndMarkFromDatum([0, 'invalid', 'invalid'], 1, new Map(), false, 2);
     expect(datum).toBeDefined();
     expect(datum?.y1).toBe(null);
     expect(datum?.y0).toBe(null);


### PR DESCRIPTION
## Summary
This PR reduces the noise generated in the console logs by passing non-numerical values as Y values in cartesian charts when in development mode.