### PR TITLE
chore: remove unused `hideLinesTooltips` prop on `LineAnnotationSpec`

### DIFF
--- a/docs/docs/api/specs/xy/line_annotation.mdx
+++ b/docs/docs/api/specs/xy/line_annotation.mdx
@@ -76,12 +76,6 @@ The default position, if this property is not specified, falls back to the linke
 
 Annotation lines are hidden
 
-### `hideLinesTooltips`
-- Type: <code>hideLinesTooltips?: boolean</code>
-- Default: `true`
-
-Hide tooltip when hovering over the line
-
 ### `zIndex`
 - Type: <code>zIndex?: number</code>
 - Default: `1`

--- a/packages/charts/api/charts.api.md
+++ b/packages/charts/api/charts.api.md
@@ -1952,7 +1952,6 @@ export type LineAnnotationSpec<D = any> = BaseAnnotationSpec<typeof AnnotationTy
     };
     markerPosition?: Position;
     hideLines?: boolean;
-    hideLinesTooltips?: boolean;
     zIndex?: number;
 };
 

--- a/packages/charts/src/chart_types/xy_chart/specs/line_annotation.ts
+++ b/packages/charts/src/chart_types/xy_chart/specs/line_annotation.ts
@@ -24,7 +24,6 @@ const buildProps = buildSFProps<LineAnnotationSpec>()(
     annotationType: AnnotationType.Line,
     hideLines: false,
     hideTooltips: false,
-    hideLinesTooltips: true,
     zIndex: 1,
   },
 );

--- a/packages/charts/src/chart_types/xy_chart/utils/specs.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/specs.ts
@@ -874,11 +874,6 @@ export type LineAnnotationSpec<D = any> = BaseAnnotationSpec<
   /** Annotation lines are hidden */
   hideLines?: boolean;
   /**
-   * Hide tooltip when hovering over the line
-   * @defaultValue `true`
-   */
-  hideLinesTooltips?: boolean;
-  /**
    * z-index of the annotation relative to other elements in the chart
    * @defaultValue 1
    */


### PR DESCRIPTION
## Summary

Removes unused `hideLinesTooltips` prop on `LineAnnotationSpec` that was left unused after #418

### Checklist

- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] New public API exports have been added to `packages/charts/src/index.ts`