### PR TITLE
chore: Use elastic charts image

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -6,35 +6,20 @@ source .buildkite/scripts/utils.sh
 
 echo '--- Setting job environment variables'
 
-if [[ "${BUILDKITE_AGENT_META_DATA_AGENT_MANAGER:-}" == "kibana" ]]; then # use old paths
-    # kibanamachine token to access org
-    GITHUB_TOKEN=$(retry 5 5 vault read -field=github_token secret/kibana-issues/dev/kibanamachine)
-    export GITHUB_TOKEN
 
-    # charts github app to send checks
-    GITHUB_AUTH=$(retry 5 5 vault read -field=auth secret/datavis/github)
-    export GITHUB_AUTH
+# kibanamachine token to access org
+GITHUB_TOKEN=$(retry 5 5 vault read -field=github_token secret/ci/elastic-elastic-charts/kibanamachine)
+export GITHUB_TOKEN
 
-    FIREBASE_AUTH=$(retry 5 5 vault read -field=auth secret/datavis/firebase)
-    export FIREBASE_AUTH
+# charts github app to send checks
+GITHUB_AUTH=$(retry 5 5 vault read -field=auth secret/ci/elastic-elastic-charts/github | base64 -d)
+export GITHUB_AUTH
 
-    BUILDKITE_TOKEN=$(retry 5 5 vault read -field=token secret/datavis/buildkite)
-    export BUILDKITE_TOKEN
-else # use new paths
-    # kibanamachine token to access org
-    GITHUB_TOKEN=$(retry 5 5 vault read -field=github_token secret/ci/elastic-elastic-charts/kibanamachine)
-    export GITHUB_TOKEN
+FIREBASE_AUTH=$(retry 5 5 vault read -field=auth secret/ci/elastic-elastic-charts/firebase | base64 -d)
+export FIREBASE_AUTH
 
-    # charts github app to send checks
-    GITHUB_AUTH=$(retry 5 5 vault read -field=auth secret/ci/elastic-elastic-charts/github | base64 -d)
-    export GITHUB_AUTH
-
-    FIREBASE_AUTH=$(retry 5 5 vault read -field=auth secret/ci/elastic-elastic-charts/firebase | base64 -d)
-    export FIREBASE_AUTH
-
-    BUILDKITE_TOKEN=$(retry 5 5 vault read -field=token secret/ci/elastic-elastic-charts/buildkite)
-    export BUILDKITE_TOKEN
-fi
+BUILDKITE_TOKEN=$(retry 5 5 vault read -field=token secret/ci/elastic-elastic-charts/buildkite)
+export BUILDKITE_TOKEN
 
 source .buildkite/scripts/node_setup.sh
 

--- a/.buildkite/pipelines/pull_request/pipeline.sh
+++ b/.buildkite/pipelines/pull_request/pipeline.sh
@@ -4,15 +4,8 @@ set -euo pipefail
 
 cd '.buildkite'
 
-if [[ "${ELASTIC_BUILDKITE_INFRA:-}" =~ ^(1|true)$ ]]; then
-  # Yarn install completely silently:
-  yarn install 1>&2
+# Yarn install completely silently:
+yarn install 1>&2
 
-  # The new infra requires the pipeline to emit the steps
-  yarn -s print:pipeline
-else
-  # The old infra required pipeline upload
-  echo '--- Build pipeline'
-
-  yarn build:pipeline
-fi
+# The new infra requires the pipeline to emit the steps
+yarn -s print:pipeline

--- a/.buildkite/scripts/node_setup.sh
+++ b/.buildkite/scripts/node_setup.sh
@@ -75,7 +75,7 @@ fi
 # from YARN_YARN_OFFLINE_MIRROR set by the docker plugin environment.
 if [[ -d "$YARN_OFFLINE_CACHE" ]]; then
   echo " -- moving yarn offline cache to $ELASTIC_CHARTS_DIR/.yarn-offline-cache"
-  mv "$YARN_OFFLINE_CACHE" "$ELASTIC_CHARTS_DIR/.yarn-offline-cache"
+  mv -v "$YARN_OFFLINE_CACHE" "$ELASTIC_CHARTS_DIR/.yarn-offline-cache"
   yarn config set yarn-offline-mirror "$ELASTIC_CHARTS_DIR/.yarn-offline-cache"
 fi
 

