### PR TITLE
style: Remove EUI Sass component-specific variable

### DIFF
--- a/packages/charts/src/components/tooltip/components/_tooltip_actions.scss
+++ b/packages/charts/src/components/tooltip/components/_tooltip_actions.scss
@@ -43,7 +43,7 @@
 
     &[disabled] {
       cursor: default;
-      color: $euiButtonColorDisabledText;
+      color: $euiColorDisabledText;
       &:hover,
       &:focus {
         text-decoration: none;


### PR DESCRIPTION
## Summary
👋 Hey y'all! I'm cleaning up some Sass exports (specifically of component-specific variables) in EUI's public exports and noticed this one variable usage that has no other usages in Kibana or Cloud. I'm switching it to a more generic equivalent that should not cause any UI regressions within the Amsterdam theme.

For the full list of mixins/variables being removed, see https://github.com/elastic/eui/pull/8031

### Checklist

- [ ] Visual changes have been tested with `light` and `dark` themes
