### PR TITLE
ci: prove screenshot SHA timing via repository activity

### DIFF
--- a/.github/workflows/update_screenshots.yml
+++ b/.github/workflows/update_screenshots.yml
@@ -40,11 +40,13 @@ jobs:
               'i',
             );
 
+            // Marks a refused pin so the 😕 step can run (setFailed alone does not set this).
             const refusePin = (message) => {
               core.setOutput('pin_refused', 'true');
               core.setFailed(message);
             };
 
+            // 404 means "not a member" (or membership is private to this token).
             const isOrgMember = async (username) => {
               try {
                 await github.request('GET /orgs/{org}/members/{username}', {
@@ -59,51 +61,42 @@ jobs:
               }
             };
 
-            // Latest PushEvent whose result was this SHA as the PR branch head
-            // (not a push of the same commit on another branch). GraphQL is only
-            // used when this listing is empty or errors — not when events exist
-            // but none match, or when a match has an unparsable created_at.
+            // Server time this SHA last became this branch's head (push / force-push / branch creation).
+            // Query the head repo (the fork, for external PRs) and this ref only.
             const latestTimeShaBecamePrBranchHead = async (headOwner, headRepo, prRef, headSha) => {
               try {
-                const events = await github.paginate(github.rest.activity.listRepoEvents, {
+                const activities = await github.paginate('GET /repos/{owner}/{repo}/activity', {
                   owner: headOwner,
                   repo: headRepo,
+                  ref: prRef,
                   per_page: 100,
                 });
-                if (events.length === 0) {
-                  return { eventsAvailable: false, becameHeadAt: null };
-                }
                 const headShaLower = headSha.toLowerCase();
+                const headActivityTypes = new Set(['push', 'force_push', 'branch_creation']);
                 let becameHeadAt = null;
                 let latestMs = Number.NEGATIVE_INFINITY;
-                let sawUnparsableMatch = false;
-                for (const event of events) {
+                for (const activity of activities) {
                   if (
-                    event.type !== 'PushEvent' ||
-                    event.payload?.ref !== prRef ||
-                    event.payload?.head?.toLowerCase() !== headShaLower
+                    !headActivityTypes.has(activity.activity_type) ||
+                    activity.after?.toLowerCase() !== headShaLower
                   ) {
                     continue;
                   }
-                  const atMs = Date.parse(event.created_at);
-                  if (Number.isNaN(atMs)) {
-                    sawUnparsableMatch = true;
-                    continue;
-                  }
-                  if (atMs < latestMs) continue;
+                  const atMs = Date.parse(activity.timestamp);
+                  if (Number.isNaN(atMs) || atMs < latestMs) continue;
                   latestMs = atMs;
-                  becameHeadAt = event.created_at;
+                  becameHeadAt = activity.timestamp;
                 }
-                if (sawUnparsableMatch) {
-                  return { eventsAvailable: true, becameHeadAt: null };
-                }
-                return { eventsAvailable: true, becameHeadAt };
+                return becameHeadAt;
               } catch (err) {
-                core.warning(`Failed to list repo events for ${headOwner}/${headRepo}: ${err}`);
-                return { eventsAvailable: false, becameHeadAt: null };
+                core.warning(
+                  `Failed to list repository activity for ${headOwner}/${headRepo} ${prRef}: ${err}`,
+                );
+                return null;
               }
             };
 
+            // Commenter must be an Approver (elastic org member).
             const commenter = context.payload.comment.user.login;
             let isApprover = false;
             try {
@@ -146,6 +139,8 @@ jobs:
               return;
             }
 
+            // No SHA: Trusted authors may omit it. Named SHA: must be current head
+            // and already the head when the comment was written.
             if (!requestedSha) {
               if (!trustedAuthor) {
                 refusePin(
@@ -175,32 +170,12 @@ jobs:
               }
 
               const [headOwner, headRepo] = headRepoFullName.split('/');
-              const headTiming = await latestTimeShaBecamePrBranchHead(
+              const headPresentAt = await latestTimeShaBecamePrBranchHead(
                 headOwner,
                 headRepo,
                 prRef,
                 headSha,
               );
-              const prBranchHeadPushAt = headTiming.eventsAvailable ? headTiming.becameHeadAt : null;
-              let commitPushedDate = null;
-              if (!headTiming.eventsAvailable) {
-                try {
-                  const result = await github.graphql(
-                    `query ($owner: String!, $repo: String!, $oid: GitObjectID!) {
-                      repository(owner: $owner, name: $repo) {
-                        object(oid: $oid) {
-                          ... on Commit { pushedDate }
-                        }
-                      }
-                    }`,
-                    { owner: headOwner, repo: headRepo, oid: headSha },
-                  );
-                  commitPushedDate = result.repository?.object?.pushedDate ?? null;
-                } catch (err) {
-                  core.warning(`Failed to read commit pushedDate for ${headSha}: ${err}`);
-                }
-              }
-              const headPresentAt = prBranchHeadPushAt ?? commitPushedDate;
               const headPresentAtMs = Date.parse(headPresentAt);
               if (Number.isNaN(headPresentAtMs)) {
                 refusePin(


### PR DESCRIPTION
## Summary
Screenshot-update comments on untrusted pull requests now prove “this SHA was already the PR head” from GitHub’s repository activity log, instead of the public Events feed.

## Details
[#2880](https://github.com/elastic/elastic-charts/pull/2880) requires an Approval comment on a non-Trusted-author PR to name the current head, and that head must already have been in place when the comment was written.

That timing check used `GET /repos/{owner}/{repo}/events` plus a GraphQL `Commit.pushedDate` fallback. Both miss common cases: web-UI commits often never appear as `PushEvent`s, `pushedDate` is deprecated and null, and an unrelated event on the fork skipped the fallback. That is why `buildkite update screenshots <sha>` was refused on [#2888](https://github.com/elastic/elastic-charts/pull/2888) even though the SHA was already `patch-2` head.

The pin now uses `GET /repos/{owner}/{repo}/activity` on the **head repository** (the fork for external PRs), filtered to that branch. The latest `push`, `force_push`, or `branch_creation` whose `after` is the named SHA supplies a server `timestamp`, which is compared to the comment time.

Unchanged:
- Commenter must be an `elastic` org member
- SHA required unless the opener is a Trusted author
- Named SHA must be the current PR head
- Workflow talks to GitHub over the REST API only; it does not check out pull-request code
- 👍 only after Buildkite accepts the build; 😕 for a non-Approver or a refused pin

The policy ADR and CONTEXT language are unchanged; only the proof source changed.

## Test plan
- [ ] From an org-member account, on a PR you opened, comment `buildkite update screenshots` (no SHA) and confirm a Buildkite screenshot-update build starts and the comment gets 👍
- [ ] From an org-member account, on a fork PR opened by a non-member, comment without a SHA and confirm 😕 and no build
- [ ] On that same fork PR, comment `buildkite update screenshots <current-head-sha>` (including a web-UI commit) and confirm the build starts and the comment gets 👍
- [ ] Comment with a SHA that is not the current PR head and confirm 😕 and no build
- [ ] After the head moves, comment naming the old SHA and confirm 😕 and no build
- [ ] Confirm a non-org-member commenter gets 😕 and no build

### Checklist
- [x] The `:ci` label has been added