### PR TITLE
ci: support running buildkite on backport branches

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -46,8 +46,7 @@
       "enable_skippable_commits": false,
       "skip_ci_on_only_changed": [],
       "always_require_ci_on_changed": [],
-      "enable_trigger_checkbox": false,
-      "target_branch": "main"
+      "enable_trigger_checkbox": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Removes `target_branch` setting from `pull-requests.json` to allow triggering ci checks.
