### PR TITLE
build(deps): bump axios from 1.7.4 to 1.8.2 in /.buildkite (#2624) [69.x]

### DIFF
--- a/.buildkite/package.json
+++ b/.buildkite/package.json
@@ -18,7 +18,7 @@
     "@types/gh-pages": "^3.2.1",
     "@types/targz": "^1.0.1",
     "@types/tmp": "^0.2.3",
-    "axios": "^1.7.4",
+    "axios": "^1.8.2",
     "buildkite-agent-node": "^0.0.11-pre.2",
     "gh-pages": "^5.0.0",
     "json-schema-to-typescript": "15.0.4",

--- a/.buildkite/yarn.lock
+++ b/.buildkite/yarn.lock
@@ -350,10 +350,10 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.7.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.4.tgz#4c8ded1b43683c8dd362973c393f3ede24052aa2"
-  integrity sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==
+axios@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.2.tgz#fabe06e241dfe83071d4edfbcaa7b1c3a40f7979"
+  integrity sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
Backports the following commits to 69.x:
 - build(deps): bump axios from 1.7.4 to 1.8.2 in /.buildkite (#2624)