--- a/.buildkite/scripts/node_setup.sh
+++ b/.buildkite/scripts/node_setup.sh
@@ -70,7 +70,11 @@ if [[ ! $(which yarn) || $(yarn --version) != "$YARN_VERSION" ]]; then
   npm_install_global yarn "^$YARN_VERSION"
 fi
 
-yarn config set yarn-offline-mirror "$YARN_OFFLINE_CACHE"
+if [[ -d "$YARN_OFFLINE_CACHE" ]]; then
+  echo " -- moving yarn offline cache to $ELASTIC_CHARTS_DIR/.yarn-offline-cache"
+  mv "$YARN_OFFLINE_CACHE" "$ELASTIC_CHARTS_DIR/.yarn-offline-cache"
+  yarn config set yarn-offline-mirror "$ELASTIC_CHARTS_DIR/.yarn-offline-cache"
+fi
 
 YARN_GLOBAL_BIN=$(yarn global bin)
 export YARN_GLOBAL_BIN

--- a/.buildkite/scripts/node_setup.sh
+++ b/.buildkite/scripts/node_setup.sh
@@ -70,6 +70,9 @@ if [[ ! $(which yarn) || $(yarn --version) != "$YARN_VERSION" ]]; then
   npm_install_global yarn "^$YARN_VERSION"
 fi
 
+# Move the prewarmed offline cache into the repo so it's visible inside the
+# docker plugin container (mounted at /app). The container reads the location
+# from YARN_YARN_OFFLINE_MIRROR set by the docker plugin environment.
 if [[ -d "$YARN_OFFLINE_CACHE" ]]; then
   echo " -- moving yarn offline cache to $ELASTIC_CHARTS_DIR/.yarn-offline-cache"
   mv "$YARN_OFFLINE_CACHE" "$ELASTIC_CHARTS_DIR/.yarn-offline-cache"

--- a/.buildkite/scripts/node_setup.sh
+++ b/.buildkite/scripts/node_setup.sh
@@ -76,9 +76,6 @@ fi
 if [[ -d "$YARN_OFFLINE_CACHE" ]]; then
   echo " -- moving yarn offline cache to $ELASTIC_CHARTS_DIR/.yarn-offline-cache"
   mv -v "$YARN_OFFLINE_CACHE" "$ELASTIC_CHARTS_DIR/.yarn-offline-cache"
-  ls -la "$ELASTIC_CHARTS_DIR/.yarn-offline-cache"
-  ls -la "$YARN_OFFLINE_CACHE"
-  ls -la "`dirname $ELASTIC_CHARTS_DIR`"
   yarn config set yarn-offline-mirror "$ELASTIC_CHARTS_DIR/.yarn-offline-cache"
 fi
 

--- a/.buildkite/scripts/node_setup.sh
+++ b/.buildkite/scripts/node_setup.sh
@@ -6,10 +6,10 @@ source .buildkite/scripts/utils.sh
 
 echo "--- Setup Node"
 
-KIBANA_DIR=$(pwd)
-CACHE_DIR="$HOME/.kibana"
+ELASTIC_CHARTS_DIR=$(pwd)
+CACHE_DIR="$HOME/.elastic-charts"
 
-NODE_VERSION="$(cat "$KIBANA_DIR/.node-version")"
+NODE_VERSION="$(cat "$ELASTIC_CHARTS_DIR/.node-version")"
 NODE_DIR="$CACHE_DIR/node/$NODE_VERSION"
 NODE_BIN_DIR="$NODE_DIR/bin"
 YARN_OFFLINE_CACHE="$CACHE_DIR/yarn-offline-cache"

--- a/.buildkite/scripts/node_setup.sh
+++ b/.buildkite/scripts/node_setup.sh
@@ -76,6 +76,9 @@ fi
 if [[ -d "$YARN_OFFLINE_CACHE" ]]; then
   echo " -- moving yarn offline cache to $ELASTIC_CHARTS_DIR/.yarn-offline-cache"
   mv -v "$YARN_OFFLINE_CACHE" "$ELASTIC_CHARTS_DIR/.yarn-offline-cache"
