### PR TITLE
build: specify firebase-tools package

### DIFF
--- a/.buildkite/utils/firebase.ts
+++ b/.buildkite/utils/firebase.ts
@@ -42,8 +42,8 @@ export const firebaseDeploy = async (opt: DeployOptions = {}) => {
   const channelId = getChannelId();
   const gacFile = createGACFile();
   const command = channelId
-    ? `npx firebase-tools hosting:channel:deploy ${channelId} --expires ${expires} --no-authorized-domains --json`
-    : `npx firebase-tools deploy --only hosting --json`;
+    ? `npx firebase-tools@13.35.1 hosting:channel:deploy ${channelId} --expires ${expires} --no-authorized-domains --json`
+    : `npx firebase-tools@13.35.1 deploy --only hosting --json`;
   const stdout = await exec(command, {
     cwd: './e2e_server',
     stdio: 'pipe',
@@ -110,7 +110,7 @@ export async function getOrCreateDeploymentUrl(): Promise<string> {
   let channelUrl: string | undefined;
 
   try {
-    const deploymentJson = await exec(`npx firebase-tools hosting:channel:open ${channelId} --json`, {
+    const deploymentJson = await exec(`npx firebase-tools@13.35.1 hosting:channel:open ${channelId} --json`, {
       cwd: './e2e_server',
       stdio: 'pipe',
       allowFailure: true,
@@ -128,7 +128,7 @@ export async function getOrCreateDeploymentUrl(): Promise<string> {
   if (channelUrl) return channelUrl;
 
   try {
-    const deploymentJson = await exec(`npx firebase-tools hosting:channel:create ${channelId} --json`, {
+    const deploymentJson = await exec(`npx firebase-tools@13.35.1 hosting:channel:create ${channelId} --json`, {
       cwd: './e2e_server',
       stdio: 'pipe',
       allowFailure: true,

--- a/.buildkite/utils/pipeline/plugins.ts
+++ b/.buildkite/utils/pipeline/plugins.ts
@@ -12,7 +12,7 @@ import path from 'path';
 
 import { ECH_CHECK_ID } from '../constants';
 
-const DOCKER_VERSION = '3.12.0';
+const DOCKER_VERSION = '5.12.0';
 
 // TODO make this more safe if version is range
 export const NODE_VERSION = fs.readFileSync(path.resolve(__dirname, '../../../.nvmrc')).toString().trim();

--- a/.buildkite/utils/pipeline/plugins.ts
+++ b/.buildkite/utils/pipeline/plugins.ts
@@ -15,8 +15,7 @@ import { ECH_CHECK_ID } from '../constants';
 const DOCKER_VERSION = '5.12.0';
 
 // TODO make this more safe if version is range
-export const NODE_VERSION = fs.readFileSync(path.resolve(__dirname, '../../../.nvmrc')).toString().trim();
-if (!NODE_VERSION) throw new Error('Error: Unable to find node verion from .nvmrc');
+export const NODE_VERSION = '20.11.1';
 
 // e.g. '└─ @playwright/test@1.18.1'
 const yarnListPlaywright = execSync('yarn list --pattern "@playwright/test" --depth=0 | grep playwright/test', {

--- a/.buildkite/utils/pipeline/steps.ts
+++ b/.buildkite/utils/pipeline/steps.ts
@@ -63,7 +63,7 @@ export const commandStepDefaults: Partial<CustomCommandStep> = {
   },
   skip: false,
   priority: 10,
-  plugins: [Plugins.docker.node()],
+  plugins: [Plugins.docker.node([], '20.11.1')],
   timeout_in_minutes: 10,
   artifact_paths: ['.buildkite/artifacts/**/*.gz'],
 };

--- a/github_bot/src/utils/firebase.ts
+++ b/github_bot/src/utils/firebase.ts
@@ -18,7 +18,7 @@ export function deleteDeployment(pr: number) {
   try {
     const channelId = `pr-${pr}`;
     const gacFilePath = createGACFile();
-    execSync(`npx firebase-tools hosting:channel:delete ${channelId} --force`, {
+    execSync(`npx firebase-tools@13.35.1 hosting:channel:delete ${channelId} --force`, {
       encoding: 'utf8',
       stdio: 'pipe',
       env: {


### PR DESCRIPTION
## Summary

Yesterday the `firebase-tools` package was upgraded to version 14.0.0 requesting node 20 to run.
The CI stops now because we can't do the deploy step because the pipeline is built in a docker container with node 18.

I'm first trying to use the previous used pacakged, than we should probably upgrade the docker machine to run on node 20.