### PR TITLE
fix: guard process.env for browser environments without bundler polyfills

### DIFF
--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -62,7 +62,7 @@ const LEFT_MOUSE_BUTTON = 1;
 const MINIMAP_SIZE_RATIO_X = 3;
 const MINIMAP_SIZE_RATIO_Y = 3;
 const SHOWN_ANCESTOR_COUNT = 2; // how many rows above the focused in node should be shown
-const SHOULD_DISABLE_WOBBLE = (typeof process === 'object' && process.env && process.env.VRT) === 'true';
+const SHOULD_DISABLE_WOBBLE = (typeof process === 'object' && process !== null && process.env && process.env.VRT) === 'true';
 const WOBBLE_DURATION = SHOULD_DISABLE_WOBBLE ? 0 : 1000;
 const WOBBLE_REPEAT_COUNT = 2;
 const WOBBLE_FREQUENCY = SHOULD_DISABLE_WOBBLE ? 0 : 2 * Math.PI * (WOBBLE_REPEAT_COUNT / WOBBLE_DURATION); // e.g. 1/30 means a cycle of every 30ms

--- a/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
+++ b/packages/charts/src/chart_types/flame_chart/flame_chart.tsx
@@ -62,7 +62,8 @@ const LEFT_MOUSE_BUTTON = 1;
 const MINIMAP_SIZE_RATIO_X = 3;
 const MINIMAP_SIZE_RATIO_Y = 3;
 const SHOWN_ANCESTOR_COUNT = 2; // how many rows above the focused in node should be shown
-const SHOULD_DISABLE_WOBBLE = (typeof process === 'object' && process !== null && process.env && process.env.VRT) === 'true';
+const SHOULD_DISABLE_WOBBLE =
+  (typeof process === 'object' && process !== null && process.env && process.env.VRT) === 'true';
 const WOBBLE_DURATION = SHOULD_DISABLE_WOBBLE ? 0 : 1000;
 const WOBBLE_REPEAT_COUNT = 2;
 const WOBBLE_FREQUENCY = SHOULD_DISABLE_WOBBLE ? 0 : 2 * Math.PI * (WOBBLE_REPEAT_COUNT / WOBBLE_DURATION); // e.g. 1/30 means a cycle of every 30ms

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/index.ts
@@ -12,7 +12,7 @@ import { debounce } from '../../../../../utils/debounce';
 import { Logger } from '../../../../../utils/logger';
 
 // TODO find a better way to do this when we have an actual build process
-const DISABLE_ANIMATIONS = (typeof process === 'object' && process.env && process.env.VRT) === 'true';
+const DISABLE_ANIMATIONS = (typeof process === 'object' && process !== null && process.env && process.env.VRT) === 'true';
 
 /**
  * Function used to animate values from within a render context.

--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/index.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/animations/index.ts
@@ -12,7 +12,8 @@ import { debounce } from '../../../../../utils/debounce';
 import { Logger } from '../../../../../utils/logger';
 
 // TODO find a better way to do this when we have an actual build process
-const DISABLE_ANIMATIONS = (typeof process === 'object' && process !== null && process.env && process.env.VRT) === 'true';
+const DISABLE_ANIMATIONS =
+  (typeof process === 'object' && process !== null && process.env && process.env.VRT) === 'true';
 
 /**
  * Function used to animate values from within a render context.

--- a/packages/charts/src/state/chart_state.ts
+++ b/packages/charts/src/state/chart_state.ts
@@ -176,11 +176,12 @@ export const createChartStore = (chartId: string, title?: string, description?: 
         // TODO https://github.com/elastic/elastic-charts/issues/2078
         serializableCheck: false,
       }),
-    devTools: process.env.ELASTIC_CHARTS_DEV_MODE
-      ? {
-          name: `@elastic/charts - ${chartId}`,
-        }
-      : undefined,
+    devTools:
+      typeof process === 'object' && process !== null && process.env && process.env.ELASTIC_CHARTS_DEV_MODE
+        ? {
+            name: `@elastic/charts - ${chartId}`,
+          }
+        : undefined,
   });
 };
 

--- a/packages/charts/src/utils/logger.ts
+++ b/packages/charts/src/utils/logger.ts
@@ -63,7 +63,7 @@ export class Logger {
    * @todo add more robust logic
    */
   private static isDevelopment(): boolean {
-    return process.env.NODE_ENV !== 'production';
+    return typeof process === 'object' && process !== null && process.env && process.env.NODE_ENV !== 'production';
   }
 
   /**
@@ -73,7 +73,7 @@ export class Logger {
    * @todo add more robust logic
    */
   private static isTest(): boolean {
-    return process.env.NODE_ENV === 'test';
+    return typeof process === 'object' && process !== null && process.env && process.env.NODE_ENV === 'test';
   }
 }
 


### PR DESCRIPTION
## Summary

Adds consistent safe guards to all `process.env` usage in shipped runtime code, since accessing `process.env` throws in browser environments where `process` is not a global (e.g. no bundler polyfill). 

## Details

### Changes

- `state/chart_state.ts` — guard `process.env.ELASTIC_CHARTS_DEV_MODE`
- `utils/logger.ts` — guard `process.env.NODE_ENV` in `isDevelopment()` and `isTest()`
- `xy_chart/.../animations/index.ts` — add missing `!== null` check to existing guard
- `flame_chart/flame_chart.tsx` — add missing `!== null` check to existing guard

All sites now use the same pattern consistent with existing POJO checks in the codebase, for example in `packages/charts/src/utils/accessor.ts.`

Fixes #2809.