+  ls -la "$ELASTIC_CHARTS_DIR/.yarn-offline-cache"
+  ls -la "$YARN_OFFLINE_CACHE"
+  ls -la "`dirname $ELASTIC_CHARTS_DIR`"
   yarn config set yarn-offline-mirror "$ELASTIC_CHARTS_DIR/.yarn-offline-cache"
 fi
 

--- a/.buildkite/utils/exec.ts
+++ b/.buildkite/utils/exec.ts
@@ -125,7 +125,7 @@ ls /app/.yarn-offline-cache | wc -l
   await exec(`yarn config get yarn-offline-mirror`, { cwd, retry: 5, retryWait: 15 });
   await exec(`ls -la /app/.yarn-offline-cache | head`, { cwd, retry: 5, retryWait: 15 });
   await exec(`ls /app/.yarn-offline-cache | wc -l`, { cwd, retry: 5, retryWait: 15 });
-  await exec(`yarn install --frozen-lockfile${scriptFlag}`, { cwd, retry: 5, retryWait: 15 });
+  await exec(`yarn install --offline --verbose --frozen-lockfile${scriptFlag}`, { cwd, retry: 5, retryWait: 15 });
 };
 
 function getErrorMsg(error: unknown): string {

--- a/.buildkite/utils/exec.ts
+++ b/.buildkite/utils/exec.ts
@@ -110,9 +110,11 @@ export const exec = async (
 };
 
 export const yarnInstall = async (cwd?: string, ignoreScripts = true) => {
-  startGroup(`Installing node modules${cwd ? ` [${cwd}]` : ''}`);
+  startGroup(`Installing node modules${cwd ? ` [${cwd}]` : `[${process.cwd()}]`}`);
   const scriptFlag = ignoreScripts ? ' --ignore-scripts' : '';
-  await exec(`yarn install --frozen-lockfile --offline${scriptFlag}`, { cwd, retry: 5, retryWait: 15 });
+  await exec(`yarn config list | grep -iv 'token'`, { cwd, retry: 5, retryWait: 15 });
+  await exec(`ls -la '.yarn-offline-cache'`, { cwd, retry: 5, retryWait: 15 });
+  await exec(`yarn install --frozen-lockfile${scriptFlag}`, { cwd, retry: 5, retryWait: 15 });
 };
 
 function getErrorMsg(error: unknown): string {

--- a/.buildkite/utils/exec.ts
+++ b/.buildkite/utils/exec.ts
@@ -112,20 +112,7 @@ export const exec = async (
 export const yarnInstall = async (cwd?: string, ignoreScripts = true) => {
   startGroup(`Installing node modules${cwd ? ` [${cwd}]` : ` [${process.cwd()}]`}`);
   const scriptFlag = ignoreScripts ? ' --ignore-scripts' : '';
-  /**
-   * Exec all these:
-echo "PWD=$(pwd)"
-echo "YARN_YARN_OFFLINE_MIRROR=${YARN_YARN_OFFLINE_MIRROR:-<unset>}"
-yarn config get yarn-offline-mirror
-ls -la /app/.yarn-offline-cache | head
-ls /app/.yarn-offline-cache | wc -l
-   */
-  await exec(`echo "PWD=$(pwd)"`, { cwd, retry: 5, retryWait: 15 });
-  await exec(`echo "YARN_YARN_OFFLINE_MIRROR=\${YARN_YARN_OFFLINE_MIRROR:-<unset>}"`, { cwd, retry: 5, retryWait: 15 });
-  await exec(`yarn config get yarn-offline-mirror`, { cwd, retry: 5, retryWait: 15 });
-  await exec(`ls -la /app/.yarn-offline-cache | head`, { cwd, retry: 5, retryWait: 15 });
-  await exec(`ls /app/.yarn-offline-cache | wc -l`, { cwd, retry: 5, retryWait: 15 });
-  await exec(`yarn install --offline --verbose --frozen-lockfile${scriptFlag}`, { cwd, retry: 5, retryWait: 15 });
+  await exec(`yarn install --frozen-lockfile${scriptFlag}`, { cwd, retry: 5, retryWait: 15 });
 };
 
 function getErrorMsg(error: unknown): string {

--- a/.buildkite/utils/exec.ts
+++ b/.buildkite/utils/exec.ts
@@ -110,10 +110,8 @@ export const exec = async (
 };
 
 export const yarnInstall = async (cwd?: string, ignoreScripts = true) => {
-  startGroup(`Installing node modules${cwd ? ` [${cwd}]` : `[${process.cwd()}]`}`);
+  startGroup(`Installing node modules${cwd ? ` [${cwd}]` : ` [${process.cwd()}]`}`);
   const scriptFlag = ignoreScripts ? ' --ignore-scripts' : '';
-  await exec(`yarn config list | grep -iv 'token'`, { cwd, retry: 5, retryWait: 15 });
-  await exec(`ls -la '.yarn-offline-cache'`, { cwd, retry: 5, retryWait: 15 });
   await exec(`yarn install --frozen-lockfile${scriptFlag}`, { cwd, retry: 5, retryWait: 15 });
 };
 

--- a/.buildkite/utils/exec.ts
+++ b/.buildkite/utils/exec.ts
@@ -112,6 +112,19 @@ export const exec = async (
 export const yarnInstall = async (cwd?: string, ignoreScripts = true) => {
   startGroup(`Installing node modules${cwd ? ` [${cwd}]` : ` [${process.cwd()}]`}`);
   const scriptFlag = ignoreScripts ? ' --ignore-scripts' : '';
+  /**
+   * Exec all these:
+echo "PWD=$(pwd)"
+echo "YARN_YARN_OFFLINE_MIRROR=${YARN_YARN_OFFLINE_MIRROR:-<unset>}"
+yarn config get yarn-offline-mirror
+ls -la /app/.yarn-offline-cache | head
+ls /app/.yarn-offline-cache | wc -l
+   */
+  await exec(`echo "PWD=$(pwd)"`, { cwd, retry: 5, retryWait: 15 });
+  await exec(`echo "YARN_YARN_OFFLINE_MIRROR=\${YARN_YARN_OFFLINE_MIRROR:-<unset>}"`, { cwd, retry: 5, retryWait: 15 });
+  await exec(`yarn config get yarn-offline-mirror`, { cwd, retry: 5, retryWait: 15 });
+  await exec(`ls -la /app/.yarn-offline-cache | head`, { cwd, retry: 5, retryWait: 15 });
+  await exec(`ls /app/.yarn-offline-cache | wc -l`, { cwd, retry: 5, retryWait: 15 });
   await exec(`yarn install --frozen-lockfile${scriptFlag}`, { cwd, retry: 5, retryWait: 15 });
 };
 

--- a/.buildkite/utils/exec.ts
+++ b/.buildkite/utils/exec.ts
@@ -112,7 +112,7 @@ export const exec = async (
 export const yarnInstall = async (cwd?: string, ignoreScripts = true) => {
   startGroup(`Installing node modules${cwd ? ` [${cwd}]` : ''}`);
   const scriptFlag = ignoreScripts ? ' --ignore-scripts' : '';
-  await exec(`yarn install --frozen-lockfile${scriptFlag}`, { cwd, retry: 5, retryWait: 15 });
+  await exec(`yarn install --frozen-lockfile --offline${scriptFlag}`, { cwd, retry: 5, retryWait: 15 });
 };
 
 function getErrorMsg(error: unknown): string {

--- a/.buildkite/utils/pipeline/plugins.ts
+++ b/.buildkite/utils/pipeline/plugins.ts
@@ -36,6 +36,8 @@ const environment = [
   ECH_CHECK_ID,
   'GITHUB_PR_MAINTAINER_CAN_MODIFY',
   'ECH_STEP_PLAYWRIGHT_UPDATE_SCREENSHOTS',
+  'YARN_YARN_OFFLINE_MIRROR=/app/.yarn-offline-cache', // see: .buildkite/scripts/node_setup.sh
+  'YARN_YARN_OFFLINE_MIRROR_PRUNING=false',
 ];
 
 export class Plugins {

--- a/.buildkite/utils/pipeline/steps.ts
+++ b/.buildkite/utils/pipeline/steps.ts
@@ -47,8 +47,8 @@ export type Step = CustomGroupStep | CustomCommandStep;
 export const commandStepDefaults: Partial<CustomCommandStep> = {
   agents: {
     provider: 'gcp',
-    image: 'family/kibana-ubuntu-2404',
-    imageProject: 'elastic-images-prod',
+    image: 'family/elastic-charts-ubuntu-2404',
+    imageProject: 'elastic-images-qa',
     machineType: 'n2-standard-2',
   },
   skip: false,

--- a/.buildkite/utils/pipeline/steps.ts
+++ b/.buildkite/utils/pipeline/steps.ts
@@ -11,24 +11,6 @@ import type { CommandStep, GroupStep } from '../../buildkite';
 import { bkEnv } from '../buildkite';
 import type { ChangeContext } from '../github';
 
-/**
- * @deprecated
- * Available agents from kibana buildkite instance
- * See [full list](https://github.com/elastic/kibana-buildkite/blob/dab1058885036ac23e8371e40dcd3e0fedb4c49c/agents.json#L19-L165)
- */
-export type AgentQueue =
-  | 'default'
-  | 'datavis-n2-2'
-  | 'ci-group'
-  | 'ci-group-4d'
-  | 'ci-group-6'
-  | 'jest'
-  | 'n2-2'
-  | 'n2-4'
-  | 'c2-16'
-  | 'c2-8'
-  | 'c2-4';
-
 export type CustomCommandStep = Omit<CommandStep, 'agents'> & {
   /**
    * Only applies to pull requests
@@ -40,8 +22,6 @@ export type CustomCommandStep = Omit<CommandStep, 'agents'> & {
    */
   ignoreForced?: boolean;
   agents?: {
-    /** @deprecated - image queues are no longer supported outside of the Kibana-Buildkite infra */
-    queue?: AgentQueue;
     imageProject?: 'elastic-images-qa' | 'elastic-images-prod' | string;
     image?: string;
     diskSizeGb?: number;
@@ -64,19 +44,13 @@ export type CustomGroupStep = Omit<GroupStep, 'steps'> & {
 // Only current supported steps
 export type Step = CustomGroupStep | CustomCommandStep;
 
-const IS_ELASTIC_BUILDKITE_INFRA = !!process.env.ELASTIC_BUILDKITE_INFRA?.match(/^(1|true)$/);
-
 export const commandStepDefaults: Partial<CustomCommandStep> = {
-  agents: IS_ELASTIC_BUILDKITE_INFRA
-    ? {
-        provider: 'gcp',
-        image: 'family/kibana-ubuntu-2404',
-        imageProject: 'elastic-images-prod',
-        machineType: 'n2-standard-2',
-      }
-    : {
-        queue: 'datavis-n2-2',
-      },
+  agents: {
+    provider: 'gcp',
+    image: 'family/kibana-ubuntu-2404',
+    imageProject: 'elastic-images-prod',
+    machineType: 'n2-standard-2',
+  },
   skip: false,
   priority: 10,
   plugins: [Plugins.docker.node()],

--- a/.buildkite/utils/pipeline/steps.ts
+++ b/.buildkite/utils/pipeline/steps.ts
@@ -48,7 +48,7 @@ export const commandStepDefaults: Partial<CustomCommandStep> = {
   agents: {
     provider: 'gcp',
     image: 'family/elastic-charts-ubuntu-2404',
-    imageProject: 'elastic-images-qa',
+    imageProject: 'elastic-images-prod',
     machineType: 'n2-standard-2',
   },
   skip: false,

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ playground/playground.tsx
 !.buildkite/yarn.lock
 !docs/yarn.lock
 !e2e/yarn.lock
+
+# We keep node module archives in this folder
+.yarn-offline-cache/

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+yarn-offline-mirror "./.yarn-offline-cache"

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,3 @@
+# .yarnrc
 yarn-offline-mirror "./.yarn-offline-cache"
+yarn-offline-mirror-pruning false


### PR DESCRIPTION
## Summary
Uses elastic-charts specific image for all elastic-charts tasks.

These images are smaller in disk usage, and they have some `elastic-charts` things pre-baked (i.e.: warmed-up yarn download cache, and docker images for the docker-buildkite-plugin) - ultimately making the cloning step faster.

## Details
https://github.com/elastic/ci-agent-images/pull/2552 builds a VM image (https://buildkite.com/elastic/ci-vm-images/builds/14215).

This PR:
 - removes vestiges from the old infra
 - makes uses of the new `elastic-charts-ubuntu-*` image
 - sets up the yarn cache for reuse (doesn't really make the install a lot faster)