### PR TITLE
fix: Scale flamechart font with CTRL-Wheel zoom

### DIFF
--- a/packages/charts/src/chart_types/flame_chart/render/draw_canvas.ts
+++ b/packages/charts/src/chart_types/flame_chart/render/draw_canvas.ts
@@ -38,7 +38,13 @@ export const drawCanvas2d = (
 ) => {
   const zoomedRowHeight = rowHeight / Math.abs(focusHiY - focusLoY);
   const rowHeightPx = zoomedRowHeight * cssHeight;
-  const fontSize = zoomedRowHeight * cssHeight - 2 * BOX_GAP_VERTICAL;
+  // Scale font size with both vertical and horizontal zoom to ensure readability
+  // when using CTRL-Wheel to zoom (which may zoom X more than Y after Y hits minimum)
+  const horizontalZoomFactor = 1 / Math.abs(focusHiX - focusLoX);
+  const verticalZoomFactor = 1 / Math.abs(focusHiY - focusLoY);
+  const zoomFactor = Math.max(horizontalZoomFactor, verticalZoomFactor);
+  const baseFontSize = rowHeight * cssHeight - 2 * BOX_GAP_VERTICAL;
+  const fontSize = baseFontSize * zoomFactor;
   const minTextLengthCssPix = MIN_TEXT_LENGTH * fontSize; // don't render shorter text than this
   const minRectWidthForTextInCssPix = minTextLengthCssPix + TEXT_PAD_LEFT + TEXT_PAD_RIGHT;
   const minRectWidth = minRectWidthForTextInCssPix / cssWidth;


### PR DESCRIPTION
## Summary

Fixes #2000: When using CTRL-Wheel to zoom into a flamechart, the font was not scaled along with the nodes. This resulted in unreadable text on many screens as the nodes became wider but the font stayed the same.

## Changes

Modified `packages/charts/src/chart_types/flame_chart/render/draw_canvas.ts` to scale font size based on both horizontal and vertical zoom levels.

**Before:** Font size was calculated only based on vertical zoom level (`zoomedRowHeight * cssHeight - 2 * BOX_GAP_VERTICAL`).

**After:** Font size is calculated based on the maximum of both horizontal and vertical zoom factors, ensuring readable text when zooming in any direction.

## Technical Details

The issue occurred because:
1. When using CTRL-Wheel zoom, both X and Y axes zoom proportionally initially
2. After a threshold, Y zoom stops (minimum row pitch reached) but X zoom continues
3. Nodes become wider but font stays the same size

The fix computes zoom factors for both axes:
```typescript
const horizontalZoomFactor = 1 / Math.abs(focusHiX - focusLoX);
const verticalZoomFactor = 1 / Math.abs(focusHiY - focusLoY);
const zoomFactor = Math.max(horizontalZoomFactor, verticalZoomFactor);
const fontSize = baseFontSize * zoomFactor;
```

This ensures font size scales with the dominant zoom direction.

## Testing

- Verified the fix works correctly by examining the code logic
- No unit tests were modified as the existing tests are screenshot-based e2e tests
- The change is backward compatible and only affects behavior when zoomed in