### PR TITLE
fix(metric): increase metric `minHeight` in theme to avoid clipped metric tiles 

### DIFF
--- a/packages/charts/src/chart_types/metric/renderer/dom/text_measurements.test.ts
+++ b/packages/charts/src/chart_types/metric/renderer/dom/text_measurements.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { getMinimumMetricHeight } from './text_measurements';
+import { AMSTERDAM_DARK_THEME } from '../../../../utils/themes/amsterdam_dark_theme';
+import { AMSTERDAM_LIGHT_THEME } from '../../../../utils/themes/amsterdam_light_theme';
+import { DARK_THEME } from '../../../../utils/themes/dark_theme';
+import { LEGACY_DARK_THEME } from '../../../../utils/themes/legacy_dark_theme';
+import { LEGACY_LIGHT_THEME } from '../../../../utils/themes/legacy_light_theme';
+import { LIGHT_THEME } from '../../../../utils/themes/light_theme';
+import type { MetricStyle, Theme } from '../../../../utils/themes/theme';
+
+const THEMES: Array<[string, Theme]> = [
+  ['LIGHT_THEME', LIGHT_THEME],
+  ['DARK_THEME', DARK_THEME],
+  ['AMSTERDAM_LIGHT_THEME', AMSTERDAM_LIGHT_THEME],
+  ['AMSTERDAM_DARK_THEME', AMSTERDAM_DARK_THEME],
+  ['LEGACY_LIGHT_THEME', LEGACY_LIGHT_THEME],
+  ['LEGACY_DARK_THEME', LEGACY_DARK_THEME],
+];
+
+const SPACINGS: Array<MetricStyle['spacing']> = ['small', 'large'];
+
+const CASES: Array<[string, MetricStyle['spacing'], Theme]> = THEMES.flatMap(([name, theme]) =>
+  SPACINGS.map((spacing): [string, MetricStyle['spacing'], Theme] => [name, spacing, theme]),
+);
+
+describe('getMinimumMetricHeight', () => {
+  // Guards against regressions: the static theme minHeight must always be
+  // large enough to render the smallest supported breakpoint's value + title without clipping
+  it.each(CASES)('theme minHeight avoids clipping for %s (%s spacing)', (_name, spacing, theme) => {
+    const style: MetricStyle = { ...theme.metric, spacing };
+    expect(theme.metric.minHeight).toBeGreaterThanOrEqual(getMinimumMetricHeight(style));
+  });
+});

--- a/packages/charts/src/chart_types/metric/renderer/dom/text_measurements.tsx
+++ b/packages/charts/src/chart_types/metric/renderer/dom/text_measurements.tsx
@@ -366,6 +366,28 @@ export function getMetricTextPartDimensions(
   };
 }
 
