### PR TITLE
chore: add GitHub CODEOWNERS FILE

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all files in this repository
+* @elastic/kibana-visualizations


### PR DESCRIPTION
## Summary

We should include the @elastic/kibana-visualization team  as the main code owner of this repo.
This will allow us to automatically assign the team as requested reviewer for any new PRs.
