### PR TITLE
fix(a11y): allow keyboard navigation of tooltips

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/annotations/line/tooltip.test.tsx
+++ b/packages/charts/src/chart_types/xy_chart/annotations/line/tooltip.test.tsx
@@ -71,6 +71,50 @@ describe('Annotation tooltips', () => {
       expect(screen.queryByTestId('echTooltipHeader')).toBeNull();
     });
 
+    test('should show tooltip on keyboard navigation', () => {
+      render(
+        <Chart size={[100, 100]}>
+          <Settings
+            theme={{
+              chartMargins: { left: 0, right: 0, top: 0, bottom: 0 },
+              chartPaddings: { left: 0, right: 0, top: 0, bottom: 0 },
+            }}
+          />
+          <LineSeries
+            id="line"
+            data={[
+              { x: 0, y: 1 },
+              { x: 2, y: 3 },
+              { x: 4, y: 5 },
+            ]}
+            xAccessor="x"
+            yAccessors={['y']}
+            xScaleType={ScaleType.Linear}
+          />
+          <LineAnnotation
+            id="foo"
+            domainType={AnnotationDomainType.YDomain}
+            dataValues={[{ dataValue: 2, details: 'foo' }]}
+            marker={<div style={{ width: '10px', height: '10px' }} />}
+          />
+        </Chart>,
+      );
+
+      expect(screen.queryByTestId('echAnnotationMarker')).not.toBeNull();
+      const marker = screen.getByTestId('echAnnotationMarker');
+      expect(screen.queryAllByTestId('echAnnotation')).toHaveLength(0);
+
+      if (marker) fireEvent.focus(marker);
+
+      expect(screen.queryByTestId('echTooltip')).not.toBeNull();
+      expect(screen.getByTestId('echTooltipHeader').textContent).toBe('2');
+      expect(screen.getByTestId('echAnnotationDetails').textContent).toBe('foo');
+
+      if (marker) fireEvent.blur(marker);
+
+      expect(screen.queryByTestId('echTooltipHeader')).toBeNull();
+    });
+
     test('should not show tooltip when using hideTooltips', () => {
       render(
         <Chart size={[100, 100]}>

--- a/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/annotation_tooltip.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/annotation_tooltip.tsx
@@ -24,11 +24,17 @@ interface AnnotationTooltipProps {
 }
 
 /** @internal */
+export const getAnnotationTooltipDomId = (chartId: string, annotationId: string) =>
+  `echAnnotationTooltip__${chartId}__${annotationId}`;
+
+/** @internal */
 export const AnnotationTooltip = ({ state, chartRef, chartId, onScroll, zIndex }: AnnotationTooltipProps) => {
   const renderTooltip = useCallback(() => {
     if (!state || !state.isVisible) {
       return null;
     }
+
+    const tooltipDomId = getAnnotationTooltipDomId(chartId, state.id);
 
     return (
       <TooltipWrapper
@@ -41,11 +47,13 @@ export const AnnotationTooltip = ({ state, chartRef, chartId, onScroll, zIndex }
         noActionsLoaded=""
         className="echAnnotation"
         data-testid="echAnnotation"
+        id={tooltipDomId}
+        role="tooltip"
       >
         <TooltipContent {...state} />
       </TooltipWrapper>
     );
-  }, [state]);
+  }, [state, chartId]);
 
   const handleScroll = () => {
     // TODO: handle scroll cursor update

--- a/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/annotations.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/annotations.tsx
@@ -75,6 +75,7 @@ type AnnotationsProps = AnnotationsDispatchProps & AnnotationsStateProps & Annot
 function renderAnnotationLineMarkers(
   chartAreaRef: RefObject<HTMLCanvasElement>,
   chartDimensions: Dimensions,
+  chartId: string,
   annotationLines: AnnotationLineProps[],
   onDOMElementEnter: typeof onDOMElementEnterAction,
   onDOMElementLeave: typeof onDOMElementLeaveAction,
@@ -92,6 +93,7 @@ function renderAnnotationLineMarkers(
         {...props}
         marker={markers[0]}
         key={`annotation-${props.id}`}
+        chartId={chartId}
         chartAreaRef={chartAreaRef}
         chartDimensions={chartDimensions}
         onDOMElementEnter={onDOMElementEnter}
@@ -135,6 +137,7 @@ const AnnotationsComponent = ({
         const lineMarkers = renderAnnotationLineMarkers(
           chartAreaRef,
           chartDimensions,
+          chartId,
           annotationLines,
           onDOMElementEnter,
           onDOMElementLeave,
@@ -153,6 +156,7 @@ const AnnotationsComponent = ({
     annotationSpecs,
     chartAreaRef,
     chartDimensions,
+    chartId,
     onDOMElementEnter,
     onDOMElementLeave,
     hoveredAnnotationIds,

--- a/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
@@ -11,6 +11,7 @@ import { createPopper } from '@popperjs/core';
 import type { RefObject, CSSProperties } from 'react';
 import React, { useRef, useEffect, useCallback } from 'react';
 
+import { getAnnotationTooltipDomId } from './annotation_tooltip';
 import { DEFAULT_CSS_CURSOR } from '../../../../../common/constants';
 import type {
   onDOMElementEnter as onDOMElementEnterAction,
@@ -25,6 +26,7 @@ import type { AnimationOptions } from '../../canvas/animations/animation';
 import type { GetAnnotationParamsFn } from '../../common/utils';
 
 type LineMarkerProps = Pick<AnnotationLineProps, 'id' | 'specId' | 'datum' | 'panel'> & {
+  chartId: string;
   marker: AnnotationLineProps['markers'][number];
   chartAreaRef: RefObject<HTMLCanvasElement>;
   chartDimensions: Dimensions;
@@ -52,6 +54,7 @@ function getMarkerCentredTransform(alignment: Position, hasMarkerDimensions: boo
  */
 export function LineMarker({
   id,
+  chartId,
   specId,
   datum,
   panel,
@@ -122,6 +125,7 @@ export function LineMarker({
   void popper?.current?.update?.();
 
   const ariaLabel = datum.ariaLabel ?? datum.details ?? datum.header ?? `line annotation ${datum.dataValue}`;
+  const tooltipDomId = getAnnotationTooltipDomId(chartId, id);
 
   const handleEnter = useCallback(() => {
     onDOMElementEnter({
@@ -144,6 +148,7 @@ export function LineMarker({
       style={{ ...markerStyle, ...transform }}
       type="button"
       aria-label={ariaLabel}
+      aria-describedby={tooltipDomId}
     >
       <div ref={iconRef} className="echAnnotation__icon">
         {renderWithProps(icon, datum)}

--- a/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
@@ -123,21 +123,24 @@ export function LineMarker({
 
   const ariaLabel = datum.ariaLabel ?? datum.details ?? datum.header ?? `line annotation ${datum.dataValue}`;
 
-  // want it to be tabbable if interactive if there is a click handler
-  return clickable ? (
+  const handleEnter = useCallback(() => {
+    onDOMElementEnter({
+      createdBySpecId: specId,
+      id,
+      type: DOMElementType.LineAnnotationMarker,
+      datum,
+    });
+  }, [onDOMElementEnter, specId, id, datum]);
+
+  return (
     <button
       className="echAnnotation__marker"
       data-testid="echAnnotationMarker"
-      onMouseEnter={() => {
-        onDOMElementEnter({
-          createdBySpecId: specId,
-          id,
-          type: DOMElementType.LineAnnotationMarker,
-          datum,
-        });
-      }}
+      onMouseEnter={handleEnter}
       onMouseLeave={() => onDOMElementLeave()}
-      onClick={() => onDOMElementClick()}
+      onFocus={handleEnter}
+      onBlur={() => onDOMElementLeave()}
+      {...(clickable ? { onClick: () => onDOMElementClick() } : {})}
       style={{ ...markerStyle, ...transform }}
       type="button"
       aria-label={ariaLabel}
@@ -151,30 +154,6 @@ export function LineMarker({
         </div>
       )}
     </button>
-  ) : (
-    <div
-      className="echAnnotation__marker"
-      data-testid="echAnnotationMarker"
-      onMouseEnter={() => {
-        onDOMElementEnter({
-          createdBySpecId: specId,
-          id,
-          type: DOMElementType.LineAnnotationMarker,
-          datum,
-        });
-      }}
-      onMouseLeave={() => onDOMElementLeave()}
-      style={{ ...markerStyle, ...transform }}
-    >
-      <div ref={iconRef} className="echAnnotation__icon">
-        {renderWithProps(icon, datum)}
-      </div>
-      {body && (
-        <div ref={testRef} className="echAnnotation__body">
-          {renderWithProps(body, datum)}
-        </div>
-      )}
-    </div>
   );
 }
 

--- a/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
@@ -149,6 +149,11 @@ export function LineMarker({
       type="button"
       aria-label={ariaLabel}
       aria-describedby={tooltipDomId}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          onDOMElementLeave();
+        }
+      }}
     >
       <div ref={iconRef} className="echAnnotation__icon">
         {renderWithProps(icon, datum)}

--- a/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
@@ -8,8 +8,8 @@
 
 import type { Instance } from '@popperjs/core';
 import { createPopper } from '@popperjs/core';
-import type { RefObject, CSSProperties } from 'react';
-import React, { useRef, useEffect, useCallback } from 'react';
+import type { RefObject, CSSProperties, HTMLAttributes } from 'react';
+import React, { useRef, useEffect, useCallback, useMemo } from 'react';
 
 import { getAnnotationTooltipDomId } from './annotation_tooltip';
 import { DEFAULT_CSS_CURSOR } from '../../../../../common/constants';
@@ -71,16 +71,7 @@ export function LineMarker({
   const iconRef = useRef<HTMLDivElement | null>(null);
   const testRef = useRef<HTMLDivElement | null>(null);
   const popper = useRef<Instance | null>(null);
-  const markerStyle: CSSProperties = {
-    ...style,
-    ...getAnimatedStyles(options, style),
-    color,
-    top: chartDimensions.top + position.top + panel.top,
-    left: chartDimensions.left + position.left + panel.left,
-    cursor: clickable ? 'pointer' : DEFAULT_CSS_CURSOR,
-  };
 
-  const transform = { transform: getMarkerCentredTransform(alignment, Boolean(dimension)) };
   const setPopper = useCallback(() => {
     if (!iconRef.current || !testRef.current) return;
 
@@ -124,9 +115,6 @@ export function LineMarker({
 
   void popper?.current?.update?.();
 
-  const ariaLabel = datum.ariaLabel ?? datum.details ?? datum.header ?? `line annotation ${datum.dataValue}`;
-  const tooltipDomId = getAnnotationTooltipDomId(chartId, id);
-
   const handleEnter = useCallback(() => {
     onDOMElementEnter({
       createdBySpecId: specId,
@@ -136,25 +124,56 @@ export function LineMarker({
     });
   }, [onDOMElementEnter, specId, id, datum]);
 
-  return (
-    <button
-      className="echAnnotation__marker"
-      data-testid="echAnnotationMarker"
-      onMouseEnter={handleEnter}
-      onMouseLeave={() => onDOMElementLeave()}
-      onFocus={handleEnter}
-      onBlur={() => onDOMElementLeave()}
-      {...(clickable ? { onClick: () => onDOMElementClick() } : {})}
-      style={{ ...markerStyle, ...transform }}
-      type="button"
-      aria-label={ariaLabel}
-      aria-describedby={tooltipDomId}
-      onKeyDown={(e) => {
+  const elementProps: HTMLAttributes<HTMLDivElement> & HTMLAttributes<HTMLButtonElement> = useMemo(() => {
+    const markerStyle: CSSProperties = {
+      ...style,
+      ...getAnimatedStyles(options, style),
+      color,
+      top: chartDimensions.top + position.top + panel.top,
+      left: chartDimensions.left + position.left + panel.left,
+      cursor: clickable ? 'pointer' : DEFAULT_CSS_CURSOR,
+    };
+
+    const transform = { transform: getMarkerCentredTransform(alignment, Boolean(dimension)) };
+
+    const ariaLabel = datum.ariaLabel ?? datum.details ?? datum.header ?? `line annotation ${datum.dataValue}`;
+    const tooltipDomId = getAnnotationTooltipDomId(chartId, id);
+
+    return {
+      className: 'echAnnotation__marker',
+      'data-testid': 'echAnnotationMarker',
+      onMouseEnter: handleEnter,
+      onMouseLeave: () => onDOMElementLeave(),
+      onFocus: handleEnter,
+      onBlur: () => onDOMElementLeave(),
+      onKeyDown: (e) => {
         if (e.key === 'Escape') {
           onDOMElementLeave();
         }
-      }}
-    >
+      },
+      style: { ...markerStyle, ...transform },
+      'aria-describedby': tooltipDomId,
+      'aria-label': ariaLabel,
+    };
+  }, [
+    handleEnter,
+    onDOMElementLeave,
+    color,
+    chartDimensions,
+    position,
+    panel,
+    clickable,
+    style,
+    options,
+    alignment,
+    dimension,
+    id,
+    chartId,
+    datum,
+  ]);
+
+  return clickable ? (
+    <button {...elementProps} onClick={() => onDOMElementClick()} type="button">
       <div ref={iconRef} className="echAnnotation__icon">
         {renderWithProps(icon, datum)}
       </div>
@@ -164,6 +183,21 @@ export function LineMarker({
         </div>
       )}
     </button>
+  ) : (
+    // Non-clickable markers use a div (not a button) so they are not exposed as controls,
+    // but they still need tabIndex={0} so keyboard users can focus the marker for tooltip / hover state
+    // and Escape to dismiss.
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+    <div {...elementProps} tabIndex={0}>
+      <div ref={iconRef} className="echAnnotation__icon">
+        {renderWithProps(icon, datum)}
+      </div>
+      {body && (
+        <div ref={testRef} className="echAnnotation__body">
+          {renderWithProps(body, datum)}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/packages/charts/src/components/tooltip/components/tooltip_wrapper.tsx
+++ b/packages/charts/src/components/tooltip/components/tooltip_wrapper.tsx
@@ -7,7 +7,7 @@
  */
 
 import classNames from 'classnames';
-import type { PropsWithChildren } from 'react';
+import type { AriaRole, PropsWithChildren } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { TooltipActions } from './tooltip_actions';
@@ -24,6 +24,8 @@ type TooltipWrapperProps<
 > = PropsWithChildren<
   {
     className?: string;
+    id?: string;
+    role?: AriaRole;
   } & Pick<
     TooltipSpec<D, SI>,
     'actions' | 'actionPrompt' | 'pinningPrompt' | 'selectionPrompt' | 'actionsLoading' | 'noActionsLoaded'
@@ -34,6 +36,8 @@ type TooltipWrapperProps<
 export const TooltipWrapper = <D extends BaseDatum = Datum, SI extends SeriesIdentifier = SeriesIdentifier>({
   children,
   className,
+  id,
+  role,
   actions,
   actionPrompt,
   pinningPrompt,
@@ -66,6 +70,8 @@ export const TooltipWrapper = <D extends BaseDatum = Datum, SI extends SeriesIde
 
   return (
     <div
+      id={id}
+      role={role}
       className={classNames('echTooltip', className, { 'echTooltip--pinned': pinned })}
       data-testid="echTooltip"
       dir={dir}


### PR DESCRIPTION
## Summary

Adds support for keyboard navigation of tooltips and `aria-describedby` label to tooltip triggers, aligning our annotation tooltips with the [APG's Tooltip Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/).

## Details

In order to link the line annotation marker buttons to their annotation tooltip in the accessibility tree, we give the tooltip a stable DOM id, and set the `aria-describedby` props on the marker to match. We pass on `chartId` from `<Annotations>` to each `<LineMarker>` to avoid possible collisions when several charts are on the same page.

Additionally, added an event handler for escape to close the tooltip to adhere to [WCAG Success Criterion 1.4.13 Content on Hover or Focus](https://www.w3.org/WAI/WCAG22/Understanding/content-on-hover-or-focus.html).

## Issues

Closes https://github.com/elastic/kibana/issues/148684, closes https://github.com/elastic/kibana/issues/148685.