### PR TITLE
fix(a11y): give role="img" to interactive annotation line marker 

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
@@ -188,7 +188,7 @@ export function LineMarker({
     // but they still need tabIndex={0} so keyboard users can focus the marker for tooltip / hover state
     // and Escape to dismiss.
     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-    <div {...elementProps} tabIndex={0}>
+    <div {...elementProps} tabIndex={0} role="img">
       <div ref={iconRef} className="echAnnotation__icon">
         {renderWithProps(icon, datum)}
       </div>


### PR DESCRIPTION
## Summary

This PR resolves an issue where the interactive line marker annotation didn't have a `role` set, causing it to break axe-core rule [Elements must only use permitted ARIA attributes](https://dequeuniversity.com/rules/axe/4.11/aria-prohibited-attr?application=axeAPI).

## Details

This PR follows up on https://github.com/elastic/elastic-charts/pull/2823. Previously, we'd decided not to set an role on `<div tabIndex={0}` element, as none of the available roles is a great fit to describe the semantic meaning of the icon marker that triggers the tooltip. 

However, having `aria-label` set in a generic div breaks the axe-core rule mentioned above, which is part of Kibana's CI. As such we add role `img`, to be compliant with Kibana's A11Y testing suite (i.e., solve version update not passing testing suite: https://github.com/elastic/kibana/pull/266581)

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)