### PR TITLE
ci: Restore build_pull_requests=true

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -24,7 +24,7 @@ spec:
       provider_settings:
         trigger_mode: code
         build_branches: true
-        build_pull_requests: false
+        build_pull_requests: true
         build_tags: false
         prefix_pull_request_fork_branch_names: false
         skip_pull_request_builds_for_existing_commits: false


### PR DESCRIPTION
## Summary
Restores `build_pull_requests`=`true` setting to fix missing PR builds.

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details
I thought this is not needed, because the PR triggering would happen from the bot - it is indeed required, otherwise the build attempts are rejected by buildkite.

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->
