### PR TITLE
chore(ci): Migrate to Elastic-wide Buildkite infra

### DIFF
--- a/.buildkite/package.json
+++ b/.buildkite/package.json
@@ -6,7 +6,7 @@
     "build:bk:types": "ts-node scripts/get_buildkite_types.ts",
     "postinstall": "yarn build:bk:types",
     "build:pipeline": "ts-node pipelines/pull_request/pipeline.ts",
-    "print:pipeline": "yarn build:bk:types && TEST_BK_PIPELINE=true ts-node -r dotenv/config pipelines/pull_request/pipeline.ts",
+    "print:pipeline": "yarn -s build:bk:types && TEST_BK_PIPELINE=true ts-node -r dotenv/config pipelines/pull_request/pipeline.ts",
     "run:script": "ts-node -r dotenv/config ",
     "run:script:top": "cd ../ && DOTENV_CONFIG_PATH=.buildkite/.env ts-node -r dotenv/config ",
     "typecheck": "tsc -p ./tsconfig.json --noEmit"

--- a/.buildkite/pipelines/pull_request/pipeline.sh
+++ b/.buildkite/pipelines/pull_request/pipeline.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 
 cd '.buildkite'
 
-echo '--- Build pipeline'
+if [[ "${ELASTIC_BUILDKITE_INFRA:-}" =~ ^(1|true)$ ]]; then
+  # The new infra requires the pipeline to emit the steps
+  yarn -s print:pipeline
+else
+  # The old infra required pipeline upload
+  echo '--- Build pipeline'
 
-yarn build:pipeline
+  yarn build:pipeline
+fi

--- a/.buildkite/utils/pipeline/steps.ts
+++ b/.buildkite/utils/pipeline/steps.ts
@@ -12,6 +12,7 @@ import { bkEnv } from '../buildkite';
 import type { ChangeContext } from '../github';
 
 /**
+ * @deprecated
  * Available agents from kibana buildkite instance
  * See [full list](https://github.com/elastic/kibana-buildkite/blob/dab1058885036ac23e8371e40dcd3e0fedb4c49c/agents.json#L19-L165)
  */
@@ -39,7 +40,13 @@ export type CustomCommandStep = Omit<CommandStep, 'agents'> & {
    */
   ignoreForced?: boolean;
   agents?: {
-    queue: AgentQueue;
+    /** @deprecated - image queues are no longer supported outside of the Kibana-Buildkite infra */
+    queue?: AgentQueue;
+    imageProject?: 'elastic-images-qa' | 'elastic-images-prod' | string;
+    image?: string;
+    diskSizeGb?: number;
+    provider?: 'gcp' | string;
+    machineType?: string;
   };
 };
 
@@ -57,9 +64,16 @@ export type CustomGroupStep = Omit<GroupStep, 'steps'> & {
 // Only current supported steps
 export type Step = CustomGroupStep | CustomCommandStep;
 
+const IS_ELASTIC_BUILDKITE_INFRA = !!process.env.ELASTIC_BUILDKITE_INFRA?.match(/^(1|true)$/);
+
 export const commandStepDefaults: Partial<CustomCommandStep> = {
-  agents: {
-    queue: 'datavis-n2-2' as AgentQueue,
+  agents: IS_ELASTIC_BUILDKITE_INFRA ? {
+    provider: 'gcp',
+    image: 'family/kibana-ubuntu-2404',
+    imageProject: 'elastic-images-prod',
+    machineType: 'n2-standard-2'
+  }: {
+    queue: 'datavis-n2-2',
   },
   skip: false,
   priority: 10,

--- a/.buildkite/utils/pipeline/steps.ts
+++ b/.buildkite/utils/pipeline/steps.ts
@@ -67,14 +67,16 @@ export type Step = CustomGroupStep | CustomCommandStep;
 const IS_ELASTIC_BUILDKITE_INFRA = !!process.env.ELASTIC_BUILDKITE_INFRA?.match(/^(1|true)$/);
 
 export const commandStepDefaults: Partial<CustomCommandStep> = {
-  agents: IS_ELASTIC_BUILDKITE_INFRA ? {
-    provider: 'gcp',
-    image: 'family/kibana-ubuntu-2404',
-    imageProject: 'elastic-images-prod',
-    machineType: 'n2-standard-2'
-  }: {
-    queue: 'datavis-n2-2',
-  },
+  agents: IS_ELASTIC_BUILDKITE_INFRA
+    ? {
+        provider: 'gcp',
+        image: 'family/kibana-ubuntu-2404',
+        imageProject: 'elastic-images-prod',
+        machineType: 'n2-standard-2',
+      }
+    : {
+        queue: 'datavis-n2-2',
+      },
   skip: false,
   priority: 10,
   plugins: [Plugins.docker.node()],

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -20,7 +20,7 @@ spec:
       env:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "false"
         ELASTIC_BUILDKITE_INFRA: "true"
-      repository: elastic/kibana
+      repository: elastic/elastic-charts
       provider_settings:
         trigger_mode: none
       pipeline_file: ".buildkite/pipelines/pull_request/pipeline.sh"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elastic-charts-build
+  description: Builds Elastic Charts
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/kibana-elastic-charts-build
+spec:
+  type: buildkite-pipeline
+  owner: group:kibana-visualizations
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: kibana / elastic-charts / build
+    spec:
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "false"
+        ELASTIC_BUILDKITE_INFRA: "true"
+      repository: elastic/kibana
+      provider_settings:
+        trigger_mode: none
+      pipeline_file: ".buildkite/pipelines/pull_request/pipeline.sh"
+      teams:
+        kibana-visualizations:
+          access_level: MANAGE_BUILD_AND_READ
+        kibana-operations:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
## Summary
This PR adds a `catalog-info.yaml` through which a new pipeline can be created in the shared elastic infrastructure.

## Details
The PR also adds a branching logic, so that the pipeline will work more or less identical on the new infrastructure. The changes required for this are: 
 - emit to `stdout` instead of uploading steps - the runner will run the pipeline file, and upload the resulting string
 - use different agent targeting rules - there aren't agent-queues on the new infra, like we had in Kibana-buildkite

Once this PR is merged, Terrazzo will pick up the changes, create the pipeline, and the two pipelines can live parallel to each other, while we're testing. If we're happy with the pipeline, we can work on triggering and if we need to keep history of the previous job.

## Issues
Doesn't fix it just yet, but part of the work of: http://github.com/elastic/elastic-charts/issues/2499

### Checklist
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
