### PR TITLE
fix: Update aria-labelledby for Sparkline svg to not use spaces (#2654) [69.x]

### DIFF
--- a/packages/charts/src/chart_types/metric/renderer/dom/sparkline.tsx
+++ b/packages/charts/src/chart_types/metric/renderer/dom/sparkline.tsx
@@ -82,7 +82,7 @@ export const SparkLine: FunctionComponent<{
         viewBox="0 0 1 1"
         preserveAspectRatio="none"
         role="img"
-        aria-labelledby={`${titleId} ${descriptionId}`}
+        aria-labelledby={`${titleId}_${descriptionId}`}
       >
         <title id={titleId} className="echScreenReaderOnly">
           {trendA11yTitle}


### PR DESCRIPTION
Backports the following commits to 69.x:
 - fix: Update aria-labelledby for Sparkline svg to not use spaces (#2654)