### PR TITLE
fix(axis): adaptive tick nicing

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/state/selectors/compute_series_geometries.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/compute_series_geometries.ts
@@ -11,6 +11,7 @@ import { computeSeriesDomainsSelector } from './compute_series_domains';
 import { getSeriesColorsSelector } from './get_series_color_map';
 import { getSeriesSpecsSelector, getAxisSpecsSelector } from './get_specs';
 import { isHistogramModeEnabledSelector } from './is_histogram_mode_enabled';
+import { getVisibleTickSetsSelector } from './visible_ticks';
 import { createCustomCachedSelector } from '../../../../state/create_selector';
 import { computeSmallMultipleScalesSelector } from '../../../../state/selectors/compute_small_multiple_scales';
 import { getChartThemeSelector } from '../../../../state/selectors/get_chart_theme';
@@ -28,10 +29,11 @@ export const computeSeriesGeometriesSelector = createCustomCachedSelector(
     getSettingsSpecSelector,
     getAxisSpecsSelector,
     computeSmallMultipleScalesSelector,
+    getVisibleTickSetsSelector,
     isHistogramModeEnabledSelector,
     getFallBackTickFormatter,
   ],
-  (specs, domain, colors, theme, settings, axis, smScales, isHistogram, fallbackFormatter) => {
+  (specs, domain, colors, theme, settings, axis, smScales, visibleTicksSet, isHistogram, fallbackFormatter) => {
     return withTextMeasure((measureText) =>
       computeSeriesGeometries(
         specs,
@@ -41,6 +43,7 @@ export const computeSeriesGeometriesSelector = createCustomCachedSelector(
         settings,
         axis,
         smScales,
+        visibleTicksSet,
         isHistogram,
         fallbackFormatter,
         measureText,

--- a/storybook/stories/test_cases/15_linear_nicing.story.tsx
+++ b/storybook/stories/test_cases/15_linear_nicing.story.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { boolean } from '@storybook/addon-knobs';
+import React from 'react';
+
+import { Axis, Chart, LineSeries, Position, ScaleType, Settings } from '@elastic/charts';
+import { getRandomNumberGenerator } from '@elastic/charts/src/mocks/utils';
+
+import type { ChartsStory } from '../../types';
+import { useBaseTheme } from '../../use_base_theme';
+
+const rng = getRandomNumberGenerator();
+
+// This data is carefully picked to trigger adaptive tick placements
+// See https://github.com/elastic/elastic-charts/issues/2687
+const data = new Array(20).fill(1).map((_, i) => ({
+  x: i === 0 ? -1e6 : (i - 1) * 13e6,
+  y: (i === 0 ? 0 : i === 2 ? -5.2 : i === 12 ? 21 : rng(-4, 20)) * 1e5,
+}));
+
+export const Example: ChartsStory = (_, { title, description }) => {
+  const xNice = boolean('Nice x ticks', true);
+  const yNice = boolean('Nice y ticks', true);
+
+  return (
+    <Chart title={title} description={description}>
+      <Settings baseTheme={useBaseTheme()} />
+      <Axis id="x" position={Position.Bottom} />
+      <Axis id="y" position={Position.Left} style={{ tickLabel: { rotation: -90 } }} />
+      <LineSeries
+        id="line-1"
+        xScaleType={ScaleType.Linear}
+        yScaleType={ScaleType.Linear}
+        data={data}
+        xNice={xNice}
+        yNice={yNice}
+        xAccessor="x"
+        yAccessors={['y']}
+      />
+    </Chart>
+  );
+};
+
+Example.parameters = {
+  resize: true,
+};

--- a/storybook/stories/test_cases/test_cases.stories.tsx
+++ b/storybook/stories/test_cases/test_cases.stories.tsx
@@ -26,4 +26,5 @@ export { Example as startDayOfWeek } from './11_start_day_of_week.story';
 export { Example as logWithNegativeValues } from './12_log_with_negative_values.story';
 export { Example as pointStyleOverrides } from './13_point_style_overrides.story';
 export { Example as errorBoundary } from './14_error_boundary.story';
+export { Example as linearNicing } from './15_linear_nicing.story';
 export { Example as lensStressTest } from './33_lens_stress.story';


### PR DESCRIPTION
## Summary

Fixes an issue where the rendered geometries used a different domain than the axis when the domain is set to `nice`.

## Details

I believe this issue was introduced in #1420 when we add the adaptive ticks. The problem is that we are iteratively finding the ideal tick count for the axes, do so when the domain is static and simply set to the data domain, there is no issue because the domain never changes. However, when we apply _nicing_ to the domain, this alters the domain which is a function of the `desiredTickCount`.

So it is possible we can end up with a domain on the axes that is different from the domain used in the rendered geometries.

This is easiest to see when there is a value at `0` such that when viewing the tooltip it clearly is in the wrong location. But this affects any domain, but particularly on smaller charts or when there is congestion in the labels tending to reduce the ideal number of ticks.

The easiest solution is to pass the adaptive tick count to the rendering in order to sync the tick counts, and thus the domain, between the axes and the geometries.

### Before

https://github.com/user-attachments/assets/1310e798-461f-4c64-ba0d-9a3905a219f2

> Notice as the tick count changes, either increase or decrease, the rendered geometries never jump to align with the new axes scales.

### After

https://github.com/user-attachments/assets/52f28cbe-7ea3-44df-bf1c-c1a22114b8c7

> Notice as the tick count changes, either increase or decrease, the rendered geometries jump to align with the new axes scales.


## Issues

Fixes #2687

### Checklist

- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [ ] Unit tests have been added or updated to match the most common scenarios
- [x] The proper documentation and/or storybook story has been added or updated