### PR TITLE
fix: remove `produce()` from selectors

### DIFF
--- a/packages/charts/src/state/reducers/interactions.ts
+++ b/packages/charts/src/state/reducers/interactions.ts
@@ -7,7 +7,6 @@
  */
 
 import type { ActionReducerMapBuilder } from '@reduxjs/toolkit';
-import { produce } from 'immer';
 
 import { ChartType } from '../../chart_types';
 import { drilldownActive } from '../../chart_types/partition_chart/state/selectors/drilldown_active';
@@ -229,10 +228,7 @@ export const handleTooltipActions = (builder: ActionReducerMapBuilder<ChartSlice
 
       const index = state.tooltip.selected.findIndex((item) => createItemId(item) === createItemId(action.payload));
       if (index !== -1) {
-        // deleting from the immutable array using immer's produce
-        state.tooltip.selected = produce(state.tooltip.selected, (draft) => {
-          draft.splice(index, 1);
-        });
+        state.tooltip.selected.splice(index, 1);
       } else {
         state.tooltip.selected.push(action.payload);
       }

--- a/packages/charts/src/state/selectors/get_chart_theme.ts
+++ b/packages/charts/src/state/selectors/get_chart_theme.ts
@@ -6,8 +6,6 @@
  * Side Public License, v 1.
  */
 
-import { isDraft, produce } from 'immer';
-
 import { getSettingsSpecSelector } from './get_settings_spec';
 import { colorToRgba, overrideOpacity, RGBATupleToString } from '../../common/color_library_wrappers';
 import { clamp, mergePartial } from '../../utils/common';
@@ -34,29 +32,28 @@ function getTheme(baseTheme?: Theme, theme?: PartialTheme | PartialTheme[]): The
 }
 
 /**
- * Validation for final theme object used throughout charts
- *
- * Note: mutates theme in place when called within an immer draft,
- * otherwise uses produce() for immutable updates.
+ * Validates and returns a corrected copy of the theme object.
  */
 function validateTheme(theme: Theme): Theme {
-  // When already inside an immer draft (e.g. called from a selector invoked within
-  // an RTK reducer), mutate directly — nested produce() on draft data is unsupported.
-  if (isDraft(theme)) {
-    applyThemeValidation(theme);
-    return theme;
-  }
-  return produce(theme, applyThemeValidation);
-}
+  const fallbackRGBA = colorToRgba(theme.background.fallbackColor);
+  const needsFallbackFix = fallbackRGBA[3] !== 1;
 