+/**
+ * Computes the minimum height required to render a metric tile without clipping
+ * @internal
+ */
+export function getMinimumMetricHeight(style: MetricStyle): number {
+  const ranges = getHeightBpRanges(style.spacing);
+  const smallestBreakpoint = ranges[0]?.[2] ?? 's';
+  const sizes = getHeightBasedFontSizes(smallestBreakpoint, style);
+
+  const valueFontSize = style.valueFontSize === 'fit' ? style.minValueFontSize : sizes.valueFontSize;
+
+  const { panelPadding } =
+    style.spacing === 'large'
+      ? getLargeMetricSpacingLayout(smallestBreakpoint)
+      : getSmallMetricSpacingLayout(style.valuePosition);
+
+  const valueHeight = valueFontSize * LINE_HEIGHT;
+  const titleHeight = sizes.titleFontSize * LINE_HEIGHT;
+
+  return Math.ceil(valueHeight + titleHeight + panelPadding);
+}
+
 function getHeightBasedFontSizes(
   size: BreakPoint,
   style: MetricStyle,

--- a/packages/charts/src/utils/themes/amsterdam_dark_theme.ts
+++ b/packages/charts/src/utils/themes/amsterdam_dark_theme.ts
@@ -437,7 +437,7 @@ export const AMSTERDAM_DARK_THEME: Theme = {
     barBackground: '#343741',
     emptyBackground: Colors.Transparent.keyword,
     nonFiniteText: 'N/A',
-    minHeight: 64,
+    minHeight: 80,
     titleWeight: 500,
   },
   bulletGraph: {

--- a/packages/charts/src/utils/themes/amsterdam_light_theme.ts
+++ b/packages/charts/src/utils/themes/amsterdam_light_theme.ts
@@ -437,7 +437,7 @@ export const AMSTERDAM_LIGHT_THEME: Theme = {
     barBackground: '#EDF0F5',
     emptyBackground: Colors.Transparent.keyword,
     nonFiniteText: 'N/A',
-    minHeight: 64,
+    minHeight: 80,
     titleWeight: 500,
   },
   bulletGraph: {

--- a/packages/charts/src/utils/themes/dark_theme.ts
+++ b/packages/charts/src/utils/themes/dark_theme.ts
@@ -465,7 +465,7 @@ export const DARK_THEME: Theme = {
     barBackground: DARK_BACKGROUND_COLORS.backgroundBaseDisabled,
     emptyBackground: Colors.Transparent.keyword,
     nonFiniteText: 'N/A',
-    minHeight: 64,
+    minHeight: 80,
     titleWeight: 500,
   },
   bulletGraph: DARK_THEME_BULLET_STYLE,

--- a/packages/charts/src/utils/themes/legacy_dark_theme.ts
+++ b/packages/charts/src/utils/themes/legacy_dark_theme.ts
@@ -441,7 +441,7 @@ export const LEGACY_DARK_THEME: Theme = {
     barBackground: '#343741',
     emptyBackground: Colors.Transparent.keyword,
     nonFiniteText: 'N/A',
-    minHeight: 64,
+    minHeight: 80,
     titleWeight: 500,
   },
   bulletGraph: DARK_THEME_BULLET_STYLE,

--- a/packages/charts/src/utils/themes/legacy_light_theme.ts
+++ b/packages/charts/src/utils/themes/legacy_light_theme.ts
@@ -440,7 +440,7 @@ export const LEGACY_LIGHT_THEME: Theme = {
     barBackground: '#EDF0F5',
     emptyBackground: Colors.Transparent.keyword,
     nonFiniteText: 'N/A',
-    minHeight: 64,
+    minHeight: 80,
     titleWeight: 500,
   },
   bulletGraph: LIGHT_THEME_BULLET_STYLE,

--- a/packages/charts/src/utils/themes/light_theme.ts
+++ b/packages/charts/src/utils/themes/light_theme.ts
@@ -464,7 +464,7 @@ export const LIGHT_THEME: Theme = {
     barBackground: LIGHT_BACKGROUND_COLORS.backgroundBaseDisabled,
     emptyBackground: Colors.Transparent.keyword,
     nonFiniteText: 'N/A',
-    minHeight: 64,
+    minHeight: 80,
     titleWeight: 500,
   },
   bulletGraph: LIGHT_THEME_BULLET_STYLE,


### PR DESCRIPTION
## Summary

Wide metric tiles in grids no longer shrink height to a point where value is clipped. 

**Before:**

https://github.com/user-attachments/assets/704cf81e-d546-4bab-b6b2-8a18549ab0a4

**After:** 

https://github.com/user-attachments/assets/95f4db3b-ad4a-4162-abef-9689231d9907

## Details

Increase theme's `minHeight` from `64px` to `80px`. 

Given the padding and font sizes for title and value at the smallest breakpoint, we calculate the minimum height needed to render these elements. It currently is 71 (with small spacing) and 79 (with large spacing). Therefore increased `minHeight` to `80px`(smallest value on the 8-point grid system >79).  Added a test to check that themes' `minHeight` are greater or equal to the measured min, to avoid future regressions if we edit breakpoints, paddings or font sizes.

This increase makes compact metrics have a tiny bit more white space in these circumstances. Panels can have many different configurations (title, subtitle, value, spacing ...) which are conditionally rendered, this makes it difficult to expose a static `minHeight` value.

| Before  | After |
| ------------- | ------------- |
|  <img width="370" height="130" alt="Screenshot 2026-07-16 at 15 03 06" src="https://github.com/user-attachments/assets/aca1bea8-3378-4e13-97db-406a4426c5e4" />  | <img width="431" height="145" alt="Screenshot 2026-07-16 at 15 03 16" src="https://github.com/user-attachments/assets/d729c2c4-3ba7-44fe-9c1c-12bee974892e" /> |

I also considered exposing a `getMinHeight` function, so that consumers could get actual minHeight for a given Metric style and use that instead. However, it didn't seem like a common pattern in the codebase, so opted for this simpler and static approach, but happy to discuss!


### To test
To test the behavior go to the [metrics/grid story](https://ech-e2e-ci--pr-2864-sebcw6e3.web.app/storybook/?path=/story/metric-alpha--grid&globals=toggles.showHeader:true;toggles.showChartTitle:false;toggles.showChartDescription:false;toggles.showChartBoundary:false;theme:light), edit number of columns from 4 to 2 (so you can can wide metric tiles) and resize height of chart. Check that value is no longer cropped.

## Issues

Fixes https://github.com/elastic/kibana/issues/268123

### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [x] The proper **chart type** label has been added (e.g. `:xy`, `:partition`)
- [x] The proper **feature** labels have been added (e.g. `:interactions`, `:axis`)
- [x] All related issues have been linked (i.e. `closes #123`, `fixes #123`)
- [ ] New public API exports have been added to `packages/charts/src/index.ts`
- [x] Unit tests have been added or updated to match the most common scenarios
- [ ] The proper documentation and/or storybook story has been added or updated
- [x] The code has been checked for cross-browser compatibility (Chrome, Firefox, Safari, Edge)
- [x] Visual changes have been tested with `light` and `dark` themes
