### PR TITLE
chore: skip flaky tooltip tests

### DIFF
--- a/e2e/tests/tooltip.test.ts
+++ b/e2e/tests/tooltip.test.ts
@@ -13,7 +13,8 @@ import { common } from '../page_objects/common';
 test.describe('Tooltip', () => {
   test.describe('Chart Types', () => {
     test.describe('Cartesian', () => {
-      test('pinning without selection', async ({ page }) => {
+      // TODO fix flakiness with resizing tooltip
+      test.skip('pinning without selection', async ({ page }) => {
         await common.expectChartWithClickAtUrlToMatchScreenshot(page)(
           'http://localhost:9001/?path=/story/components-tooltip--cartesian-charts&globals=theme:light&knob-Chart%20type=treemap&knob-SeriesType=bar&knob-async%20delay%20(ms)=1500&knob-character%20set=rtl&knob-data%20polarity=Mixed&knob-pinned=true&knob-rtl%20language=AR&knob-show%20legend=true&knob-stacked=true&knob-visible=true',
           { left: 240, bottom: 260 },
@@ -21,7 +22,8 @@ test.describe('Tooltip', () => {
         );
       });
 
-      test('pinning over selection', async ({ page }) => {
+      // TODO fix flakiness with resizing tooltip
+      test.skip('pinning over selection', async ({ page }) => {
         await common.expectChartWithClickAtUrlToMatchScreenshot(page)(
           'http://localhost:9001/?path=/story/components-tooltip--cartesian-charts&globals=theme:light&knob-Chart type=treemap&knob-SeriesType=bar&knob-async delay=1000&knob-async delay (ms)=1500&knob-character set=rtl&knob-chart type=line&knob-data polarity=Mixed&knob-pinned=true&knob-rtl language=AR&knob-show legend=true&knob-stacked=true&knob-visible=true&knob-reduce data=true&knob-async actions delay=0',
           { left: 220, bottom: 285 },
@@ -55,7 +57,8 @@ test.describe('Tooltip', () => {
         );
       });
 
-      test('selecting series on pinned tooltip async', async ({ page }) => {
+      // TODO fix flakiness with resizing tooltip
+      test.skip('selecting series on pinned tooltip async', async ({ page }) => {
         const delay = 100;
         await common.expectChartAtUrlToMatchScreenshot(page)(
           `http://localhost:9001/?path=/story/components-tooltip--cartesian-charts&globals=theme:light&knob-Chart type=treemap&knob-SeriesType=bar&knob-async delay=1000&knob-async delay (ms)=1500&knob-character set=rtl&knob-chart type=bar&knob-data polarity=Mixed&knob-pinned=true&knob-rtl language=AR&knob-show legend=true&knob-stacked=true&knob-visible=true&knob-reduce data=true&knob-async actions delay=${delay}`,


### PR DESCRIPTION
Skips some flaky e2e tooltip tests. The size of the tooltips isn't consistent so the visual regression tests don't pass from time to time.

<img width="2036" height="1238" alt="CleanShot 2025-08-14 at 11 43 10@2x" src="https://github.com/user-attachments/assets/82c137b8-7677-4424-aab6-75d89ce31454" />
