### PR TITLE
fix: Update aria-labelledby for Sparkline svg to not use spaces

### DIFF
--- a/packages/charts/src/chart_types/metric/renderer/dom/sparkline.tsx
+++ b/packages/charts/src/chart_types/metric/renderer/dom/sparkline.tsx
@@ -82,7 +82,7 @@ export const SparkLine: FunctionComponent<{
         viewBox="0 0 1 1"
         preserveAspectRatio="none"
         role="img"
-        aria-labelledby={`${titleId} ${descriptionId}`}
+        aria-labelledby={`${titleId}_${descriptionId}`}
       >
         <title id={titleId} className="echScreenReaderOnly">
           {trendA11yTitle}


### PR DESCRIPTION
## Summary

fix: Sparkline svg `aria-labelledby` now generates a valid ID that will make Metric charts more accessible.

## Details

This patch would modify the `aria-labelledby` attribute that is generated for the svg rendered by the Sparkline component within the Metric chart type. Downstream in Kibana we are failing an accessibility audit because our metrics charts do not contain `alt` or `aria` for this SVG. We can allow the svg to be described by an existing element that contains a proper label for the chart, but the `aria-labelledby` contains a space, which is not valid for this attribute and causes the attempt to link up an element ID to fail.

**Before (from [hosted storybook](https://elastic.github.io/elastic-charts/storybook/?path=/story/metric-alpha--basic&globals=toggles.showHeader:true;toggles.showChartTitle:false;toggles.showChartDescription:false;toggles.showChartBoundary:false;theme:light)):**
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/a8a1ca0a-099c-4a40-8ef3-9ac3798e0924" />


**After:**
<img width="1108" alt="image" src="https://github.com/user-attachments/assets/2f061f5e-7f16-4ab3-98f7-1e400e59bd62" />

I've tested this with the Axe testing plugin by manually changing the `aria-labelledby` attributes on my Sparkline svg elements in the DOM in Kibana, and supplying an element with a matching ID and verified this fixed the accessibility failures:

<img width="1550" alt="image" src="https://github.com/user-attachments/assets/8d02bc4c-2e89-4e29-af09-d4ad6bcc8ee4" />

Without these edits, this is the result of the scan, where each Sparkline SVG gets logged as a failure:

<img width="1564" alt="image" src="https://github.com/user-attachments/assets/3baede71-9755-46df-9400-fd5f3890a566" />

## Issues

This addresses an accessibility failure occurring in the Synthetics app in Kibana: [#212242](https://github.com/elastic/kibana/issues/212242). Once this change is released and consumed by Kibana, a subsequent PR to the Synthetics app will resolve the issue.

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [ ] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [ ] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [X] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
