### PR TITLE
feat(a11y): add graphics-document role to charts

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
+++ b/packages/charts/src/chart_types/xy_chart/renderer/dom/annotations/line_marker.tsx
@@ -188,7 +188,7 @@ export function LineMarker({
     // but they still need tabIndex={0} so keyboard users can focus the marker for tooltip / hover state
     // and Escape to dismiss.
     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-    <div {...elementProps} tabIndex={0} role="img">
+    <div {...elementProps} tabIndex={0} role="graphics-symbol">
       <div ref={iconRef} className="echAnnotation__icon">
         {renderWithProps(icon, datum)}
       </div>

--- a/packages/charts/src/components/chart.tsx
+++ b/packages/charts/src/components/chart.tsx
@@ -174,7 +174,13 @@ export class Chart extends React.Component<ChartProps, ChartState> {
 
     return (
       <Provider store={this.chartStore}>
-        <div className="echChart" style={containerSizeStyle} data-testid="echChart">
+        <div
+          className="echChart"
+          style={containerSizeStyle}
+          data-testid="echChart"
+          role="graphics-document"
+          aria-roledescription="visualization"
+        >
           <Titles
             displayTitles={this.state.displayTitles}
             title={this.props.title}


### PR DESCRIPTION
## Summary

This PR adds ARIA roles and descriptions to the chart container and updates role for annotations line markers to be `graphics-symbol` since they are now in a `graphics-document`. 

## Details

Added `role="graphics-document"` and `aria-roledescription="visualization"` attributes to the main chart container `div` in `chart.tsx` to improve accessibility for screen readers.


### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)

