### PR TITLE
ci: remove `@elastic/datavis CI` overall check

### DIFF
--- a/.buildkite/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/pipelines/pull_request/pipeline.ts
@@ -28,7 +28,6 @@ import {
 } from '../../steps';
 import type { Step, CustomCommandStep } from '../../utils';
 import { bkEnv, ChangeContext, uploadPipeline } from '../../utils';
-import { getBuildConfig } from '../../utils/build';
 import { MetaDataKeys } from '../../utils/constants';
 import { createDeployment, createDeploymentStatus, createOrUpdateDeploymentComment } from '../../utils/deployment';
 
@@ -40,15 +39,6 @@ void (async () => {
 
     const changeCtx = new ChangeContext();
     await changeCtx.init();
-
-    // Update main job status
-    await updateCheckStatus(
-      {
-        status: 'in_progress',
-        details_url: bkEnv.buildUrl,
-      },
-      getBuildConfig().main.id,
-    );
 
     const steps: Step[] = [
       jestStep(),

--- a/.buildkite/utils/build.ts
+++ b/.buildkite/utils/build.ts
@@ -14,7 +14,6 @@ interface Job {
 }
 
 interface BuildConfig {
-  main: Job;
   jobs: Job[];
 }
 
@@ -25,7 +24,6 @@ interface BuildConfig {
  */
 export const getBuildConfig = (): BuildConfig => {
   return {
-    main: { name: '@elastic/datavis CI', id: 'main' },
     jobs: [
       { name: 'Types', id: 'types' },
       { name: 'API', id: 'api' },
@@ -45,12 +43,11 @@ export const getBuildConfig = (): BuildConfig => {
 };
 
 export const getJobCheckName = (checkId: string) => {
-  const { main, jobs } = getBuildConfig();
-  const job = [main, ...jobs].find(({ id }) => id === checkId);
+  const { jobs } = getBuildConfig();
+  const job = jobs.find(({ id }) => id === checkId);
+
   if (!job) {
-    throw new Error(
-      `Failed to find check name from step id ${checkId}. Job ids are:\n\n\t${[main, ...jobs].join('\n\t')}`,
-    );
+    throw new Error(`Failed to find check name from step id ${checkId}. Job ids are:\n\n\t${jobs.join('\n\t')}`);
   }
   return job.name;
 };


### PR DESCRIPTION
## Summary

Removes the main **@elastic/datavis CI**. Currently. this check get stuck in the **pending** state as the old ci is now disabled.

This was handled partially by the old `github_bot`, but with the new ci changes we no longer really need this. We can instead just rely on the individual job status checks from the build.

If we still wanted this we could add a post-build step but I don't think it's necessary. We could also enable the pr check status from `buildkite-pr-bot` to get a similar check.

![Zight Recording 2026-01-23 at 01 45 40 PM](https://github.com/user-attachments/assets/d4b37a4c-3fa1-40f2-875a-8d1fda22abf1)