-function applyThemeValidation(draft: Theme): void {
-  const fallbackRGBA = colorToRgba(draft.background.fallbackColor);
-  if (fallbackRGBA[3] !== 1) {
+  const clampedRotation = clamp(theme.heatmap.xAxisLabel.rotation, 0, 90);
+  const needsRotationFix = clampedRotation !== theme.heatmap.xAxisLabel.rotation;
+
+  if (!needsFallbackFix && !needsRotationFix) return theme;
+
+  if (needsFallbackFix) {
     Logger.warn(`background.fallbackColor must be opaque, found alpha of ${fallbackRGBA[3]}. Overriding alpha to 1.`);
-    const newFallback = overrideOpacity(fallbackRGBA, 1);
-    draft.background.fallbackColor = RGBATupleToString(newFallback);
   }
 
-  // heatmap rotation constraint:
-  draft.heatmap.xAxisLabel.rotation = clamp(draft.heatmap.xAxisLabel.rotation, 0, 90);
+  return {
+    ...theme,
+    ...(needsFallbackFix && {
+      background: { ...theme.background, fallbackColor: RGBATupleToString(overrideOpacity(fallbackRGBA, 1)) },
+    }),
+    ...(needsRotationFix && {
+      heatmap: { ...theme.heatmap, xAxisLabel: { ...theme.heatmap.xAxisLabel, rotation: clampedRotation } },
+    }),
+  };
 }

--- a/packages/charts/src/state/selectors/get_chart_theme.ts
+++ b/packages/charts/src/state/selectors/get_chart_theme.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { produce } from 'immer';
+import { isDraft, produce } from 'immer';
 
 import { getSettingsSpecSelector } from './get_settings_spec';
 import { colorToRgba, overrideOpacity, RGBATupleToString } from '../../common/color_library_wrappers';
@@ -36,18 +36,27 @@ function getTheme(baseTheme?: Theme, theme?: PartialTheme | PartialTheme[]): The
 /**
  * Validation for final theme object used throughout charts
  *
- * Note: mutates theme in place
+ * Note: mutates theme in place when called within an immer draft,
+ * otherwise uses produce() for immutable updates.
  */
 function validateTheme(theme: Theme): Theme {
-  return produce(theme, (draft) => {
-    const fallbackRGBA = colorToRgba(draft.background.fallbackColor);
-    if (fallbackRGBA[3] !== 1) {
-      Logger.warn(`background.fallbackColor must be opaque, found alpha of ${fallbackRGBA[3]}. Overriding alpha to 1.`);
-      const newFallback = overrideOpacity(fallbackRGBA, 1);
-      draft.background.fallbackColor = RGBATupleToString(newFallback);
-    }
+  // When already inside an immer draft (e.g. called from a selector invoked within
+  // an RTK reducer), mutate directly — nested produce() on draft data is unsupported.
+  if (isDraft(theme)) {
+    applyThemeValidation(theme);
+    return theme;
+  }
+  return produce(theme, applyThemeValidation);
+}
 
-    // heatmap rotation constraint:
-    draft.heatmap.xAxisLabel.rotation = clamp(draft.heatmap.xAxisLabel.rotation, 0, 90);
-  });
+function applyThemeValidation(draft: Theme): void {
+  const fallbackRGBA = colorToRgba(draft.background.fallbackColor);
+  if (fallbackRGBA[3] !== 1) {
+    Logger.warn(`background.fallbackColor must be opaque, found alpha of ${fallbackRGBA[3]}. Overriding alpha to 1.`);
+    const newFallback = overrideOpacity(fallbackRGBA, 1);
+    draft.background.fallbackColor = RGBATupleToString(newFallback);
+  }
+
+  // heatmap rotation constraint:
+  draft.heatmap.xAxisLabel.rotation = clamp(draft.heatmap.xAxisLabel.rotation, 0, 90);
 }

--- a/packages/charts/src/state/selectors/get_settings_spec.ts
+++ b/packages/charts/src/state/selectors/get_settings_spec.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { produce } from 'immer';
+import { isDraft, produce } from 'immer';
 
 import { getSpecs } from './get_specs';
 import { ChartType } from '../../chart_types';
@@ -33,17 +33,25 @@ function getSettingsSpec(specs: SpecList): SettingsSpec {
 }
 
 function validateSpec(spec: SettingsSpec): SettingsSpec {
-  return produce(spec, (draft) => {
-    const delay = draft.pointerUpdateDebounce ?? DEFAULT_POINTER_UPDATE_DEBOUNCE;
+  // When already inside an immer draft (e.g. called from a selector invoked within
+  // an RTK reducer), mutate directly — nested produce() on draft data is unsupported.
+  if (isDraft(spec)) {
+    applySpecValidation(spec);
+    return spec;
+  }
+  return produce(spec, applySpecValidation);
+}
 
-    if (draft.onPointerUpdate) {
-      draft.onPointerUpdate = debounce(draft.onPointerUpdate, delay);
-    }
+function applySpecValidation(draft: SettingsSpec): void {
+  const delay = draft.pointerUpdateDebounce ?? DEFAULT_POINTER_UPDATE_DEBOUNCE;
 
-    if (draft.dow < 1 || draft.dow > 7 || !Number.isInteger(draft.dow)) {
-      Logger.warn(`Settings.dow option must be an integer from 1 to 7, received ${draft.dow}. Using default of 1.`);
+  if (draft.onPointerUpdate) {
+    draft.onPointerUpdate = debounce(draft.onPointerUpdate, delay);
+  }
 
-      draft.dow = settingsBuildProps.defaults.dow;
-    }
-  });
+  if (draft.dow < 1 || draft.dow > 7 || !Number.isInteger(draft.dow)) {
+    Logger.warn(`Settings.dow option must be an integer from 1 to 7, received ${draft.dow}. Using default of 1.`);
+
+    draft.dow = settingsBuildProps.defaults.dow;
+  }
 }

--- a/packages/charts/src/state/selectors/get_settings_spec.ts
+++ b/packages/charts/src/state/selectors/get_settings_spec.ts
@@ -6,8 +6,6 @@
  * Side Public License, v 1.
  */
 
-import { isDraft, produce } from 'immer';
-
 import { getSpecs } from './get_specs';
 import { ChartType } from '../../chart_types';
 import type { SettingsSpec } from '../../specs';
@@ -33,25 +31,19 @@ function getSettingsSpec(specs: SpecList): SettingsSpec {
 }
 
 function validateSpec(spec: SettingsSpec): SettingsSpec {
-  // When already inside an immer draft (e.g. called from a selector invoked within
-  // an RTK reducer), mutate directly — nested produce() on draft data is unsupported.
-  if (isDraft(spec)) {
-    applySpecValidation(spec);
-    return spec;
-  }
-  return produce(spec, applySpecValidation);
-}
+  const delay = spec.pointerUpdateDebounce ?? DEFAULT_POINTER_UPDATE_DEBOUNCE;
+  const needsDebounceFix = !!spec.onPointerUpdate;
+  const needsDowFix = spec.dow < 1 || spec.dow > 7 || !Number.isInteger(spec.dow);
 
-function applySpecValidation(draft: SettingsSpec): void {
-  const delay = draft.pointerUpdateDebounce ?? DEFAULT_POINTER_UPDATE_DEBOUNCE;
+  if (!needsDebounceFix && !needsDowFix) return spec;
 
-  if (draft.onPointerUpdate) {
-    draft.onPointerUpdate = debounce(draft.onPointerUpdate, delay);
+  if (needsDowFix) {
+    Logger.warn(`Settings.dow option must be an integer from 1 to 7, received ${spec.dow}. Using default of 1.`);
   }
 
-  if (draft.dow < 1 || draft.dow > 7 || !Number.isInteger(draft.dow)) {
-    Logger.warn(`Settings.dow option must be an integer from 1 to 7, received ${draft.dow}. Using default of 1.`);
-
-    draft.dow = settingsBuildProps.defaults.dow;
-  }
+  return {
+    ...spec,
+    ...(needsDebounceFix && { onPointerUpdate: debounce(spec.onPointerUpdate!, delay) }),
+    ...(needsDowFix && { dow: settingsBuildProps.defaults.dow }),
+  };
 }


### PR DESCRIPTION
## Summary

Fixes a bug where clicking a legend item would throw with `Uncaught TypeError: Cannot read properties of undefined (reading 'background')`.

## Details

The bug is an edge case that surfaced because of a combination of things a play:

1. Using selectors in redux slice reducers is an anti-pattern
2. Using immer's `produce` in selectors is an anti-pattern (we ended up doing it because of the previous anti-pattern)
3. Certain consuming build setups will end up with 2 different instances of `immer`, one within redux toolkit and a separate one when directly importing from `immer`. This in combination with the previous to anti-pattern will cause the throw.

Elastic Chart's own setup was not affected by the third issue. That's why we didn't encounter the bug in Elastic Chart's own jest tests or storybook. The bug surfaced in a project using `vite` as the bundler that consumed Elastic Charts.

The bug fix in this PR addresses 2) by removing the use of `produce` in the selector. This way 3) can no longer happen. In the long run we should address 1) too.

I tried creating a jest test scenario that would fail on `main` and pass with the fix applied in this PR but it's not really possible because the error is tied to certain build setup and therefor cannot be reproduced in our jest setup.

Some more analysis showed the error happened because RTK's `immer` and the directly imported `immer` ended up differently minified. 

- RTK's minified immer state: `{ t, o, k, j, ... }` (base, copy, draft, revoke)
- Charts' unminified immer state: `{ base_, copy_, draft_, revoke_, ... }`
 
So each instance recognizes the other's drafts. But when charts' `produce()` tries to read internals of a draft created by RTK's immer, it accesses `state.copy_` / `state.base_` on an object that only has `state.o` / `state.t` — both `undefined` — causing the crash.

I tested changing `import { produce } from 'immer'` to `import { createNextState as produce } from '@reduxjs/toolkit'` which would make both calls use the same immer instance which worked. But since again using `produce` in a selector is an anti-pattern I removed it's use anyway.

## Issues

Fixes https://github.com/elastic/elastic-charts/issues/2814

### Checklist

- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
