### PR TITLE
fix(flame): failure when accessing `visualViewport.visualViewport` from within `iFrame`

### DIFF
--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -262,17 +262,7 @@ class FlameComponent extends React.Component<FlameProps> {
     this.navigator = new NavButtonControlledZoomPanHistory({ ...this.getFocusOnRoot(), index: 0 });
 
     // browser pinch zoom handling
-    this.pinchZoomSetInterval = NaN;
-
-    try {
-      // if in an iframe we need the top-level `visualViewport`
-      if (browserRootWindow().visualViewport) {
-        // Only setup listener if access to `visualViewport` is allowed
-        this.setupViewportScaleChangeListener();
-      }
-    } catch {
-      // unable to access `window.visualViewport`
-    }
+    this.setupViewportScaleChangeListener();
 
     // search
     this.currentColor = columns.color;
@@ -384,18 +374,24 @@ class FlameComponent extends React.Component<FlameProps> {
 
   /**
    * Setup interval to update pinch zoom scale factor
-   *
-   * Note: method accesses `window.visualViewport`
    */
   private setupViewportScaleChangeListener = () => {
-    window.clearInterval(this.pinchZoomSetInterval);
-    this.pinchZoomSetInterval = window.setInterval(() => {
-      const pinchZoomScale = browserRootWindow().visualViewport?.scale ?? 1;
-      if (pinchZoomScale !== this.pinchZoomScale) {
-        this.pinchZoomScale = pinchZoomScale;
-        this.setState({});
+    try {
+      // if in an iframe we need the top-level `visualViewport`
+      if (browserRootWindow().visualViewport) {
+        // Only setup listener if access to `visualViewport` is allowed
+        window.clearInterval(this.pinchZoomSetInterval);
+        this.pinchZoomSetInterval = window.setInterval(() => {
+          const pinchZoomScale = browserRootWindow().visualViewport?.scale ?? 1;
+          if (pinchZoomScale !== this.pinchZoomScale) {
+            this.pinchZoomScale = pinchZoomScale;
+            this.setState({});
+          }
+        }, PINCH_ZOOM_CHECK_INTERVAL_MS);
       }
-    }, PINCH_ZOOM_CHECK_INTERVAL_MS);
+    } catch {
+      // unable to access `window.visualViewport`
+    }
   };
 
   componentDidMount = () => {


### PR DESCRIPTION
## Summary

Fixes issue where the `Flame` chart was attempting to access [`window.visualViewport`](https://developer.mozilla.org/en-US/docs/Web/API/Window/visualViewport) from within an iframe.

## Details

The `Flame` chart was attempting to access the [`window.visualViewport`](https://developer.mozilla.org/en-US/docs/Web/API/Window/visualViewport) of the top most `window` from an iframe. However this triggered a `DOMException` error as the `visualViewport` property is forbidden expect when accessed by the top `window` context, for cross-origins.

```
DOMException: Failed to read a named property 'visualViewport' from 'Window': Blocked a frame with origin "https://my.kibana.com" from accessing a cross-origin frame.
```

We were only updating this value every `100ms` to capture the latest `pinchZoomScale`. Since this is not accessible from an iframe I elected to simply disable this update loop when in the iframe and access the value in place directly from `window.visualViewport?.scale`;

Now renders fine within iframe 👇🏼 

![Zight Recording 2024-08-07 at 01 21 10 PM](https://github.com/user-attachments/assets/64de9e13-c303-4cd7-9251-25975f3d2784)

## Issues

Related to https://github.com/elastic/kibana/issues/188288

### Checklist

- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] Unit tests have been added or updated to match the most common scenarios