### PR TITLE
ci(playwright): update playwright to use proprietary merge-reports

### DIFF
--- a/.buildkite/scripts/steps/e2e_reports.ts
+++ b/.buildkite/scripts/steps/e2e_reports.ts
@@ -187,6 +187,10 @@ void (async () => {
 
   await downloadArtifacts(artifactPath);
 
+  // Collect every shard's `blob` report (`*.zip`) into a single directory so the
+  // native `playwright merge-reports` can consume them. Blob report names contain
+  // the shard number, so they will not clash.
+  const blobReportsDir = 'reports/all-blob-reports';
   const files = fs.readdirSync(reportDir);
   await Promise.all<void>(
     files
@@ -194,7 +198,7 @@ void (async () => {
       .map((f) =>
         decompress({
           src: path.join(reportDir, f),
-          dest: path.join('e2e/reports', path.basename(f, '.gz')),
+          dest: path.join('e2e', blobReportsDir),
         }),
       ),
   );
@@ -205,6 +209,7 @@ void (async () => {
     cwd: 'e2e',
     env: {
       HTML_REPORT_DIR: outputDir,
+      BLOB_REPORTS_DIR: blobReportsDir,
     },
   });
 

--- a/.buildkite/scripts/steps/playwright_a11y.ts
+++ b/.buildkite/scripts/steps/playwright_a11y.ts
@@ -52,10 +52,10 @@ void (async () => {
   await exec('arch');
 
   startGroup('Running e2e a11y playwright job');
-  const reportDir = `reports/a11y_report_${shardIndex}`;
+  const blobDir = 'reports/a11y-blob';
   async function postCommandTasks() {
     await compress({
-      src: path.join('e2e', reportDir),
+      src: path.join('e2e', blobDir),
       dest: `.buildkite/artifacts/a11y_reports/report_${shardIndex}.gz`,
     });
   }
@@ -67,7 +67,8 @@ void (async () => {
       cwd: 'e2e',
       env: {
         [ENV_URL]: 'http://127.0.0.1:9002',
-        PLAYWRIGHT_HTML_REPORT: reportDir,
+        PLAYWRIGHT_BLOB_REPORT: 'true',
+        PLAYWRIGHT_BLOB_OUTPUT_FILE: path.join(blobDir, `report_${shardIndex}.zip`),
         PLAYWRIGHT_JSON_OUTPUT_NAME: `reports/a11y-json/report_${shardIndex}.json`,
       },
     });

--- a/.buildkite/scripts/steps/playwright_vrt.ts
+++ b/.buildkite/scripts/steps/playwright_vrt.ts
@@ -99,10 +99,10 @@ void (async () => {
   await exec('node ./e2e/scripts/extract_examples.js');
 
   startGroup('Running e2e vrt playwright job');
-  const reportDir = `reports/vrt_report_${shardIndex}`;
+  const blobDir = 'reports/blob';
   async function postCommandTasks() {
     await compress({
-      src: path.join('e2e', reportDir),
+      src: path.join('e2e', blobDir),
       dest: `.buildkite/artifacts/vrt_reports/report_${shardIndex}.gz`,
     });
 
@@ -118,7 +118,8 @@ void (async () => {
       cwd: 'e2e',
       env: {
         [ENV_URL]: 'http://127.0.0.1:9002',
-        PLAYWRIGHT_HTML_REPORT: reportDir,
+        PLAYWRIGHT_BLOB_REPORT: 'true',
+        PLAYWRIGHT_BLOB_OUTPUT_FILE: path.join(blobDir, `report_${shardIndex}.zip`),
         PLAYWRIGHT_JSON_OUTPUT_NAME: `reports/vrt-json/report_${shardIndex}.json`,
       },
     });

--- a/e2e/merge_html_reports.ts
+++ b/e2e/merge_html_reports.ts
@@ -6,31 +6,40 @@
  * Side Public License, v 1.
  */
 
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
-import { mergeHTMLReports } from 'playwright-merge-html-reports';
+// Directory holding the per-shard `blob` reports (`*.zip`) to merge.
+const BLOB_REPORTS_DIR = process.env.BLOB_REPORTS_DIR ?? './reports/blob';
 
-void (async () => {
-  const inputReportPaths = fs
-    .readdirSync('./reports', { withFileTypes: true })
-    .filter((item) => item.isDirectory())
-    .map(({ name }) => path.resolve('reports', name));
+void (() => {
+  const blobReportsDir = path.resolve(process.cwd(), BLOB_REPORTS_DIR);
 
-  if (inputReportPaths.length === 0) {
-    throw new Error('Error: No e2e reports found in e2e/reports/* to merge');
+  if (!fs.existsSync(blobReportsDir)) {
+    throw new Error(`Error: blob reports directory not found at ${blobReportsDir}`);
+  }
+
+  const blobReports = fs.readdirSync(blobReportsDir).filter((name) => name.endsWith('.zip'));
+
+  if (blobReports.length === 0) {
+    throw new Error(`Error: No blob reports (*.zip) found in ${blobReportsDir} to merge`);
   }
 
   // eslint-disable-next-line no-console
-  console.log(`Merging ${inputReportPaths.length} playwright html reports:\n\n\t${inputReportPaths.join('\n\t')}\n`);
+  console.log(`Merging ${blobReports.length} playwright blob reports:\n\n\t${blobReports.join('\n\t')}\n`);
 
-  const config = {
-    outputFolderName: process.env.HTML_REPORT_DIR ?? 'merged_html_report',
-    outputBasePath: path.resolve(process.cwd(), process.env.HTML_REPORT_PATH ?? ''),
-  };
+  const outputFolderName = process.env.HTML_REPORT_DIR ?? 'merged_html_report';
+  const outputBasePath = path.resolve(process.cwd(), process.env.HTML_REPORT_PATH ?? '');
+  const outputDir = path.join(outputBasePath, outputFolderName);
 
-  const outputDir = path.join(config.outputBasePath, config.outputFolderName);
-  fs.mkdirSync(outputDir, { recursive: true });
-
-  await mergeHTMLReports(inputReportPaths, config);
+  // The html reporter honors PLAYWRIGHT_HTML_REPORT for the output directory.
+  execFileSync('yarn', ['playwright', 'merge-reports', '--reporter', 'html', blobReportsDir], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      PLAYWRIGHT_HTML_REPORT: outputDir,
+      PLAYWRIGHT_HTML_OPEN: 'never',
+    },
+  });
 })();

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,7 +10,7 @@
     "start": "npx http-server ./server --port 9002",
     "test:playwright": "./scripts/test.sh",
     "test:playwright:a11y": "./scripts/test.sh --a11y",
-    "merge:reports": "ts-node ./merge_html_reports.ts",
+    "merge:reports": "ts-node --transpile-only ./merge_html_reports.ts",
     "playwright": "playwright"
   },
   "dependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -18,7 +18,6 @@
     "@types/node": "^20.10.0",
     "change-case": "^4.1.2",
     "expect-playwright": "^0.8.0",
-    "playwright-merge-html-reports": "^0.2.3",
     "slugify": "^1.6.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3"

--- a/e2e/playwright.a11y.config.ts
+++ b/e2e/playwright.a11y.config.ts
@@ -10,13 +10,17 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 import baseConfig from './playwright.config';
 
+const useBlobReport = process.env.PLAYWRIGHT_BLOB_REPORT === 'true';
+
 const config: PlaywrightTestConfig = {
   ...baseConfig,
   testDir: 'tests_a11y',
   testMatch: ['**/tests_a11y/**/*.test.ts'],
   reporter: [
     ['list'],
-    ['html', { open: 'never', outputFolder: 'reports/a11y-html' }],
+    useBlobReport
+      ? ['blob', { outputDir: 'reports/a11y-blob' }]
+      : ['html', { open: 'never', outputFolder: 'reports/a11y-html' }],
     ['json', { outputFile: 'reports/a11y-json/report.json' }],
   ],
   use: {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -14,6 +14,11 @@ expect.extend(pwExpect.matchers);
 
 const isCI = process.env.CI === 'true';
 
+// On sharded CI runs each shard emits a `blob` report that is later merged into a
+// single HTML report via `playwright merge-reports`. Locally we keep the directly
+// viewable `html` report.
+const useBlobReport = process.env.PLAYWRIGHT_BLOB_REPORT === 'true';
+
 const config: PlaywrightTestConfig = {
   use: {
     headless: true,
@@ -29,7 +34,7 @@ const config: PlaywrightTestConfig = {
   },
   reporter: [
     ['list'],
-    ['html', { open: 'never', outputFolder: 'reports/html' }],
+    useBlobReport ? ['blob', { outputDir: 'reports/blob' }] : ['html', { open: 'never', outputFolder: 'reports/html' }],
     ['json', { outputFile: 'reports/json/report.json' }],
   ],
   expect: {

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -76,11 +76,6 @@ arg@^4.1.0:
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
-
 camel-case@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
@@ -125,11 +120,6 @@ constant-case@^3.0.4:
     tslib "^2.0.3"
     upper-case "^2.0.2"
 
-core-util-is@~1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
-  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
-
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
@@ -166,38 +156,6 @@ header-case@^2.0.4:
     capital-case "^1.0.4"
     tslib "^2.0.3"
 
-immediate@~3.0.5:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
-  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
-
-inherits@~2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-isarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
-
-jszip@^3.7.1:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.9.1.tgz#784e87f328450d1e8151003a9c67733e2b901051"
-  integrity sha512-H9A60xPqJ1CuC4Ka6qxzXZeU8aNmgOeP5IFqwJbQQwtu2EUYxota3LdsiZWplF7Wgd9tkAd0mdu36nceSaPuYw==
-  dependencies:
-    lie "~3.3.0"
-    pako "~1.0.2"
-    readable-stream "~2.3.6"
-    set-immediate-shim "~1.0.1"
-
-lie@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
-  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
-  dependencies:
-    immediate "~3.0.5"
-
 lower-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
@@ -217,11 +175,6 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
-
-pako@~1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 param-case@^3.0.4:
   version "3.0.4"
@@ -252,14 +205,6 @@ playwright-core@1.54.2:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.54.2.tgz#73cc5106f19ec6b9371908603d61a7f171ebd8f0"
   integrity sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==
 
-playwright-merge-html-reports@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/playwright-merge-html-reports/-/playwright-merge-html-reports-0.2.3.tgz#4979c929f7a8fc7b5a5bb26ab5e99de488424ea4"
-  integrity sha512-YDTTLfRannqy64tSElNQzoj1zDlHzx9zo5nLu0shBOI515CQxOMKyAKY+7Lfv7BRjxQcYOdNA3sPUpf4MwpM+Q==
-  dependencies:
-    jszip "^3.7.1"
-    yazl "^2.5.1"
-
 playwright@1.54.2:
   version "1.54.2"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.54.2.tgz#e2435abb2db3a96a276f8acc3ada1a85b587dff3"
@@ -269,29 +214,6 @@ playwright@1.54.2:
   optionalDependencies:
     fsevents "2.3.2"
 
-process-nextick-args@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
-  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
-
-readable-stream@~2.3.6:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
 sentence-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
@@ -300,11 +222,6 @@ sentence-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
     upper-case-first "^2.0.2"
-
-set-immediate-shim@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
-  integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
 
 slugify@^1.6.5:
   version "1.6.5"
@@ -318,13 +235,6 @@ snake-case@^3.0.4:
   dependencies:
     dot-case "^3.0.4"
     tslib "^2.0.3"
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
 
 ts-node@^10.9.2:
   version "10.9.2"
@@ -374,22 +284,10 @@ upper-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
-util-deprecate@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
-
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
-
-yazl@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
-  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
-  dependencies:
-    buffer-crc32 "~0.2.3"
 
 yn@3.1.1:
   version "3.1.1"

--- a/packages/charts/src/utils/themes/theme_common.ts
+++ b/packages/charts/src/utils/themes/theme_common.ts
@@ -22,10 +22,10 @@ export const DEFAULT_CHART_PADDING: Margins = {
 };
 /** @internal */
 export const DEFAULT_CHART_MARGINS: Margins = {
-  left: 10,
-  right: 10,
-  top: 10,
-  bottom: 10,
+  left: 0,
+  right: 0,
+  top: 0,
+  bottom: 0,
 };
 
 /**

--- a/packages/charts/src/utils/themes/theme_common.ts
+++ b/packages/charts/src/utils/themes/theme_common.ts
@@ -22,10 +22,10 @@ export const DEFAULT_CHART_PADDING: Margins = {
 };
 /** @internal */
 export const DEFAULT_CHART_MARGINS: Margins = {
-  left: 0,
-  right: 0,
-  top: 0,
-  bottom: 0,
+  left: 10,
+  right: 10,
+  top: 10,
+  bottom: 10,
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR updates the playwright setup to generate correct Blobs out of each sharded test using the official merge tool to merge them into a single report.

fix https://github.com/elastic/elastic-charts/issues/2258