### PR TITLE
feat(metric): make value fit logic uniform across panels

### DIFF
--- a/packages/charts/src/chart_types/metric/renderer/dom/metric.tsx
+++ b/packages/charts/src/chart_types/metric/renderer/dom/metric.tsx
@@ -43,6 +43,7 @@ export const Metric: React.FunctionComponent<{
   backgroundColor: Color;
   contrastOptions: ColorContrastOptions;
   locale: string;
+  fittedValueFontSize: number;
   onElementClick?: ElementClickListener;
   onElementOver?: ElementOverListener;
   onElementOut?: BasicListener;
@@ -62,6 +63,7 @@ export const Metric: React.FunctionComponent<{
   onElementClick,
   onElementOver,
   onElementOut,
+  fittedValueFontSize
 }) => {
   const progressBarSize = 'small'; // currently we provide only the small progress bar;
   const [mouseState, setMouseState] = useState<'leave' | 'enter' | 'down'>('leave');
@@ -175,6 +177,7 @@ export const Metric: React.FunctionComponent<{
         progressBarSize={progressBarSize}
         highContrastTextColor={finalTextColor.keyword}
         locale={locale}
+        fittedValueFontSize={fittedValueFontSize}
       />
       {isMetricWTrend(datumWithInteractionColor) && <SparkLine id={metricHTMLId} datum={datumWithInteractionColor} />}
       {isMetricWProgress(datumWithInteractionColor) && (

--- a/storybook/stories/metric/2_grid.story.tsx
+++ b/storybook/stories/metric/2_grid.story.tsx
@@ -52,6 +52,16 @@ export const Example: ChartsStory = (_, { title, description }) => {
   const progressBarDirection = select('progress bar direction', ['horizontal', 'vertical'], 'vertical');
   const maxDataPoints = number('max trend data points', 30, { min: 0, max: 50, step: 1 });
   const emptyBackground = color('empty background', 'transparent');
+  const valueFontSizeMode = select(
+    'value font mode',
+    {
+      Default: 'default',
+      Fit: 'fit',
+      Custom: 'custom',
+    },
+    'default',
+  );
+  const valueFontSize = number('value font size (px)', 40, { min: 0, step: 10 });
 
   const data: (MetricDatum | undefined)[] = useMemo(
     () => [
@@ -215,6 +225,7 @@ export const Example: ChartsStory = (_, { title, description }) => {
           theme={{
             metric: {
               emptyBackground,
+              valueFontSize: valueFontSizeMode === 'custom' ? valueFontSize : valueFontSizeMode,
             },
           }}
           baseTheme={useBaseTheme()}


### PR DESCRIPTION
## Summary

The `fit` option for the `theme.metric.valueFontSize` now determines the best `fontSize` across all panels uniformly. Previously, the `fit` option was applied to each individual panel.

### New behavior

![Zight Recording 2024-07-12 at 04 00 24 PM](https://github.com/user-attachments/assets/4db2e9ba-09fe-46bc-9e32-65cc5d93c7c0)

### Previous behavior

![Zight Recording 2024-07-12 at 03 53 15 PM](https://github.com/user-attachments/assets/47b2ed31-49d6-4f08-969e-dac425b910a4)

## Issues

fix #2483

### Checklist

- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [x] New public API exports have been added to `packages/charts/src/index.ts`
- [x] The proper documentation and/or storybook story has been added or updated