### PR TITLE
ci: reduce overly sharded playwright tests

### DIFF
--- a/.buildkite/steps/playwright_vrt.ts
+++ b/.buildkite/steps/playwright_vrt.ts
@@ -21,7 +21,7 @@ export const playwrightVrtStep = createStep<CustomGroupStep>(() => {
         ...commandStepDefaults,
         label: ':playwright: Playwright e2e VRT',
         skip,
-        parallelism: 10,
+        parallelism: 5,
         retry: {
           automatic: [
             {


### PR DESCRIPTION
## Summary

Reduce number of parallel jobs on playwright ci job. Currently 10 jobs results in ~2m average runtime, we should target about ~5m or so.