### PR TITLE
fix: remove wrong traversal path

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -368,6 +368,12 @@ module.exports = {
         'elastic-charts/require-tsdocs': 2,
         'elastic-charts/require-documentation': 1,
 
+        'import/no-useless-path-segments': [
+          'error',
+          {
+            noUselessIndex: true,
+          },
+        ],
         /*
          *****************************************
          * Rules with high processing demand

--- a/packages/charts/src/chart_types/bullet_graph/selectors/get_bullet_spec.ts
+++ b/packages/charts/src/chart_types/bullet_graph/selectors/get_bullet_spec.ts
@@ -6,11 +6,11 @@
  * Side Public License, v 1.
  */
 
-import { ChartType } from '../../../chart_types';
-import type { BulletSpec } from '../../../chart_types/bullet_graph/spec';
+import { ChartType } from '../..';
 import { SpecType } from '../../../specs/spec_type'; // kept as long-winded import on separate line otherwise import circularity emerges
 import type { GlobalChartState } from '../../../state/chart_state';
 import { getSpecFromStore } from '../../../state/utils/get_spec_from_store';
+import type { BulletSpec } from '../spec';
 
 /** @internal */
 

--- a/packages/charts/src/chart_types/bullet_graph/selectors/get_layout.ts
+++ b/packages/charts/src/chart_types/bullet_graph/selectors/get_layout.ts
@@ -8,13 +8,13 @@
 
 import { getBulletSpec } from './get_bullet_spec';
 import { getChartSize } from './get_chart_size';
-import type { BulletDatum } from '../../../chart_types/bullet_graph/spec';
-import { BulletSubtype } from '../../../chart_types/bullet_graph/spec';
 import { createCustomCachedSelector } from '../../../state/create_selector';
 import { getSettingsSpecSelector } from '../../../state/selectors/get_settings_spec';
 import { withTextMeasure } from '../../../utils/bbox/canvas_text_bbox_calculator';
 import type { Size } from '../../../utils/dimensions';
 import { wrapText } from '../../../utils/text/wrap';
+import { BulletSubtype } from '../spec';
+import type { BulletDatum } from '../spec';
 import {
   FONT_PADDING,
   HEADER_PADDING,

--- a/packages/charts/src/chart_types/bullet_graph/spec.ts
+++ b/packages/charts/src/chart_types/bullet_graph/spec.ts
@@ -10,7 +10,7 @@ import type { ComponentProps } from 'react';
 import type { $Values, Optional } from 'utility-types';
 
 import type { BulletColorConfig } from './utils/color';
-import { ChartType } from '../../chart_types/index';
+import { ChartType } from '..';
 import type { Spec } from '../../specs/spec_type';
 import { SpecType } from '../../specs/spec_type'; // kept as long-winded import on separate line otherwise import circularity emerges
 import type { SFProps } from '../../state/spec_factory';

--- a/packages/charts/src/chart_types/chart_type_renderers.ts
+++ b/packages/charts/src/chart_types/chart_type_renderers.ts
@@ -6,11 +6,11 @@
  * Side Public License, v 1.
  */
 
+import { ChartType } from '.';
 import { chartRenderer as bulletRenderer } from './bullet_graph/chart_renderer';
 import { FlameWithTooltip as flameRenderer } from './flame_chart/flame_chart';
 import { chartRenderer as goalRenderer } from './goal_chart/state/chart_renderer';
 import { chartRenderer as heatmapRenderer } from './heatmap/state/chart_renderer';
-import { ChartType } from './index';
 import { chartRenderer as metricRenderer } from './metric/state/chart_renderer';
 import { chartRenderer as partitionRenderer } from './partition_chart/renderer/dom/layered_partition_chart';
 import { chartRenderer as timeslipRenderer } from './timeslip/timeslip_chart';

--- a/packages/charts/src/chart_types/chart_type_selectors.ts
+++ b/packages/charts/src/chart_types/chart_type_selectors.ts
@@ -6,11 +6,11 @@
  * Side Public License, v 1.
  */
 
+import { ChartType } from '.';
 import { chartSelectorsFactory as bulletSelectorsFactory } from './bullet_graph/chart_selectors';
 import { chartSelectorsFactory as flameSelectorsFactory } from './flame_chart/chart_selectors';
 import { chartSelectorsFactory as goalSelectorsFactory } from './goal_chart/state/chart_selectors';
 import { chartSelectorsFactory as heatmapSelectorsFactory } from './heatmap/state/chart_selectors';
-import { ChartType } from './index';
 import { chartSelectorsFactory as metricSelectorsFactory } from './metric/state/chart_selectors';
 import { chartSelectorsFactory as partitionSelectorsFactory } from './partition_chart/state/chart_selectors';
 import { chartSelectorsFactory as timeslipSelectorsFactory } from './timeslip/chart_selectors';

--- a/packages/charts/src/chart_types/goal_chart/layout/viewmodel/utils.test.ts
+++ b/packages/charts/src/chart_types/goal_chart/layout/viewmodel/utils.test.ts
@@ -6,8 +6,8 @@
  * Side Public License, v 1.
  */
 
-import type { Radian } from './../../../../common/geometry';
 import { normalizeAngles } from './utils';
+import type { Radian } from '../../../../common/geometry';
 
 const normalize = (a: Radian): number => a / Math.PI;
 const denormalize = (a: number): Radian => a * Math.PI;

--- a/packages/charts/src/chart_types/goal_chart/layout/viewmodel/viewmodel.ts
+++ b/packages/charts/src/chart_types/goal_chart/layout/viewmodel/viewmodel.ts
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
-import { clamp, clampAll, isBetween, isFiniteNumber, isNil } from './../../../../utils/common';
 import type { Radian } from '../../../../common/geometry';
 import { ScaleContinuous } from '../../../../scales';
+import { clamp, clampAll, isBetween, isFiniteNumber, isNil } from '../../../../utils/common';
 import type { Dimensions } from '../../../../utils/dimensions';
 import type { Theme } from '../../../../utils/themes/theme';
 import type { GoalSpec } from '../../specs';

--- a/packages/charts/src/chart_types/goal_chart/state/selectors/picked_shapes.ts
+++ b/packages/charts/src/chart_types/goal_chart/state/selectors/picked_shapes.ts
@@ -6,11 +6,11 @@
  * Side Public License, v 1.
  */
 
-import { getActivePointerPosition } from './../../../../state/selectors/get_active_pointer_position';
 import { geometries, getPrimitiveGeoms } from './geometries';
 import type { Rectangle } from '../../../../common/geometry';
 import type { LayerValue } from '../../../../specs';
 import { createCustomCachedSelector } from '../../../../state/create_selector';
+import { getActivePointerPosition } from '../../../../state/selectors/get_active_pointer_position';
 import type { BulletViewModel } from '../../layout/types/viewmodel_types';
 import type { Mark } from '../../layout/viewmodel/geoms';
 import { initialBoundingBox } from '../../layout/viewmodel/geoms';

--- a/packages/charts/src/chart_types/heatmap/layout/viewmodel/scenegraph.ts
+++ b/packages/charts/src/chart_types/heatmap/layout/viewmodel/scenegraph.ts
@@ -6,16 +6,16 @@
  * Side Public License, v 1.
  */
 
+import { shapeViewModel } from './viewmodel';
 import type { ColorScale } from '../../../../common/colors';
 import type { SmallMultipleScales, SmallMultiplesGroupBy } from '../../../../common/panel_utils';
 import { withTextMeasure } from '../../../../utils/bbox/canvas_text_bbox_calculator';
 import type { ChartDimensions } from '../../../../utils/dimensions';
 import type { Theme } from '../../../../utils/themes/theme';
-import type { ShapeViewModel } from '../../layout/types/viewmodel_types';
-import { shapeViewModel } from '../../layout/viewmodel/viewmodel';
 import type { HeatmapSpec } from '../../specs';
 import type { ChartElementSizes } from '../../state/selectors/compute_chart_element_sizes';
 import type { HeatmapTable } from '../../state/selectors/get_heatmap_table';
+import type { ShapeViewModel } from '../types/viewmodel_types';
 
 /** @internal */
 export function computeScenegraph(

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_brushed_highlighted_shapes.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_brushed_highlighted_shapes.ts
@@ -6,10 +6,10 @@
  * Side Public License, v 1.
  */
 
-import { getActivePointerPosition } from './../../../../state/selectors/get_active_pointer_position';
 import { getPerPanelHeatmapGeometries } from './get_per_panel_heatmap_geometries';
 import type { GlobalChartState } from '../../../../state/chart_state';
 import { createCustomCachedSelector } from '../../../../state/create_selector';
+import { getActivePointerPosition } from '../../../../state/selectors/get_active_pointer_position';
 import type { DragShape } from '../../layout/types/viewmodel_types';
 
 function getCurrentPointerStates(state: GlobalChartState) {

--- a/packages/charts/src/chart_types/partition_chart/layout/viewmodel/hierarchy_of_arrays.test.ts
+++ b/packages/charts/src/chart_types/partition_chart/layout/viewmodel/hierarchy_of_arrays.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { getHierarchyOfArrays } from './hierarchy_of_arrays';
-import { CHILDREN_KEY, entryValue } from '../../layout/utils/group_by_rollup';
+import { CHILDREN_KEY, entryValue } from '../utils/group_by_rollup';
 
 const rawFacts = [
   { sitc1: '7', exportVal: 0 },

--- a/packages/charts/src/chart_types/partition_chart/layout/viewmodel/scenegraph.ts
+++ b/packages/charts/src/chart_types/partition_chart/layout/viewmodel/scenegraph.ts
@@ -6,11 +6,11 @@
  * Side Public License, v 1.
  */
 
-import type { BackgroundStyle } from './../../../../utils/themes/theme';
 import { shapeViewModel } from './viewmodel';
 import { withTextMeasure } from '../../../../utils/bbox/canvas_text_bbox_calculator';
 import type { Dimensions } from '../../../../utils/dimensions';
 import type { PartitionStyle } from '../../../../utils/themes/partition';
+import type { BackgroundStyle } from '../../../../utils/themes/theme';
 import type { Layer, PartitionSpec } from '../../specs';
 import { VALUE_GETTERS } from '../config';
 import type {

--- a/packages/charts/src/chart_types/partition_chart/state/selectors/picked_shapes.ts
+++ b/packages/charts/src/chart_types/partition_chart/state/selectors/picked_shapes.ts
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
-import { getActivePointerPosition } from './../../../../state/selectors/get_active_pointer_position';
 import { partitionDrilldownFocus, partitionMultiGeometries } from './geometries';
 import { createCustomCachedSelector } from '../../../../state/create_selector';
+import { getActivePointerPosition } from '../../../../state/selectors/get_active_pointer_position';
 import { pickedShapes, pickShapesLayerValues } from '../../layout/viewmodel/picked_shapes';
 
 /** @internal */

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/animation.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/animation.ts
@@ -8,9 +8,9 @@
 
 import type { $Keys } from 'utility-types';
 
-import { TimeFunction, TimingFunctions } from './../../../../../utils/time_functions';
 import type { TimeMs } from '../../../../../common/geometry';
 import { clamp, isFiniteNumber } from '../../../../../utils/common';
+import { TimeFunction, TimingFunctions } from '../../../../../utils/time_functions';
 
 /**
  * TODO add logic for other types like colors

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/index.ts
@@ -6,10 +6,10 @@
  * Side Public License, v 1.
  */
 
-import { Logger } from './../../../../../utils/logger';
 import type { AnimatedValue, AnimationOptions, AnimationState } from './animation';
 import { Animation } from './animation';
 import { debounce } from '../../../../../utils/debounce';
+import { Logger } from '../../../../../utils/logger';
 
 // TODO find a better way to do this when we have an actual build process
 const DISABLE_ANIMATIONS = (typeof process === 'object' && process.env && process.env.VRT) === 'true';

--- a/packages/charts/src/chart_types/xy_chart/renderer/common/utils.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/common/utils.ts
@@ -6,11 +6,11 @@
  * Side Public License, v 1.
  */
 
-import type { AnimationConfig } from './../../utils/specs';
-import { AnnotationAnimationTrigger } from './../../utils/specs';
 import { mergePartial } from '../../../../utils/common';
 import type { GeometryStateStyle, SharedGeometryStateStyle } from '../../../../utils/themes/theme';
 import { TimeFunction } from '../../../../utils/time_functions';
+import { AnnotationAnimationTrigger } from '../../utils/specs';
+import type { AnimationConfig } from '../../utils/specs';
 import type { AnimationOptions } from '../canvas/animations/animation';
 
 const DEFAULT_ANNOTATION_ANIMATION_OPTIONS: AnimationOptions = {

--- a/packages/charts/src/chart_types/xy_chart/state/selectors/is_tooltip_visible.ts
+++ b/packages/charts/src/chart_types/xy_chart/state/selectors/is_tooltip_visible.ts
@@ -6,17 +6,17 @@
  * Side Public License, v 1.
  */
 
-import type { TooltipSpec } from './../../../../specs/tooltip';
-import { isFollowTooltipType } from './../../../../specs/tooltip';
-import { getTooltipSpecSelector } from './../../../../state/selectors/get_tooltip_spec';
 import { getProjectedPointerPositionSelector } from './get_projected_pointer_position';
 import type { TooltipAndHighlightedGeoms } from './get_tooltip_values_highlighted_geoms';
 import { getTooltipInfoAndGeomsSelector } from './get_tooltip_values_highlighted_geoms';
 import { isAnnotationTooltipVisibleSelector } from './is_annotation_tooltip_visible';
 import { TooltipType } from '../../../../specs/constants';
+import { isFollowTooltipType } from '../../../../specs/tooltip';
+import type { TooltipSpec } from '../../../../specs/tooltip';
 import { createCustomCachedSelector } from '../../../../state/create_selector';
 import type { InteractionsState } from '../../../../state/interactions_state';
 import { getTooltipInteractionState } from '../../../../state/selectors/get_tooltip_interaction_state';
+import { getTooltipSpecSelector } from '../../../../state/selectors/get_tooltip_spec';
 import { isExternalTooltipVisibleSelector } from '../../../../state/selectors/is_external_tooltip_visible';
 import type { TooltipVisibility } from '../../../../state/tooltip_visibility';
 import type { Point } from '../../../../utils/point';

--- a/packages/charts/src/chart_types/xy_chart/utils/specs.ts
+++ b/packages/charts/src/chart_types/xy_chart/utils/specs.ts
@@ -9,9 +9,8 @@
 import type { ReactNode } from 'react';
 import type { $Values } from 'utility-types';
 
-import type { AnimationOptions } from './../renderer/canvas/animations/animation';
 import type { XYChartSeriesIdentifier, DataSeriesDatum } from './series';
-import type { ChartType } from '../../../chart_types';
+import type { ChartType } from '../..';
 import type { Color } from '../../../common/colors';
 import type { TooltipPortalSettings } from '../../../components/portal/types';
 import type { LogScaleOptions, ScaleContinuousType } from '../../../scales';
@@ -39,6 +38,7 @@ import type {
   ComponentWithAnnotationDatum,
   CustomAnnotationTooltip,
 } from '../annotations/types';
+import type { AnimationOptions } from '../renderer/canvas/animations/animation';
 
 /** @public */
 export type BarStyleOverride = RecursivePartial<BarSeriesStyle> | Color | null;

--- a/packages/charts/src/components/brush/brush.tsx
+++ b/packages/charts/src/components/brush/brush.tsx
@@ -10,13 +10,13 @@ import type { RefObject } from 'react';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { BrushAxis } from '../../../src/specs/brush_axis';
 import { isVerticalRotation } from '../../chart_types/xy_chart/state/utils/common';
 import { colorToRgba, overrideOpacity } from '../../common/color_library_wrappers';
 import { Colors } from '../../common/colors';
 import { clearCanvas, withContext, withClip } from '../../renderers/canvas';
 import { renderRectStroke, renderRect } from '../../renderers/canvas/primitives/rect';
 import type { StrokedSides } from '../../renderers/canvas/primitives/rect';
+import { BrushAxis } from '../../specs/brush_axis';
 import { DEFAULT_SETTINGS_SPEC } from '../../specs/default_settings_spec';
 import type { GlobalChartState } from '../../state/chart_state';
 import { getChartRotationSelector } from '../../state/selectors/get_chart_rotation';

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -49,7 +49,7 @@ export { GeometryValue, BandedAccessorType } from './utils/geometry';
 export { LegendPath, LegendPathElement } from './state/actions/legend';
 export { LegendItemValue, LegendValue } from './common/legend';
 export { CategoryKey, CategoryLabel } from './common/category';
-export { Layer as PartitionLayer, PartitionProps } from './chart_types/partition_chart/specs/index';
+export { Layer as PartitionLayer, PartitionProps } from './chart_types/partition_chart/specs';
 export { FillLabelConfig as PartitionFillLabel, PartitionStyle } from './utils/themes/partition';
 export { PartitionLayout } from './chart_types/partition_chart/layout/types/config_types';
 

--- a/packages/charts/src/renderers/canvas/primitives/line.ts
+++ b/packages/charts/src/renderers/canvas/primitives/line.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { withContext } from '../';
+import { withContext } from '..';
 import { RGBATupleToString } from '../../../common/color_library_wrappers';
 import type { Line, Stroke } from '../../../geoms/types';
 

--- a/packages/charts/src/renderers/canvas/primitives/text.ts
+++ b/packages/charts/src/renderers/canvas/primitives/text.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { withContext } from '../';
+import { withContext } from '..';
 import type { Degrees } from '../../../common/geometry';
 import type { Font, TextAlign, TextBaseline } from '../../../common/text_utils';
 import { cssFontShorthand } from '../../../common/text_utils';

--- a/packages/charts/src/renderers/canvas/utils/debug.ts
+++ b/packages/charts/src/renderers/canvas/utils/debug.ts
@@ -6,13 +6,13 @@
  * Side Public License, v 1.
  */
 
-import { withContext } from '../';
+import { withContext } from '..';
 import { overrideOpacity, RGBATupleToString } from '../../../common/color_library_wrappers';
 import { Colors } from '../../../common/colors';
 import type { Fill, Stroke, Rect } from '../../../geoms/types';
-import { renderRect } from '../../../renderers/canvas/primitives/rect';
 import { degToRad } from '../../../utils/common';
 import type { Point } from '../../../utils/point';
+import { renderRect } from '../primitives/rect';
 
 /** @internal */
 export const DEFAULT_DEBUG_FILL: Fill = {

--- a/packages/charts/src/state/chart_selectors.ts
+++ b/packages/charts/src/state/chart_selectors.ts
@@ -9,6 +9,7 @@
 import type { CSSProperties } from 'react';
 
 import type { GlobalChartState } from './chart_state';
+import { getA11ySettingsSelector } from './selectors/get_accessibility_config';
 import { InitStatus } from './selectors/get_internal_is_intialized';
 import type { TooltipVisibility } from './tooltip_visibility';
 import type { DebugState } from './types';
@@ -19,7 +20,6 @@ import type { SmallMultiplesSeriesDomains } from '../common/panel_utils';
 import type { SeriesKey } from '../common/series_id';
 import type { AnchorPosition } from '../components/portal/types';
 import type { TooltipInfo } from '../components/tooltip/types';
-import { getA11ySettingsSelector } from '../state/selectors/get_accessibility_config';
 import type { Dimensions } from '../utils/dimensions';
 
 /** @internal */

--- a/packages/charts/src/state/chart_state.ts
+++ b/packages/charts/src/state/chart_state.ts
@@ -13,6 +13,7 @@ import { onChartRendered } from './actions/chart';
 import { updateParentDimensions, updateChartTitles } from './actions/chart_settings';
 import { clearTemporaryColors, setTemporaryColor, setPersistedColor } from './actions/colors';
 import { onExternalPointerEvent } from './actions/events';
+import { upsertSpec, removeSpec, specParsed, specUnmounted } from './actions/specs';
 import { onComputedZIndex } from './actions/z_index';
 import type { ChartSliceState } from './chart_slice_state';
 import { chartTypeFromSpecs } from './chart_type_from_specs';
@@ -28,7 +29,6 @@ import { getInitialPointerState } from './utils/get_initial_pointer_state';
 import { getInitialTooltipState } from './utils/get_initial_tooltip_state';
 import type { Color } from '../common/colors';
 import { DEFAULT_SETTINGS_SPEC } from '../specs/default_settings_spec';
-import { upsertSpec, removeSpec, specParsed, specUnmounted } from '../state/actions/specs';
 import { deepEqual } from '../utils/fast_deep_equal';
 
 export type { InteractionsState, TooltipInteractionState } from './interactions_state';

--- a/packages/charts/src/state/reducers/interactions.ts
+++ b/packages/charts/src/state/reducers/interactions.ts
@@ -9,7 +9,6 @@
 import type { ActionReducerMapBuilder } from '@reduxjs/toolkit';
 import { produce } from 'immer';
 
-import { getTooltipSpecSelector } from './../selectors/get_tooltip_spec';
 import { ChartType } from '../../chart_types';
 import { drilldownActive } from '../../chart_types/partition_chart/state/selectors/drilldown_active';
 import { getPickedShapesLayerValues } from '../../chart_types/partition_chart/state/selectors/picked_shapes';
@@ -30,6 +29,7 @@ import { getInternalIsInitializedSelector, InitStatus } from '../selectors/get_i
 import { getInternalIsTooltipVisibleSelector } from '../selectors/get_internal_is_tooltip_visible';
 import { getInternalTooltipInfoSelector } from '../selectors/get_internal_tooltip_info';
 import { getLegendItemsSelector } from '../selectors/get_legend_items';
+import { getTooltipSpecSelector } from '../selectors/get_tooltip_spec';
 import { getInitialPointerState } from '../utils/get_initial_pointer_state';
 import { getInitialTooltipState } from '../utils/get_initial_tooltip_state';
 

--- a/packages/charts/src/state/spec_factory.ts
+++ b/packages/charts/src/state/spec_factory.ts
@@ -11,8 +11,8 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import type { OptionalKeys, RequiredKeys } from 'utility-types';
 
+import { upsertSpec, removeSpec } from './actions/specs';
 import type { Spec } from '../specs/spec_type'; // kept as long-winded import on separate line otherwise import circularity emerges
-import { upsertSpec, removeSpec } from '../state/actions/specs';
 import { stripUndefined } from '../utils/common';
 
 /**


### PR DESCRIPTION
## Summary

A too long traversal path import is causing issues with the generated package.
The code was importing the file this way:
```
import { BrushAxis } from '../../../src/specs/brush_axis';
```
traversing the folders one level below the `src` and then up again.
This causes an issue with the bundled file because the `src` folder is not present and the compiled bundle doesn't rewrite the paths.

I've added an eslint rule https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-useless-path-segments.md to avoid this type of imports and cleaned up useless path segments from the imports.
