### PR TITLE
chore: add util for getting charts theme based on eui theme/colorMode

### DIFF
--- a/packages/charts/api/charts.api.md
+++ b/packages/charts/api/charts.api.md
@@ -1340,6 +1340,15 @@ export interface GeometryValue {
     y: any;
 }
 
+// @public
+export function getChartsTheme({ name, darkMode }: {
+    name: string;
+    darkMode: boolean;
+}): Theme;
+
+// @public
+export function getChartsTheme(themeName: string, colorMode: 'DARK' | 'LIGHT'): Theme;
+
 // Warning: (ae-forgotten-export) The symbol "DataDemand" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "TimeslipDataRows" needs to be exported by the entry point index.d.ts
 //

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -76,6 +76,7 @@ export {
 // theme
 export * from './utils/themes/theme';
 export * from './utils/themes/theme_common';
+export { getChartsTheme } from './utils/themes/get_charts_theme';
 export { LIGHT_THEME } from './utils/themes/light_theme';
 export { DARK_THEME } from './utils/themes/dark_theme';
 export { LIGHT_BASE_COLORS, DARK_BASE_COLORS } from './utils/themes/base_colors';

--- a/packages/charts/src/utils/themes/get_charts_theme.ts
+++ b/packages/charts/src/utils/themes/get_charts_theme.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { DARK_THEME } from './dark_theme';
+import { LIGHT_THEME } from './light_theme';
+import { Theme } from './theme';
+import { mergePartial } from '../common';
+
+const lightBackground = '#FFFFFF'; // euiColorEmptyShade
+const darkBackground = '#0B1628'; // euiColorEmptyShade
+
+const BOREALIS_LIGHT_THEME = mergePartial(LIGHT_THEME, {
+  background: {
+    color: lightBackground,
+    fallbackColor: lightBackground,
+  },
+});
+const BOREALIS_DARK_THEME = mergePartial(DARK_THEME, {
+  background: {
+    color: darkBackground,
+    fallbackColor: darkBackground,
+  },
+});
+
+/**
+ * Returns charts `Theme` given theme `name` and `darkMode`
+ * @public
+ */
+export function getChartsTheme({ name, darkMode }: { name: string; darkMode: boolean }): Theme;
+/**
+ * Returns charts `Theme` given theme `themeName` and `colorMode`
+ * @public
+ */
+export function getChartsTheme(themeName: string, colorMode: 'DARK' | 'LIGHT'): Theme;
+/**
+ * Returns charts `Theme`
+ * @public
+ */
+export function getChartsTheme(
+  theme: { name: string; darkMode: boolean } | string,
+  colorMode?: 'DARK' | 'LIGHT',
+): Theme {
+  const { name, darkMode } = typeof theme !== 'string' ? theme : { name: theme, darkMode: colorMode === 'DARK' };
+  if (name !== 'amsterdam' && name !== 'EUI_THEME_AMSTERDAM')
+    return darkMode ? BOREALIS_DARK_THEME : BOREALIS_LIGHT_THEME;
+  return darkMode ? DARK_THEME : LIGHT_THEME;
+}


### PR DESCRIPTION
## Summary

The new Borealis theme introduced a theme-aware and darkMode-aware theming. Charts however only exports 2 themes based only on darkMode. Rather than export 4 themes and having the user pick the correct one, I created a util that accepts either the `CoreTheme` definition from kibana, or the `UseEuiTheme` type from eui.

### Previous usage

```ts
// Kibana theme
import { DARK_THEME, LIGHT_THEME } from '@elastic/charts';

const coreTheme = { name: 'amsterdam', darkMode: false };
const chartsTheme = coreTheme.darkMode ? DARK_THEME : LIGHT_THEME;

// Eui theme
import { useEuiTheme } from '@elastic/eui';

const euiTheme = useEuiTheme();
const chartsTheme = coreTheme.colorMode === 'DARK' ? DARK_THEME : LIGHT_THEME;
```

### New usage

```ts
// Kibana theme
import { getChartsTheme } from '@elastic/charts';

const coreTheme = { name: 'amsterdam', darkMode: false };
const chartsTheme = getChartsTheme(coreTheme);

// Eui theme
import { getChartsTheme } from '@elastic/charts';
import { useEuiTheme } from '@elastic/eui';

const euiTheme = useEuiTheme();
const chartsTheme = getChartsTheme(euiTheme.euiTheme.themeName, coreTheme.colorMode);
```

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] New public API exports have been added to `packages/charts/src/index.ts`
- [x] Unit tests have been added or updated to match the most common scenarios