### PR TITLE
build: release dry-run only runs commit analyzer

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -42,36 +42,36 @@ module.exports = {
     ],
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
-    [
-      '@semantic-release/exec',
-      {
-        prepareCmd: 'node ./packages/charts/scripts/move_txt_files.js',
-        execCwd: '.',
-      },
-    ],
-    [
-      '@semantic-release/github',
-      {
-        successComment: false,
-        failComment: false,
-      },
-    ],
-    [
-      '@semantic-release/npm',
-      {
-        // must point to the child package
-        pkgRoot: './packages/charts',
-      },
-    ],
-    [
-      '@semantic-release/git',
-      {
-        assets: ['./packages/charts/package.json', 'CHANGELOG.md'],
-      },
-    ],
     ...(isDryRun
       ? []
       : [
+          [
+            '@semantic-release/exec',
+            {
+              prepareCmd: 'node ./packages/charts/scripts/move_txt_files.js',
+              execCwd: '.',
+            },
+          ],
+          [
+            '@semantic-release/github',
+            {
+              successComment: false,
+              failComment: false,
+            },
+          ],
+          [
+            '@semantic-release/npm',
+            {
+              // must point to the child package
+              pkgRoot: './packages/charts',
+            },
+          ],
+          [
+            '@semantic-release/git',
+            {
+              assets: ['./packages/charts/package.json', 'CHANGELOG.md'],
+            },
+          ],
           [
             'semantic-release-slack-bot',
             {


### PR DESCRIPTION
## Summary

I've cleaned a but the semantic-release configuration giving a simplified version of the dry-run command.
Before that change you need 3 tokens in your ENV to make it pass with different permissions.
I don't see a reason to run these checks locally because the tokens are different from the one in the CI, so I've reduced the dry-run steps to only execute the `commit-analyzer` and the `release-notes-generator`. These two are enough to understand if the current commits are correctly configured and what will be the output of the CHANGELOG.
