### PR TITLE
ci: redirect gh-pages cache out of workspace mount

### DIFF
--- a/.buildkite/scripts/steps/ghp_deploy.ts
+++ b/.buildkite/scripts/steps/ghp_deploy.ts
@@ -11,6 +11,12 @@ import path from 'path';
 
 import { downloadArtifacts, startGroup, decompress, ghpDeploy } from '../../utils';
 
+// gh-pages uses find-cache-dir, which resolves to <repoRoot>/node_modules/.cache/gh-pages.
+// This step runs in the docker node plugin as root with the workspace bind-mounted, so
+// writing there leaves root-owned dirs on the host and breaks the host pre-exit yarn install.
+// CACHE_DIR is honored by find-cache-dir and keeps the clone inside the container.
+process.env.CACHE_DIR = process.env.CACHE_DIR || '/tmp/ech-cache';
+
 void (async () => {
   const outDir = '.out';
 


### PR DESCRIPTION
## Summary
Fix github pages deployment step. Currently the Github pages deployment succeeds, but the pre-exit step fails trying to install node_modules.

## Details
The ghp_deploy step runs in the docker node plugin as root with the workspace bind-mounted at `/app`. `gh-pages.publish` uses `find-cache-dir`, which resolves to `<repoRoot>/node_modules/.cache/gh-pages` and creates root-owned dirs on the host. The host pre-exit `yarn install` then fails with EACCES on `node_modules/`. Setting `CACHE_DIR` keeps the `gh-pages` clone inside the container (`/tmp`) and leaves the workspace untouched.